### PR TITLE
Fix/rdf4j in fatjar

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -168,8 +168,27 @@ application {
 
 jar {
     reproducibleFileOrder = true
+
+    // Needed to deal with other duplicate resources in META-INF
+    duplicatesStrategy = 'exclude'
+
+    // Adapted from: https://gist.github.com/lukhnos/31abbea7492d06179ecb
+    doFirst {
+        def serviceDir = file("$buildDir/META-INF/services")
+        serviceDir.deleteDir()
+        serviceDir.mkdirs()
+
+        // Copy and merge all service files from deps to buildDir
+        for(file in configurations.runtimeClasspath) {
+            zipTree(file).matching{ include 'META-INF/services/*' }.each { f ->
+                new File(serviceDir, f.name) << f.getText("UTF-8")
+            }
+        }
+    }
+
     manifest {
         attributes(
+                "Main-Class": javaMainClass,
                 'Specification-Version': project.version.toString(),
                 'Implementation-Version': getGitHash(),
                 'Created-By': "Gradle ${gradle.gradleVersion}",
@@ -177,6 +196,14 @@ jar {
                 'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
         )
     }
+
+    // Don't let Gradle merge service files
+    from(configurations.runtimeClasspath.collect{ it.isDirectory() ? it : zipTree(it) }) {
+        exclude 'META-INF/services/*'
+    }
+
+    // Include merged service files from the buildDir
+    from fileTree(buildDir).matching{ include 'META-INF/services/*' }
 }
 
 task cleandb(type: JavaExec) {

--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,7 @@ dependencies {
 mainClassName = 'org.molgenis.emx2.RunMolgenisEmx2'
 shadowJar {
     archiveBaseName = 'molgenis-emx2'
+    mergeServiceFiles()
 }
 
 publishing {
@@ -168,27 +169,8 @@ application {
 
 jar {
     reproducibleFileOrder = true
-
-    // Needed to deal with other duplicate resources in META-INF
-    duplicatesStrategy = 'exclude'
-
-    // Adapted from: https://gist.github.com/lukhnos/31abbea7492d06179ecb
-    doFirst {
-        def serviceDir = file("$buildDir/META-INF/services")
-        serviceDir.deleteDir()
-        serviceDir.mkdirs()
-
-        // Copy and merge all service files from deps to buildDir
-        for(file in configurations.runtimeClasspath) {
-            zipTree(file).matching{ include 'META-INF/services/*' }.each { f ->
-                new File(serviceDir, f.name) << f.getText("UTF-8")
-            }
-        }
-    }
-
     manifest {
         attributes(
-                "Main-Class": javaMainClass,
                 'Specification-Version': project.version.toString(),
                 'Implementation-Version': getGitHash(),
                 'Created-By': "Gradle ${gradle.gradleVersion}",
@@ -196,14 +178,6 @@ jar {
                 'Build-OS': "${System.properties['os.name']} ${System.properties['os.arch']} ${System.properties['os.version']}"
         )
     }
-
-    // Don't let Gradle merge service files
-    from(configurations.runtimeClasspath.collect{ it.isDirectory() ? it : zipTree(it) }) {
-        exclude 'META-INF/services/*'
-    }
-
-    // Include merged service files from the buildDir
-    from fileTree(buildDir).matching{ include 'META-INF/services/*' }
 }
 
 task cleandb(type: JavaExec) {
@@ -212,4 +186,3 @@ task cleandb(type: JavaExec) {
     classpath = sourceSets.main.runtimeClasspath
     main = "org.molgenis.emx2.AToolToCleanDatabase"
 }
-


### PR DESCRIPTION
The new FAIR Data Point API does not work on EMX2 deployed on servers. The error thrown is:

```
{
  "errors" : [
    {
      "message" : "Did not recognise RDF format object Turtle (mimeTypes=text/turtle, application/x-turtle; ext=ttl)"
    }
  ]
}
```

The reason for this best explained in the top answer at StackOverflow:
https://stackoverflow.com/questions/40907324/rdf4j-rio-unsupportedrdformatexception-when-adding-data-to-an-httprepository-usi

In short: multiple RDF4J parsers must be registered via Java's Service Provider Interface in order for the API to write its output. This happens in the `META-INF/services/org.eclipse.rdf4j.rio.RDFWriterFactory` file located in `META-INF/services`.

However, in the current build process to creat the 'fat JAR' that is used to deploy EMX2 on servers, this file gets copied multiple times from various RDF4J components, leaving only the last copied file as the source for RDF4J parser registration.

So, instead of:

```
org.eclipse.rdf4j.rio.jsonld.JSONLDWriterFactory
org.eclipse.rdf4j.rio.ndjsonld.NDJSONLDWriterFactory
org.eclipse.rdf4j.rio.turtle.TurtleWriterFactory
org.eclipse.rdf4j.rio.turtlestar.TurtleStarWriterFactory
```

RDFWriterFactory contains only:

```
org.eclipse.rdf4j.rio.jsonld.JSONLDWriterFactory
org.eclipse.rdf4j.rio.ndjsonld.NDJSONLDWriterFactory
```

The FAIR Data Point API works when unzipping the build JAR, adding these lines, re-ZIPing and renaming back to *.jar.

To properly fix this problem and make it future-proof, the build procedure should be improved. Instead of copying and overwriting/ignoring duplicates, the files located in `META-INF/services` should be merged by appending their content if a file with the same name already exists.

This PR achieves this desired behaviour. However, there is at least one quirk. Instead of a single JAR, somehow two JARs are produced in `build/libs/`:

- `molgenis-emx2-8.107.1-fix-rdf4j-in-fatjar-SNAPSHOT-all.jar` which does NOT have merged `META-INF/services`, and thus the API does not work
- `emx2-8.107.1-fix-rdf4j-in-fatjar-SNAPSHOT.jar` which DOES have the merged `META-INF/services`, and thus the API works

Review from a Gradle expert is requested to investigate and fix this quirk, in addition to making sure any other unintended behaviour is avoided.