### PR TITLE
chore: remove unused property

### DIFF
--- a/apps/molgenis-components/src/components/forms/baseInputs/BaseInput.vue
+++ b/apps/molgenis-components/src/components/forms/baseInputs/BaseInput.vue
@@ -44,15 +44,6 @@ export default {
       type: String,
       required: false,
     },
-    /**
-     * A string specifying the type of control to render.
-     * (note: no direct relation to emx2 type, emx2 types are implemented as vue components)
-     */
-    type: {
-      type: String,
-      required: false,
-      default: () => "text",
-    },
     required: {
       type: Boolean,
       default: false,


### PR DESCRIPTION
Remove html type property from base input as each input component has a hardcoded type.