### PR TITLE
fix: add missing default keys to session settings fetch

### DIFF
--- a/apps/styleguide/src/layout/MolgenisSession.vue
+++ b/apps/styleguide/src/layout/MolgenisSession.vue
@@ -93,7 +93,7 @@ export default {
       this.loading = true;
       request(
         this.graphql,
-        `{_session{email,roles},_settings(keys: ["menu", "page."]){key,value},_manifest{ImplementationVersion,SpecificationVersion,DatabaseVersion}}`
+        `{_session{email,roles},_settings(keys: ["menu", "page.", "cssURL", "logoURL"]){key,value},_manifest{ImplementationVersion,SpecificationVersion,DatabaseVersion}}`
       )
         .then((data) => {
           if (data._session != undefined) {


### PR DESCRIPTION
Adds missing keys to session fetch

Closes: https://github.com/molgenis/molgenis-emx2/issues/476 ( however issue is older then session keys feature )