### PR TITLE
fix: data is lost when entering data via forms and clicking outside form. closes #212

### DIFF
--- a/apps/styleguide/src/layout/LayoutModal.vue
+++ b/apps/styleguide/src/layout/LayoutModal.vue
@@ -7,7 +7,6 @@
       style="display: block"
       tabindex="-1"
       aria-modal="true"
-      @click="closeUnlessInDialog"
     >
       <div v-if="show" class="modal-dialog modal-xl" role="document">
         <div class="modal-content">
@@ -92,11 +91,6 @@ export default {
     close() {
       /** when the close x button is clicked */
       this.$emit("close");
-    },
-    closeUnlessInDialog() {
-      if (event.target === event.currentTarget) {
-        this.$emit("close");
-      }
     },
   },
 };


### PR DESCRIPTION
In light of "Data is lost when entering data via forms and clicking outside form."  

[x] when clicking outside of a modal it does NOT close.

closes #212

