### PR TITLE
chore: remove unneeded data fetch calls

### DIFF
--- a/apps/catalogue/src/components/HarmonizationDefinition.vue
+++ b/apps/catalogue/src/components/HarmonizationDefinition.vue
@@ -46,9 +46,7 @@
 </template>
 
 <script>
-import Spinner from "../../../styleguide/src/layout/Spinner.vue";
 export default {
-  components: { Spinner },
   name: "HarmonizationDefinition",
   props: {
     variable: Object,

--- a/apps/catalogue/src/store/actions.js
+++ b/apps/catalogue/src/store/actions.js
@@ -10,6 +10,7 @@ export default {
       state.isLoading = false;
     });
     commit("setSchema", resp._schema.name);
+    return resp._schema.name;
   },
   fetchVariables: async ({ state, commit, getters }, offset = 0) => {
     state.isLoading = true;

--- a/apps/catalogue/src/views/SingleVarDetailsView.vue
+++ b/apps/catalogue/src/views/SingleVarDetailsView.vue
@@ -62,7 +62,6 @@
 <script>
 import VariableDetails from "../components/VariableDetails.vue";
 import { fetchDatabanks } from "../store/repository/databankRepository";
-import { fetchDetails } from "../store/repository/variableRepository";
 export default {
   name: "SingleVarDetailsView",
   components: { VariableDetails },
@@ -70,10 +69,10 @@ export default {
     name: String,
     network: String,
     version: String,
+    variable: Object,
   },
   data() {
     return {
-      variable: null,
       databanks: null,
     };
   },
@@ -99,7 +98,6 @@ export default {
     },
   },
   async created() {
-    this.variable = await fetchDetails(this.name, this.network, this.version);
     this.databanks = await fetchDatabanks();
   },
 };

--- a/apps/catalogue/src/views/SingleVarHarmonizationView.vue
+++ b/apps/catalogue/src/views/SingleVarHarmonizationView.vue
@@ -22,26 +22,20 @@
         </router-link>
       </li>
     </ul>
-    <router-view :key="$route.fullPath"></router-view>
+    <router-view :key="$route.fullPath" :variable="variable"></router-view>
   </div>
 </template>
 
 <script>
-import { fetchDetails } from "../store/repository/variableRepository";
 export default {
   name: "SingleVarHarmonizationView",
   props: {
     name: String,
     network: String,
     version: String,
-  },
-  data() {
-    return {
-      variable: {},
-    };
+    variable: Object,
   },
   async created() {
-    this.variable = await fetchDetails(this.name, this.network, this.version);
     // initialy select the first mapping
     if (
       this.variable.mappings &&

--- a/apps/catalogue/src/views/VariableDetailView.vue
+++ b/apps/catalogue/src/views/VariableDetailView.vue
@@ -29,7 +29,7 @@
         <a class="nav-link">Harmonization</a>
       </li>
     </ul>
-    <router-view></router-view>
+    <router-view :variable="variable"></router-view>
   </div>
 </template>
 


### PR DESCRIPTION
Remove calls to fetch variable details from child-views
The child is renderd in the context of the parent,
the parent can fetch the data and pass as prop to the child