### PR TITLE
Fix: admin settings not available / when user switches graphqlapi was not refreshed 

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -329,8 +329,7 @@ public class SqlDatabase implements Database {
         }
       }
     } else {
-      if (username == null && connectionProvider.getActiveUser() != null
-          || username != null && !username.equals(connectionProvider.getActiveUser())) {
+      if (!Objects.equals(username, connectionProvider.getActiveUser())) {
         clearCache();
         listener.userChanged();
       }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -377,6 +377,9 @@ public class SqlDatabase implements Database {
             });
         // only when commit succeeds we copy state to 'this'
         this.sync(db);
+        if (!Objects.equals(db.getActiveUser(), getActiveUser())) {
+          db.getListener().userChanged();
+        }
         if (db.getListener().isDirty()) {
           this.getListener().afterCommit();
         }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -378,7 +378,7 @@ public class SqlDatabase implements Database {
         // only when commit succeeds we copy state to 'this'
         this.sync(db);
         if (!Objects.equals(db.getActiveUser(), getActiveUser())) {
-          db.getListener().userChanged();
+          this.getListener().userChanged();
         }
         if (db.getListener().isDirty()) {
           this.getListener().afterCommit();

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -39,6 +39,11 @@ public class SqlDatabase implements Database {
   private DatabaseListener listener =
       new DatabaseListener() {
         @Override
+        public void userChanged() {
+          clearCache();
+        }
+
+        @Override
         public void afterCommit() {
           clearCache();
           super.afterCommit();
@@ -327,6 +332,7 @@ public class SqlDatabase implements Database {
       if (username == null && connectionProvider.getActiveUser() != null
           || username != null && !username.equals(connectionProvider.getActiveUser())) {
         clearCache();
+        listener.userChanged();
       }
     }
     this.connectionProvider.setActiveUser(username);

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -330,7 +330,6 @@ public class SqlDatabase implements Database {
       }
     } else {
       if (!Objects.equals(username, connectionProvider.getActiveUser())) {
-        clearCache();
         listener.userChanged();
       }
     }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManager.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManager.java
@@ -119,13 +119,15 @@ public class MolgenisSessionManager {
         // create private database wrapper to session
         Database database = new SqlDatabase(false);
         database.setActiveUser("anonymous"); // set default use to "anonymous"
-        database.setListener(new MolgenisSessionManagerDatabaseListener(_this, database));
 
         // create session and add to sessions lists so we can also access all active
         // sessions
         MolgenisSession molgenisSession = new MolgenisSession(database);
         sessions.put(httpSessionEvent.getSession().getId(), molgenisSession);
         logger.info("session created: " + httpSessionEvent.getSession().getId());
+
+        // create listener
+        database.setListener(new MolgenisSessionManagerDatabaseListener(_this, molgenisSession));
       }
 
       public void sessionDestroyed(HttpSessionEvent httpSessionEvent) {

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManagerDatabaseListener.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManagerDatabaseListener.java
@@ -27,6 +27,7 @@ public class MolgenisSessionManagerDatabaseListener extends DatabaseListener {
   public void afterCommit() {
     super.afterCommit();
     sessionManager.clearAllCaches();
-    logger.info("cleared all caches after commit that may include changes on schema(s) or permissions");
+    logger.info(
+        "cleared all caches after commit that may include changes on schema(s) or permissions");
   }
 }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManagerDatabaseListener.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManagerDatabaseListener.java
@@ -1,6 +1,5 @@
 package org.molgenis.emx2.web;
 
-import org.molgenis.emx2.Database;
 import org.molgenis.emx2.DatabaseListener;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -9,20 +8,25 @@ import org.slf4j.LoggerFactory;
 public class MolgenisSessionManagerDatabaseListener extends DatabaseListener {
   private static final Logger logger =
       LoggerFactory.getLogger(MolgenisSessionManagerDatabaseListener.class);
-  private Database database;
   private MolgenisSessionManager sessionManager;
+  private MolgenisSession session;
 
   public MolgenisSessionManagerDatabaseListener(
-      MolgenisSessionManager sessionManager, Database database) {
+      MolgenisSessionManager sessionManager, MolgenisSession session) {
     this.sessionManager = sessionManager;
-    this.database = database;
+    this.session = session;
+  }
+
+  @Override
+  public void userChanged() {
+    logger.info("cleared cache for this session because user changed");
+    session.clearCache();
   }
 
   @Override
   public void afterCommit() {
     super.afterCommit();
-    database.clearCache();
     sessionManager.clearAllCaches();
-    logger.info("cleared caches after commit that includes changes on schema(s)");
+    logger.info("cleared all caches after commit that may include changes on schema(s) or permissions");
   }
 }

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -2,8 +2,7 @@ package org.molgenis.emx2.web;
 
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.molgenis.emx2.web.Constants.*;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -266,6 +265,16 @@ public class WebApiSmokeTests {
             .asString();
     assertTrue(result.contains("anonymous"));
 
+    // if anonymous then should not be able to see users
+    result =
+        given()
+            .sessionId(sessionId)
+            .body("{\"query\":\"{_admin{userCount}}\"}")
+            .when()
+            .post(path)
+            .asString();
+    assertTrue(result.contains("Error"));
+
     result =
         given()
             .sessionId(sessionId)
@@ -285,6 +294,16 @@ public class WebApiSmokeTests {
             .asString();
     assertTrue(result.contains("admin"));
 
+    // if admin then should  be able to see users
+    result =
+        given()
+            .sessionId(sessionId)
+            .body("{\"query\":\"{_admin{userCount}}\"}")
+            .when()
+            .post(path)
+            .asString();
+    assertFalse(result.contains("Error"));
+
     String schemaPath = "/pet store/api/graphql";
     result =
         given()
@@ -303,6 +322,16 @@ public class WebApiSmokeTests {
             .post(path)
             .asString();
     assertTrue(result.contains("signed out"));
+
+    // if anonymous then should not be able to see users
+    result =
+        given()
+            .sessionId(sessionId)
+            .body("{\"query\":\"{_admin{userCount}}\"}")
+            .when()
+            .post(path)
+            .asString();
+    assertTrue(result.contains("Error"));
   }
 
   @Test

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/DatabaseListener.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/DatabaseListener.java
@@ -3,7 +3,7 @@ package org.molgenis.emx2;
 import java.util.HashSet;
 import java.util.Set;
 
-public class DatabaseListener {
+public abstract class DatabaseListener {
   private Set<String> schemaChanged = new HashSet<>();
   private Set<String> schemaRemoved = new HashSet<>();
 
@@ -22,6 +22,8 @@ public class DatabaseListener {
   public Set<String> getSchemaRemoved() {
     return this.schemaRemoved;
   }
+
+  public abstract void userChanged();
 
   /** Abstract method, called on each commit. When override call to reset the listener */
   public void afterCommit() {

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/DatabaseListener.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/DatabaseListener.java
@@ -3,6 +3,12 @@ package org.molgenis.emx2;
 import java.util.HashSet;
 import java.util.Set;
 
+/**
+ * Allows SqlDatabase to notify users that important changes have happened.
+ *
+ * <p>In particular, we use it now to ensure sessions are refreshed if users change, or if there are
+ * transactions that may have changed schema structure and/or permissions.
+ */
 public abstract class DatabaseListener {
   private Set<String> schemaChanged = new HashSet<>();
   private Set<String> schemaRemoved = new HashSet<>();


### PR DESCRIPTION
resulting in 'admin' settings not available when logging in as admin. See #431

To see fail
- on old server, login as 'admin' and go to https://emx2.test.molgenis.org/apps/central/#/admin

To see success
- on this pull request log in as admin and go to https://localhost:8080/apps/central/#/admin

Also see WebApiSmokeTests.testGraphqlApi in the pull request.