### PR TITLE
Fix/catalog breadcrumb

### DIFF
--- a/apps/catalogue/src/App.vue
+++ b/apps/catalogue/src/App.vue
@@ -1,9 +1,6 @@
 <template>
   <div id="app">
-    <Molgenis
-      v-model="session"
-      :key="JSON.stringify(session)"
-    >
+    <Molgenis v-model="session" :key="JSON.stringify(session)">
       <div
         v-if="!session || !session.roles || !session.roles.includes('Viewer')"
       >
@@ -27,12 +24,6 @@ export default {
     return {
       session: {},
     };
-  },
-  computed: {
-    //temporary until variable explorer is fixed
-    showCrumbs() {
-      return !this.$route.path.startsWith("/explorer");
-    },
   },
 };
 </script>

--- a/apps/catalogue/src/App.vue
+++ b/apps/catalogue/src/App.vue
@@ -3,7 +3,6 @@
     <Molgenis
       v-model="session"
       :key="JSON.stringify(session)"
-      :showCrumbs="showCrumbs"
     >
       <div
         v-if="!session || !session.roles || !session.roles.includes('Viewer')"

--- a/apps/catalogue/src/components/HarmonizationDefinition.vue
+++ b/apps/catalogue/src/components/HarmonizationDefinition.vue
@@ -29,8 +29,8 @@
             >
               <router-link
                 :to="{
-                  name: 'fromVariableDetails',
-                  params: { ...$route.paramns, fromName: fromVariable.name },
+                  name: 'VariableDetailView',
+                  query: { ...$route.query, fromName: fromVariable.name },
                 }"
               >
                 {{ fromVariable.name }}

--- a/apps/catalogue/src/components/VariableListItem.vue
+++ b/apps/catalogue/src/components/VariableListItem.vue
@@ -22,11 +22,13 @@
       <router-link
         class="nav-link"
         :to="{
-          name: 'singleVariableDetails',
+          name: 'VariableDetailView',
           params: {
+            name: variable.name,
+          },
+          query: {
             network: variable.release.resource.acronym,
             version: variable.release.version,
-            name: variable.name,
           },
         }"
         >view details

--- a/apps/catalogue/src/main.js
+++ b/apps/catalogue/src/main.js
@@ -18,10 +18,6 @@ import VariableMappingsView from "./views/VariableMappingsView";
 import TableMappingsView from "./views/TableMappingsView";
 import VariableExplorer from "./views/VariableExplorer";
 import VariableDetailView from "./views/VariableDetailView";
-import SingleVarDetailsView from "./views/SingleVarDetailsView";
-import SingleVarHarmonizationView from "./views/SingleVarHarmonizationView";
-import ResourceHarmonizationDetails from "./views/ResourceHarmonizationDetails";
-import FromVariableDetails from "./views/FromVariableDetails";
 import CohortView from "./views/CohortView";
 
 Vue.config.productionTip = false;
