### PR TITLE
fix: remove empty parent route

### DIFF
--- a/apps/catalogue/src/views/SingleVarHarmonizationView.vue
+++ b/apps/catalogue/src/views/SingleVarHarmonizationView.vue
@@ -72,7 +72,7 @@ export default {
       this.variable.mappings[0] &&
       !this.$route.params.acronym
     ) {
-      this.$router.push({
+      this.$router.replace({
         name: "resourceHarmonizationDetails",
         params: {
           name: this.name,


### PR DESCRIPTION
Fixes issue where using the browser back button would result in empty vue due to no tab ( child view ) being selected
by using replace instead of push the empty view is not put in the history