### PR TITLE
chore: Add cohort metadata staging area model

### DIFF
--- a/data/datacatalogue/UmcgCatalogue/staging-model.csv
+++ b/data/datacatalogue/UmcgCatalogue/staging-model.csv
@@ -1,0 +1,124 @@
+tableName,tableExtends,columnName,columnType,key,required,refSchema,refTable,refLink,refBack,validation,semantics,description
+Contacts,,,,,,,,,,,,
+Publications,,,,,,,,,,,,Publications following bibtex format
+Resources,,,,,,,,,,,,"Generic listing of all resources. Should not be used directly, instead use specific types such as Databanks and Studies"
+Cohorts,Resources,,,,,,,,,,,Group of individuals sharing a defining demographic characteristic
+Contributions,,,,,,,,,,,,Persons that contributed to the creation of a resource
+Partners,,,,,,,,,,,,Institutions that partnered in the creation of a resource
+Documentation,,,,,,,,,,,,Documentation attached to a resource
+Subcohorts,,,,,,,,,,,,Subcohorts defined for this resource
+CollectionEvents,,,,,,,,,,,,Definition of a data collection event for a resource
+Resources,,overview,heading,,,,,,,,,General information about this resource
+Resources,,pid,,1,true,,,,,,,Persistent identifier for this resource
+Resources,,name,,2,true,,,,,,,Name of used in European projects
+Resources,,localName,,,,,,,,,,"If different from above, name in the national language"
+Resources,,acronym,,,,,,,,,,Resource acronym
+Resources,,website,,,,,,,,,,Link to the website of this resource
+Resources,,description,text,,,,,,,,,Short description of this resource
+Resources,,keywords,text,,,,,,,,,Keywords to increase findability of this resource. Try to use words that are not used in the description.
+Resources,,externalIdentifiers,,,,,,,,,,External identifier for this resource
+Cohorts,,type,ref_array,,,UMCG,ResourceTypes,,,,,"Type of resource, e.g. registry, cohort, biobank"
+Cohorts,,typeOther,,,,,,,,,,"If other, describe the type of resource"
+Cohorts,,design,ref,,,UMCG,CohortDesigns,,,,,"The study design of this cohort, e.g. cross-sectional or longitudinal"
+Cohorts,,collectionType,ref_array,,,UMCG,CollectionTypes,,,,,"The data collection type of this cohort, e.g. retrospective or prospective; if both, select both"
+Resources,,institution,ref_array,,,UMCG,Institutions,,,,,Institution providing and/or coordinating access to this resource
+Resources,,logo,file,,,,,,,,,Logo for use on homepages etc.
+Resources,,contact,ref_array,,,,Contacts,,,,,Primary contact person for this resource
+Resources,,population,heading,,,,,,,,,Description of the population that can potentially be captured in the resource
+Resources,,numberOfParticipants,int,,,,,,,,,Total number of individuals for which data is collected
+Resources,,numberOfParticipantsWithSamples,int,,,,,,,,,Number of individuals for which samples are collected
+Resources,,regions,ontology_array,,,UMCG,Regions,,,,,Countries and geographical regions where data from this resource originate from
+Resources,,populationAgeGroups,ontology_array,,,UMCG,AgeGroups,,,,,Age groups of the participants of this resource
+Cohorts,,inclusionCriteria,text,,,,,,,,,Other inclusion criteria applied to the participants of this resource
+Resources,,startYear,int,,,,,,,,,Year when first data was collected
+Resources,,endYear,int,,,,,,,,,Year when last data was collected. Leave empty if collection is ongoing
+Cohorts,,subcohorts,refback,,,,Subcohorts,,resource,,,List of subcohorts or subpopulations for this resource
+Resources,,contents,heading,,,,,,,,,Data model and contents
+Cohorts,,collectionEvents,refback,,,,CollectionEvents,,resource,,,List of collection events defined for this resource
+Cohorts,,access,heading,,,,,,,,,
+Cohorts,,dataAccessConditions,ontology_array,,,UMCG,Conditions,,,,,Codes defining data access terms and use conditions
+Cohorts,,dataAccessConditionsDescription,text,,,,,,,,,Description of data access terms and use conditions
+Cohorts,,releaseType,ontology,,,UMCG,ReleaseTypes,,,,,"Whether this resource releases data continuously, or at a termly basis"
+Cohorts,,releaseDescription,text,,,,,,,,,Description of the release cycle of this resource
+Cohorts,,linkageOptions,text,,,,,,,,,Linkage options with additional data sources that are available for this resource
+Resources,,otherInformation,heading,,,,,,,,,Other information
+Resources,,publication,text,,,,,,,,,Publication(s) that describe(s) the design of this resource
+Resources,,otherPublications,ref_array,,,,Publications,,,,,Other publication(s) about this resource
+Resources,,fundingStatement,text,,,,,,,,,Statement listing funding that was obtained for this resource
+Resources,,acknowledgements,text,,,,,,,,,Acknowledgement statement and citation regulation for this resource
+Resources,,documentation,refback,,,,Documentation,,resource,,,List of documentation available for this resource
+Resources,,collaborations,heading,,,,,,,,,List of relevant collaborations
+Cohorts,,studies,refback,,,UMCG,Studies,,cohorts,,,Listing of studies that used this resource
+Resources,,contributors,refback,,,,Contributions,,resource,,,Listing who is/has been involved in the creation and maintenance of this resource
+Resources,,partners,refback,,,UMCG,Partners,,resource,,,Institutions that partnered in the creation of this resource
+Cohorts,,networks,refback,,,UMCG,Networks,,cohorts,,,The consortia or networks that this cohort is involved in
+Publications,,doi,,1,true,,,,,,,Digital object identifier
+Publications,,title,,,true,,,,,,,Publication title
+Publications,,authors,string_array,,,,,,,,,"List of authors, one entry per author"
+Publications,,year,int,,,,,,,,,"Year of publication (or, if unpublished, year of creation)"
+Publications,,journal,,,,,,,,,,Journal or magazine the work was published in
+Publications,,volume,int,,,,,,,,,Journal or magazine volume
+Publications,,number,int,,,,,,,,,Journal or maragzine issue number
+Publications,,pagination,,,,,,,,,,"Page numbers, separated either by commas or double-hyphens."
+Publications,,publisher,,,,,,,,,,Publisher's name
+Publications,,school,,,,,,,,,,School where the thesis was written (in case of thesis)
+Publications,,abstract,text,,,,,,,,,Publication abstract
+Publications,,resources,refback,,,,Resources,,otherPublications,,,List of resources that refer to this publication
+Partners,,resource,ref,1,true,,Resources,,,,,Resource that is contributed to
+Partners,,institution,ref,1,true,UMCG,Institutions,,,,,institution that contributed
+Partners,,department,text,,,,,,,,,"Optionally, the institutational unit(s) that play a role in this resource"
+Partners,,role,ontology,,,UMCG,PartnerRoles,,,,,Role in this resource
+Partners,,roleDescription,text,,,,,,,,,Description of the role in this resource
+Contributions,,resource,ref,1,true,,Resources,,,,,Resource person has contributed to
+Contributions,,contact,ref,1,true,,Contacts,,,,,Person who contributed to a resource
+Contributions,,contributionType,ontology_array,,,UMCG,ContributionTypes,,,,,Type of the contribution
+Contributions,,contributionDescription,text,,,,,,,,,Contribution description
+Contacts,,name,,1,true,,,,,,,Name of the contact person
+Contacts,,institution,ref,,,UMCG,Institutions,,,,,Affiliated institution of the contact person
+Contacts,,department,text,,,,,,,,,Affiliated department of the contact person
+Contacts,,email,,2,,,,,,,,Contact's email address
+Contacts,,orcid,,3,,,,,,,,Orcid of the contact person
+Contacts,,homepage,,,,,,,,,,Link to contact's homepage
+Contacts,,photo,file,,,,,,,,,Contact's photograph
+Contacts,,expertise,,,,,,,,,,Description of contact's expertise
+Documentation,,resource,ref,1,true,,Resources,,,,,The resource this documentation is for
+Documentation,,name,,1,true,,,,,,,Document name
+Documentation,,type,ontology,,,UMCG,DocumentTypes,,,,,Type of documentation
+Documentation,,description,text,,,,,,,,,Description of the document
+Documentation,,url,,,,,,,,,,Hyperlink to the source of the documentation
+Documentation,,file,file,,,,,,,,,Optional file attachment containing the documentation
+CollectionEvents,,resource,ref,1,true,,Resources,,,,,Resource this collection event is part of
+CollectionEvents,,name,,1,true,,,,,,,Name of the collection event
+CollectionEvents,,description,,,,,,,,,,Description of the collection event
+CollectionEvents,,subcohorts,ref_array,,,,Subcohorts,resource,,,,Subcohorts that are targetted by this collection event
+CollectionEvents,,startYear,int,,,,,,,,,Start year of data collection
+CollectionEvents,,endYear,int,,,,,,,,,End year of data collection. Leave empty if collection is ongoing
+CollectionEvents,,ageGroups,ontology_array,,,UMCG,AgeGroups,,,,,Age groups included in this data collection event
+CollectionEvents,,numberOfParticipants,int,,,,,,,,,Number of participants sampled in this data collection event
+CollectionEvents,,areasOfInformation,ontology_array,,,UMCG,AreasOfInformation,,,,,Areas of information that were extracted in this data collection event
+CollectionEvents,,dataCategories,ontology_array,,,UMCG,DataCategories,,,,,Methods of data collection used in this collection event
+CollectionEvents,,sampleCategories,ontology_array,,,UMCG,SampleCategories,,,,,Samples that were collected in this collection even
+CollectionEvents,,supplementaryInformation,text,,,,,,,,,Any other information that needs to be disclosed for this collection event
+Subcohorts,,resource,ref,1,true,,Resources,,,,,Resource this subcohort is part of
+Subcohorts,,name,,1,true,,,,,,,"Subcohort name, e.g. 'mothers in first trimester','newborns'"
+Subcohorts,,description,text,,,,,,,,,Subcohort description
+Subcohorts,,numberOfParticipants,int,,,,,,,,,Number of participants in this subcohort
+Subcohorts,,inclusionStart,int,,,,,,,,,Year of first included participant
+Subcohorts,,inclusionEnd,int,,,,,,,,,Year of last included participant. Leave empty if collection is ongoing
+Subcohorts,,ageGroups,ontology_array,,,UMCG,AgeGroups,,,,,Age groups within this subcohort
+Subcohorts,,mainMedicalCondition,ontology_array,,,UMCG,Diseases,,,,,Disease groups of within this subcohort
+Subcohorts,,regions,ontology_array,,,UMCG,Regions,,,,,Countries or geographic regions for this subcohort
+Subcohorts,,inclusionCriteria,text,,,,,,,,,Other inclusion criteria applied to this subcohort
+Subcohorts,,supplementaryInformation,text,,,,,,,,,Any other information that needs to be disclosed for this subcohort
+Networks,Resources,,,,,,,,,,,Collaborations of multiple institutions
+Networks,,datasources,ref_array,,,UMCG,Datasources,,,,,
+Networks,,databanks,ref_array,,,UMCG,Databanks,,,,,
+Networks,,cohorts,ref_array,,,,Cohorts,,,,,
+Networks,,models,ref_array,,,UMCG,Models,,,,,
+Networks,,studies,refback,,,,Studies,,networks,,,
+Studies,Resources,,,,,,,,,,,"Collaborations of multiple institutions, addressing research questions using data sources and/or data banks"
+Studies,,networks,ref_array,,,,Networks,,,,,
+Studies,,datasources,ref_array,,,UMCG,Datasources,,,,,
+Studies,,databanks,ref_array,,,UMCG,Databanks,,,,,Databanks that provided data into this study
+Studies,,cohorts,ref_array,,,,Cohorts,,,,,Cohorts that provided data into this study
+Studies,,leadInstitution,ref,,,UMCG,Institutions,,,,,Name of lead institution that conducted the study


### PR DESCRIPTION
- Stripped down version of catalogue model to be used as staging area
- Refers to 'UMCG' Schema for shared resources

note unsure if this should be part of EMX2 repository, if not maybe move to https://github.com/molgenis/molgenis-py-cohorts-etl and include version number to keep models in sync