### PR TITLE
feat: added LANDING_PAGE setting 

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/MetadataUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/MetadataUtils.java
@@ -533,33 +533,32 @@ public class MetadataUtils {
         .execute();
   }
 
-  protected static List<Setting> loadSettings(DSLContext jooq, SchemaMetadata schema) {
+  protected static Map<String, String> loadSettings(DSLContext jooq, SchemaMetadata schema) {
     List<org.jooq.Record> settingRecords =
         jooq.selectFrom(SETTINGS_METADATA)
             .where(TABLE_SCHEMA.eq(schema.getName()), SETTINGS_TABLE_NAME.eq(NOT_PROVIDED))
             .fetch();
-    return asSettingsList(settingRecords);
+    return asSettingsMap(settingRecords);
   }
 
   /**
    * Loads a list of all database settings ( i.e., settings not related to a specific Schema or
    * Table)
    */
-  protected static List<Setting> loadSettings(DSLContext jooq) {
+  protected static Map<String, String> loadSettings(DSLContext jooq) {
     List<org.jooq.Record> settingRecords =
         jooq.selectFrom(SETTINGS_METADATA)
             .where(TABLE_SCHEMA.eq(NOT_PROVIDED), SETTINGS_TABLE_NAME.eq(NOT_PROVIDED))
             .fetch();
-    return asSettingsList(settingRecords);
+    return asSettingsMap(settingRecords);
   }
 
-  private static List<Setting> asSettingsList(List<Record> settingRecords) {
-    List<Setting> settings = new ArrayList<>();
+  private static Map<String, String> asSettingsMap(List<Record> settingRecords) {
+    Map<String, String> settings = new LinkedHashMap<>();
     for (Record settingRecord : settingRecords) {
-      settings.add(
-          new Setting(
-              settingRecord.get(SETTINGS_NAME, String.class),
-              settingRecord.get(SETTINGS_VALUE, String.class)));
+      settings.put(
+          settingRecord.get(SETTINGS_NAME, String.class),
+          settingRecord.get(SETTINGS_VALUE, String.class));
     }
     return settings;
   }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/Constants.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/Constants.java
@@ -3,6 +3,7 @@ package org.molgenis.emx2.web;
 public class Constants {
   static final String TABLE = "table";
   public static final String CONTENT_TYPE = "Content-type";
+  public static final String LANDING_PAGE = "LANDING_PAGE";
 
   private Constants() {
     // hide constructor

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisWebservice.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisWebservice.java
@@ -13,10 +13,7 @@ import io.swagger.v3.oas.models.OpenAPI;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
-import org.molgenis.emx2.MolgenisException;
-import org.molgenis.emx2.Schema;
-import org.molgenis.emx2.Table;
-import org.molgenis.emx2.Version;
+import org.molgenis.emx2.*;
 import org.molgenis.emx2.web.controllers.OIDCController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -59,16 +56,21 @@ public class MolgenisWebservice {
     get(("/" + OIDC_LOGIN_PATH), oidcController::handleLoginRequest);
     get("/" + ROBOTS_TXT, MolgenisWebservice::robotsDotTxt);
 
-    // root
+    // get setting for home
     get(
         "/",
         ACCEPT_HTML,
-        (request, response) ->
-            "Welcome to MOLGENIS EMX2 "
-                + Version.getVersion()
-                + ".<br/>. See <a href=\"/api/\">/api/</a> and  <a href=\"/apps/central/\">/apps/central/</a>");
-
-    redirect.get("/", "/apps/central/");
+        (request, response) -> {
+          // check for setting
+          String ladingPagePath =
+              sessionManager.getSession(request).getDatabase().getSettingValue(LANDING_PAGE);
+          if (ladingPagePath != null) {
+            response.redirect(ladingPagePath);
+          } else {
+            response.redirect("/apps/central/");
+          }
+          return response;
+        });
 
     redirect.get("/api", "/api/");
 

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Database.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Database.java
@@ -29,6 +29,8 @@ public interface Database {
 
   Collection<Setting> getSettings();
 
+  String getSettingValue(String key);
+
   Setting createSetting(String key, String value);
 
   Boolean deleteSetting(String key);

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaMetadata.java
@@ -9,7 +9,7 @@ import org.molgenis.emx2.utils.TableSort;
 public class SchemaMetadata {
 
   protected Map<String, TableMetadata> tables = new LinkedHashMap<>();
-  protected Map<String, Setting> settings = new LinkedHashMap<>();
+  protected Map<String, String> settings = new LinkedHashMap<>();
   protected String name;
   // optional
   protected String description;
@@ -122,20 +122,28 @@ public class SchemaMetadata {
 
   public List<Setting> getSettings() {
     List<Setting> result = new ArrayList<>();
-    result.addAll(this.settings.values());
+    result.addAll(
+        this.settings.entrySet().stream()
+            .map(entry -> new Setting(entry.getKey(), entry.getValue()))
+            .toList());
     return result;
+  }
+
+  public SchemaMetadata setSettings(Map<String, String> settingsMap) {
+    this.settings.putAll(settingsMap);
+    return this;
   }
 
   public SchemaMetadata setSettings(Collection<Setting> settings) {
     if (settings == null) return this;
     for (Setting setting : settings) {
-      this.settings.put(setting.key(), setting);
+      this.settings.put(setting.key(), setting.value());
     }
     return this;
   }
 
   public SchemaMetadata setSetting(String name, String value) {
-    this.settings.put(name, new Setting(name, value));
+    this.settings.put(name, value);
     return this;
   }
 
@@ -186,5 +194,9 @@ public class SchemaMetadata {
         addExternalTablesRecursive(tables, c.getRefTable());
       }
     }
+  }
+
+  protected Map<String, String> getSettingsAsMap() {
+    return Collections.unmodifiableMap(this.settings);
   }
 }

--- a/docs/molgenis/use_global_settings.md
+++ b/docs/molgenis/use_global_settings.md
@@ -1,7 +1,11 @@
 # Admin settings
 
-You can find the 'admin' menu when on the MOLGENIS start page, when you view the list of databases (click the MOLGENIS logo to get there).
-Only when signed in as 'admin' user will this menu item be shown.
+You can find the 'admin' menu when on the MOLGENIS start page, when you view the list of databases (click the MOLGENIS
+logo to get there). Only when signed in as 'admin' user will this menu item be shown.
+
+Settings currently supported:
+
+* LANDING_PAGE - to change landing page from default /apps/central to something else
 
 ## User management
 


### PR DESCRIPTION
to make users directly go to path you like the to go, skipping /apps/central

To test:
* sign in as admin
* use admin settings -> LANDING_PAGE and set that to /pet store/
* open new browser and go to root of the preview server, you will see you navigate to /pet store/ instead of /apps/central/

You can still go back to /apps/central using the breadcrumb pull down.

TODO: if you have no permission on the url the breadcrumb doesnt show well

NOTE: refactored settings internals at backend to fix a bug where settings could have duplicate key