### PR TITLE
chore: ignore vue 3 major change

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,18 @@
 {
   "extends": [
     "config:base"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["vue"],
+      "allowedVersions": ">=2.6"
+    },    {
+      "matchPackageNames": ["vue-router"],
+      "allowedVersions": ">=3.5"
+    },
+    {
+      "matchPackageNames": ["vuex"],
+      "allowedVersions": ">=3.6"
+    }
   ]
 }


### PR DESCRIPTION
All components need to be migrated to vue 3 before using the vue framework