### PR TITLE
feat: schema settings can be set by managers, table settings can be set by editors

### DIFF
--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestGrantRolesToUsers.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestGrantRolesToUsers.java
@@ -63,6 +63,24 @@ public class TestGrantRolesToUsers {
     schema.addMember("user_testRolePermissions_editor", EDITOR.toString());
     schema.addMember("user_testRolePermissions_manager", MANAGER.toString());
 
+    // test that manager also had editor and viewer roles
+    List<String> roles = schema.getInheritedRolesForUser("user_testRolePermissions_manager");
+    assertTrue(roles.contains(VIEWER.toString()));
+    assertTrue(roles.contains(EDITOR.toString()));
+    assertTrue(roles.contains(MANAGER.toString()));
+
+    // test that editor also had editor and viewer roles
+    roles = schema.getInheritedRolesForUser("user_testRolePermissions_editor");
+    assertTrue(roles.contains(VIEWER.toString()));
+    assertTrue(roles.contains(EDITOR.toString()));
+    assertFalse(roles.contains(MANAGER.toString()));
+
+    // test that editor also had editor and viewer roles
+    roles = schema.getInheritedRolesForUser("user_testRolePermissions_viewer");
+    assertTrue(roles.contains(VIEWER.toString()));
+    assertFalse(roles.contains(EDITOR.toString()));
+    assertFalse(roles.contains(MANAGER.toString()));
+
     StopWatch.print("testRolePermissions schema created");
 
     // test that viewer and editor cannot createColumn, and manager can

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestSettings.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestSettings.java
@@ -26,6 +26,7 @@ public class TestSettings {
   public void testSchemaSettings() {
 
     database.tx(
+        // prevent side effect of user changes on other tests using tx
         db -> {
           Schema s = db.dropCreateSchema("testSchemaSettings");
 
@@ -79,6 +80,7 @@ public class TestSettings {
   @Test
   public void testTableSettings() {
     database.tx(
+        // prevent side effect of user changes on other tests using tx
         db -> {
           Schema s = db.dropCreateSchema("testTableSettings");
 

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestSettings.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestSettings.java
@@ -15,109 +15,124 @@ import org.molgenis.emx2.Setting;
 import org.molgenis.emx2.Table;
 
 public class TestSettings {
-  private static Database db;
+  private static Database database;
 
   @BeforeClass
   public static void setUp() {
-    db = TestDatabaseFactory.getTestDatabase();
+    database = TestDatabaseFactory.getTestDatabase();
   }
 
   @Test
   public void testSchemaSettings() {
-    Schema s = db.dropCreateSchema("testSchemaSettings");
 
-    // set roles
-    // viewer should only be able to see, not change
-    // manager should be able to set values
-    s.addMember("testsettingseditor", EDITOR.toString());
-    s.addMember("testsettingsmanager", MANAGER.toString());
+    database.tx(
+        db -> {
+          Schema s = db.dropCreateSchema("testSchemaSettings");
 
-    db.setActiveUser("testsettingseditor");
-    try {
-      s = db.getSchema("testSchemaSettings"); // reload schema
-      s.getMetadata().setSetting("key", "value");
-      fail("editors should not be able to change schema settings");
-    } catch (Exception e) {
-      // failed correctly
-    }
+          // set roles
+          // viewer should only be able to see, not change
+          // manager should be able to set values
+          s.addMember("testsettingseditor", EDITOR.toString());
+          s.addMember("testsettingsmanager", MANAGER.toString());
 
-    db.setActiveUser("testsettingsmanager");
-    try {
-      s = db.getSchema("testSchemaSettings"); // reload schema
-      s.getMetadata().setSetting("key", "value");
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("managers should  be able to change schema settings");
-    }
+          db.setActiveUser("testsettingseditor");
+          try {
+            s = db.getSchema("testSchemaSettings"); // reload schema
+            s.getMetadata().setSetting("key", "value");
+            fail("editors should not be able to change schema settings");
+          } catch (Exception e) {
+            // failed correctly
+          }
 
-    assertEquals("key", s.getMetadata().getSettings().get(0).getKey());
-    assertEquals("value", s.getMetadata().getSettings().get(0).getValue());
+          db.setActiveUser("testsettingsmanager");
+          try {
+            s = db.getSchema("testSchemaSettings"); // reload schema
+            s.getMetadata().setSetting("key", "value");
+          } catch (Exception e) {
+            e.printStackTrace();
+            fail("managers should  be able to change schema settings");
+          }
 
-    assertEquals(
-        "key", db.getSchema("testSchemaSettings").getMetadata().getSettings().get(0).getKey());
-    assertEquals(
-        "value", db.getSchema("testSchemaSettings").getMetadata().getSettings().get(0).getValue());
+          assertEquals("key", s.getMetadata().getSettings().get(0).getKey());
+          assertEquals("value", s.getMetadata().getSettings().get(0).getValue());
 
-    db.clearCache();
+          assertEquals(
+              "key",
+              db.getSchema("testSchemaSettings").getMetadata().getSettings().get(0).getKey());
+          assertEquals(
+              "value",
+              db.getSchema("testSchemaSettings").getMetadata().getSettings().get(0).getValue());
 
-    assertEquals(
-        "key", db.getSchema("testSchemaSettings").getMetadata().getSettings().get(0).getKey());
-    assertEquals(
-        "value", db.getSchema("testSchemaSettings").getMetadata().getSettings().get(0).getValue());
+          db.clearCache();
+
+          assertEquals(
+              "key",
+              db.getSchema("testSchemaSettings").getMetadata().getSettings().get(0).getKey());
+          assertEquals(
+              "value",
+              db.getSchema("testSchemaSettings").getMetadata().getSettings().get(0).getValue());
+
+          db.clearActiveUser();
+        });
   }
 
   @Test
   public void testTableSettings() {
-    Schema s = db.dropCreateSchema("testTableSettings");
+    database.tx(
+        db -> {
+          Schema s = db.dropCreateSchema("testTableSettings");
 
-    // set roles
-    // viewer should only be able to see, not change
-    // editor should be able to set values
-    s.addMember("testtablesettingsviewer", VIEWER.toString());
-    s.addMember("testtablesettingseditor", EDITOR.toString());
+          // set roles
+          // viewer should only be able to see, not change
+          // editor should be able to set values
+          s.addMember("testtablesettingsviewer", VIEWER.toString());
+          s.addMember("testtablesettingseditor", EDITOR.toString());
 
-    s.create(table("test").add(column("test")));
+          s.create(table("test").add(column("test")));
 
-    db.setActiveUser("testtablesettingsviewer");
-    try {
-      Table t = db.getSchema("testTableSettings").getTable("test");
-      t.getMetadata().setSetting("key", "value");
-      fail("viewers should not be able to change schema settings");
-    } catch (Exception e) {
-      // failed correctly
-    }
+          db.setActiveUser("testtablesettingsviewer");
+          try {
+            Table t = db.getSchema("testTableSettings").getTable("test");
+            t.getMetadata().setSetting("key", "value");
+            fail("viewers should not be able to change schema settings");
+          } catch (Exception e) {
+            // failed correctly
+          }
 
-    db.setActiveUser("testtablesettingseditor");
-    try {
-      Table t = db.getSchema("testTableSettings").getTable("test");
-      t.getMetadata().setSetting("key", "value");
-    } catch (Exception e) {
-      e.printStackTrace();
-      fail("managers should  be able to change schema settings");
-    }
+          db.setActiveUser("testtablesettingseditor");
+          try {
+            Table t = db.getSchema("testTableSettings").getTable("test");
+            t.getMetadata().setSetting("key", "value");
+          } catch (Exception e) {
+            e.printStackTrace();
+            fail("managers should  be able to change schema settings");
+          }
 
-    db.clearCache();
-    List<Setting> test =
-        db.getSchema("testTableSettings").getTable("test").getMetadata().getSettings();
-    assertEquals(1, test.size());
-    assertEquals("key", test.get(0).getKey());
-    assertEquals("value", test.get(0).getValue());
+          db.clearCache();
+          List<Setting> test =
+              db.getSchema("testTableSettings").getTable("test").getMetadata().getSettings();
+          assertEquals(1, test.size());
+          assertEquals("key", test.get(0).getKey());
+          assertEquals("value", test.get(0).getValue());
 
-    assertEquals(
-        "key",
-        db.getSchema("testTableSettings")
-            .getTable("test")
-            .getMetadata()
-            .getSettings()
-            .get(0)
-            .getKey());
-    assertEquals(
-        "value",
-        db.getSchema("testTableSettings")
-            .getTable("test")
-            .getMetadata()
-            .getSettings()
-            .get(0)
-            .getValue());
+          assertEquals(
+              "key",
+              db.getSchema("testTableSettings")
+                  .getTable("test")
+                  .getMetadata()
+                  .getSettings()
+                  .get(0)
+                  .getKey());
+          assertEquals(
+              "value",
+              db.getSchema("testTableSettings")
+                  .getTable("test")
+                  .getMetadata()
+                  .getSettings()
+                  .get(0)
+                  .getValue());
+
+          db.clearActiveUser();
+        });
   }
 }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -355,12 +355,12 @@ public class SqlDatabase implements Database {
           throw new SqlMolgenisException("Set active user failed", dae);
         }
       }
-      this.clearCache();
     } else {
       if (!Objects.equals(username, connectionProvider.getActiveUser())) {
         listener.userChanged();
       }
     }
+    this.clearCache();
     this.connectionProvider.setActiveUser(username);
   }
 

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
@@ -278,7 +278,9 @@ public class SqlSchema implements Schema {
         }
 
         // update table settings
-        oldTable.setSettings(mergeTable.getSettings());
+        if (!mergeTable.getSettings().isEmpty()) {
+          oldTable.setSettings(mergeTable.getSettings());
+        }
         oldTable.setDescription(mergeTable.getDescription());
         oldTable.setSemantics(mergeTable.getSemantics());
         MetadataUtils.saveTableMetadata(targetSchema.getMetadata().getJooq(), oldTable);

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
@@ -2,7 +2,6 @@ package org.molgenis.emx2.sql;
 
 import static org.molgenis.emx2.sql.SqlColumnExecutor.executeRemoveRefConstraints;
 import static org.molgenis.emx2.sql.SqlDatabase.ADMIN_USER;
-import static org.molgenis.emx2.sql.SqlDatabase.ANONYMOUS;
 import static org.molgenis.emx2.sql.SqlSchemaMetadataExecutor.*;
 import static org.molgenis.emx2.utils.TableSort.sortTableByDependency;
 
@@ -82,12 +81,7 @@ public class SqlSchema implements Schema {
 
   @Override
   public String getRoleForUser(String user) {
-    if (user == null) user = ANONYMOUS;
-    user = user.trim();
-    for (Member m : executeGetMembers(getMetadata().getJooq(), getMetadata())) {
-      if (m.getUser().equals(user)) return m.getRole();
-    }
-    return null;
+    return getMetadata().getRoleForUser(user);
   }
 
   @Override
@@ -108,7 +102,7 @@ public class SqlSchema implements Schema {
 
   @Override
   public List<String> getInheritedRolesForActiveUser() {
-    return getInheritedRolesForUser(db.getActiveUser());
+    return getMetadata().getInheritedRolesForActiveUser();
   }
 
   @Override

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -1,5 +1,8 @@
 package org.molgenis.emx2.sql;
 
+import static org.molgenis.emx2.Privileges.MANAGER;
+import static org.molgenis.emx2.sql.SqlDatabase.ANONYMOUS;
+import static org.molgenis.emx2.sql.SqlSchemaMetadataExecutor.executeGetMembers;
 import static org.molgenis.emx2.sql.SqlTableMetadataExecutor.executeCreateTable;
 import static org.molgenis.emx2.utils.TableSort.sortTableByDependency;
 
@@ -8,7 +11,6 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import org.javers.common.collections.Lists;
 import org.jooq.DSLContext;
 import org.molgenis.emx2.*;
 import org.slf4j.Logger;
@@ -18,6 +20,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
   private static Logger logger = LoggerFactory.getLogger(SqlSchemaMetadata.class);
   // cache for retrieved roles
   private List<String> rolesCache = null;
+  private List<Member> memberCache = null;
 
   // copy constructor
   protected SqlSchemaMetadata(Database db, SqlSchemaMetadata copy) {
@@ -88,6 +91,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     this.tables.clear();
     this.settings.clear();
     this.rolesCache = null;
+    this.memberCache = null;
     for (TableMetadata table : MetadataUtils.loadTables(getDatabase().getJooq(), this)) {
       super.create(new SqlTableMetadata(this, table));
     }
@@ -154,15 +158,28 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     return sm;
   }
 
+  public boolean hasActiveUserRole(String role) {
+    return this.getInheritedRolesForActiveUser().contains(role);
+  }
+
   @Override
   public SqlSchemaMetadata setSettings(Collection<Setting> settings) {
-    getDatabase()
-        .tx(
-            db -> {
-              sync(setSettingsTransaction((SqlDatabase) db, getName(), settings));
-            });
-    getDatabase().getListener().schemaChanged(getName());
-    return this;
+    if (hasActiveUserRole(MANAGER.toString())) {
+      getDatabase()
+          .tx(
+              db -> {
+                sync(setSettingsTransaction((SqlDatabase) db, getName(), settings));
+              });
+      getDatabase().getListener().schemaChanged(getName());
+      return this;
+    } else {
+      throw new MolgenisException(
+          "Permission denied for user "
+              + getDatabase().getActiveUser()
+              + " to change setting on schema "
+              + getName()
+              + ". You need at least MANAGER permission for schema settings");
+    }
   }
 
   @Override
@@ -244,24 +261,40 @@ public class SqlSchemaMetadata extends SchemaMetadata {
 
   public List<String> getIneritedRolesForUser(String user) {
     if (user == null) return new ArrayList<>();
+    final String username = user.trim();
+    List<String> result = new ArrayList<>();
+    // need elevated privileges, so clear user and run as root
+    // this is not thread safe therefore must be in a transaction
+    getDatabase()
+        .tx(
+            tdb -> {
+              String current = tdb.getActiveUser();
+              tdb.clearActiveUser(); // elevate privileges
+              result.addAll(
+                  SqlSchemaMetadataExecutor.getInheritedRoleForUser(
+                      ((SqlDatabase) tdb).getJooq(), getName(), username));
+              tdb.setActiveUser(current);
+            });
+    return result;
+  }
+
+  public List<String> getInheritedRolesForActiveUser() {
     // add cache because this function is called often
     if (rolesCache == null) {
-      final String username = user.trim();
-      List<String> result = new ArrayList<>();
-      // need elevated privileges, so clear user and run as root
-      // this is not thread safe therefore must be in a transaction
-      getDatabase()
-          .tx(
-              tdb -> {
-                String current = tdb.getActiveUser();
-                tdb.clearActiveUser();
-                result.addAll(
-                    SqlSchemaMetadataExecutor.getInheritedRoleForUser(
-                        ((SqlDatabase) tdb).getJooq(), getName(), username));
-                tdb.setActiveUser(current);
-              });
-      rolesCache = result;
+      rolesCache = getIneritedRolesForUser(getDatabase().getActiveUser());
     }
-    return Lists.immutableCopyOf(rolesCache);
+    return rolesCache;
+  }
+
+  public String getRoleForUser(String user) {
+    if (memberCache == null) {
+      memberCache = executeGetMembers(getJooq(), this);
+    }
+    if (user == null) user = ANONYMOUS;
+    user = user.trim();
+    for (Member m : memberCache) {
+      if (m.getUser().equals(user)) return m.getRole();
+    }
+    return null;
   }
 }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -20,7 +20,6 @@ public class SqlSchemaMetadata extends SchemaMetadata {
   private static Logger logger = LoggerFactory.getLogger(SqlSchemaMetadata.class);
   // cache for retrieved roles
   private List<String> rolesCache = null;
-  private List<Member> memberCache = null;
 
   // copy constructor
   protected SqlSchemaMetadata(Database db, SqlSchemaMetadata copy) {
@@ -91,7 +90,6 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     this.tables.clear();
     this.settings.clear();
     this.rolesCache = null;
-    this.memberCache = null;
     for (TableMetadata table : MetadataUtils.loadTables(getDatabase().getJooq(), this)) {
       super.create(new SqlTableMetadata(this, table));
     }
@@ -287,12 +285,9 @@ public class SqlSchemaMetadata extends SchemaMetadata {
   }
 
   public String getRoleForUser(String user) {
-    if (memberCache == null) {
-      memberCache = executeGetMembers(getJooq(), this);
-    }
     if (user == null) user = ANONYMOUS;
     user = user.trim();
-    for (Member m : memberCache) {
+    for (Member m : executeGetMembers(getJooq(), this)) {
       if (m.getUser().equals(user)) return m.getRole();
     }
     return null;

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -162,7 +162,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
 
   @Override
   public SqlSchemaMetadata setSettings(Collection<Setting> settings) {
-    if (hasActiveUserRole(MANAGER.toString())) {
+    if (getDatabase().isAdmin() || hasActiveUserRole(MANAGER.toString())) {
       getDatabase()
           .tx(
               db -> {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
@@ -395,7 +395,8 @@ class SqlTableMetadata extends TableMetadata {
 
   @Override
   public SqlTableMetadata setSettings(List<Setting> settings) {
-    if (((SqlSchemaMetadata) getSchema()).hasActiveUserRole(EDITOR.toString())) {
+    if (getDatabase().isAdmin()
+        || ((SqlSchemaMetadata) getSchema()).hasActiveUserRole(EDITOR.toString())) {
       getDatabase()
           .tx(
               db -> {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
@@ -4,6 +4,7 @@ import static org.jooq.impl.DSL.*;
 import static org.molgenis.emx2.Column.column;
 import static org.molgenis.emx2.Constants.MG_EDIT_ROLE;
 import static org.molgenis.emx2.Constants.MG_TABLECLASS;
+import static org.molgenis.emx2.Privileges.EDITOR;
 import static org.molgenis.emx2.sql.MetadataUtils.deleteColumn;
 import static org.molgenis.emx2.sql.MetadataUtils.saveColumnMetadata;
 import static org.molgenis.emx2.sql.SqlColumnExecutor.*;
@@ -394,15 +395,24 @@ class SqlTableMetadata extends TableMetadata {
 
   @Override
   public SqlTableMetadata setSettings(List<Setting> settings) {
-    getDatabase()
-        .tx(
-            db -> {
-              sync(
-                  setSettingTransaction(
-                      (SqlDatabase) db, getSchemaName(), getTableName(), settings));
-            });
-    getDatabase().getListener().schemaChanged(getSchemaName());
-    return this;
+    if (((SqlSchemaMetadata) getSchema()).hasActiveUserRole(EDITOR.toString())) {
+      getDatabase()
+          .tx(
+              db -> {
+                sync(
+                    setSettingTransaction(
+                        (SqlDatabase) db, getSchemaName(), getTableName(), settings));
+              });
+      getDatabase().getListener().schemaChanged(getSchemaName());
+      return this;
+    } else {
+      throw new MolgenisException(
+          "Permission denied for user "
+              + getDatabase().getActiveUser()
+              + " to change setting on table "
+              + getTableName()
+              + ". You need at least EDITOR permission for table settings.");
+    }
   }
 
   private static SqlTableMetadata setSettingTransaction(

--- a/docs/molgenis/use_permissions.md
+++ b/docs/molgenis/use_permissions.md
@@ -27,14 +27,17 @@ the 'admin'. Only this user can see and create other users.
 
 ## Sign-in using Open ID Connect (OIDC)
 
-Users can be authenticated using an existing account via Open ID Connect (OIDC).
-To enable users to sign-in using OIDC, the Molgenis instance must be configured to use OIDC.
-When OIDC is enabled, users are no longer presented with the option to sign-up
+Users can be authenticated using an existing account via Open ID Connect (OIDC). To enable users to sign-in using OIDC,
+the Molgenis instance must be configured to use OIDC. When OIDC is enabled, users are no longer presented with the
+option to sign-up
 
-When OIDC is enabled, the admin user can bypass the oidc login by using the admin route (```[service-location]/apps/central/#/admin```)
+When OIDC is enabled, the admin user can bypass the oidc login by using the admin
+route (```[service-location]/apps/central/#/admin```)
 
 ### Enabling OIDC
+
 To enable OIDC the following environment variables need to be set:
+
 ```
 MOLGENIS_OIDC_CLIENT_ID // the id for the molgenis instance as set in the authentication provider
 MOLGENIS_OIDC_CLIENT_SECRET // the client secret as set in the authentication provider
@@ -44,4 +47,14 @@ MOLGENIS_OIDC_CALLBACK_URL // public available endpoint for molgenis service to 
 ```
 
 ### Disabling OIDC
+
 Remove the ```MOLGENIS_OIDC_CLIENT_ID``` environment variable and restart the server
+
+## Settings
+
+At various places in MOLGENIS users can edit/update settings.
+
+* Schema level settings can only be set by users with role MANAGER or higher
+* Table level settings can only be set by users with role EDITOR or higher
+
+Currently, all settings can be read by all users

--- a/docs/molgenis/use_permissions.md
+++ b/docs/molgenis/use_permissions.md
@@ -49,12 +49,3 @@ MOLGENIS_OIDC_CALLBACK_URL // public available endpoint for molgenis service to 
 ### Disabling OIDC
 
 Remove the ```MOLGENIS_OIDC_CLIENT_ID``` environment variable and restart the server
-
-## Settings
-
-At various places in MOLGENIS users can edit/update settings.
-
-* Schema level settings can only be set by users with role MANAGER or higher
-* Table level settings can only be set by users with role EDITOR or higher
-
-Currently, all settings can be read by all users


### PR DESCRIPTION
How to test:
* create a manager (or owner, who also has manager permission)
* create a editor 
* create a viewer
* observe that managers can set settings on schema level (e.g. theme) and editors cannot
* observe that editors can set settings on table level (e.g. using cog on table list view, right top) and viewers cannot

Discuss: we could limit also table settings to managers only