### PR TITLE
feat: Schema description

### DIFF
--- a/apps/central/src/components/Groups.vue
+++ b/apps/central/src/components/Groups.vue
@@ -43,7 +43,14 @@
                 schema.name
               }}</a>
             </td>
-            <td>{{ schema.description }}</td>
+            <td>
+              {{ schema.description }}
+              <IconAction
+                  v-if="session && session.email == 'admin' && schema.description"
+                  icon="edit"
+                  @click="openEditSchema(schema.name, schema.description)"
+              />
+            </td>
           </tr>
         </tbody>
       </table>
@@ -52,6 +59,12 @@
         v-if="showDeleteSchema"
         @close="closeDeleteSchema"
         :schemaName="showDeleteSchema"
+      />
+      <SchemaEditModal
+          v-if="showEditSchema"
+          @close="closeEditSchema"
+          :schemaName="showEditSchema"
+          :schemaDescription="editDescription"
       />
     </div>
   </div>
@@ -62,6 +75,7 @@ import { request } from "graphql-request";
 
 import SchemaCreateModal from "./SchemaCreateModal";
 import SchemaDeleteModal from "./SchemaDeleteModal";
+import SchemaEditModal from "./SchemaEditModal";
 import {
   IconAction,
   IconBar,
@@ -76,6 +90,7 @@ export default {
     Spinner,
     SchemaCreateModal,
     SchemaDeleteModal,
+    SchemaEditModal,
     IconBar,
     IconAction,
     IconDanger,
@@ -91,6 +106,8 @@ export default {
       loading: false,
       showCreateSchema: false,
       showDeleteSchema: false,
+      showEditSchema: false,
+      editDescription: null,
       graphqlError: null,
       search: null,
     };
@@ -134,9 +151,18 @@ export default {
       this.showDeleteSchema = null;
       this.getSchemaList();
     },
+    openEditSchema(schemaName, schemaDescription) {
+      this.showEditSchema = schemaName;
+      this.editDescription = schemaDescription
+    },
+    closeEditSchema() {
+      this.showEditSchema = null;
+      this.editDescription = null;
+      this.getSchemaList();
+    },
     getSchemaList() {
       this.loading = true;
-      request("graphql", "{Schemas{name}}")
+      request("graphql", "{Schemas{name description}}")
         .then((data) => {
           this.schemas = data.Schemas;
           this.loading = false;

--- a/apps/central/src/components/SchemaEditModal.vue
+++ b/apps/central/src/components/SchemaEditModal.vue
@@ -6,7 +6,7 @@
         <Spinner />
       </template>
     </LayoutModal>
-    <!-- when update succesfull show result before close -->
+    <!-- when completed -->
     <LayoutModal
       v-else-if="success"
       :title="title"
@@ -15,37 +15,21 @@
     >
       <template v-slot:body>
         <MessageSuccess>{{ success }}</MessageSuccess>
-        Go to edit <a :href="'/' + schemaName + '/schema/'">schema</a><br />
-        Go to upload <a :href="'/' + schemaName + '/updownload/'">files</a>
       </template>
       <template v-slot:footer>
         <ButtonAction @click="$emit('close')">Close</ButtonAction>
       </template>
     </LayoutModal>
-    <!-- create schema -->
+    <!-- edit schema -->
     <LayoutModal v-else :title="title" :show="true" @close="$emit('close')">
       <template v-slot:body>
-        <Spinner v-if="loading" />
-        <div v-else>
-          <MessageError v-if="graphqlError">{{ graphqlError }}</MessageError>
-          <LayoutForm :key="key">
-            <InputString
-              v-model="schemaName"
-              label="name"
-              :defaultValue="schemaName"
-            />
-            <InputText
-              v-model="schemaDescription"
-              label="description"
-              :defaultValue="schemaDescription"
-            />
-          </LayoutForm>
-        </div>
+        <MessageError v-if="graphqlError">{{ graphqlError }}</MessageError>
+        <input v-model="newSchemaDescription">
       </template>
       <template v-slot:footer>
         <ButtonAlt @click="$emit('close')">Close</ButtonAlt>
-        <ButtonAction @click="executeCreateSchema"
-          >Create database
+        <ButtonAction @click="executeDeleteSchema"
+          >Edit database
         </ButtonAction>
       </template>
     </LayoutModal>
@@ -59,8 +43,6 @@ import {
   ButtonAction,
   ButtonAlt,
   IconAction,
-  InputString,
-  InputText,
   LayoutForm,
   LayoutModal,
   MessageError,
@@ -75,11 +57,13 @@ export default {
     ButtonAction,
     ButtonAlt,
     LayoutModal,
-    InputString,
-    InputText,
     LayoutForm,
     Spinner,
     IconAction,
+  },
+  props: {
+    schemaName: String,
+    schemaDescription: String
   },
   data: function () {
     return {
@@ -87,33 +71,32 @@ export default {
       loading: false,
       graphqlError: null,
       success: null,
-      schemaName: null,
-      schemaDescription: null,
+      newSchemaDescription: this.schemaDescription
     };
   },
   computed: {
     title() {
-      return "Create database";
+      return "Edit database";
     },
     endpoint() {
       return "/api/graphql";
     },
   },
   methods: {
-    executeCreateSchema() {
+    executeDeleteSchema() {
       this.loading = true;
       this.graphqlError = null;
       this.success = null;
       request(
         this.endpoint,
-        `mutation createSchema($name:String, $description:String){createSchema(name:$name, description:$description){message}}`,
+        `mutation editSchema($name:String, $description:String){editSchema(name:$name, description: $description){message}}`,
         {
           name: this.schemaName,
-          description: this.schemaDescription
+          description: this.newSchemaDescription,
         }
       )
         .then((data) => {
-          this.success = data.createSchema.message;
+          this.success = data.editSchema.message;
           this.loading = false;
         })
         .catch((error) => {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/MetadataUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/MetadataUtils.java
@@ -32,6 +32,8 @@ public class MetadataUtils {
   // table
   private static final org.jooq.Field TABLE_SCHEMA =
       field(name("table_schema"), VARCHAR.nullable(false));
+  private static final org.jooq.Field SCHEMA_DESCRIPTION =
+      field(name("description"), VARCHAR.nullable(true));
   private static final org.jooq.Field TABLE_NAME =
       field(name("table_name"), VARCHAR.nullable(false));
   private static final org.jooq.Field TABLE_INHERITS =
@@ -146,7 +148,9 @@ public class MetadataUtils {
             }
 
             try (CreateTableColumnStep t = jooq.createTableIfNotExists(SCHEMA_METADATA)) {
-              t.columns(TABLE_SCHEMA).constraint(primaryKey(TABLE_SCHEMA)).execute();
+              t.columns(TABLE_SCHEMA, SCHEMA_DESCRIPTION)
+                  .constraint(primaryKey(TABLE_SCHEMA))
+                  .execute();
 
               jooq.execute("ALTER TABLE {0} ENABLE ROW LEVEL SECURITY", SCHEMA_METADATA);
 
@@ -158,7 +162,8 @@ public class MetadataUtils {
                   name(SCHEMA_METADATA.getName() + "_POLICY"),
                   SCHEMA_METADATA,
                   MG_ROLE_PREFIX,
-                  TABLE_SCHEMA);
+                  TABLE_SCHEMA,
+                  SCHEMA_DESCRIPTION);
             }
             try (CreateTableColumnStep t = jooq.createTableIfNotExists(TABLE_METADATA)) {
               int result =
@@ -249,7 +254,11 @@ public class MetadataUtils {
 
   protected static void saveSchemaMetadata(DSLContext sql, SchemaMetadata schema) {
     try {
-      sql.insertInto(SCHEMA_METADATA).columns(TABLE_SCHEMA).values(schema.getName()).execute();
+      String description = Objects.isNull(schema.getDescription()) ? "" : schema.getDescription();
+      sql.insertInto(SCHEMA_METADATA)
+          .columns(TABLE_SCHEMA, SCHEMA_DESCRIPTION)
+          .values(schema.getName(), description)
+          .execute();
     } catch (Exception e) {
       throw new MolgenisException("save of schema metadata failed", e);
     }
@@ -257,6 +266,18 @@ public class MetadataUtils {
 
   protected static Collection<String> loadSchemaNames(SqlDatabase db) {
     return db.getJooq().selectFrom(SCHEMA_METADATA).fetch().getValues(TABLE_SCHEMA, String.class);
+  }
+
+  protected static Collection<SchemaInfo> loadSchemaInfos(SqlDatabase db) {
+    List<org.jooq.Record> schemaInfoRecords = db.getJooq().selectFrom(SCHEMA_METADATA).fetch();
+    List<SchemaInfo> schemaInfos = new ArrayList<>();
+    for (org.jooq.Record record : schemaInfoRecords) {
+      schemaInfos.add(
+          new SchemaInfo(
+              record.get(TABLE_SCHEMA, String.class),
+              record.get(SCHEMA_DESCRIPTION, String.class)));
+    }
+    return schemaInfos;
   }
 
   protected static SchemaMetadata loadSchemaMetadata(DSLContext jooq, SchemaMetadata schema) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -64,6 +64,14 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     }
   }
 
+  public SqlSchemaMetadata(Database db, String name, String description) {
+    super(
+        db,
+        MetadataUtils.loadSchemaMetadata(
+            ((SqlDatabase) db).getJooq(), new SchemaMetadata(name, description)));
+    this.reload();
+  }
+
   public SqlSchemaMetadata(Database db, String name) {
     super(
         db,

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Database.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Database.java
@@ -11,11 +11,15 @@ public interface Database {
 
   Schema createSchema(String name);
 
+  Schema createSchema(String name, String description);
+
   Schema dropCreateSchema(String name);
 
   void dropSchema(String name);
 
   Collection<String> getSchemaNames();
+
+  Collection<SchemaInfo> getSchemaInfos();
 
   Schema getSchema(String name);
 

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaInfo.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaInfo.java
@@ -1,0 +1,3 @@
+package org.molgenis.emx2;
+
+public record SchemaInfo(String tableSchema, String description) {}

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaMetadata.java
@@ -9,6 +9,8 @@ public class SchemaMetadata {
   protected Map<String, Setting> settings = new LinkedHashMap<>();
   protected String name;
   // optional
+  protected String description;
+  // optional
   protected Database database;
 
   public SchemaMetadata() {}
@@ -19,8 +21,14 @@ public class SchemaMetadata {
     this.name = name;
   }
 
+  public SchemaMetadata(String name, String description) {
+    this(name);
+    this.description = description;
+  }
+
   public SchemaMetadata(SchemaMetadata schema) {
     this.name = schema.getName();
+    this.description = schema.getDescription();
     this.database = schema.getDatabase();
     this.setSettings(schema.getSettings());
     for (Setting setting : schema.getSettings()) {
@@ -30,6 +38,7 @@ public class SchemaMetadata {
 
   public SchemaMetadata(Database db, SchemaMetadata schema) {
     this.name = schema.getName();
+    this.description = schema.getDescription();
     this.database = db;
     for (Setting setting : schema.getSettings()) {
       this.setSetting(setting.getKey(), setting.getValue());
@@ -42,6 +51,14 @@ public class SchemaMetadata {
 
   public void setName(String name) {
     this.name = name;
+  }
+
+  public String getDescription() {
+    return description;
+  }
+
+  public void setDescription(String description) {
+    this.description = description;
   }
 
   public Set<String> getTableNames() {


### PR DESCRIPTION
Allow adding a description string to a schema.
Description can be added op schema creation (this could be used to store schema version information)
Admins can edit the schema description.

- [x] add description on create
- [x] show description
- [ ]  edit description ( impl mutation, clean up ui)
- [ ] add migration for description column
- [ ] add / extend tests