### PR TITLE
fix: when linking from central to schema then first menu item should be selected

### DIFF
--- a/apps/central/src/components/Groups.vue
+++ b/apps/central/src/components/Groups.vue
@@ -135,7 +135,7 @@ export default {
   },
   methods: {
     openGroup(name) {
-      window.open("/" + name + "/tables/", "_self");
+      window.open("/" + name, "_self");
     },
     openCreateSchema() {
       this.showCreateSchema = true;

--- a/apps/central/src/components/Groups.vue
+++ b/apps/central/src/components/Groups.vue
@@ -44,9 +44,7 @@
               </div>
             </td>
             <td>
-              <a href="#" @click.prevent="openGroup(schema.name)">{{
-                schema.name
-              }}</a>
+              <a :href="'/' + schema.name">{{ schema.name }}</a>
             </td>
             <td>
               {{ schema.description }}
@@ -134,9 +132,6 @@ export default {
     this.getSchemaList();
   },
   methods: {
-    openGroup(name) {
-      window.open("/" + name, "_self");
-    },
     openCreateSchema() {
       this.showCreateSchema = true;
     },


### PR DESCRIPTION
To test:
* change menu of a database such that e.g. 'schema' is the first menu item
* then go back to 'list databases' and select your database again
* you should then see 'schema'