### PR TITLE
fix: in table explorer refback columns had template error when names …

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Column.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Column.java
@@ -52,7 +52,7 @@ public class Column {
         column.getRefSchema().equals(column.getSchemaName()) ? null : column.getRefSchema();
     this.refTable = column.getRefTableName();
     this.refLink = column.getRefLink();
-    this.refLabel = column.getRefLabel();
+    this.refLabel = escape(column.getRefLabel());
     // this.cascadeDelete = column.isCascadeDelete();
     this.refBack = column.getRefBack();
     this.validation = column.getValidation();


### PR DESCRIPTION
…with spaces