### PR TITLE
fix: Fix filter-well remove all handler

### DIFF
--- a/apps/styleguide/src/tables/FilterWells.vue
+++ b/apps/styleguide/src/tables/FilterWells.vue
@@ -103,7 +103,7 @@ export default {
       let update = this.filters;
       for (var idx in update) {
         if (Array.isArray(update[idx].conditions)) {
-          update[idx].conditions = [];
+          update[idx].conditions.splice(0); // use splice to avoid removing vue reactivity
         }
       }
       this.$emit("update:filters", update);


### PR DESCRIPTION
Vue adds props to make objects reactive, by replacing a object the reactivity is removed.
If the object (the array) is altered ( cleared ) instead of replaced the reactivity stays intact