### PR TITLE
Retrieve precompiled theme when theme compilation fails

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BootstrapThemeService.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BootstrapThemeService.java
@@ -1,12 +1,15 @@
 package org.molgenis.emx2.web;
 
-import static org.molgenis.emx2.web.MolgenisWebservice.getSchema;
-import static org.molgenis.emx2.web.MolgenisWebservice.logger;
-import static spark.Spark.get;
-
 import io.bit3.jsass.Compiler;
 import io.bit3.jsass.Options;
 import io.bit3.jsass.importer.Import;
+import org.apache.commons.io.IOUtils;
+import org.jetbrains.annotations.NotNull;
+import org.molgenis.emx2.MolgenisException;
+import org.molgenis.emx2.Schema;
+import spark.Request;
+import spark.Response;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -21,12 +24,10 @@ import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.commons.io.IOUtils;
-import org.jetbrains.annotations.NotNull;
-import org.molgenis.emx2.MolgenisException;
-import org.molgenis.emx2.Schema;
-import spark.Request;
-import spark.Response;
+
+import static org.molgenis.emx2.web.MolgenisWebservice.getSchema;
+import static org.molgenis.emx2.web.MolgenisWebservice.logger;
+import static spark.Spark.get;
 
 public class BootstrapThemeService {
   private static final String HEX_WEBCOLOR_PATTERN = "^#([a-fA-F0-9]{6}|[a-fA-F0-9]{3})$";
@@ -99,14 +100,41 @@ public class BootstrapThemeService {
         String.format(
             "$theme-colors:(%nprimary: %s, %nsecondary: %s%n);%n%n@import 'theme.scss'",
             primaryColor, secondaryColor);
-    Compiler compiler = new Compiler();
-    Options options = new Options();
-    options.setImporters(Collections.singleton(BootstrapThemeService::doScssImport));
+    Compiler compiler;
     try {
+      // new Compiler() fails with java.lang.UnsatisfiedLinkError or java.lang.NoClassDefFoundError
+      // if the required OS dependencies (system libraries or NativeAdapter) cannot be resolved
+      compiler = new Compiler();
+      Options options = new Options();
+      options.setImporters(Collections.singleton(BootstrapThemeService::doScssImport));
       return compiler.compileString(input, options).getCss();
-    } catch (Exception e) {
+    } catch (Throwable e) {
+      logger.error(e.getMessage());
       logger.error(String.format("SASS compilation failed, input was:%n%s", input));
-      throw new MolgenisException("SASS compilation failed", e);
+      return retrieveThemeFromServer();
+    }
+  }
+
+  /**
+   * If local compilation of the theme CSS fails, retrieve a precompiled default theme CSS from an
+   * online EMX2 instance. If the retrieval also fails, log the error and return null, resulting in
+   * no theme available for styling the app.
+   *
+   * @return String containing theme CSS for styling the EMX2 app, or null if retrieval fails.
+   * @throws IOException
+   */
+  public static String retrieveThemeFromServer() {
+    try {
+      return new Scanner(
+              new URL("https://emx2.test.molgenis.org/apps/central/theme.css").openStream(),
+              "UTF-8")
+          .useDelimiter("\\A")
+          .next();
+    } catch (Exception e) {
+      logger.error(
+          "Fallback theme could not be retrieved because device is not connected to internet or server is unreachable.");
+      logger.error(e.getMessage());
+      return null;
     }
   }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BootstrapThemeService.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BootstrapThemeService.java
@@ -121,7 +121,6 @@ public class BootstrapThemeService {
    * no theme available for styling the app.
    *
    * @return String containing theme CSS for styling the EMX2 app, or null if retrieval fails.
-   * @throws IOException
    */
   public static String retrieveThemeFromServer() {
     try {


### PR DESCRIPTION
Implemented a fallback mechanism where a precompiled theme CSS is retrieved from EMX2 server when CSS compilation fails because of missing OS dependencies. Does not change normal app behaviour and does not cause problems when the precompiled theme cannot be retrieved for any reason.
