### PR TITLE
fix: need explicit org.jooq.Record since jdk14 added Record to java.lang

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/MetadataUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/MetadataUtils.java
@@ -99,7 +99,7 @@ public class MetadataUtils {
 
   protected static synchronized String getVersion(DSLContext jooq) {
     try {
-      Result<Record> result = jooq.selectFrom(VERSION_METADATA).fetch();
+      Result<org.jooq.Record> result = jooq.selectFrom(VERSION_METADATA).fetch();
       if (result.size() > 0) {
         return (String) result.get(0).get(VERSION);
       }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -674,7 +674,7 @@ public class SqlQuery extends QueryBean {
       }
     }
 
-    SelectJoinStep<Record> groupByQuery =
+    SelectJoinStep<org.jooq.Record> groupByQuery =
         table.getJooq().select(selectFields).from(subQuery.get(0));
     for (int i = 1; i < subQuery.size(); i++) {
       groupByQuery = groupByQuery.naturalJoin(subQuery.get(i));


### PR DESCRIPTION
in a few files because 'Record' is now ambiguous because it has been added to java.lang since java14