### PR TITLE
chore(Jenkinsfile): set env with dot notation

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -59,7 +59,7 @@ podTemplate(inheritFrom:'shared', containers: [
                         -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
                         -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"  
                     def props = readProperties file: 'build/ci.properties'
-                    env['TAG_NAME'] = props['tagName']
+                    env.TAG_NAME = props.tagName
                 }
             }
             container('rancher') {


### PR DESCRIPTION
assigning to env['TAG_NAME'] uses putAt which is unsafe