### PR TITLE
fix: remove references to columnFormat that broke schema editor tool

### DIFF
--- a/apps/schema/src/components/Schema.vue
+++ b/apps/schema/src/components/Schema.vue
@@ -324,7 +324,7 @@ export default {
       this.tables = null;
       request(
         "graphql",
-        "{_schema{name,tables{name,inherit,externalSchema,description,semantics,columns{name,columnType,columnFormat,inherited,key,refSchema,refTable,refLink,refBack,required,description,semantics,validation,visible}}}}"
+        "{_schema{name,tables{name,inherit,externalSchema,description,semantics,columns{name,columnType,inherited,key,refSchema,refTable,refLink,refBack,required,description,semantics,validation,visible}}}}"
       )
         .then((data) => {
           this.schema = data._schema.name;

--- a/apps/schema/src/components/SchemaSimple.vue
+++ b/apps/schema/src/components/SchemaSimple.vue
@@ -118,7 +118,7 @@ export default {
       this.tables = null;
       request(
         "graphql",
-        "{_schema{name,tables{name,inherit,externalSchema,description,semantics,columns{name,columnType,columnFormat,inherited,key,refSchema,refTable,refLink,refBack,required,description,semantics,validation,visible}}}}"
+        "{_schema{name,tables{name,inherit,externalSchema,description,semantics,columns{name,columnType,inherited,key,refSchema,refTable,refLink,refBack,required,description,semantics,validation,visible}}}}"
       )
         .then((data) => {
           this.schema = this.addOldNamesAndRemoveMeta(data._schema);

--- a/apps/styleguide/src/tables/FilterSidebar.vue
+++ b/apps/styleguide/src/tables/FilterSidebar.vue
@@ -144,8 +144,7 @@ examples
               "name": "tags",
               "refTable": "AreasOfInformation",
               "graphqlURL": "/CohortNetworks/graphql",
-              "columnType": "REF_ARRAY",
-              "columnFormat": "OntologyTerm",
+              "columnType": "ONTOLOGY_ARRAY",
               "showFilter": true
             }]
         }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlConstants.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlConstants.java
@@ -8,7 +8,6 @@ public class GraphqlConstants {
   public static final String REQUIRED = "required";
   public static final String COLUMN_POSITION = "position";
   public static final String COLUMN_TYPE = "columnType";
-  public static final String COLUMN_FORMAT = "columnFormat";
   public static final String VALIDATION_EXPRESSION = "validation";
   public static final String FILTER_ARGUMENT = "filter";
   public static final String KEY = "key";


### PR DESCRIPTION
Motivation:
* we had error when opening 'schema'.
* we had error in styleguide test for sidebar (not important)