### PR TITLE
fix: textinput should not show scroll 

### DIFF
--- a/apps/catalogue/src/views/CohortView.vue
+++ b/apps/catalogue/src/views/CohortView.vue
@@ -23,7 +23,7 @@
         <h6>Countries</h6>
         <OntologyTerms :terms="cohort.countries" color="primary" />
         <h6>Regions</h6>
-        <OntologyTerms :terms="cohort.countries" color="primary" />
+        <OntologyTerms :terms="cohort.regions" color="primary" />
         <h6 v-if="cohort.numberOfParticipants">Number of participants:</h6>
         <p v-if="cohort.numberOfParticipants">
           {{ cohort.numberOfParticipants }}

--- a/apps/styleguide/src/forms/InputText.vue
+++ b/apps/styleguide/src/forms/InputText.vue
@@ -16,25 +16,27 @@
       :key="idx"
       v-bind="$props"
       :showClear="showClear(idx)"
-      @clear="clearValue(idx)"
+      @clear="
+        clearValue(idx);
+        key++;
+      "
       :showPlus="showPlus(idx)"
       :showMinus="showMinus(idx)"
       @add="addRow"
     >
-      <textarea
-        v-focus="inplace && !list"
-        v-autogrow
-        ref="textarea"
-        :id="id + idx"
-        v-model="valueArray[idx]"
-        :class="{ 'form-control': true, 'is-invalid': errorMessage }"
-        :aria-describedby="id + 'Help'"
-        :placeholder="placeholder"
-        :readonly="readonly"
-        @input="emitValue($event, idx)"
-        style="resize: none"
-        @blur="toggleFocus"
-      />
+      <ResizableTextarea :key="key">
+        <textarea
+          v-focus="inplace && !list"
+          :id="id + idx"
+          v-model="valueArray[idx]"
+          :class="{ 'form-control': true, 'is-invalid': errorMessage }"
+          :aria-describedby="id + 'Help'"
+          :placeholder="placeholder"
+          :readonly="readonly"
+          @input="emitValue($event, idx)"
+          @blur="toggleFocus"
+        />
+      </ResizableTextarea>
     </InputAppend>
   </FormGroup>
 </template>
@@ -43,6 +45,7 @@
 import _baseInput from "./_baseInput.vue";
 import InputAppend from "./_inputAppend";
 import IconAction from "./IconAction";
+import ResizableTextarea from "./ResizableTextarea";
 
 /** Input for text */
 export default {
@@ -51,91 +54,13 @@ export default {
     InputAppend,
     FormGroup: () => import("./_formGroup"), //because it uses itself in nested form
     IconAction,
+    ResizableTextarea,
   },
-  directives: {
-    autogrow: {
-      //thank you! https://github.com/wrabit/vue-textarea-autogrow-directive/blob/master/src/VueTextareaAutogrowDirective.js
-      inserted(el) {
-        let observe, minHeight;
-
-        // If used in a component library such as buefy, a wrapper will be used on the component so check if a child is the textarea
-        el =
-          el.tagName.toLowerCase() === "textarea"
-            ? el
-            : el.querySelector("textarea");
-
-        minHeight = parseFloat(
-          getComputedStyle(el).getPropertyValue("min-height")
-        );
-
-        if (window.attachEvent) {
-          observe = function (element, event, handler) {
-            element.attachEvent("on" + event, handler);
-          };
-        } else {
-          observe = function (element, event, handler) {
-            element.addEventListener(event, handler, false);
-          };
-        }
-
-        let resize = () => {
-          el.style.height = "auto";
-          let border = el.style.borderTopWidth * 2;
-          el.style.height =
-            (el.scrollHeight < minHeight ? minHeight : el.scrollHeight) +
-            border +
-            "px";
-        };
-
-        // 0-timeout to get the already changed el
-        let delayedResize = () => {
-          window.setTimeout(resize, 0);
-        };
-
-        // When the textarea is being shown / hidden
-        var respondToVisibility = (element, callback) => {
-          let intersectionObserver = new IntersectionObserver(
-            (entries) => {
-              entries.forEach((entry) => {
-                if (entry.intersectionRatio > 0) callback();
-              });
-            },
-            {
-              root: document.documentElement,
-            }
-          );
-
-          intersectionObserver.observe(element);
-        };
-
-        respondToVisibility(el, resize);
-        observe(el, "beforeInput", resize);
-        observe(el, "change", resize);
-        observe(el, "cut", delayedResize);
-        observe(el, "paste", delayedResize);
-        observe(el, "drop", delayedResize);
-        observe(el, "input", resize);
-
-        resize();
-      },
-      componentUpdated(el) {
-        //in case values are changed from outside in
-        let minHeight = parseFloat(
-          getComputedStyle(el).getPropertyValue("min-height")
-        );
-
-        let resize = () => {
-          el.style.height = "auto";
-          let border = el.style.borderTopWidth * 2;
-          el.style.height =
-            (el.scrollHeight < minHeight ? minHeight : el.scrollHeight) +
-            border +
-            "px";
-        };
-
-        resize();
-      },
-    },
+  data() {
+    return {
+      //used to elegantly trigger refresh the textareas on clear
+      key: 0,
+    };
   },
 };
 </script>

--- a/apps/styleguide/src/forms/ResizableTextarea.vue
+++ b/apps/styleguide/src/forms/ResizableTextarea.vue
@@ -1,0 +1,25 @@
+<script>
+export default {
+  methods: {
+    resizeTextarea(event) {
+      event.target.style.height = "auto";
+      event.target.style.height = event.target.scrollHeight + "px";
+    },
+  },
+  mounted() {
+    this.$nextTick(() => {
+      this.$el.setAttribute(
+        "style",
+        "height:" + this.$el.scrollHeight + "px;overflow-y:hidden;"
+      );
+    });
+    this.$el.addEventListener("input", this.resizeTextarea);
+  },
+  beforeDestroy() {
+    this.$el.addEventListener("input", this.resizeTextarea);
+  },
+  render() {
+    return this.$slots.default[0];
+  },
+};
+</script>


### PR DESCRIPTION
and also refactored so it doesn't use 'document' anymore easing the way towards ssr.

To test
- view textarea
- see there is no scroll bar
- see you can use clear button without overlapping scroll bar #732 
- see you can't accidentally click clear while using a scroll bar #601 

closes #732 
closes #601 