### PR TITLE
feature: added prototype of per network catalogue; included small fixes

### DIFF
--- a/apps/catalogue/src/components/VariableDetails.vue
+++ b/apps/catalogue/src/components/VariableDetails.vue
@@ -58,11 +58,8 @@
           <dt class="col-2">mapped by</dt>
           <dd class="col-10">
             <span v-if="variableDetails.mappings">
-              <span
-                v-for="mapping in variableDetails.mappings"
-                :key="mapping.fromTable.dataDictionary.pid"
-              >
-                {{ mapping.fromTable.dataDictionary.resource.pid }}
+              <span v-for="cohort in mappedByCohorts" :key="cohort">
+                {{ cohort }}
               </span>
             </span>
             <span v-else>none</span>
@@ -88,6 +85,12 @@ export default {
       return this.variableDetails.permittedValues
         .map((pv) => pv) // clone to avoid prop mutation
         .sort((a, b) => a.order <= b.order);
+    },
+    mappedByCohorts() {
+      //order alphabetically
+      return this.variableDetails.mappings
+        .map((mapping) => mapping.fromTable.dataDictionary.resource.pid)
+        .sort();
     },
   },
 };

--- a/apps/catalogue/src/components/VariableListItem.vue
+++ b/apps/catalogue/src/components/VariableListItem.vue
@@ -22,6 +22,23 @@
     </div>
     <p class="mt-3" v-if="showDetail">
       <router-link
+        v-if="network"
+        class="nav-link"
+        :to="{
+          name: 'NetworkVariableDetailView',
+          params: {
+            name: variable.name,
+            network: network,
+          },
+          query: {
+            model: variable.dataDictionary.resource.pid,
+            version: variable.dataDictionary.version,
+          },
+        }"
+        >view details
+      </router-link>
+      <router-link
+        v-else
         class="nav-link"
         :to="{
           name: 'VariableDetailView',
