### PR TITLE
feat: add pr previews

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,7 @@ derby.log
 .idea/*
 .idea/fileTemplates/*/
 !.idea/fileTemplates/
+.vscode/*
 **/npm-debug.log
 **/.factorypath
 **/node_modules

--- a/.jenkins/build-pod.yaml
+++ b/.jenkins/build-pod.yaml
@@ -1,0 +1,39 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: jenkins-agent
+spec:
+  containers:
+  - name: java
+    image: gradle:jdk16-hotspot
+    imagePullPolicy: IfNotPresent
+    command:
+    - cat
+    tty: true
+    resources:
+      requests:
+        cpu: 2
+        memory: 4Gi
+      limits:
+        cpu: 2
+        memory: 4Gi
+  - name: postgres
+    image: postgres:13-alpine
+    imagePullPolicy: IfNotPresent
+    args: ["-c", "shared_buffers=256MB", "-c", "max_locks_per_transaction=1024"]
+    tty: true
+    resources:
+      requests:
+        cpu: 2
+        memory: 2Gi
+      limits:
+        cpu: 2
+        memory: 2Gi
+    env:
+      - name: POSTGRES_USER
+        value: molgenis  
+      - name: POSTGRES_PASSWORD
+        value: molgenis  
+      - name: POSTGRES_DB
+        value: molgenis  
+  restartPolicy: Never

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -70,6 +70,7 @@ pipeline {
                         "c-qx6c7:nexus-helm3-emx2 " +
                         "${NAME} " +
                         "--no-prompt " +
+                        "--set adminPassword=admin " +
                         "--set image.tag=${TAG_NAME} " +
                         "--set image.repository=molgenis/molgenis-emx2-snapshot " +
                         "--set image.pullPolicy=Always " +

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,73 +1,113 @@
-podTemplate(inheritFrom:'shared', containers: [
-    containerTemplate(
-      name: 'java',
-      image: 'gradle:jdk16-hotspot',
-      ttyEnabled: true,
-      command: 'cat',
-      args: '',
-      resourceRequestCpu: '1',
-      resourceRequestMemory: '1Gi'),
-    containerTemplate(
-      name: 'postgres',
-      image: 'postgres:13-alpine',
-      workingDir:'',
-      command: '',
-      args: '-c shared_buffers=256MB -c max_locks_per_transaction=1024',
-      resourceRequestCpu: '1',
-      resourceRequestMemory: '1Gi',
-      resourceLimitMemory: '1Gi',
-      envVars: [
-        envVar(key: 'POSTGRES_USER', value: 'molgenis'),
-        envVar(key: 'POSTGRES_PASSWORD', value: 'molgenis'),
-        envVar(key: 'POSTGRES_DB', value: 'molgenis')
-      ]
-    )
-  ]) {
-    node(POD_LABEL) {
-        stage('Retrieve build secrets') {
-            container('vault') {
-                script {
-                    sh "mkdir ${JENKINS_AGENT_WORKDIR}/.m2"
-                    sh "mkdir ${JENKINS_AGENT_WORKDIR}/.rancher"
-                    sh(script: "vault read -field=value secret/ops/jenkins/rancher/cli2.json > ${JENKINS_AGENT_WORKDIR}/.rancher/cli2.json")
-                    sh(script: "vault read -field=value secret/ops/jenkins/maven/settings.xml > ${JENKINS_AGENT_WORKDIR}/.m2/settings.xml")
-                    env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/ops/token/sonar', returnStdout: true)
-                    env.GITHUB_TOKEN = sh(script: 'vault read -field=token-emx2 secret/ops/token/github', returnStdout: true)
-                    env.DOCKER_USERNAME = sh(script: 'vault read -field=username secret/gcc/account/dockerhub', returnStdout: true)
-                    env.DOCKER_PASSWORD = sh(script: 'vault read -field=password secret/gcc/account/dockerhub', returnStdout: true)
-                }
-            }
-            dir("${JENKINS_AGENT_WORKDIR}/.m2") {
-                stash includes: 'settings.xml', name: 'maven-settings'
-            }
-            dir("${JENKINS_AGENT_WORKDIR}/.rancher") {
-                stash includes: 'cli2.json', name: 'rancher-config'
-            }
+pipeline {
+    agent {
+        kubernetes {
+            inheritFrom "shared"
+            yamlFile ".jenkins/build-pod.yaml"
         }
-        stage('Build, Test') {
-            container('java') {
-                script {
-                    checkout scm
+    }
+    environment {
+        DOCKER_CONFIG = "/root/.docker"
+        CHART_VERSION = "0.0.13"
+    }
+    stages {
+        stage('Prepare') {
+            steps {
+                checkout scm
+                container('vault') {
+                    script {
+                        sh "mkdir ${JENKINS_AGENT_WORKDIR}/.m2"
+                        sh "mkdir ${JENKINS_AGENT_WORKDIR}/.rancher"
+                        sh(script: "vault read -field=value secret/ops/jenkins/rancher/cli2.json > ${JENKINS_AGENT_WORKDIR}/.rancher/cli2.json")
+                        sh(script: "vault read -field=value secret/ops/jenkins/maven/settings.xml > ${JENKINS_AGENT_WORKDIR}/.m2/settings.xml")
+                        env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/ops/token/sonar', returnStdout: true)
+                        env.GITHUB_TOKEN = sh(script: 'vault read -field=token-emx2 secret/ops/token/github', returnStdout: true)
+                        env.DOCKERHUB_AUTH = sh(script: 'vault read -field=value secret/gcc/token/dockerhub', returnStdout: true)
+                        env.NEXUS_USER = sh(script: 'vault read -field=username secret/ops/account/nexus', returnStdout: true)
+                        env.NEXUS_PWD = sh(script: 'vault read -field=password secret/ops/account/nexus', returnStdout: true)
+                    }
+                }
+                container("java") {
                     sh 'apt update'
                     sh 'apt -y install docker.io'
                     sh 'git fetch --depth 10000'
-                    sh "git config user.email \"m.a.swertz@rug.nl\""
+                    sh "git config user.email \"molgenis@gmail.com\""
                     sh "git config user.name \"molgenis-jenkins\""
                     sh 'git config url.https://.insteadOf git://'
-                    sh "set +x && echo \"${DOCKER_PASSWORD}\" | docker login -u \"${DOCKER_USERNAME}\" --password-stdin"
-                    sh "./gradlew test jacocoMergedReport sonarqube shadowJar jib release ci \
-                        -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
-                        -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"  
-                    def props = readProperties file: 'build/ci.properties'
-                    env.TAG_NAME = props.tagName
+                    sh "mkdir -p ${DOCKER_CONFIG}"
+                    sh "echo '{\"auths\": {\"https://index.docker.io/v1/\": {\"auth\": \"${DOCKERHUB_AUTH}\"}, \"registry.hub.docker.com\": {\"auth\": \"${DOCKERHUB_AUTH}\"}}}' > ${DOCKER_CONFIG}/config.json"
+                }
+                dir("${JENKINS_AGENT_WORKDIR}/.m2") {
+                    stash includes: 'settings.xml', name: 'maven-settings'
+                }
+                dir("${JENKINS_AGENT_WORKDIR}/.rancher") {
+                    stash includes: 'cli2.json', name: 'rancher-config'
                 }
             }
-            container('rancher') {
-                script {
-                    if (env.TAG_NAME && !env.TAG_NAME.contains('-SNAPSHOT')) {
+        }
+        stage("Pull request") {
+            when {
+                changeRequest()
+            }
+            environment {
+                NAME = "preview-pr-emx2-${CHANGE_ID.toLowerCase()}"
+            }
+            steps {
+                container('java') {
+                    script {
+                        sh "./gradlew test jacocoMergedReport sonarqube shadowJar jib release ci \
+                        -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
+                        -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
+                        def props = readProperties file: 'build/ci.properties'
+                        env.TAG_NAME = props.tagName
+                        sh "./gradlew helmLintMainChart --info"
+                    }
+                }
+                container('rancher') {
+                    sh "rancher apps delete ${NAME} || true"
+                    sh "sleep 15s" // wait for deletion
+                    sh "rancher apps install " + 
+                        "-n ${NAME} " +
+                        "c-qx6c7:nexus-helm3-emx2 " +
+                        "${NAME} " +
+                        "--no-prompt " +
+                        "--set image.tag=${TAG_NAME} " +
+                        "--set image.repository=molgenis/molgenis-emx2-snapshot " +
+                        "--set image.pullPolicy=Always " +
+                        "--set ingress.hosts[0].host=${NAME}.dev.molgenis.org"
+                }
+            }
+            post {
+                success {
+                    molgenisSlack(message: "PR Preview available on https://${NAME}.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
+                }
+            }
+        }
+        stage('Master') {
+            when {
+                allOf {
+                    branch 'master'
+                }
+            }
+            steps {
+                container('java') {
+                    script {
+                        sh "./gradlew test jacocoMergedReport sonarqube shadowJar jib release helmPublishMainChart ci \
+                        -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
+                        -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
+                        def props = readProperties file: 'build/ci.properties'
+                        env.TAG_NAME = props.tagName
+                    }
+                }
+                container('rancher') {
+                    script {
                         sh 'rancher context switch dev-molgenis'
                         sh "rancher apps upgrade --set image.tag=${TAG_NAME} --force molgenis-emx2 0.0.13"
                     }
+                }
+            }
+            post {
+                success {
+                    molgenisSlack(message: "EMX2 version: ${TAG_NAME} is released. Check it out: https://emx2.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
                 }
             }
         }

--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,9 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '7.0.0'
     id 'application'
     id 'com.google.cloud.tools.jib' version '3.1.1'
+    id 'org.unbroken-dome.helm' version '1.6.1'
+    id 'org.unbroken-dome.helm-publish' version '1.6.1'
+    id 'org.unbroken-dome.helm-commands' version '1.6.1'
 }
 
 
@@ -92,6 +95,37 @@ jib {
     }
 }
 
+def nexusUser = System.getenv('NEXUS_USER') ? System.getenv('NEXUS_USER') : null
+def nexusPassword = System.getenv('NEXUS_PWD') ? System.getenv('NEXUS_PWD') : null
+helm {
+    downloadClient {
+        enabled = true
+    }
+    
+    publishing {
+        repositories {
+            nexus {
+                url = uri('https://registry.molgenis.org/')
+                repository = 'helm'
+                apiVersion = 'v1'
+                credentials {
+                    username = "${nexusUser}"
+                    password = "${nexusPassword}"
+                }
+            }
+        }
+    }
+
+    charts {
+        main {
+            sourceDir = file('helm-chart')
+            lint {
+               strict = true
+            }
+        }
+    }
+}
+
 String getGitHash() {
     // git hash
     def command = Runtime.getRuntime().exec("git rev-parse --short HEAD")
@@ -103,12 +137,6 @@ String getGitHash() {
     String gitCommitHash = command.inputStream.text.trim()
 
     return gitCommitHash
-}
-
-//gradle cleanTest test --no-build-cache
-task createHelm(type: Exec) {
-    commandLine 'helm', 'package', 'deploy/helm-chart/', '-d', 'docs/helm-charts/'
-    commandLine 'helm', 'repo', 'index', 'docs/helm-charts', '--url', 'http://mswertz.github.io/molgenis-emx2/helm-charts'
 }
 
 ext {

--- a/helm-chart/Chart.yaml
+++ b/helm-chart/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
 name: emx2
-version: 0.1.2
-appVersion: "6.x"
+version: 0.0.0
+appVersion: "8.x"
 icon: https://raw.githubusercontent.com/molgenis/molgenis-ops-helm/master/charts/molgenis/catalogIcon-molgenis.png
-description: Preview of EMX2
+description: MOLGENIS EMX2
 type: application

--- a/helm-chart/questions.yaml
+++ b/helm-chart/questions.yaml
@@ -26,7 +26,7 @@ questions:
     default: "latest"
     group: "Provisioning"
   - variable: adminPassword
-    label: Admoinistrator password
+    label: Administrator password
     description: "Specify an administrator password"
     type: password
     required: true

--- a/helm-chart/questions.yaml
+++ b/helm-chart/questions.yaml
@@ -1,17 +1,34 @@
 categories:
   - EMX2
 questions:
-  - variable: ingress.hosts[0].name
+  - variable: ingress.hosts[0].host
     label: Hostname(s)
-    description: "Specify a hostname for this EMX2  instance"
+    description: "Specify a hostname for this EMX2 instance"
     type: string
     required: true
     default: "emx2.test.molgenis.org"
     group: "Loadbalancing"
+  - variable: image.repository
+    label: Repository
+    description: "Specify a repository"
+    type: enum
+    required: true
+    options:
+      - molgenis/molgenis-emx2
+      - molgenis/molgenis-emx2-snapshot
+    default: "molgenis/molgenis-emx2"
+    group: "Provisioning"
+  - variable: image.tag
+    label: Version
+    description: "Specify a version of the application"
+    type: string
+    required: true
+    default: "latest"
+    group: "Provisioning"
   - variable: adminPassword
     label: Admoinistrator password
     description: "Specify an administrator password"
     type: password
     required: true
     default: ""
-    group: "Provisioning"
+    

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -3,7 +3,10 @@ kind: Deployment
 metadata:
   name: {{ include "emx2.fullname" . }}
   labels:
-    {{- include "emx2.labels" . | nindent 4 }}
+    app: {{ template "emx2.name" . }}
+    chart: {{ template "emx2.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   replicas: 1
   selector:
@@ -45,13 +48,6 @@ spec:
               value: molgenis
             - name: POSTGRES_USER
               value: molgenis
-          #          resources:
-          #            requests:
-          #              cpu: 1
-          #              memory: 2.5Gi
-          #            limits:
-          #              cpu: 1
-          #              memory: 2.5Gi
           ports:
             - containerPort: 5432
           volumeMounts:

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -8,25 +8,23 @@ apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
   name: {{ include "emx2.fullname" . }}
+  labels:
+    app: {{ template "emx2.name" . }}
+    chart: {{ template "emx2.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
   annotations:
     kubernetes.io/ingress.class: "nginx"
 spec:
   rules:
   {{- range .Values.ingress.hosts }}
-  - http:
+  - host: {{ .host | quote }}
+    http:
       paths:
         - path: {{ default "/" .path }}
           backend:
             serviceName: {{ $fullName }}
-            servicePort: 8088
-  {{- end }}
-  {{- if .tls }}
-  tls:
-    - hosts:
-      {{- range .Values.ingress.hosts }}
-      - {{ .name }}
-      {{- end }}
-      secretName: {{ .Values.ingress.tlsSecret }}
+            servicePort: {{ $.Values.service.port }}
   {{- end }}
 ---
 {{- end }}

--- a/helm-chart/templates/pvc.yaml
+++ b/helm-chart/templates/pvc.yaml
@@ -2,6 +2,11 @@ apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "emx2.fullname" . }}-postgres-pv
+  labels:
+    app: {{ template "emx2.name" . }}
+    chart: {{ template "emx2.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   accessModes:
     - ReadWriteOnce

--- a/helm-chart/templates/svc.yaml
+++ b/helm-chart/templates/svc.yaml
@@ -3,13 +3,16 @@ kind: Service
 metadata:
   name: {{ include "emx2.fullname" . }}
   labels:
-    {{- include "emx2.labels" . | nindent 4 }}
+    app: {{ template "emx2.name" . }}
+    chart: {{ template "emx2.chart" . }}
+    release: {{ .Release.Name | quote }}
+    heritage: {{ .Release.Service | quote }}
 spec:
   type: {{ .Values.service.type }}
   ports:
-    - port: 8088
-      protocol: TCP
+    - port: {{ .Values.service.port }}
       targetPort: 8080
+      protocol: TCP
   selector:
     {{- include "emx2.selectorLabels" . | nindent 4}}
 status:

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -3,13 +3,14 @@ nameOverride: ""
 fullnameOverride: ""
 adminPassword: admin
 image:
-  repository: "mswertz/emx2"
+  repository: "molgenis/molgenis-emx2"
   tag: "latest"
   pullPolicy: IfNotPresent
 service:
   type: ClusterIP
+  port: 80
 ingress:
   hosts:
-    - name: emx2.local
+     - host: emx2.dev.molgenis.org
   enabled: true
   path: /


### PR DESCRIPTION
Changes:

- Chart is now build and published on the chart repo during merge
- Chart is using the MOLGENIS version (we could do this differently and only trigger the chart build when chart files are changed)
- The PR flow differs now from the master build in terms of rancher deployment and chart builds
- The pod-template is in a separate file in `.jenkins/build-pod.yaml` to clean up the Jenkinsfile
- The build result is posted on slack in the **pr-emx2** channel