### PR TITLE
fix: queries fail on large tables (e.g. Databanks)

### DIFF
--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQueryJsonGraph.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQueryJsonGraph.java
@@ -184,6 +184,7 @@ public class TestQueryJsonGraph {
     PetStoreExample.populate(schema);
 
     String json = schema.query("Order_agg", s("max", s("quantity"))).retrieveJSON();
+    assertTrue(json.contains("{\"Order_agg\": {\"max\": {\"quantity\": 7}}}"));
   }
 
   // todo @Test

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQueryJsonGraph.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQueryJsonGraph.java
@@ -105,7 +105,7 @@ public class TestQueryJsonGraph {
 
     result = s.retrieveJSON();
     System.out.println(result);
-    assertTrue(result.contains("\"children\" : [{\"name\" : \"kind\"}]}"));
+    assertTrue(result.contains("\"children\": [{\"name\": \"kind\"}]}"));
 
     // smoke test limit offset
     s = schema.getTable("Person").query();

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestRefBack.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestRefBack.java
@@ -132,18 +132,18 @@ public class TestRefBack {
     System.out.println(query.retrieveJSON());
 
     query = parts.agg(s("count"));
-    assertTrue(query.retrieveJSON().contains("\"count\" : 5"));
+    assertTrue(query.retrieveJSON().contains("\"count\": 5"));
 
     query = products.agg(s("count"));
-    assertTrue(query.retrieveJSON().contains("\"count\" : 2"));
+    assertTrue(query.retrieveJSON().contains("\"count\": 2"));
 
     query = products.select(s("parts_agg", s("count"))).where(f("productname", EQUALS, "bigphone"));
 
-    assertTrue(query.retrieveJSON().contains("\"count\" : 3"));
+    assertTrue(query.retrieveJSON().contains("\"count\": 3"));
 
     query = parts.select(s("products_agg", s("count"))).where(f("partname", EQUALS, "battery"));
 
-    assertTrue(query.retrieveJSON().contains("\"count\" : 2"));
+    assertTrue(query.retrieveJSON().contains("\"count\": 2"));
 
     query = products.select(s("parts", s("partname")));
     System.out.println(query.retrieveJSON());
@@ -220,7 +220,7 @@ public class TestRefBack {
 
     // check graph query
     Query query = users.agg(s("count"));
-    assertTrue(query.retrieveJSON().contains("\"count\" : 2"));
+    assertTrue(query.retrieveJSON().contains("\"count\": 2"));
 
     query =
         users
@@ -229,7 +229,7 @@ public class TestRefBack {
     assertTrue(query.retrieveJSON().contains("jacks post"));
 
     query = users.agg(s("count")).where(f("posts", f("title", EQUALS, "jacks post")));
-    assertTrue(query.retrieveJSON().contains("\"count\" : 1"));
+    assertTrue(query.retrieveJSON().contains("\"count\": 1"));
 
     // delete of user should fail as long as there are posts refering to this user, unless cascading
     // delete


### PR DESCRIPTION
caused by psql json_object() receiving >100 params

e.g. https://github.com/hasura/graphql-engine/issues/4004

n.b. arbitrary formatting changes required fixing of tests.