### PR TITLE
add breadcrumb to ease going back to schema list. closes #299

### DIFF
--- a/apps/styleguide/src/layout/Breadcrumb.vue
+++ b/apps/styleguide/src/layout/Breadcrumb.vue
@@ -1,0 +1,36 @@
+<template>
+  <nav aria-label="breadcrumb">
+    <ol class="breadcrumb">
+      <li
+        v-for="(url, label) in crumbs"
+        :key="label"
+        class="breadcrumb-item"
+        :class="{ active: label === lastKey }"
+      >
+        <a v-if="label == lastKey" aria-current="page">{{ label }}</a>
+        <a v-else :href="url">{{ label }}</a>
+      </li>
+    </ol>
+  </nav>
+</template>
+
+<script>
+export default {
+  props: {
+    /* pass Object {'label':'url'} pairs*/
+    crumbs: Object,
+  },
+  computed: {
+    lastKey() {
+      return Object.keys(this.crumbs)[Object.keys(this.crumbs).length - 1];
+    },
+  },
+};
+</script>
+
+<docs>
+Example:
+```
+<Breadcrumb :crumbs="{'Home':'/', 'Schema':'/schema', 'Page':'/schema/page'}"/>
+```
+</docs>

--- a/apps/styleguide/src/layout/Molgenis.vue
+++ b/apps/styleguide/src/layout/Molgenis.vue
@@ -12,6 +12,9 @@
       >
         <MolgenisSession v-model="session" :key="timestamp" />
       </MolgenisMenu>
+      <small>
+        <Breadcrumb v-if="Object.keys(crumbs).length > 0" :crumbs="crumbs" />
+      </small>
       <div class="container-fluid p-3" style="padding-bottom: 50px">
         <MessageWarning v-if="majorDatabaseVersionToOldError"
           >{{ majorDatabaseVersionToOldError }}
@@ -52,6 +55,7 @@ import MolgenisTheme from "./MolgenisTheme";
 import Footer from "./MolgenisFooter";
 import DefaultMenuMixin from "../mixins/DefaultMenuMixin";
 import MessageWarning from "../forms/MessageWarning";
+import Breadcrumb from "./Breadcrumb";
 
 /**
  Provides wrapper for your apps, including a little bit of contextual state, most notably 'account' that can be reacted to using v-model.
@@ -63,6 +67,7 @@ export default {
     MolgenisMenu,
     Footer,
     MolgenisTheme,
+    Breadcrumb,
   },
   mixins: [DefaultMenuMixin],
   props: {
@@ -80,6 +85,31 @@ export default {
     };
   },
   computed: {
+    crumbs() {
+      this.$route;
+      let path = decodeURI(window.location.pathname).split("/");
+      let url = "/";
+      let result = { molgenis: url };
+      if (window.location.pathname != "/apps/central/") {
+        path.forEach((el) => {
+          if (el != "") {
+            url += el + "/";
+            result[el] = url;
+          }
+        });
+      }
+      if (this.$route) {
+        path = decodeURI(location.hash).substr(1).split("/");
+        url += "#";
+        path.forEach((el) => {
+          if (el != "") {
+            url += "/" + el;
+            result[el] = url;
+          }
+        });
+      }
+      return result;
+    },
     majorDatabaseVersionToOldError() {
       if (this.session) {
         let dbVer = this.session.manifest.DatabaseVersion;

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisWebservice.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisWebservice.java
@@ -4,10 +4,14 @@ import static org.molgenis.emx2.json.JsonExceptionMapper.molgenisExceptionToJson
 import static org.molgenis.emx2.web.Constants.*;
 import static spark.Spark.*;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import io.swagger.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Schema;
 import org.molgenis.emx2.Table;
@@ -63,6 +67,22 @@ public class MolgenisWebservice {
     // services (matched in order of creation)
     AppsProxyService.create(new SqlDatabase(false));
 
+    // add trailing /
+    get(
+        "/:schema",
+        (req, res) -> {
+          res.redirect("/" + req.params("schema") + "/");
+          return null;
+        });
+    get(
+        "/:schema/:app",
+        (req, res) -> {
+          res.redirect("/" + req.params("schema") + "/" + req.params("app") + "/");
+          return null;
+        });
+
+    get("/:schema/", MolgenisWebservice::redirectSchemaToFirstMenuItem);
+
     get(
         "/:schema/api",
         (request, response) -> "Welcome to schema api. Check <a href=\"api/openapi\">openapi</a>");
@@ -94,6 +114,39 @@ public class MolgenisWebservice {
 
     // after handle session changes
     afterAfter(sessionManager::updateSession);
+  }
+
+  private static Object redirectSchemaToFirstMenuItem(Request request, Response response) {
+    try {
+      Schema schema = getSchema(request);
+      String role = schema.getRoleForActiveUser();
+      List<Map<String, String>> menu =
+          new ObjectMapper().readValue(schema.getMetadata().getSetting("menu"), List.class);
+      menu =
+          menu.stream()
+              .filter(
+                  el ->
+                      role == null
+                          || role.equals("admin")
+                          || el.get("role") == null
+                          || el.get("role").equals("Viewer")
+                              && List.of("Viewer", "Editor", "Manager").contains(role)
+                          || el.get("role").equals("Editor")
+                              && List.of("Editor", "Manager").contains(role)
+                          || el.get("role").equals("Manager") && role.equals("Manager"))
+              .collect(Collectors.toList());
+
+      if (menu.size() > 0) {
+        response.redirect(
+            "/" + request.params("schema") + "/" + menu.get(0).get("href").replace("../", ""));
+        return null;
+      }
+    } catch (Exception e) {
+      // silly default
+      logger.debug(e.getMessage());
+    }
+    response.redirect("/" + request.params("schema") + "/tables");
+    return null;
   }
 
   public static void stop() {


### PR DESCRIPTION
shows a breadcrumb with
[x] 'molgenis' as its root which brings you back to apps/central
[x] 'current schema' which brings you back to the first menu item (same as log0)
[x] 'current app' which brings you back to root of current app
[x] 'hash path' which uses the vue route parameters (might be too much)

In addition
[x] redirect if trailing '/' is missing, e.g. 'localhost:8080/myschema' redirects to 'localhost:8080/myschema/'
[x] redirect to first app in your schema when you enter url only including the schema, e.g. 'localhost:8080/myschema' redirects to 'localhost:8080/myschema/tables/'