@@ -29,7 +25,6 @@ Vue.config.productionTip = false;
 Vue.use(VueRouter);
 
 const router = new VueRouter({
-  linkActiveClass: "active", // bootstrap 4 active tab class
   routes: [
     { name: "Catalogue", path: "/", component: CatalogueView },
     { name: "Cohorts", path: "/alt", component: NetworkView },
@@ -194,38 +189,10 @@ const router = new VueRouter({
       component: VariableExplorer,
     },
     {
-      name: "variable-detail",
-      path: "/explorer/details/:network/:version/:name",
+      name: "VariableDetailView",
+      path: "/variable-explorer/:name",
+      props: (route) => ({ ...route.params, ...route.query }), // both key and value are dynamic
       component: VariableDetailView,
-      props: true,
-      children: [
-        {
-          name: "singleVariableDetails",
-          path: "details",
-          component: SingleVarDetailsView,
-          props: true,
-        },
-        {
-          name: "singleVariableHarmonization",
-          path: "harmonization",
-          component: SingleVarHarmonizationView,
-          props: true,
-          children: [
-            {
-              name: "resourceHarmonizationDetails",
-              path: ":sourceCohort",
-              component: ResourceHarmonizationDetails,
-              props: true,
-            },
-          ],
-        },
-      ],
-    },
-    {
-      name: "fromVariableDetails",
-      path: "/explorer/source/:network/:version/:name/from/:sourceCohort/:fromName",
-      component: FromVariableDetails,
-      props: true,
     },
   ],
 });

--- a/apps/catalogue/src/main.js
+++ b/apps/catalogue/src/main.js
@@ -17,8 +17,6 @@ import VariableView from "./views/VariableView";
 import VariableMappingsView from "./views/VariableMappingsView";
 import TableMappingsView from "./views/TableMappingsView";
 import VariableExplorer from "./views/VariableExplorer";
-import VariablesDetailsView from "./views/VariablesDetailsView";
-import HarmonizationView from "./views/HarmonizationView";
 import VariableDetailView from "./views/VariableDetailView";
 import SingleVarDetailsView from "./views/SingleVarDetailsView";
 import SingleVarHarmonizationView from "./views/SingleVarHarmonizationView";
@@ -191,21 +189,9 @@ const router = new VueRouter({
       component: TableMappingsView,
     },
     {
-      path: "/explorer",
+      path: "/variable-explorer",
+      props: true,
       component: VariableExplorer,
-      children: [
-        {
-          name: "variableDetails",
-          path: "details",
-          component: VariablesDetailsView,
-        },
-        {
-          name: "variableHarmonization",
-          path: "harmonization",
-          component: HarmonizationView,
-        },
-        { path: "", redirect: "/explorer/details" },
-      ],
     },
     {
       name: "variable-detail",

--- a/apps/catalogue/src/views/FromVariableDetails.vue
+++ b/apps/catalogue/src/views/FromVariableDetails.vue
@@ -1,34 +1,29 @@
 <template>
   <div>
-    <nav class="mg-page-nav" aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item">
-          <router-link :to="{ name: 'variableDetails' }">
-            variables
-          </router-link>
-        </li>
-        <li class="breadcrumb-item">
-          <router-link :to="{ name: 'singleVariableDetails' }">
-            {{ name }}
-          </router-link>
-        </li>
-        <li class="breadcrumb-item" aria-current="page">
-          <router-link :to="{ name: 'resourceHarmonizationDetails' }">
-            {{ sourceCohort }}
-          </router-link>
-        </li>
-        <li class="breadcrumb-item active" aria-current="page">
-          {{ fromName }}
-        </li>
-      </ol>
-    </nav>
     <div v-if="variable">
-      <h3>{{ variable.label }}</h3>
+      <h5>
+        <router-link
+          :to="{
+            name: 'VariableDetailView',
+            query: {
+              ...$route.query,
+              fromName: '',
+            },
+          }"
+        >
+          {{ toName }}
+        </router-link>
+        >
+        {{ variable.label }}
+      </h5>
       <div class="row">
-        <variable-details class="col" :variableDetails="variable" :showMappedBy="false" />
+        <variable-details
+          class="col"
+          :variableDetails="variable"
+          :showMappedBy="false"
+        />
       </div>
     </div>
-    <variable-details></variable-details>
   </div>
 </template>
 
@@ -40,11 +35,10 @@ export default {
   name: "FromVariableDetails",
   components: { VariableDetails },
   props: {
-    name: String,
-    network: String,
     version: String,
     sourceCohort: String,
-    fromName: String
+    fromName: String,
+    toName: String,
   },
   data() {
     return {

--- a/apps/catalogue/src/views/SingleVarHarmonizationView.vue
+++ b/apps/catalogue/src/views/SingleVarHarmonizationView.vue
@@ -8,12 +8,15 @@
       >
         <router-link
           class="nav-link"
+          :class="{
+            active:
+              $route.query.sourceCohort ===
+              mapping.fromTable.release.resource.acronym,
+          }"
           :to="{
-            name: 'resourceHarmonizationDetails',
-            params: {
-              name,
-              version,
-              network,
+            name: 'VariableDetailView',
+            query: {
+              ...$route.query,
               sourceCohort: mapping.fromTable.release.resource.acronym,
             },
           }"
@@ -22,13 +25,21 @@
         </router-link>
       </li>
     </ul>
-    <router-view :key="$route.fullPath" :variable="variable"></router-view>
+    <template v-if="$route.query.tab === 'harmonization'">
+      <resource-harmonization-details
+        :variable="variable"
+        :name="name"
+        :sourceCohort="$route.query.sourceCohort"
+      />
+    </template>
   </div>
 </template>
 
 <script>
+import ResourceHarmonizationDetails from "./ResourceHarmonizationDetails";
 export default {
   name: "SingleVarHarmonizationView",
+  components: { ResourceHarmonizationDetails },
   props: {
     name: String,
     network: String,
@@ -40,14 +51,12 @@ export default {
     if (
       this.variable.mappings &&
       this.variable.mappings[0] &&
-      !this.$route.params.acronym
+      !this.$route.query.sourceCohort
     ) {
       this.$router.replace({
-        name: "resourceHarmonizationDetails",
-        params: {
-          name: this.name,
-          network: this.network,
-          version: this.version,
+        name: "VariableDetailView",
+        query: {
+          ...this.$route.query,
           sourceCohort:
             this.variable.mappings[0].fromTable.release.resource.acronym,
         },

--- a/apps/catalogue/src/views/VariableDetailView.vue
+++ b/apps/catalogue/src/views/VariableDetailView.vue
@@ -1,26 +1,27 @@
 <template>
-  <div>
-    <nav class="mg-page-nav" aria-label="breadcrumb">
-      <ol class="breadcrumb">
-        <li class="breadcrumb-item">
-          <router-link :to="{ name: 'variableDetails' }">
-            variables
-          </router-link>
-        </li>
-        <li class="breadcrumb-item active" aria-current="page">{{ name }}</li>
-      </ol>
-    </nav>
-    <h3 v-if="variable">{{ variable.label }}</h3>
-    <ul class="nav nav-tabs">
+  <div v-if="variable">
+    <h3 v-if="!$route.query.fromName">{{ variable.label }}</h3>
+    <ul class="nav nav-tabs" v-if="!$route.query.fromName">
       <li class="nav-item">
-        <router-link class="nav-link" :to="{ name: 'singleVariableDetails' }">
+        <router-link
+          class="nav-link"
+          :class="{ active: $route.query.tab !== 'harmonization' }"
+          :to="{
+            name: 'VariableDetailView',
+            query: { ...$route.query, tab: 'detail' },
+          }"
+        >
           Details
         </router-link>
       </li>
       <li v-if="variable.mappings" class="nav-item">
         <router-link
           class="nav-link"
-          :to="{ name: 'singleVariableHarmonization' }"
+          :class="{ active: $route.query.tab === 'harmonization' }"
+          :to="{
+            name: 'VariableDetailView',
+            query: { ...$route.query, tab: 'harmonization' },
+          }"
         >
           Harmonization
         </router-link>
@@ -29,15 +30,38 @@
         <a class="nav-link">Harmonization</a>
       </li>
     </ul>
-    <router-view :variable="variable"></router-view>
+    <template
+      v-if="$route.query.tab === 'harmonization' && !$route.query.fromName"
+    >
+      <single-var-harmonization-view :variable="variable" />
+    </template>
+    <template v-else-if="$route.query.fromName">
+      <from-variable-details
+        :version="version"
+        :sourceCohort="$route.query.sourceCohort"
+        :fromName="$route.query.fromName"
+        :toName="variable.label"
+      />
+    </template>
+    <template v-else>
+      <single-var-details-view :variable="variable" />
+    </template>
   </div>
 </template>
 
 <script>
 import { fetchDetails } from "../store/repository/variableRepository";
+import SingleVarDetailsView from "./SingleVarDetailsView";
+import SingleVarHarmonizationView from "./SingleVarHarmonizationView";
+import FromVariableDetails from "./FromVariableDetails";
 
 export default {
   name: "VariableDetailView",
+  components: {
+    SingleVarDetailsView,
+    SingleVarHarmonizationView,
+    FromVariableDetails,
+  },
   props: {
     name: String,
     network: String,

--- a/apps/catalogue/src/views/VariableExplorer.vue
+++ b/apps/catalogue/src/views/VariableExplorer.vue
@@ -46,7 +46,12 @@
                 </router-link>
               </li>
             </ul>
-            <router-view></router-view>
+            <template v-if="$route.query.tab === 'harmonization'">
+              <harmonization-view />
+            </template>
+            <template v-else>
+              <variables-details-view />
+            </template>
           </div>
         </div>
       </div>
@@ -55,6 +60,8 @@
 </template>
 
 <script>
+import VariablesDetailsView from "./VariablesDetailsView";
+import HarmonizationView from "./HarmonizationView";
 import { mapActions, mapGetters, mapState, mapMutations } from "vuex";
 import { InputSearch } from "@mswertz/emx2-styleguide";
 import TreeComponent from "../../../styleguide/src/tree/TreeComponent";
@@ -64,6 +71,8 @@ import FilterWells from "../../../styleguide/src/tables/FilterWells";
 export default {
   name: "VariableExplorer",
   components: {
+    VariablesDetailsView,
+    HarmonizationView,
     InputSearch,
     TreeComponent,
     FilterWells,

--- a/apps/catalogue/src/views/VariableExplorer.vue
+++ b/apps/catalogue/src/views/VariableExplorer.vue
@@ -1,7 +1,5 @@
 <template>
   <div class="container-fluid">
-    <h1>Variable Explorer</h1>
-
     <div class="row">
       <div class="col-3">
         <h5>Filters</h5>
@@ -16,9 +14,9 @@
       <div class="col-9">
         <div class="row">
           <div class="col-3">
-            <h5>
+            <h3>
               Variables <span v-if="variableCount">({{ variableCount }})</span>
-            </h5>
+            </h3>
           </div>
           <div class="col-9">
             <InputSearch v-model="searchInput" placeholder="Search variables" />
@@ -33,14 +31,22 @@
           <div class="col">
             <ul class="nav nav-tabs">
               <li class="nav-item">
-                <router-link class="nav-link" :to="{ name: 'variableDetails' }">
+                <router-link
+                  class="nav-link"
+                  :class="{ active: $route.query.tab !== 'harmonization' }"
+                  :to="{ path: 'variable-explorer', query: { tab: 'detail' } }"
+                >
                   Details
                 </router-link>
               </li>
               <li class="nav-item">
                 <router-link
                   class="nav-link"
-                  :to="{ name: 'variableHarmonization' }"
+                  :class="{ active: $route.query.tab === 'harmonization' }"
+                  :to="{
+                    path: 'variable-explorer',
+                    query: { tab: 'harmonization' },
+                  }"
                 >
                   Harmonization
                 </router-link>


### PR DESCRIPTION
Use auto generated app path instead of setting the path form the view
Flatten the routes to avoid empty or strange auto-generated path elements
Switch view details using query instead of path 

BREAKING: altered path of variable-explorer this needs to be changed on all servers in the menu