@@ -119,6 +136,7 @@ export default {
   components: { Spinner },
   props: {
     variable: Object,
+    network: String,
   },
   data() {
     return {

--- a/apps/catalogue/src/components/harmonization/HarmonizationCell.vue
+++ b/apps/catalogue/src/components/harmonization/HarmonizationCell.vue
@@ -14,13 +14,13 @@ export default {
     iconClass() {
       switch (this.status) {
         case "unmapped":
-          return "fa-question";
+          return "fa-none";
         case "partial":
           return "fa-percent";
         case "complete":
           return "fa-check";
         default:
-          return "fa-question";
+          return "fa-none";
       }
     },
     tableClass() {

--- a/apps/catalogue/src/main.js
+++ b/apps/catalogue/src/main.js
@@ -5,7 +5,6 @@ import store from "./store/store";
 import CatalogueView from "./views/CatalogueView";
 import ResourceDetailsView from "./views/ResourceDetailsView";
 import TableView from "./views/TableView";
-import NetworkView from "./views/NetworkView";
 import ResourceListView from "./views/ResourceListView";
 import VariableView from "./views/VariableView";
 import VariableMappingsView from "./views/VariableMappingsView";
@@ -18,6 +17,8 @@ import SearchResourceView from "./views/SearchResourceView";
 import ResourceRedirectView from "./views/ResourceRedirectView";
 import Subcohort from "./views/cohorts/Subcohort";
 import CollectionEvent from "./views/cohorts/CollectionEvent";
+import NetworksHome from "./network/NetworksHome";
+import NetworkVariables from "./network/NetworkVariables";
 
 Vue.config.productionTip = false;
 
@@ -64,7 +65,7 @@ const router = new VueRouter({
     },
     {
       name: "Networks",
-      path: "/networks",
+      path: "/networksold",
       props: (route) => ({
         searchTerm: route.query.q,
         tableName: "Networks",
@@ -183,7 +184,7 @@ const router = new VueRouter({
     },
     {
       name: "Networks-details",
-      path: "/networks/:pid",
+      path: "/networksold/:pid",
       component: ResourceDetailsView,
       props: (route) => ({
         table: "Networks",
@@ -260,7 +261,7 @@ const router = new VueRouter({
     },
     {
       name: "network",
-      path: "/networks/:pid",
+      path: "/networksold/:pid",
       component: ResourceDetailsView,
       props: (route) => ({
         table: "Networks",
@@ -392,6 +393,23 @@ const router = new VueRouter({
       // hacky redirects to solve breadcrumb issue
       path: "/cohorts/:cohort/subcohorts",
       redirect: "/cohorts/:cohort",
+    },
+    {
+      name: "NetworkLandingPage",
+      path: "/networks",
+      component: NetworksHome,
+    },
+    {
+      name: "NetworkVariables",
+      path: "/networks/:network",
+      props: true,
+      component: NetworkVariables,
+    },
+    {
+      name: "NetworkVariableDetailView",
+      path: "/networks/:network/:name",
+      props: (route) => ({ ...route.params, ...route.query }), // both key and value are dynamic
+      component: VariableDetailView,
     },
   ],
 });

--- a/apps/catalogue/src/network/NetworkVariables.vue
+++ b/apps/catalogue/src/network/NetworkVariables.vue
@@ -1,0 +1,27 @@
+<template>
+  <div class="container-fluid">
+    <div class="container-fluid bg-white">
+      <h1>{{ network }} harmonized variables</h1>
+      <p>
+        This page lists all variables harmonized in the {{ network }} network.
+        You can search and filter variables, and drill down to see their
+        harmonization details.
+      </p>
+    </div>
+    <VariableExplorer :network="network" class="mt-2" />
+  </div>
+</template>
+
+<script>
+import VariableExplorer from "../views/VariableExplorer";
+
+export default {
+  components: { VariableExplorer },
+  props: {
+    network: {
+      type: String,
+      required: true,
+    },
+  },
+};
+</script>

--- a/apps/catalogue/src/network/NetworksHome.vue
+++ b/apps/catalogue/src/network/NetworksHome.vue
@@ -1,0 +1,61 @@
+<template>
+  <div class="container">
+    <h1>Welcome at the European cohort network catalogue.</h1>
+    <p>Choose a network below to explore.</p>
+    <div class="card-deck">
+      <div class="card p-4">
+        <img
+          src="https://lifecycle-project.eu/wp-content/uploads/2020/03/euchild_logo-e1583949892302.jpg"
+          class="card-img-top"
+          style="max-width: 300px"
+          alt="..."
+        />
+        <div class="card-body">
+          <h5 class="card-title">EUChildNetwork</h5>
+          <p>
+            A Europe-wide network of cohort studies started in early life Cohort
+            studies started from pregnancy or childhood give the unique
+            opportunity to relate early-life stressors with variation in
+            development, health and disease throughout the life course.
+          </p>
+          <a href="#" class="btn btn-primary disabled">View cohorts</a>
+          <RouterLink
+            class="btn btn-primary ml-2"
+            :to="{ name: 'NetworkVariables', params: { network: 'LifeCycle' } }"
+            >View variables
+          </RouterLink>
+        </div>
+      </div>
+      <div class="card p-4">
+        <img
+          src="https://h2020-remedia.eu/wp-content/themes/lbs/images/ehen-European-Human-Exposome-Network-medium-logo.png"
+          class="card-img-top"
+          alt="..."
+        />
+        <div class="card-body">
+          <h5 class="card-title">European Human Exposome Network</h5>
+          <p>
+            The European Human Exposome Network brings together research
+            projects studying the impact of environmental exposure on human
+            health. These projects address issues such as exposures to air
+            quality, noise, chemicals, urbanisation etc. and health impacts.
+          </p>
+          <a href="#" class="btn btn-primary disabled">View cohorts</a>
+          <a href="#" class="btn btn-primary ml-2 disabled">View variables</a>
+        </div>
+      </div>
+    </div>
+    <p>
+      This catalogue was made possible by EUCAN-connect, EU-LifeCycle,
+      EU-Athlete and EU-LongITools, in collaboration with members of European
+      Human Exposome Network.
+    </p>
+  </div>
+</template>
+
+<style>
+.card-img-top {
+  width: 100%;
+  object-fit: contain;
+}
+</style>

--- a/apps/catalogue/src/store/actions.js
+++ b/apps/catalogue/src/store/actions.js
@@ -16,7 +16,7 @@ export default {
     state.isLoading = true;
     const query = gql`
             query TargetVariables($search: String, $filter: TargetVariablesFilter) {
-                TargetVariables(limit: 100, offset: ${offset}, search: $search, filter: $filter) {
+                TargetVariables(limit: 100, offset: ${offset}, search: $search, filter: $filter, orderby:{label: ASC}) {
                     name
                     dataDictionary {
                         resource {
@@ -54,6 +54,19 @@ export default {
         }),
       };
     }
+
+    if (getters.selectedCohorts.length) {
+      queryVariables.filter.mappings = {
+        fromDataDictionary: {
+          resource: {
+            pid: {
+              equals: getters.selectedCohorts.map((cohort) => cohort.pid),
+            },
+          },
+        },
+      };
+    }
+    console.log(JSON.stringify(queryVariables));
 
     if (getters.selectedKeywords.length) {
       queryVariables.filter.keywords = {
@@ -144,7 +157,10 @@ export default {
 
     const mappingQuery = gql`
       query VariableMappings($filter: VariableMappingsFilter) {
-        VariableMappings(filter: $filter) {
+        VariableMappings(
+          filter: $filter
+          orderby: { fromDataDictionary: ASC }
+        ) {
           fromTable {
             dataDictionary {
               resource {

--- a/apps/catalogue/src/store/getters.js
+++ b/apps/catalogue/src/store/getters.js
@@ -26,6 +26,10 @@ export default {
     return state.filters.find((filters) => filters.name === "networks")
       .conditions;
   },
+  selectedCohorts: (state) => {
+    return state.filters.find((filters) => filters.name === "cohorts")
+      .conditions;
+  },
   resources: (state) => state.resources,
   /**
    * @returns Grid like object o[x][y], where;

--- a/apps/catalogue/src/store/mutations.js
+++ b/apps/catalogue/src/store/mutations.js
@@ -27,6 +27,10 @@ export default {
     state.filters.find((f) => f.name === "networks").conditions =
       selectedNetworks;
   },
+  setSelectedCohorts(state, selectedCohorts) {
+    state.filters.find((f) => f.name === "cohorts").conditions =
+      selectedCohorts;
+  },
   setSelectedKeywords(state, selectedKeywords) {
     state.filters.find((f) => f.name === "keywords").conditions =
       selectedKeywords;

--- a/apps/catalogue/src/store/query/resources.gql
+++ b/apps/catalogue/src/store/query/resources.gql
@@ -1,5 +1,5 @@
 query Resources {
-    Resources {
+    Resources(orderby:{pid: ASC}) {
         pid
         name
         mg_tableclass

--- a/apps/catalogue/src/store/state.js
+++ b/apps/catalogue/src/store/state.js
@@ -14,6 +14,10 @@ const state = {
       name: "networks",
       conditions: [],
     },
+    {
+      name: "cohorts",
+      conditions: [],
+    },
   ],
   resources: [],
   variableMappings: {},

--- a/apps/catalogue/src/views/SingleVarDetailsView.vue
+++ b/apps/catalogue/src/views/SingleVarDetailsView.vue
@@ -20,12 +20,6 @@
               /></span>
               = partial,
             </span>
-            <span
-              ><span class="table-light"
-                ><i class="fa fa-fw fa-question"
-              /></span>
-              = unharmonized</span
-            >
           </caption>
           <thead>
             <tr>

--- a/apps/catalogue/src/views/SingleVarHarmonizationView.vue
+++ b/apps/catalogue/src/views/SingleVarHarmonizationView.vue
@@ -3,25 +3,23 @@
     <ul v-if="variable" class="nav nav-tabs">
       <li
         class="nav-item"
-        v-for="mapping in variable.mappings"
-        :key="mapping.fromTable.dataDictionary.resource.pid"
+        v-for="resource in resourceListSorted"
+        :key="resource"
       >
         <router-link
           class="nav-link"
           :class="{
-            active:
-              $route.query.sourceCohort ===
-              mapping.fromTable.dataDictionary.resource.pid,
+            active: $route.query.sourceCohort === resource,
           }"
           :to="{
-            name: 'VariableDetailView',
+            path: $route.path,
             query: {
               ...$route.query,
-              sourceCohort: mapping.fromTable.dataDictionary.resource.pid,
+              sourceCohort: resource,
             },
           }"
         >
-          {{ mapping.fromTable.dataDictionary.resource.pid }}
+          {{ resource }}
         </router-link>
       </li>
     </ul>
@@ -47,6 +45,17 @@ export default {
     version: String,
     variable: Object,
   },
+  computed: {
+    resourceListSorted() {
+      if (this.variable.mappings) {
+        return this.variable.mappings
+          .map((m) => m.fromTable.dataDictionary.resource.pid)
+          .sort();
+      } else {
+        return [];
+      }
+    },
+  },
   async created() {
     // initialy select the first mapping
     if (
@@ -55,7 +64,7 @@ export default {
       !this.$route.query.sourceCohort
     ) {
       this.$router.replace({
-        name: "VariableDetailView",
+        path: this.$route.path,
         query: {
           ...this.$route.query,
           sourceCohort:

--- a/apps/catalogue/src/views/VariableDetailView.vue
+++ b/apps/catalogue/src/views/VariableDetailView.vue
@@ -7,7 +7,7 @@
           class="nav-link"
           :class="{ active: $route.query.tab !== 'harmonization' }"
           :to="{
-            name: 'VariableDetailView',
+            path: this.$route.path,
             query: { ...$route.query, tab: 'detail' },
           }"
         >
@@ -19,7 +19,7 @@
           class="nav-link"
           :class="{ active: $route.query.tab === 'harmonization' }"
           :to="{
-            name: 'VariableDetailView',
+            path: this.$route.path,
             query: { ...$route.query, tab: 'harmonization' },
           }"
         >

--- a/apps/catalogue/src/views/VariableExplorer.vue
+++ b/apps/catalogue/src/views/VariableExplorer.vue
@@ -3,8 +3,14 @@
     <div class="row">
       <div class="col-6 col-sm-5 col-md-4 col-lg-3">
         <h5>Filters</h5>
-        <h6 class="mt-3">Networks</h6>
-        <input-ref table="Networks" v-model="networks" :list="true"></input-ref>
+        <div v-if="!network" class="bg-white">
+          <h6 class="mt-3">Networks</h6>
+          <input-ref
+            table="Networks"
+            v-model="networks"
+            :list="true"
+          ></input-ref>
+        </div>
         <template v-if="hasKeywords">
           <h6 class="mt-3">Topics</h6>
           <InputOntology
@@ -14,54 +20,68 @@
             :show-expanded="true"
           />
         </template>
+        <h6 class="mt-3">Cohorts</h6>
+        <input-ref
+          table="Cohorts"
+          v-model="cohorts"
+          :list="true"
+          :maxNum="100"
+          :orderBy="{ pid: 'ASC' }"
+        ></input-ref>
       </div>
       <div class="col-6 col-sm-7 col-md-8 col-lg-9">
-        <div class="row">
-          <div class="col-3">
-            <h3>
-              Variables <span v-if="variableCount">({{ variableCount }})</span>
-            </h3>
+        <div class="ml-2">
+          <div class="row">
+            <div class="col-3">
+              <h3>
+                Variables
+                <span v-if="variableCount">({{ variableCount }})</span>
+              </h3>
+            </div>
+            <div class="col-9">
+              <InputSearch
+                v-model="searchInput"
+                placeholder="Search variables"
+              />
+            </div>
           </div>
-          <div class="col-9">
-            <InputSearch v-model="searchInput" placeholder="Search variables" />
+          <div class="row">
+            <div class="col-12">
+              <filter-wells :filters="filtersFiltered" />
+            </div>
           </div>
-        </div>
-        <div class="row">
-          <div class="col-12">
-            <filter-wells :filters="filters" />
-          </div>
-        </div>
-        <div class="row">
-          <div class="col">
-            <ul class="nav nav-tabs">
-              <li class="nav-item">
-                <router-link
-                  class="nav-link"
-                  :class="{ active: $route.query.tab !== 'harmonization' }"
-                  :to="{ name: 'variableExplorer', query: { tab: 'detail' } }"
-                >
-                  Details
-                </router-link>
-              </li>
-              <li class="nav-item">
-                <router-link
-                  class="nav-link"
-                  :class="{ active: $route.query.tab === 'harmonization' }"
-                  :to="{
-                    name: 'variableExplorer',
-                    query: { tab: 'harmonization' },
-                  }"
-                >
-                  Harmonization
-                </router-link>
-              </li>
-            </ul>
-            <template v-if="$route.query.tab === 'harmonization'">
-              <harmonization-view />
-            </template>
-            <template v-else>
-              <variables-details-view />
-            </template>
+          <div class="row">
+            <div class="col">
+              <ul class="nav nav-tabs">
+                <li class="nav-item">
+                  <router-link
+                    class="nav-link"
+                    :class="{ active: $route.query.tab !== 'harmonization' }"
+                    :to="{ path: this.$route.path, query: { tab: 'detail' } }"
+                  >
+                    Details
+                  </router-link>
+                </li>
+                <li class="nav-item">
+                  <router-link
+                    class="nav-link"
+                    :class="{ active: $route.query.tab === 'harmonization' }"
+                    :to="{
+                      path: this.$route.path,
+                      query: { tab: 'harmonization' },
+                    }"
+                  >
+                    Harmonization
+                  </router-link>
+                </li>
+              </ul>
+              <template v-if="$route.query.tab === 'harmonization'">
+                <harmonization-view />
+              </template>
+              <template v-else>
+                <variables-details-view :network="network" />
+              </template>
+            </div>
           </div>
         </div>
       </div>
@@ -90,6 +110,12 @@ export default {
     FilterWells,
     InputRef,
   },
+  props: {
+    network: {
+      type: String,
+      default: null,
+    },
+  },
   computed: {
     ...mapState(["filters"]),
     ...mapGetters([
@@ -98,7 +124,14 @@ export default {
       "searchString",
       "selectedNetworks",
       "selectedKeywords",
+      "selectedCohorts",
     ]),
+    filtersFiltered() {
+      //filter if network filter set external
+      return this.filters.filter(
+        (f) => f.name !== "networks" || this.network == null
+      );
+    },
     searchInput: {
       get() {
         return this.$store.state.searchInput;
@@ -113,6 +146,14 @@ export default {
       },
       set(value) {
         this.setSelectedNetworks(value);
+      },
+    },
+    cohorts: {
+      get() {
+        return this.selectedCohorts;
+      },
+      set(value) {
+        this.setSelectedCohorts(value);
       },
     },
     keywords: {
@@ -130,7 +171,11 @@ export default {
     },
   },
   methods: {
-    ...mapMutations(["setSelectedNetworks", "setSelectedKeywords"]),
+    ...mapMutations([
+      "setSelectedNetworks",
+      "setSelectedKeywords",
+      "setSelectedCohorts",
+    ]),
     ...mapActions(["fetchVariables", "fetchKeywords", "fetchSchema"]),
     onError(e) {
       this.graphqlError = e.response ? e.response.errors[0].message : e;
@@ -146,12 +191,18 @@ export default {
     selectedNetworks() {
       this.fetchVariables();
     },
+    selectedCohorts() {
+      this.fetchVariables();
+    },
   },
   async created() {
     await this.fetchSchema();
     if (!this.variables.length) {
       // Only on initial creation
       this.fetchVariables();
+    }
+    if (this.network) {
+      this.setSelectedNetworks([{ pid: this.network }]);
     }
     this.fetchKeywords();
   },

--- a/apps/catalogue/src/views/VariablesDetailsView.vue
+++ b/apps/catalogue/src/views/VariablesDetailsView.vue
@@ -1,10 +1,12 @@
 <template>
   <div class="mt-1">
+    {{ network }}
     <ul v-if="variables.length" class="list-group">
       <variable-list-item
         v-for="(variable, index) in variables"
         :key="index"
         :variable="variable"
+        :network="network"
         @request-variable-detail="handleVariableDetailsRequest(variable)"
       />
       <button
@@ -33,6 +35,9 @@ import { mapGetters, mapActions, mapState } from "vuex";
 export default {
   name: "VariableDetailsView",
   components: { Spinner, VariableListItem },
+  props: {
+    network: String,
+  },
   computed: {
     ...mapState(["isLoading"]),
     ...mapGetters(["variables", "variableCount"]),


### PR DESCRIPTION
new prototype for 'networks' landingspage
- go to /networks in your schema to see new landing page
- you can then see variables for network LifeCycle 

variable explorer, following user request
- added cohort filter
- added sorting to various part
- removed the question marks