### PR TITLE
Fix: csv api upload/download

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableWriter.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableWriter.java
@@ -20,10 +20,13 @@ public class CsvTableWriter {
     Set<String> columnNames = new LinkedHashSet<>();
     for (Row r : rows) {
       columnNames.addAll(r.getColumnNames());
+      break;
     }
     // we filter mg_ columns. TODO make option to choose
     columnNames =
-        columnNames.stream().filter(name -> !name.startsWith("mg_")).collect(Collectors.toSet());
+        columnNames.stream()
+            .filter(name -> !name.startsWith("mg_"))
+            .collect(Collectors.toCollection(LinkedHashSet::new));
 
     CsvWriter.CsvWriterDSL<Map> writerDsl =
         CsvWriter.from(Map.class).columns(columnNames.toArray(new String[columnNames.size()]));

--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableWriter.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableWriter.java
@@ -18,10 +18,9 @@ public class CsvTableWriter {
 
     // get most extensive headers
     Set<String> columnNames = new LinkedHashSet<>();
-    for (Row r : rows) {
-      columnNames.addAll(r.getColumnNames());
-      break;
-    }
+    Row firstRow = rows.iterator().next();
+    columnNames.addAll(firstRow.getColumnNames());
+
     // we filter mg_ columns. TODO make option to choose
     columnNames =
         columnNames.stream()

--- a/backend/molgenis-emx2-run/src/main/java/org/molgenis/emx2/AToolToCleanDatabase.java
+++ b/backend/molgenis-emx2-run/src/main/java/org/molgenis/emx2/AToolToCleanDatabase.java
@@ -23,7 +23,7 @@ public class AToolToCleanDatabase {
     deleteAllForeignKeyConstraints();
     deleteAllSchemas();
     deleteAllRoles();
-    db = null;
+    db = new SqlDatabase(true);
   }
 
   private static void deleteAllRoles() {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/MetadataUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/MetadataUtils.java
@@ -370,6 +370,7 @@ public class MetadataUtils {
     org.jooq.Record tableRecord =
         jooq.selectFrom(TABLE_METADATA)
             .where(TABLE_SCHEMA.eq(schemaName).and(TABLE_NAME.eq(tableName)))
+            .orderBy(TABLE_NAME)
             .fetchOne();
 
     List<org.jooq.Record> columnRecords =

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -231,7 +231,7 @@ public class WebApiSmokeTests {
     String path = "/pet store/api/csv/Tag";
 
     String result = given().sessionId(SESSION_ID).accept(ACCEPT_CSV).when().get(path).asString();
-    assertTrue(result.contains("colors,green"));
+    assertTrue(result.contains("green,colors"));
 
     String update = "name,parent\r\nyellow,colors\r\n";
     given().sessionId(SESSION_ID).body(update).when().post(path).then().statusCode(200);
@@ -242,7 +242,7 @@ public class WebApiSmokeTests {
     given().sessionId(SESSION_ID).body(update).when().delete(path).then().statusCode(200);
 
     result = given().sessionId(SESSION_ID).accept(ACCEPT_CSV).when().get(path).asString();
-    assertTrue(result.contains("colors,green"));
+    assertTrue(result.contains("green,colors"));
   }
 
   @Test

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TableSort.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TableSort.java
@@ -1,6 +1,7 @@
 package org.molgenis.emx2.utils;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.molgenis.emx2.Column;
@@ -16,6 +17,15 @@ public class TableSort {
   public static void sortTableByDependency(List<TableMetadata> tableList) {
     ArrayList<TableMetadata> result = new ArrayList<>();
     ArrayList<TableMetadata> todo = new ArrayList<>(tableList);
+
+    // ensure deterministic order
+    todo.sort(
+        new Comparator<TableMetadata>() {
+          @Override
+          public int compare(TableMetadata o1, TableMetadata o2) {
+            return o1.getTableName().compareTo(o2.getTableName());
+          }
+        });
 
     // dependency come from foreign key and from inheritance
 


### PR DESCRIPTION
Implemented:
* deterministic column ordering for csv download
* deterministic table ordering in metadata molgenis.csv download

Motivation:
* testCsvApi_zipUploadDownload was regularly breaking on order 
* when you download molgenis.csv via api https://emx2.dev.molgenis.org/pet%20store/api/csv then order emx columns is weird