### PR TITLE
fix: logos should not be stretched

### DIFF
--- a/apps/catalogue/src/components/NetworkCards.vue
+++ b/apps/catalogue/src/components/NetworkCards.vue
@@ -1,15 +1,15 @@
 <template>
   <div class="card p-4 w-100">
-    <img
-      :src="
-        network.logo.url
-          ? network.logo.url
-          : 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
-      "
-      class="card-img-top"
-      style="height: 4em"
-      alt="..."
-    />
+    <div class="image-container">
+      <img
+          :src="
+            network.logo.url
+              ? network.logo.url
+              : 'data:image/gif;base64,R0lGODlhAQABAAAAACH5BAEKAAEALAAAAAABAAEAAAICTAEAOw=='
+          "
+          alt="..."
+      />
+    </div>
     <div class="card-body">
       <h5 class="card-title">{{ network.pid }}</h5>
       <p v-if="network.description && network.description.trim().length > 0">
@@ -57,5 +57,13 @@ export default {
   border: none;
   position: absolute;
   bottom: 0;
+}
+.image-container {
+  height: 4em;
+  display: flex;
+  justify-content: center;
+}
+.image-container > img {
+  height:100%;
 }
 </style>


### PR DESCRIPTION
Before
<img width="1126" alt="image" src="https://user-images.githubusercontent.com/120060/177123096-7b5de596-041f-418c-9f8f-22eaabbeafb7.png">

After:
<img width="1046" alt="image" src="https://user-images.githubusercontent.com/120060/177123061-02a03f3f-2170-4c0e-8bec-0fbb902daa1f.png">

Thank you to @jelmerveen 
