### PR TITLE
fix(catalogue): Fix 1137

### DIFF
--- a/apps/catalogue/src/components/VariableDetails.vue
+++ b/apps/catalogue/src/components/VariableDetails.vue
@@ -54,7 +54,7 @@
           <span v-else>none</span>
         </dd>
 
-        <template v-if="showMappedBy">
+        <template v-if="showMappedBy && !variableDetails.repeats">
           <dt class="col-2">mapped by</dt>
           <dd class="col-10">
             <span v-if="variableDetails.mappings">


### PR DESCRIPTION
When viewing a single repeated variable detail, do not show the mapped by field,
The mappedBy status is displayed in the table

Closes #1137