### PR TITLE
fix: progress of substasks was not shown in Excel upload

### DIFF
--- a/apps/updownload/src/components/Task.vue
+++ b/apps/updownload/src/components/Task.vue
@@ -3,7 +3,7 @@
     <i class="fa-li fa" :class="icon"></i>
     {{ task.description }}
     <ul class="fa-ul">
-      <task :task="subtask" v-for="(subtask, id) in task.steps" :key="id" />
+      <task :task="subtask" v-for="(subtask, id) in task.subTasks" :key="id" />
     </ul>
   </li>
 </template>


### PR DESCRIPTION
At last refector we renamed 'steps' to 'subTasks' in API, but failed to update the UI. When download and then upload Excel of pet store then:

Old
<img width="503" alt="image" src="https://user-images.githubusercontent.com/120060/175932562-c1985acd-0e5e-4529-a0c2-ce815eea1344.png">

Fixed
<img width="666" alt="image" src="https://user-images.githubusercontent.com/120060/175932596-210a52ca-0dd1-4ea1-9763-0d56923bd51d.png">

Closes #1258
