### PR TITLE
chore: fix dead link OIDC integration (sidebar)

### DIFF
--- a/docs/molgenis/_sidebar.md
+++ b/docs/molgenis/_sidebar.md
@@ -17,7 +17,7 @@
     - [Run with docker compose](run_docker.md)
     - [Run in kubernetes cloud](run_helm.md)
     - [Updating your MOLGENIS](run_updates.md)
-    - [OIDC integration](user_permissions.md)
+    - [OIDC integration](use_permissions.md)
 - **Developer guide**
     - [How to build](dev_quickstart.md)
     - [Architecture](dev_architecture.md)


### PR DESCRIPTION
fix dead link OIDC integration (sidebar) in documentation