### PR TITLE
fix: long table names result in error in table view

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -10,10 +10,7 @@ import static org.molgenis.emx2.sql.SqlTableMetadataExecutor.searchColumnName;
 import static org.molgenis.emx2.utils.TypeUtils.*;
 
 import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.jooq.*;
 import org.jooq.Table;
@@ -47,7 +44,8 @@ public class SqlQuery extends QueryBean {
 
   private static final Logger logger = LoggerFactory.getLogger(SqlQuery.class);
 
-  private SqlSchemaMetadata schema;
+  private final SqlSchemaMetadata schema;
+  private final List<String> tableAliasList = new LinkedList<>();
 
   public SqlQuery(SqlSchemaMetadata schema, String field) {
     super(field);
@@ -58,6 +56,18 @@ public class SqlQuery extends QueryBean {
     super(field);
     this.schema = schema;
     this.select(selection);
+  }
+
+  /** Create alias that is short enough for postgresql to not complain */
+  public String alias(String label) {
+    if (!label.contains("-")) {
+      // we only need aliases for subquery tables
+      return label;
+    }
+    if (!tableAliasList.contains(label)) {
+      tableAliasList.add(label);
+    }
+    return "a" + tableAliasList.indexOf(label);
   }
 
   @Override
@@ -100,7 +110,7 @@ public class SqlQuery extends QueryBean {
         table
             .getJooq()
             .select(rowSelectFields(table, tableAlias, "", select))
-            .from(tableWithInheritanceJoin(table).as(tableAlias));
+            .from(tableWithInheritanceJoin(table).as(alias(tableAlias)));
 
     // joins, only filtered tables
     from = refJoins(table, tableAlias, from, filter, select, new ArrayList<>());
@@ -126,8 +136,7 @@ public class SqlQuery extends QueryBean {
     }
   }
 
-  // todo: allow query expansion accross tables?
-  private static List<Field<?>> rowSelectFields(
+  private List<Field<?>> rowSelectFields(
       TableMetadata table, String tableAlias, String prefix, SelectColumn selection) {
 
     List<Field<?>> fields = new ArrayList<>();
@@ -136,7 +145,7 @@ public class SqlQuery extends QueryBean {
       String columnAlias = prefix.equals("") ? column.getName() : prefix + "-" + column.getName();
       if (column.isFile()) {
         // check what they want to get, contents, mimetype, size and/or extension
-        if (select.getSubselect().size() == 0 || select.has("id")) {
+        if (select.getSubselect().isEmpty() || select.has("id")) {
           fields.add(field(name(column.getName())));
         }
         if (select.has("contents")) {
@@ -177,16 +186,18 @@ public class SqlQuery extends QueryBean {
                   + column.getName()
                   + "' failed: composite foreign key requires subselection or explicit naming of underlying fields");
         } else {
-          fields.add(field(name(tableAlias, column.getName()), ref.getJooqType()).as(columnAlias));
+          fields.add(
+              field(name(alias(tableAlias), column.getName()), ref.getJooqType()).as(columnAlias));
         }
       } else if (!column.isHeading()) {
-        fields.add(field(name(tableAlias, column.getName()), column.getJooqType()).as(columnAlias));
+        fields.add(
+            field(name(alias(tableAlias), column.getName()), column.getJooqType()).as(columnAlias));
       }
     }
     return fields;
   }
 
-  private static SelectConditionStep<org.jooq.Record> rowBackrefSubselect(
+  private SelectConditionStep<org.jooq.Record> rowBackrefSubselect(
       Column column, String tableAlias) {
     Column refBack = column.getRefBackColumn();
     List<Condition> where = new ArrayList<>();
@@ -196,12 +207,12 @@ public class SqlQuery extends QueryBean {
       if (refBack.isRef()) {
         where.add(
             field(name(refBack.getTable().getTableName(), ref.getName()))
-                .eq(field(name(tableAlias, ref.getRefTo()))));
+                .eq(field(name(alias(tableAlias), ref.getRefTo()))));
       } else if (refBack.isRefArray()) {
         where.add(
             condition(
                 ANY_SQL,
-                field(name(tableAlias, ref.getRefTo())),
+                field(name(alias(tableAlias), ref.getRefTo())),
                 field(name(refBack.getTable().getTableName(), ref.getName()))));
       } else {
         throw new MolgenisException(
@@ -238,7 +249,7 @@ public class SqlQuery extends QueryBean {
               table, null, table.getTableName(), select, getFilter(), getSearchTerms()));
     } else {
       // select all on root level as default
-      if (select.getSubselect().size() == 0) {
+      if (select.getSubselect().isEmpty()) {
         for (Column c : table.getColumns()) {
           if (!c.isHeading()) {
             select.select(c.getName());
@@ -262,7 +273,7 @@ public class SqlQuery extends QueryBean {
     return result;
   }
 
-  private static Field<?> jsonSubselect(
+  private Field<?> jsonSubselect(
       SqlTableMetadata table,
       Column column,
       String tableAlias,
@@ -276,7 +287,7 @@ public class SqlQuery extends QueryBean {
 
     SelectJoinStep<org.jooq.Record> from =
         jooq.select(jsonSubselectFields(table, subAlias, select))
-            .from(tableWithInheritanceJoin(table).as(subAlias));
+            .from(tableWithInheritanceJoin(table).as(alias(subAlias)));
 
     List<Condition> conditions = new ArrayList<>();
     Select<org.jooq.Record> filterQuery =
@@ -286,7 +297,7 @@ public class SqlQuery extends QueryBean {
         || select.getLimit() > 0
         || select.getOffset() > 0) {
       List<Field> pkeyFields = table.getPrimaryKeyFields();
-      if (pkeyFields.size() == 0) throw new MolgenisException("primary key not set");
+      if (pkeyFields.isEmpty()) throw new MolgenisException("primary key not set");
       conditions.add(row(pkeyFields).in(filterQuery));
     }
     if (column != null) {
@@ -302,7 +313,7 @@ public class SqlQuery extends QueryBean {
         .as(select.getColumn());
   }
 
-  private static SelectConditionStep<org.jooq.Record> jsonFilterQuery(
+  private SelectConditionStep<org.jooq.Record> jsonFilterQuery(
       SqlTableMetadata table,
       Column column,
       String tableAlias,
@@ -332,7 +343,7 @@ public class SqlQuery extends QueryBean {
     }
   }
 
-  private static List<Condition> jsonFilterQueryConditions(
+  private List<Condition> jsonFilterQueryConditions(
       SqlTableMetadata table,
       Column column,
       String tableAlias,
@@ -352,8 +363,6 @@ public class SqlQuery extends QueryBean {
         } else {
           Column c = isValidColumn(table, f.getColumn());
           if (c.isReference()) {
-            // add subfilter where reference is in tuples from subquery
-            // todo, if filter is on pkey we don't even need subquery!
             SelectConditionStep<org.jooq.Record> subQuery =
                 jsonFilterQuery(
                     (SqlTableMetadata) c.getRefTable(),
@@ -384,15 +393,13 @@ public class SqlQuery extends QueryBean {
                 }
               } else if (c.isRefback()) {
                 Column refBack = c.getRefBackColumn();
-                List<Field> pkey =
-                    c.getTable().getPrimaryKeyFields().stream().collect(Collectors.toList());
+                List<Field> pkey = c.getTable().getPrimaryKeyFields().stream().toList();
                 List<Field> backRef =
                     c.getRefBackColumn().getReferences().stream()
                         .map(Reference::getJooqField)
-                        .collect(Collectors.toList());
+                        .toList();
                 List<Field> backRefKey =
-                    c.getRefBackColumn().getTable().getPrimaryKeyFields().stream()
-                        .collect(Collectors.toList());
+                    c.getRefBackColumn().getTable().getPrimaryKeyFields().stream().toList();
                 // can be ref, ref_array (mref is checked above)
                 if (refBack.isRef()) {
                   // pkey in (backref from refBack table where backrefKey in subquery)
@@ -416,16 +423,13 @@ public class SqlQuery extends QueryBean {
                                                       ? field(name(bref.getName()))
                                                       : field("UNNEST({0})", name(bref.getName()))
                                                           .as(name(bref.getName())))
-                                          .collect(Collectors.toList()))
+                                          .toList())
                                   .from(c.getRefTable().getJooqTable())
                                   .where(row(backRefKey).in(subQuery))));
                 }
               } else {
                 // normal ref
-                List<Field> refs =
-                    c.getReferences().stream()
-                        .map(Reference::getJooqField)
-                        .collect(Collectors.toList());
+                List<Field> refs = c.getReferences().stream().map(Reference::getJooqField).toList();
                 conditions.add(row(refs).in(subQuery));
               }
             }
@@ -463,7 +467,7 @@ public class SqlQuery extends QueryBean {
     return or(search);
   }
 
-  private static Collection<Field<?>> jsonSubselectFields(
+  private Collection<Field<?>> jsonSubselectFields(
       TableMetadata table, String tableAlias, SelectColumn selection) {
     List<Field<?>> fields = new ArrayList<>();
 
@@ -508,20 +512,20 @@ public class SqlQuery extends QueryBean {
                 new String[0]));
       } else {
         // primitive fields
-        fields.add(field(name(tableAlias, column.getName())));
+        fields.add(field(name(alias(tableAlias), column.getName())));
       }
     }
     return fields;
   }
 
-  private static Field<Object> jsonFileField(
+  private Field<Object> jsonFileField(
       SqlTableMetadata table, String tableAlias, SelectColumn select, Column column) {
     DSLContext jooq = table.getJooq();
     List<Field> subFields = new ArrayList<>();
     for (String ext : new String[] {"id", "contents", "size", "extension", "mimetype", "url"}) {
       if (select.has(ext)) {
         if (ext.equals("id")) {
-          subFields.add(field(name(tableAlias, column.getName())).as(ext));
+          subFields.add(field(name(alias(tableAlias), column.getName())).as(ext));
         } else if (ext.equals("url")) {
           subFields.add(
               field(
@@ -532,10 +536,10 @@ public class SqlQuery extends QueryBean {
                           + "/"
                           + column.getName()
                           + "/' || {0}",
-                      field(name(tableAlias, column.getName())))
+                      field(name(alias(tableAlias), column.getName())))
                   .as(ext));
         } else {
-          subFields.add(field(name(tableAlias, column.getName() + "_" + ext)).as(ext));
+          subFields.add(field(name(alias(tableAlias), column.getName() + "_" + ext)).as(ext));
         }
       }
     }
@@ -543,7 +547,7 @@ public class SqlQuery extends QueryBean {
         .as(select.getColumn());
   }
 
-  private static Field<?> jsonAggregateSelect(
+  private Field<?> jsonAggregateSelect(
       SqlTableMetadata table,
       Column column,
       String tableAlias,
@@ -563,7 +567,7 @@ public class SqlQuery extends QueryBean {
         .as(select.getColumn());
   }
 
-  private static Collection<Field<?>> jsonAggregateFields(
+  private Collection<Field<?>> jsonAggregateFields(
       SqlTableMetadata table,
       Column column,
       String tableAlias,
@@ -594,7 +598,7 @@ public class SqlQuery extends QueryBean {
     return fields;
   }
 
-  private static Field jsonAggregateGroupBy(
+  private Field jsonAggregateGroupBy(
       SqlTableMetadata table,
       Column column,
       SelectColumn groupBy,
@@ -632,11 +636,12 @@ public class SqlQuery extends QueryBean {
         if (condition != null) {
           subQuery.add(
               jooq.select(subselectFields)
-                  .from(tableWithInheritanceJoin(table).as(tableAlias))
+                  .from(tableWithInheritanceJoin(table).as(alias(tableAlias)))
                   .where(condition));
         } else {
           subQuery.add(
-              jooq.select(subselectFields).from(tableWithInheritanceJoin(table).as(tableAlias)));
+              jooq.select(subselectFields)
+                  .from(tableWithInheritanceJoin(table).as(alias(tableAlias))));
         }
         groupByFields.add(c.getJooqField());
       }
@@ -654,7 +659,7 @@ public class SqlQuery extends QueryBean {
         .as(GROUPBY_FIELD);
   }
 
-  private static Field jsonAggField(
+  private Field jsonAggField(
       SqlTableMetadata table,
       Column column,
       String tableAlias,
@@ -670,16 +675,19 @@ public class SqlQuery extends QueryBean {
         field(
             "json_build_object({0},{1},{2},{3},{4},{5},{6},{7})",
             MAX_FIELD,
-            max(field(name(tableAlias, c.getName()))),
+            max(field(name(alias(tableAlias), c.getName()))),
             MIN_FIELD,
-            min(field(name(tableAlias, c.getName()))),
+            min(field(name(alias(tableAlias), c.getName()))),
             AVG_FIELD,
-            avg(field(name(tableAlias, c.getName()), c.getJooqType())),
+            avg(field(name(alias(tableAlias), c.getName()), c.getJooqType())),
             SUM_FIELD,
-            sum(field(name(tableAlias, c.getName()), c.getJooqType())));
+            sum(field(name(alias(tableAlias), c.getName()), c.getJooqType())));
 
     SelectJoinStep aggQuery =
-        table.getJooq().select(aggField).from(tableWithInheritanceJoin(table).as(tableAlias));
+        table
+            .getJooq()
+            .select(aggField)
+            .from(tableWithInheritanceJoin(table).as(alias(tableAlias)));
 
     // filter on any filter settings
     if (column != null || filter != null || searchTerms.length > 1) {
@@ -691,7 +699,7 @@ public class SqlQuery extends QueryBean {
     return field(aggQuery).as(field.getColumn());
   }
 
-  private static Field jsonCountField(
+  private Field jsonCountField(
       SqlTableMetadata table,
       Column column,
       String tableAlias,
@@ -703,7 +711,7 @@ public class SqlQuery extends QueryBean {
       List<Condition> conditions = new ArrayList<>();
       if (filter != null || searchTerms.length > 1) {
         List<Field> pkeyFields = table.getPrimaryKeyFields();
-        if (pkeyFields.size() == 0) throw new MolgenisException("primary key not set");
+        if (pkeyFields.isEmpty()) throw new MolgenisException("primary key not set");
         conditions.add(
             row(pkeyFields)
                 .in(jsonFilterQuery(table, column, tableAlias, subAlias, filter, searchTerms)));
@@ -714,7 +722,7 @@ public class SqlQuery extends QueryBean {
                   table
                       .getJooq()
                       .select(count())
-                      .from(tableWithInheritanceJoin(table).as(subAlias))
+                      .from(tableWithInheritanceJoin(table).as(alias(subAlias)))
                       .where(conditions))
               .as(COUNT_FIELD);
     } else {
@@ -751,7 +759,7 @@ public class SqlQuery extends QueryBean {
     return result;
   }
 
-  private static SelectJoinStep<org.jooq.Record> refJoins(
+  private SelectJoinStep<org.jooq.Record> refJoins(
       TableMetadata table,
       String tableAlias,
       SelectJoinStep<org.jooq.Record> join,
@@ -772,7 +780,7 @@ public class SqlQuery extends QueryBean {
               // to ensure only join once
               aliasList.add(subAlias);
               // the join
-              join.leftJoin(tableWithInheritanceJoin(column.getRefTable()).as(subAlias))
+              join.leftJoin(tableWithInheritanceJoin(column.getRefTable()).as(alias(subAlias)))
                   .on(refJoinCondition(column, tableAlias, subAlias));
               // recurse
               join =
@@ -798,7 +806,7 @@ public class SqlQuery extends QueryBean {
           // only join if subselection extists
           if (!aliasList.contains(subAlias) && !select.getSubselect().isEmpty()) {
             aliasList.add(subAlias);
-            join.leftJoin(tableWithInheritanceJoin(column.getRefTable()).as(subAlias))
+            join.leftJoin(tableWithInheritanceJoin(column.getRefTable()).as(alias(subAlias)))
                 .on(refJoinCondition(column, tableAlias, subAlias));
             // recurse
             join =
@@ -816,30 +824,31 @@ public class SqlQuery extends QueryBean {
     return join;
   }
 
-  private static Condition refJoinCondition(Column column, String tableAlias, String subAlias) {
+  private Condition refJoinCondition(Column column, String tableAlias, String subAlias) {
     List<Condition> foreignKeyMatch = new ArrayList<>();
 
     if (column.isRef()) {
       if (column.getReferences().size() == 1) {
         Reference ref = column.getReferences().get(0);
         foreignKeyMatch.add(
-            field(name(subAlias, ref.getRefTo())).eq(field(name(tableAlias, ref.getName()))));
+            field(name(alias(subAlias), ref.getRefTo()))
+                .eq(field(name(alias(tableAlias), ref.getName()))));
       } else {
         foreignKeyMatch.add(
             and(
                 // at least one column not null
                 or(
                     column.getReferences().stream()
-                        .map(ref -> field(name(tableAlias, ref.getName())).isNotNull())
-                        .collect(Collectors.toList())),
+                        .map(ref -> field(name(alias(tableAlias), ref.getName())).isNotNull())
+                        .toList()),
                 // and matches on values or nulls
                 and(
                     column.getReferences().stream()
                         .map(
                             ref ->
-                                field(name(subAlias, ref.getRefTo()))
-                                    .eq(field(name(tableAlias, ref.getName()))))
-                        .collect(Collectors.toList()))));
+                                field(name(alias(subAlias), ref.getRefTo()))
+                                    .eq(field(name(alias(tableAlias), ref.getName()))))
+                        .toList())));
       }
     } else if (column.isRefArray()) {
       if (column.getReferences().size() == 1) {
@@ -847,22 +856,23 @@ public class SqlQuery extends QueryBean {
         // simple array comparison
         foreignKeyMatch.add(
             condition(
-                "{0} = ANY({1})", name(subAlias, ref.getRefTo()), name(tableAlias, ref.getName())));
+                "{0} = ANY({1})",
+                name(alias(subAlias), ref.getRefTo()), name(alias(tableAlias), ref.getName())));
       } else {
         // expensive 'in' query to enable join on all fields
-        List<Field> to =
+        List<Field<Object>> to =
             column.getReferences().stream()
-                .map(ref -> field(name(subAlias, ref.getRefTo()).toString()))
-                .collect(Collectors.toList());
+                .map(ref -> field(name(alias(subAlias), ref.getRefTo()).toString()))
+                .toList();
 
-        List<Field> unnest =
+        List<Field<Object>> unnest =
             column.getReferences().stream()
                 .map(
                     r ->
                         r.isOverlappingRef()
-                            ? field(name(tableAlias, r.getName()))
-                            : field("UNNEST({0})", name(tableAlias, r.getName())))
-                .collect(Collectors.toList());
+                            ? field(name(alias(tableAlias), r.getName()))
+                            : field("UNNEST({0})", name(alias(tableAlias), r.getName())))
+                .toList();
         foreignKeyMatch.add(row(to).in(DSL.select(unnest)));
       }
     } else if (column.isRefback()) {
@@ -872,22 +882,22 @@ public class SqlQuery extends QueryBean {
             refBack.getReferences().stream()
                 .map(
                     ref ->
-                        field(name(subAlias, ref.getName()))
-                            .eq(field(name(tableAlias, ref.getRefTo()))))
-                .collect(Collectors.toList()));
+                        field(name(alias(subAlias), ref.getName()))
+                            .eq(field(name(alias(tableAlias), ref.getRefTo()))))
+                .toList());
       } else if (refBack.isRefArray()) {
         foreignKeyMatch.addAll(
             refBack.getReferences().stream()
                 .map(
                     ref ->
                         ref.isOverlappingRef()
-                            ? field(name(tableAlias, ref.getRefTo()))
-                                .eq(field(name(subAlias, ref.getName())))
+                            ? field(name(alias(tableAlias), ref.getRefTo()))
+                                .eq(field(name(alias(subAlias), ref.getName())))
                             : condition(
                                 ANY_SQL,
-                                field(name(tableAlias, ref.getRefTo())),
-                                field(name(subAlias, ref.getName()))))
-                .collect(Collectors.toList()));
+                                field(name(alias(tableAlias), ref.getRefTo())),
+                                field(name(alias(subAlias), ref.getName()))))
+                .toList());
       }
     } else {
       throw new SqlQueryException(
@@ -899,7 +909,7 @@ public class SqlQuery extends QueryBean {
     return and(foreignKeyMatch);
   }
 
-  private static Condition whereConditions(
+  private Condition whereConditions(
       TableMetadata table, String tableAlias, Filter filter, String[] searchTerms) {
     Condition searchCondition = whereConditionSearch(table, tableAlias, searchTerms);
     Condition filterCondition = whereConditionsFilter(table, tableAlias, filter);
@@ -915,8 +925,7 @@ public class SqlQuery extends QueryBean {
     }
   }
 
-  private static Condition whereConditionsFilter(
-      TableMetadata table, String tableAlias, Filter filters) {
+  private Condition whereConditionsFilter(TableMetadata table, String tableAlias, Filter filters) {
     List<Condition> conditions = new ArrayList<>();
 
     if (Operator.OR.equals(filters.getOperator())) {
@@ -924,25 +933,23 @@ public class SqlQuery extends QueryBean {
           or(
               filters.getSubfilters().stream()
                   .map(f -> whereConditionsFilter(table, tableAlias, f))
-                  .collect(Collectors.toList())));
+                  .toList()));
     } else if (Operator.AND.equals(filters.getOperator())) {
       conditions.add(
           and(
               filters.getSubfilters().stream()
                   .map(f -> whereConditionsFilter(table, tableAlias, f))
-                  .collect(Collectors.toList())));
+                  .toList()));
     } else {
       Column column = isValidColumn(table, filters.getColumn());
-      if (filters.getSubfilters().size() > 0) {
+      if (!filters.getSubfilters().isEmpty()) {
         for (Filter subfilter : filters.getSubfilters()) {
           if (column.isReference()) {
-
             conditions.add(
                 whereConditionsFilter(
                     column.getRefTable(), tableAlias + "-" + column.getName(), subfilter));
           } else if (column.isFile()) {
             Filter sub = filters.getSubfilter("id");
-            // todo expand properly
             if (sub != null && EQUALS.equals(sub.getOperator())) {
               conditions.add(field(name(column.getName())).in(sub.getValues()));
             } else {
@@ -963,17 +970,15 @@ public class SqlQuery extends QueryBean {
     return conditions.isEmpty() ? null : and(conditions);
   }
 
-  private static Condition whereCondition(
+  private Condition whereCondition(
       String tableAlias,
       String columnName,
       ColumnType type,
       org.molgenis.emx2.Operator operator,
       Object[] values) {
-    Name name = name(tableAlias, columnName);
+    Name name = name(alias(tableAlias), columnName);
     switch (type) {
-      case TEXT:
-      case STRING:
-      case FILE:
+      case TEXT, STRING, FILE:
         return whereConditionText(name, operator, toStringArray(values));
       case BOOL:
         return whereConditionEquals(name, operator, toBoolArray(values));
@@ -989,8 +994,7 @@ public class SqlQuery extends QueryBean {
         return whereConditionOrdinal(name, operator, toDateArray(values));
       case DATETIME:
         return whereConditionOrdinal(name, operator, toDateTimeArray(values));
-      case STRING_ARRAY:
-      case TEXT_ARRAY:
+      case STRING_ARRAY, TEXT_ARRAY:
         return whereConditionTextArray(name, operator, toStringArray(values));
       case BOOL_ARRAY:
         return whereConditionArrayEquals(name, operator, toBoolArray(values));
@@ -1156,8 +1160,7 @@ public class SqlQuery extends QueryBean {
     boolean not = false;
     for (int i = 0; i < values.length; i++) {
       switch (operator) {
-        case EQUALS:
-        case NOT_EQUALS:
+        case EQUALS, NOT_EQUALS:
           return whereConditionEquals(columnName, operator, values);
         case NOT_BETWEEN:
           not = true;
@@ -1201,7 +1204,7 @@ public class SqlQuery extends QueryBean {
     else return or(conditions);
   }
 
-  private static Condition whereConditionSearch(
+  private Condition whereConditionSearch(
       TableMetadata table, String tableAlias, String[] searchTerms) {
     List<Condition> searchConditions = new ArrayList<>();
     while (table != null) {
@@ -1210,7 +1213,8 @@ public class SqlQuery extends QueryBean {
       for (String term : searchTerms) {
         for (String subTerm : term.split(" ")) {
           subTerm = subTerm.trim();
-          Field<Object> field = field(name(tableAlias, searchColumnName(table.getTableName())));
+          Field<Object> field =
+              field(name(alias(tableAlias), searchColumnName(table.getTableName())));
           // short terms with 'like', longer with trigram
           subConditions.add(field.likeIgnoreCase("%" + subTerm + "%"));
         }
@@ -1262,14 +1266,14 @@ public class SqlQuery extends QueryBean {
       }
       // is file?
       for (Column c : table.getColumns()) {
-        if (c.isFile() && columnName.startsWith(c.getName())) {
-          if (columnName.equals(c.getName())
-              || columnName.endsWith("_mimetype")
-              || columnName.endsWith("_extension")
-              || columnName.endsWith("_size")
-              || columnName.endsWith("_contents")) {
-            return new Column(table, columnName);
-          }
+        if (c.isFile()
+            && columnName.startsWith(c.getName())
+            && (columnName.equals(c.getName())
+                || columnName.endsWith("_mimetype")
+                || columnName.endsWith("_extension")
+                || columnName.endsWith("_size")
+                || columnName.endsWith("_contents"))) {
+          return new Column(table, columnName);
         }
       }
       throw new MolgenisException(


### PR DESCRIPTION
In SqlQuery we used concatenation of table names within the query as table alias for subqueries. When table names are long, or graphql query is deep then this table alias becomes longer than postgresql allows (64 characters on most servers). In this pull request we replace these aliases with short alias of the form a1, a2, a3, etc.

To test
* upload a data model with long table names
* for example from #798 => go to table view for RepeatedTargetTables

