### PR TITLE
chore: drop debug info

### DIFF
--- a/apps/catalogue/src/components/Explorer.vue
+++ b/apps/catalogue/src/components/Explorer.vue
@@ -66,16 +66,6 @@
           <router-view :search="search" />
         </div>
       </div>
-      <ShowMore title="debug">
-        <pre>
-        timestamp = {{ timestamp }}
-          search = {{ search }}
-          selectedTopic = {{ selectedTopic }}
-          selectedDatabanks = {{ selectedDatabanks }}
-          topics = {{ topics }}
-      </pre
-        >
-      </ShowMore>
     </Molgenis>
   </div>
 </template>
@@ -100,7 +90,6 @@ import {
   MessageSuccess,
   Molgenis,
   Pagination,
-  ShowMore,
   Spinner,
 } from "@mswertz/emx2-styleguide";
 import { request } from "graphql-request";
@@ -129,7 +118,6 @@ export default {
     InputCheckbox,
     InputString,
     InputSelect,
-    ShowMore,
     VariablePanel,
   },
   data: function () {

--- a/apps/catalogue/src/components/HarmonisationDetails.vue
+++ b/apps/catalogue/src/components/HarmonisationDetails.vue
@@ -107,14 +107,6 @@
             </table>
           </div>
         </span>
-        <ShowMore title="debug">
-          <pre>
-          {{ JSON.stringify(harmonisation) }}
-
-          match = {{ match }}
-       </pre
-          >
-        </ShowMore>
       </template>
       <template v-slot:footer>
         <ButtonAction @click="show = false">Close</ButtonAction>
@@ -143,12 +135,11 @@ import {
   ButtonAlt,
   LayoutModal,
   MessageError,
-  ShowMore,
 } from "@mswertz/emx2-styleguide";
 import { request } from "graphql-request";
 
 export default {
-  components: { LayoutModal, ButtonAlt, MessageError, ShowMore, ButtonAction },
+  components: { LayoutModal, ButtonAlt, MessageError, ButtonAction },
   props: {
     sourceCollection: String,
     sourceTable: String,

--- a/apps/catalogue/src/components/HarmonisationList.vue
+++ b/apps/catalogue/src/components/HarmonisationList.vue
@@ -51,7 +51,7 @@ dd {
 
 <script>
 import { request } from "graphql-request";
-import { MessageError, Pagination, ShowMore } from "@mswertz/emx2-styleguide";
+import { MessageError, Pagination } from "@mswertz/emx2-styleguide";
 import HarmonisationDetails from "./HarmonisationDetails";
 
 export default {
@@ -59,7 +59,6 @@ export default {
     HarmonisationDetails,
     Pagination,
     MessageError,
-    ShowMore,
   },
   props: {
     resourceAcronym: String,

--- a/apps/catalogue/src/components/VariableTree.vue
+++ b/apps/catalogue/src/components/VariableTree.vue
@@ -39,7 +39,6 @@ import {
   MessageSuccess,
   Molgenis,
   Pagination,
-  ShowMore,
   Spinner,
 } from "@mswertz/emx2-styleguide";
 import { request } from "graphql-request";
@@ -65,7 +64,6 @@ export default {
     InputCheckbox,
     InputString,
     InputSelect,
-    ShowMore,
     VariablesList,
   },
   props: {

--- a/apps/catalogue/src/components/VariablesList.vue
+++ b/apps/catalogue/src/components/VariablesList.vue
@@ -19,9 +19,6 @@
         />
       </div>
     </div>
-    <ShowMore title="debug">
-      {{ variables }}
-    </ShowMore>
   </div>
 </template>
 
@@ -45,7 +42,6 @@ import {
   InputSearch,
   MessageError,
   Pagination,
-  ShowMore,
 } from "@mswertz/emx2-styleguide";
 import HarmonisationDetails from "./HarmonisationDetails";
 import VariableCard from "./VariableCard";
@@ -57,7 +53,6 @@ export default {
     MessageError,
     VariableCard,
     InputSearch,
-    ShowMore,
   },
   props: {
     resourceAcronym: String,

--- a/apps/central/src/components/Groups.vue
+++ b/apps/central/src/components/Groups.vue
@@ -57,9 +57,6 @@
         @close="closeDeleteSchema"
         :schemaName="showDeleteSchema"
       />
-      <ShowMore title="debug"
-        >session = {{ session }}, schemas = {{ schemas }}
-      </ShowMore>
     </div>
   </div>
 </template>
@@ -73,7 +70,6 @@ import {
   IconAction,
   IconBar,
   IconDanger,
-  ShowMore,
   Spinner,
   MessageWarning,
   InputSearch,
@@ -87,7 +83,6 @@ export default {
     IconBar,
     IconAction,
     IconDanger,
-    ShowMore,
     MessageWarning,
     InputSearch,
   },

--- a/apps/pages/src/components/EditPage.vue
+++ b/apps/pages/src/components/EditPage.vue
@@ -11,17 +11,6 @@
         <ButtonAction @click="savePage">Save '{{ page }}'</ButtonAction>
       </div>
     </div>
-    <br />
-    <br />
-    <ShowMore title="debug">
-      <pre>
-page = {{ page }}
-
-draft = {{ draft }}
-
-session = {{ session }}
-      </pre>
-    </ShowMore>
   </div>
 </template>
 
@@ -32,7 +21,6 @@ import {
   ButtonAlt,
   MessageError,
   MessageSuccess,
-  ShowMore,
 } from "@mswertz/emx2-styleguide";
 import { request } from "graphql-request";
 
@@ -41,7 +29,6 @@ export default {
     ckeditor: CKEditor.component,
     ButtonAction,
     ButtonAlt,
-    ShowMore,
     MessageError,
     MessageSuccess,
   },

--- a/apps/pages/src/components/ListPages.vue
+++ b/apps/pages/src/components/ListPages.vue
@@ -19,12 +19,6 @@
         </td>
       </tr>
     </table>
-
-    <ShowMore title="debug">
-      <pre>
-session = {{ session }}
-      </pre>
-    </ShowMore>
   </div>
 </template>
 

--- a/apps/schema/src/components/FomrEditOld.vue
+++ b/apps/schema/src/components/FomrEditOld.vue
@@ -87,11 +87,6 @@
       </div>
       <div v-else class="col"></div>
     </div>
-    <ShowMore title="debug">
-      columns: {{ table }} <br />
-      selectedColumn: {{ selectedColumn }} <br />
-      errorPerColumn: {{ errorPerColumn }} <br />
-    </ShowMore>
   </div>
 </template>
 
@@ -114,7 +109,6 @@ import {
   IconAction,
   RowFormInput,
   InputSelect,
-  ShowMore,
   InputString,
   MessageSuccess,
   MessageError,
@@ -133,7 +127,6 @@ export default {
     ColumnEditModal,
     RowFormInput,
     InputSelect,
-    ShowMore,
     MessageSuccess,
     MessageError,
     ButtonAction,

--- a/apps/schema/src/components/FormEdit.vue
+++ b/apps/schema/src/components/FormEdit.vue
@@ -102,11 +102,6 @@
         />
       </div>
     </div>
-    <ShowMore title="debug">
-      columns: {{ table }} <br />
-      selectedColumn: {{ selectedColumn }} <br />
-      errorPerColumn: {{ errorPerColumn }} <br />
-    </ShowMore>
   </div>
 </template>
 
@@ -129,7 +124,6 @@ import {
   IconAction,
   RowFormInput,
   InputSelect,
-  ShowMore,
   InputString,
   MessageSuccess,
   MessageError,
@@ -149,7 +143,6 @@ export default {
     InputString,
     RowFormInput,
     InputSelect,
-    ShowMore,
     MessageSuccess,
     MessageError,
     ButtonAction,

--- a/apps/schema/src/components/SchemaEditor.vue
+++ b/apps/schema/src/components/SchemaEditor.vue
@@ -7,10 +7,6 @@
         :schema="schema"
       />
     </div>
-    <ShowMore title="debug">
-      {{ timestamp }}
-      <pre>{{ schema }}</pre>
-    </ShowMore>
   </div>
 </template>
 
@@ -22,7 +18,6 @@ import {
   InputText,
   ButtonAlt,
   IconDanger,
-  ShowMore,
 } from "@mswertz/emx2-styleguide";
 import columnTypes from "../columnTypes";
 import Draggable from "vuedraggable";
@@ -36,7 +31,6 @@ export default {
     InputText,
     ButtonAlt,
     IconDanger,
-    ShowMore,
     TableEditor,
     Draggable,
   },

--- a/apps/schema/src/components/TableEditor.vue
+++ b/apps/schema/src/components/TableEditor.vue
@@ -112,7 +112,6 @@ import {
   ButtonAlt,
   IconDanger,
   IconAction,
-  ShowMore,
   LayoutModal,
 } from "@mswertz/emx2-styleguide";
 import columnTypes from "../columnTypes";
@@ -131,7 +130,6 @@ export default {
     InputText,
     ButtonAlt,
     IconDanger,
-    ShowMore,
     ColumnEditor,
     LayoutModal,
     Draggable,

--- a/apps/settings/src/components/Members.vue
+++ b/apps/settings/src/components/Members.vue
@@ -46,19 +46,6 @@
       </TableSimple>
     </div>
     <div v-else>Not a member, cannot see settings</div>
-
-    <ShowMore title="debug">
-      <br />
-      members: {{ JSON.stringify(members) }}
-      <br />
-      roles: {{ JSON.stringify(roles) }}
-      <br />
-      selectedItems: {{ JSON.stringify(selectedItems) }}
-      <br />
-      editMember: {{ JSON.stringify(editMember) }}
-      <br />
-      session: {{ JSON.stringify(session) }}
-    </ShowMore>
   </div>
 </template>
 
@@ -74,7 +61,6 @@ import {
   LayoutCard,
   MessageError,
   MessageSuccess,
-  ShowMore,
   Spinner,
 } from "@mswertz/emx2-styleguide";
 import { request } from "graphql-request";
@@ -92,7 +78,6 @@ export default {
     InputCheckbox,
     InputString,
     InputSelect,
-    ShowMore,
   },
   props: {
     session: Object,

--- a/apps/settings/src/components/MenuManager.vue
+++ b/apps/settings/src/components/MenuManager.vue
@@ -22,17 +22,6 @@
         <ButtonAction @click="saveSettings">Save</ButtonAction>
       </div>
     </div>
-    <br />
-    <br />
-    <ShowMore title="debug">
-      <pre>
-draft = {{ draft }}
-
-menu = {{ menu }}
-
-session = {{ session }}
-      </pre>
-    </ShowMore>
   </div>
 </template>
 
@@ -44,7 +33,6 @@ import {
   IconAction,
   MessageError,
   MessageSuccess,
-  ShowMore,
   DefaultMenuMixin,
 } from "@mswertz/emx2-styleguide";
 import { request } from "graphql-request";
@@ -53,7 +41,6 @@ export default {
   mixins: [DefaultMenuMixin],
   components: {
     MenuDesign,
-    ShowMore,
     IconAction,
     ButtonAlt,
     ButtonAction,

--- a/apps/settings/src/components/Theme.vue
+++ b/apps/settings/src/components/Theme.vue
@@ -23,14 +23,6 @@
       <br /><br />
       <a :href="this.session.settings.cssURL">view theme css</a>
     </div>
-    <ShowMore title="debug">
-      <pre>
-primary: {{ primary }}
-logoURL: {{ logoURL }}
-session: {{ session }}
-        </pre
-      >
-    </ShowMore>
   </div>
 </template>
 
@@ -40,7 +32,6 @@ import {
   InputString,
   MessageError,
   MessageSuccess,
-  ShowMore,
 } from "@mswertz/emx2-styleguide";
 import VSwatches from "vue-swatches";
 import { request } from "graphql-request";
@@ -52,7 +43,6 @@ export default {
     ButtonAction,
     MessageError,
     MessageSuccess,
-    ShowMore,
     VSwatches,
   },
   props: {

--- a/apps/styleguide/src/mixins/TableMetadataMixin.vue
+++ b/apps/styleguide/src/mixins/TableMetadataMixin.vue
@@ -1,11 +1,3 @@
-<template>
-  <ShowMore>
-    <pre>graphqlError = {{ graphqlError }}</pre>
-    <pre>session = {    { session }}</pre>
-    <pre>schema = {{ schema }}</pre>
-  </ShowMore>
-</template>
-
 <script>
 import { request } from "graphql-request";
 

--- a/apps/styleguide/src/mixins/TableMixin.vue
+++ b/apps/styleguide/src/mixins/TableMixin.vue
@@ -1,11 +1,3 @@
-<template>
-  <ShowMore>
-    <pre>graphqlError = {{ graphqlError }}</pre>
-    <pre>graphql = {{ graphql }}</pre>
-    <pre>data = {{ data }}</pre>
-  </ShowMore>
-</template>
-
 <script>
 import { request } from "graphql-request";
 import TableMetadataMixin from "./TableMetadataMixin";

--- a/apps/styleguide/src/tables/FilterSidebar.vue
+++ b/apps/styleguide/src/tables/FilterSidebar.vue
@@ -24,12 +24,6 @@
           />
         </FilterContainer>
       </Draggable>
-      <ShowMore title="debug">
-        <pre>
-filters = {{ filters }}
-      </pre
-        >
-      </ShowMore>
     </div>
   </div>
 </template>
@@ -37,7 +31,6 @@ filters = {{ filters }}
 <script>
 import FilterContainer from "./FilterContainer";
 import FilterInput from "./FilterInput";
-import ShowMore from "../layout/ShowMore";
 import Draggable from "vuedraggable";
 
 export default {
@@ -45,7 +38,6 @@ export default {
     FilterInput,
     FilterContainer,
     Draggable,
-    ShowMore,
   },
   props: {
     filters: Array,

--- a/apps/styleguide/src/tables/RowEditModal.vue
+++ b/apps/styleguide/src/tables/RowEditModal.vue
@@ -31,28 +31,6 @@
           />
         </span>
       </LayoutForm>
-      <ShowMore title="debug">
-        <pre>
-
-defaultValue = {{ defaultValue }}
-
-visibleColumns = {{ visibleColumns }}
-
-value={{ JSON.stringify(value) }}
-
-data={{ JSON.stringify(data) }}
-
-graphql = {{ JSON.stringify(graphql) }}
-
-filter = {{ JSON.stringify(filter) }}
-
-errorPerColumn = {{ JSON.stringify(errorPerColumn) }}
-
-schema = {{ JSON.stringify(schema, null, 2) }}
-
-
-        </pre>
-      </ShowMore>
     </template>
     <template v-slot:footer>
       <MessageSuccess v-if="success">{{ success }}</MessageSuccess>
@@ -76,7 +54,6 @@ import SigninForm from "../layout/MolgenisSignin";
 import TableMixin from "../mixins/TableMixin";
 import GraphqlRequestMixin from "../mixins/GraphqlRequestMixin";
 import RowFormInput from "./RowFormInput.vue";
-import ShowMore from "../layout/ShowMore";
 
 export default {
   extends: TableMixin,
@@ -106,7 +83,6 @@ export default {
     MessageError,
     MessageSuccess,
     SigninForm,
-    ShowMore,
     ButtonOutline,
   },
   methods: {

--- a/apps/styleguide/src/tables/TableExplorer.vue
+++ b/apps/styleguide/src/tables/TableExplorer.vue
@@ -171,37 +171,6 @@
         </div>
       </div>
     </div>
-    <ShowMore title="debug">
-      <pre>
-        columns = {{ columns }}
-
-        selection = {{ selectedItems }}
-
-      graphqlFilter = {{ JSON.stringify(graphqlFilter) }}
-
-      session = {{ session }}
-
-        graphqlError = {{ graphqlError }}
-
-        schema = {{ schema }}
-
-
-      columns = {{ JSON.stringify(columns) }}
-
-      table = {{ table }} }
-
-      graphql={{ JSON.stringify(graphql) }}
-
-      columnNames = {{ columnNames }}
-
-      rows = {{ data }}
-
-      tableMetadata={{ JSON.stringify(tableMetadata, null, "\t") }}
-
-    data={{ JSON.stringify(data, null, "\t") }}
-    </pre
-      >
-    </ShowMore>
   </div>
 </template>
 
@@ -215,7 +184,6 @@ import RowButtonDelete from "./RowButtonDelete";
 import RowButtonEdit from "./RowButtonEdit";
 import Spinner from "../layout/Spinner";
 import TableMixin from "../mixins/TableMixin";
-import ShowMore from "../layout/ShowMore";
 import ShowHide from "./ShowHide";
 import InputSearch from "../forms/InputSearch";
 import Pagination from "./Pagination";
@@ -241,7 +209,6 @@ export default {
     RowButtonEdit,
     RowButtonAdd,
     RowButtonDelete,
-    ShowMore,
     ShowHide,
     InputSearch,
     Pagination,

--- a/apps/styleguide/src/tables/TableSearch.vue
+++ b/apps/styleguide/src/tables/TableSearch.vue
@@ -71,14 +71,6 @@
         </TableMolgenis>
       </div>
     </div>
-    <ShowMore title="debug">
-      <pre>
-canEdit = {{ canEdit }}
-session = {{ session }}
-schema = {{ schema }}
-data = {{ data }}
-      </pre>
-    </ShowMore>
   </div>
 </template>
 
@@ -90,7 +82,6 @@ import InputSearch from "../forms/InputSearch";
 import Pagination from "./Pagination.vue";
 import Spinner from "../layout/Spinner.vue";
 import SelectionBox from "./SelectionBox";
-import ShowMore from "../layout/ShowMore";
 import RowButtonAdd from "./RowButtonAdd";
 import RowButtonEdit from "./RowButtonEdit";
 import RowButtonDelete from "./RowButtonDelete";
@@ -103,7 +94,6 @@ export default {
     InputSearch,
     Pagination,
     Spinner,
-    ShowMore,
     RowButtonEdit,
     RowButtonDelete,
     RowButtonAdd,

--- a/apps/tables/src/components/ListTables.vue
+++ b/apps/tables/src/components/ListTables.vue
@@ -37,10 +37,6 @@
         </tr>
       </table>
     </div>
-    <ShowMore title="debug">
-      session: {{ session }} <br /><br />
-      schema: {{ schema }}
-    </ShowMore>
   </div>
 </template>
 
@@ -51,7 +47,6 @@ import {
   InputCheckbox,
   MessageWarning,
   InputSearch,
-  ShowMore,
 } from "@mswertz/emx2-styleguide";
 
 export default {
@@ -62,7 +57,6 @@ export default {
     InputCheckbox,
     ButtonDropdown,
     InputSearch,
-    ShowMore,
   },
   props: {
     session: Object,

--- a/apps/updownload/src/components/Import.vue
+++ b/apps/updownload/src/components/Import.vue
@@ -95,14 +95,6 @@
         </div>
       </div>
     </div>
-    <ShowMore>
-      <pre>
-        session = {{ session }}
-        taskUrl = {{ taskUrl }}
-        task = {{ task }}
-        file = {{ file }}
-      </pre>
-    </ShowMore>
   </Molgenis>
 </template>
 
@@ -115,7 +107,6 @@ import {
   MessageWarning,
   Molgenis,
   Spinner,
-  ShowMore,
 } from "@mswertz/emx2-styleguide";
 import { request } from "graphql-request";
 import Task from "./Task";
@@ -131,7 +122,6 @@ export default {
     Spinner,
     Molgenis,
     Task,
-    ShowMore,
   },
   data: function () {
     return {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       - POSTGRES_USER=molgenis
       - POSTGRES_PASSWORD=molgenis
       - POSTGRES_DB=molgenis
-    ports:
-      - "5432:5432"
+    expose:
+      - "5432"
     volumes:
       - ./psql_data:/var/lib/postgresql/data
     command: -c 'shared_buffers=256MB' -c 'max_locks_per_transaction=1024'

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       - POSTGRES_USER=molgenis
       - POSTGRES_PASSWORD=molgenis
       - POSTGRES_DB=molgenis
-    expose:
-      - "5432"
+    ports:
+      - "5432:5432"
     volumes:
       - ./psql_data:/var/lib/postgresql/data
     command: -c 'shared_buffers=256MB' -c 'max_locks_per_transaction=1024'


### PR DESCRIPTION
The initial thought was to enable debug info when you are developer. We found it hard to match against the user that is logged in. Our idea an implementation was to put the session object in every view that was showing the debug logging. 
This was very verbose in our opinion. 

We have now chosen to drop the debug information because the same information is exposed in an easy way in the vue developer environment in the browser.

What do you think?