### PR TITLE
fix: required check failed on ref, ref_array, ontology, ontology_array

### DIFF
--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestCreateForeignKeys.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestCreateForeignKeys.java
@@ -74,7 +74,7 @@ public class TestCreateForeignKeys {
         schema.create(
             table("B")
                 .add(column("ID").setType(INT).setPkey())
-                .add(column(refFromBToA).setType(REF).setRefTable("A")));
+                .add(column(refFromBToA).setType(REF).setRefTable("A").setRequired(true)));
     Row bRow = new Row().setInt("ID", 2).set(refFromBToA, insertValue);
     bTable.insert(bRow);
 
@@ -82,7 +82,16 @@ public class TestCreateForeignKeys {
     Row bErrorRow = new Row().setInt("ID", 3).set(refFromBToA, updateValue);
     try {
       bTable.insert(bErrorRow);
-      fail("insert should fail because value is missing");
+      fail("insert should fail because value is not in other table");
+    } catch (Exception e) {
+      System.out.println("insert exception correct: \n" + e);
+    }
+
+    // insert null should fail
+    bErrorRow = new Row().setInt("ID", 3).set(refFromBToA, null);
+    try {
+      bTable.insert(bErrorRow);
+      fail("insert should fail because value is null");
     } catch (Exception e) {
       System.out.println("insert exception correct: \n" + e);
     }

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestCreateForeignKeysArrays.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestCreateForeignKeysArrays.java
@@ -1,6 +1,7 @@
 package org.molgenis.emx2.sql;
 
 import static junit.framework.TestCase.fail;
+import static org.junit.Assert.assertTrue;
 import static org.molgenis.emx2.Column.column;
 import static org.molgenis.emx2.ColumnType.INT;
 import static org.molgenis.emx2.ColumnType.REF_ARRAY;
@@ -89,7 +90,7 @@ public class TestCreateForeignKeysArrays {
         schema.create(
             table("B")
                 .add(column("id").setPkey())
-                .add(column(refToA).setType(REF_ARRAY).setRefTable("A"))
+                .add(column(refToA).setType(REF_ARRAY).setRefTable("A").setRequired(true))
                 .add(column(refToA + "Nullable").setType(REF_ARRAY).setRefTable("A")));
 
     // error on insert of faulty fkey
@@ -98,6 +99,28 @@ public class TestCreateForeignKeysArrays {
       bTable.insert(bErrorRow);
       fail("insert should fail because value is missing");
     } catch (Exception e) {
+      System.out.println(
+          "insert exception correct because value " + testValues[2] + " is missing: \n" + e);
+    }
+
+    // error on insert of faulty null fkey
+    bErrorRow = new Row().set("id", 1).set(refToA, null);
+    try {
+      bTable.insert(bErrorRow);
+      fail("insert should fail because required value is null");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("required"));
+      System.out.println(
+          "insert exception correct because value " + testValues[2] + " is missing: \n" + e);
+    }
+
+    // error on insert of faulty empty array fkey
+    bErrorRow = new Row().set("id", 1).set(refToA, new Object[0]);
+    try {
+      bTable.insert(bErrorRow);
+      fail("insert should fail because required value is empty array");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("required"));
       System.out.println(
           "insert exception correct because value " + testValues[2] + " is missing: \n" + e);
     }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Reference.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Reference.java
@@ -112,7 +112,7 @@ public class Reference {
     return isOverlapping() && getOverlapping().getColumnType().getBaseType().equals(ColumnType.REF);
   }
 
-  public Column getPrimitiveColumn() {
+  public Column toPrimitiveColumn() {
     return new Column(this.column.getTable(), this.getName(), true)
         .setType(this.getPrimitiveType())
         .setRequired(this.column.isRequired());

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Reference.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Reference.java
@@ -111,4 +111,10 @@ public class Reference {
   public boolean isOverlappingRef() {
     return isOverlapping() && getOverlapping().getColumnType().getBaseType().equals(ColumnType.REF);
   }
+
+  public Column getPrimitiveColumn() {
+    return new Column(this.column.getTable(), this.getName(), true)
+        .setType(this.getPrimitiveType())
+        .setRequired(this.column.isRequired());
+  }
 }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Row.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Row.java
@@ -358,6 +358,9 @@ public class Row {
   }
 
   public boolean isNull(String columnName, ColumnType type) {
+    if (type.isArray()) {
+      return get(columnName, type) == null || ((Object[]) get(columnName, type)).length == 0;
+    }
     return get(columnName, type) == null;
   }
 

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -218,7 +218,7 @@ public class TableMetadata implements Comparable {
       if (c.isReference()) {
         for (Reference ref : c.getReferences()) {
           if (!ref.isOverlapping()) { // only add overlapping once
-            result.put(ref.getName(), ref.getPrimitiveColumn());
+            result.put(ref.getName(), ref.toPrimitiveColumn());
           }
         }
       } else {

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -218,11 +218,7 @@ public class TableMetadata implements Comparable {
       if (c.isReference()) {
         for (Reference ref : c.getReferences()) {
           if (!ref.isOverlapping()) { // only add overlapping once
-            result.put(
-                ref.getName(),
-                new Column(c.getTable(), ref.getName(), true)
-                    .setType(ref.getPrimitiveType())
-                    .setRequired(c.isRequired()));
+            result.put(ref.getName(), ref.getPrimitiveColumn());
           }
         }
       } else {

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -220,7 +220,9 @@ public class TableMetadata implements Comparable {
           if (!ref.isOverlapping()) { // only add overlapping once
             result.put(
                 ref.getName(),
-                new Column(c.getTable(), ref.getName(), true).setType(ref.getPrimitiveType()));
+                new Column(c.getTable(), ref.getName(), true)
+                    .setType(ref.getPrimitiveType())
+                    .setRequired(c.isRequired()));
           }
         }
       } else {


### PR DESCRIPTION
this was consequence when we added 'validation' that required checks were removed from postgresql and moved to java.
setRequired() was not correctly passed to the technical columns for insert/update.

fixes #1294