### PR TITLE
Fix: check for table length was incorrect

### DIFF
--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestAddColumnUpdateSearchTrigger.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestAddColumnUpdateSearchTrigger.java
@@ -23,7 +23,7 @@ public class TestAddColumnUpdateSearchTrigger {
     Schema schema = db.dropCreateSchema(TestAddColumnUpdateSearchTrigger.class.getSimpleName());
     table =
         schema.create(
-            table("TestAddColumnUpdateSearchTrigger")
+            table("TestAddColUpdateSearchTrigger")
                 .add(column("col1").setPkey())
                 .add(column("col2").setType(STRING)));
 

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestMergeAlter.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestMergeAlter.java
@@ -294,7 +294,7 @@ public class TestMergeAlter {
 
   private void executeAlterType(
       ColumnType fromType, Object fromVal, ColumnType toType, Object toVal, boolean roundtrip) {
-    String tableName = "TEST_ALTER_" + fromType.toString() + "_TO_" + toType.toString();
+    String tableName = "TMA_" + fromType.toString() + "_" + toType.toString();
     schema.create(
         new TableMetadata(tableName).add(column("id").setPkey(), column("col1").setType(fromType)));
     schema.getTable(tableName).insert(new Row().set("id", "test1").set("col1", fromVal));

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -12,6 +12,8 @@ import org.jooq.impl.DSL;
 
 public class TableMetadata implements Comparable {
 
+  public static final String TABLE_NAME_MESSAGE =
+      ": Table name must start with a letter, followed by letters, underscores, a space or numbers, i.e. [a-zA-Z][a-zA-Z0-9_]*. Maximum length: 31 characters (so it fits in Excel sheet names)";
   // if a table extends another table (optional)
   public String inherit = null;
   // to allow indicate that a table should be dropped
@@ -45,11 +47,12 @@ public class TableMetadata implements Comparable {
   public TableMetadata(String tableName) {
     // max length 31 because of Excel
     // we allow only graphql compatible names PLUS spaces
-    if (!tableName.matches("[a-zA-Z][a-zA-Z0-9_ ]*") || tableName.length() > 31) {
+    if (!tableName.matches("[a-zA-Z][a-zA-Z0-9_ ]*")) {
+      throw new MolgenisException("Invalid table name '" + tableName + TABLE_NAME_MESSAGE);
+    }
+    if (tableName.length() > 31) {
       throw new MolgenisException(
-          "Invalid table name '"
-              + tableName
-              + "': Table name must start with a letter , followed by letters, underscores, a space or numbers, i.e. [a-zA-Z][a-zA-Z0-9_]*. Maximum length: 31 characters (so it fits in Excel sheet names)");
+          "Table name '" + tableName + "' is too long" + TABLE_NAME_MESSAGE);
     }
     if (tableName.contains("_ ") || tableName.contains(" _")) {
       throw new MolgenisException(

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -43,7 +43,9 @@ public class TableMetadata implements Comparable {
   private String[] semantics = null;
 
   public TableMetadata(String tableName) {
-    if (!tableName.matches("[a-zA-Z][a-zA-Z0-9_ ]*") || tableName.length() > 341) {
+    // max length 31 because of Excel
+    // we allow only graphql compatible names PLUS spaces
+    if (!tableName.matches("[a-zA-Z][a-zA-Z0-9_ ]*") || tableName.length() > 31) {
       throw new MolgenisException(
           "Invalid table name '"
               + tableName


### PR DESCRIPTION
Note: some test cases also had too long table names. This means that these tests fail unless you have a clean database.
So that is a caveat for developers to consider.