### PR TITLE
chore: remove unused mockito dependency

### DIFF
--- a/backend/molgenis-emx2-webapi/build.gradle
+++ b/backend/molgenis-emx2-webapi/build.gradle
@@ -11,7 +11,5 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.9.3'
     implementation 'com.squareup.okhttp3:okhttp-brotli:4.9.3'
     testImplementation 'io.rest-assured:rest-assured:4.5.1'
-    testImplementation 'org.mockito:mockito-core:3.+'
-    testImplementation 'org.mockito:mockito-inline:3.+'
     implementation 'io.bit3:jsass:5.10.4'
 }


### PR DESCRIPTION
motivation: was breaking github action (because that one is not cached I suppose)