### PR TITLE
fix: Use name instead of path for main variable explorer routing

### DIFF
--- a/apps/catalogue/src/main.js
+++ b/apps/catalogue/src/main.js
@@ -184,6 +184,7 @@ const router = new VueRouter({
       component: TableMappingsView,
     },
     {
+      name: "variableExplorer",
       path: "/variable-explorer",
       props: true,
       component: VariableExplorer,

--- a/apps/catalogue/src/views/VariableExplorer.vue
+++ b/apps/catalogue/src/views/VariableExplorer.vue
@@ -34,7 +34,7 @@
                 <router-link
                   class="nav-link"
                   :class="{ active: $route.query.tab !== 'harmonization' }"
-                  :to="{ path: 'variable-explorer', query: { tab: 'detail' } }"
+                  :to="{ name: 'variableExplorer', query: { tab: 'detail' } }"
                 >
                   Details
                 </router-link>
@@ -44,7 +44,7 @@
                   class="nav-link"
                   :class="{ active: $route.query.tab === 'harmonization' }"
                   :to="{
-                    path: 'variable-explorer',
+                    name: 'variableExplorer',
                     query: { tab: 'harmonization' },
                   }"
                 >


### PR DESCRIPTION
To avoid conflict bewteen '/variable-explorer' and '/variable-explorer/:name' where name is empty , use name instead of path