### PR TITLE
fix: fix broken deleteAll

### DIFF
--- a/backend/molgenis-emx2-run/src/main/java/org/molgenis/emx2/AToolToCleanDatabase.java
+++ b/backend/molgenis-emx2-run/src/main/java/org/molgenis/emx2/AToolToCleanDatabase.java
@@ -19,11 +19,12 @@ public class AToolToCleanDatabase {
   public static void deleteAll() {
     SqlDatabase db = new SqlDatabase(true);
     jooq = db.getJooq();
+    db.becomeAdmin();
     jooq.dropSchemaIfExists("MOLGENIS").cascade().execute();
     deleteAllForeignKeyConstraints();
     deleteAllSchemas();
     deleteAllRoles();
-    db = new SqlDatabase(true);
+    new SqlDatabase(true);
   }
 
   private static void deleteAllRoles() {


### PR DESCRIPTION
due to changes in the user management, the deleteAll function stopt working
by making the user the admim the tool has the rights it needs to delete everything