### PR TITLE
fix[catalogue]: when in tables view you couldn't click to the ETL

### DIFF
--- a/apps/catalogue/src/views/TableView.vue
+++ b/apps/catalogue/src/views/TableView.vue
@@ -41,10 +41,10 @@
           :to="{
             name: 'tablemapping',
             params: {
-              frompid: m.fromRelease.resource.pid,
+              fromPid: m.fromRelease.resource.pid,
               fromVersion: m.fromRelease.version,
               fromTable: m.fromTable.name,
-              topid: table.release.resource.pid,
+              toPid: table.release.resource.pid,
               toVersion: table.release.version,
               toTable: table.name,
             },
@@ -62,10 +62,10 @@
           :to="{
             name: 'tablemapping',
             params: {
-              topid: m.toRelease.resource.pid,
+              toPid: m.toRelease.resource.pid,
               toVersion: m.toRelease.version,
               toTable: m.toTable.name,
-              frompid: table.release.resource.pid,
+              fromPid: table.release.resource.pid,
               fromVersion: table.release.version,
               fromTable: table.name,
             },


### PR DESCRIPTION
When you go to https://minerva.molgeniscloud.org/Minerva/catalogue/#/tables/AP/1.0/AP  and then try to click link for the tables high up on the page it fails.

In this pull request that should not happen.

So download the minerva, upload in preview, go to URL above and click the link