### PR TITLE
Fix: import fails on empty csv file

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableReader.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableReader.java
@@ -24,25 +24,23 @@ public class CsvTableReader {
       BufferedReader bufferedReader = new BufferedReader(in);
       bufferedReader.mark(2000000);
       String firstLine = bufferedReader.readLine();
-      char separator = ',';
+      String secondLine = bufferedReader.readLine();
 
+      // if file is empty we return empty iterator
+      if (firstLine == null || firstLine.trim().equals("") || secondLine == null) {
+        return Collections.EMPTY_LIST;
+      }
+      char separator = ',';
       // if file is empty we return empty iterator
       if (firstLine == null || firstLine.trim().equals("")) {
         return Collections.EMPTY_LIST;
       }
-
       // guess the separator
       if (firstLine.contains("\t")) {
         separator = '\t';
       }
       if (firstLine.contains(";")) {
         separator = ';';
-      }
-
-      // check if has data, otherwise also return empty iterator (workaround for flatmapper failing
-      // on this)
-      if (bufferedReader.readLine() == null) {
-        return Collections.EMPTY_LIST;
       }
 
       // push back in

--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForCsvInZipFile.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForCsvInZipFile.java
@@ -67,6 +67,11 @@ public class TableStoreForCsvInZipFile implements TableStore {
 
   @Override
   public void writeTable(String name, List<String> columnNames, Iterable<Row> rows) {
+    // skip if columnNames is empty (edge case of a table without columns yet defined, like
+    // 'Version' table)
+    if (columnNames.size() == 0) {
+      return;
+    }
     if (!Files.exists(zipFilePath)) {
       create();
     }

--- a/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/TestCsvTableReader.java
+++ b/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/TestCsvTableReader.java
@@ -1,0 +1,36 @@
+package org.molgenis.emx2.io;
+
+import static org.junit.Assert.fail;
+
+import java.io.StringReader;
+import java.util.Iterator;
+import org.junit.Test;
+import org.molgenis.emx2.Row;
+import org.molgenis.emx2.io.readers.CsvTableReader;
+
+public class TestCsvTableReader {
+
+  @Test
+  public void testCsvTableReader() {
+    // test it works with empty file
+    Iterator<Row> iterator = CsvTableReader.read(new StringReader("")).iterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      fail("should not happen");
+    }
+
+    // test it works with only header
+    iterator = CsvTableReader.read(new StringReader("test,test")).iterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      fail("should not happen");
+    }
+
+    // test it works with only header
+    iterator = CsvTableReader.read(new StringReader("test,test\n")).iterator();
+    while (iterator.hasNext()) {
+      iterator.next();
+      fail("should not happen");
+    }
+  }
+}


### PR DESCRIPTION
This should solve recent issue we had that a csv.zip file couldn't be imported with error:

"Import failed: Transaction failed: Import failed: java.lang.ArrayIndexOutOfBoundsException: arraycopy: source index -43 out of bounds for char[8192]. Error at line 1.: arraycopy: source index -43 out of bounds for char[8192] in 3100ms"