### PR TITLE
fix: replaced jsass.Compiler with de.larsgrefer.sass.embedded.SassCompiler

### DIFF
--- a/backend/molgenis-emx2-webapi/build.gradle
+++ b/backend/molgenis-emx2-webapi/build.gradle
@@ -11,6 +11,6 @@ dependencies {
     implementation 'com.squareup.okhttp3:okhttp:4.10.0'
     implementation 'com.squareup.okhttp3:okhttp-brotli:4.10.0'
     testImplementation 'io.rest-assured:rest-assured:5.1.1'
-    implementation 'io.bit3:jsass:5.10.4'
     implementation 'com.github.dfabulich:sitemapgen4j:1.1.2'
+    implementation 'de.larsgrefer.sass:sass-embedded-host:1.4.0'
 }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BootstrapThemeService.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BootstrapThemeService.java
@@ -4,27 +4,23 @@ import static org.molgenis.emx2.web.MolgenisWebservice.getSchema;
 import static org.molgenis.emx2.web.MolgenisWebservice.logger;
 import static spark.Spark.get;
 
-import io.bit3.jsass.Compiler;
-import io.bit3.jsass.Options;
-import io.bit3.jsass.importer.Import;
-import java.io.FileNotFoundException;
+import de.larsgrefer.sass.embedded.SassCompiler;
+import de.larsgrefer.sass.embedded.SassCompilerFactory;
+import java.io.BufferedReader;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URISyntaxException;
-import java.net.URL;
+import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.*;
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
-import org.apache.commons.io.IOUtils;
 import org.jetbrains.annotations.NotNull;
 import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Schema;
+import sass.embedded_protocol.EmbeddedSass;
 import spark.Request;
 import spark.Response;
 
@@ -89,24 +85,78 @@ public class BootstrapThemeService {
     return query_pairs;
   }
 
+  /**
+   * Generate compressed CSS based on input colors and contents of theme.scss using an embedded SASS
+   * compiler.
+   */
   public static String generateCss(Map<String, String> params) {
     String primaryColor =
         getColor(params.get("primaryColor"), "#017FFD", "Primary color invalid: ");
     String secondaryColor =
         getColor(params.get("secondaryColor"), "#005EC4", "Secondary color invalid: ");
-
     String input =
         String.format(
-            "$theme-colors:(%nprimary: %s, %nsecondary: %s%n);%n%n@import 'theme.scss'",
-            primaryColor, secondaryColor);
-    Compiler compiler = new Compiler();
-    Options options = new Options();
-    options.setImporters(Collections.singleton(BootstrapThemeService::doScssImport));
+            "$theme-colors:(%nprimary: %s, %nsecondary: %s%n);%n%n", primaryColor, secondaryColor);
+    StringBuilder CssPlusScss = new StringBuilder();
+    CssPlusScss.append(input);
     try {
-      return compiler.compileString(input, options).getCss();
+      CssPlusScss.append(getScssFileContents("theme/theme.scss"));
+      SassCompiler sassCompiler = SassCompilerFactory.bundled();
+      sassCompiler.setOutputStyle(EmbeddedSass.OutputStyle.COMPRESSED);
+      String cssCompiled = sassCompiler.compileScssString(CssPlusScss.toString()).getCss();
+      sassCompiler.close();
+      return cssCompiled;
     } catch (Exception e) {
       logger.error(String.format("SASS compilation failed, input was:%n%s", input));
       throw new MolgenisException("SASS compilation failed", e);
+    }
+  }
+
+  /**
+   * Based on the location of an SCSS file, grab all contents from that file, as well as recursively
+   * following any @import links to append the contents those mports as well.
+   */
+  public static String getScssFileContents(String file) throws IOException {
+    StringBuilder stringBuilder = new StringBuilder();
+    InputStream fileFromResourceAsStream = getFileFromResourceAsStream(file);
+    InputStreamReader inputStreamReader =
+        new InputStreamReader(fileFromResourceAsStream, StandardCharsets.UTF_8);
+    BufferedReader bufferedReader = new BufferedReader(inputStreamReader);
+    String line;
+    while ((line = bufferedReader.readLine()) != null) {
+      if (line.startsWith("@import")) {
+        String importFileLocation =
+            line.replace("@import", "").replace("\"", "").replace("'", "").replace(";", "").trim();
+        if (!importFileLocation.endsWith(".scss")) {
+          int lastFwdSlashIndex = importFileLocation.lastIndexOf("/");
+          if (lastFwdSlashIndex == -1) {
+            importFileLocation = "_" + importFileLocation + ".scss";
+          } else {
+            importFileLocation =
+                importFileLocation.substring(0, lastFwdSlashIndex + 1)
+                    + "_"
+                    + importFileLocation.substring(lastFwdSlashIndex + 1)
+                    + ".scss";
+          }
+        }
+        String fileParent = file.substring(0, file.lastIndexOf("/"));
+        String completeFileImportLocation = fileParent + "/" + importFileLocation;
+        stringBuilder.append(getScssFileContents(completeFileImportLocation));
+      } else {
+        stringBuilder.append(line).append(System.lineSeparator());
+      }
+    }
+    return stringBuilder.toString();
+  }
+
+  /** Get a file from the resources folder as an InputStream. */
+  private static InputStream getFileFromResourceAsStream(String fileName) {
+    ClassLoader classLoader = BootstrapThemeService.class.getClassLoader();
+    InputStream inputStream = classLoader.getResourceAsStream(fileName);
+    if (inputStream == null) {
+      throw new IllegalArgumentException("File not found: " + fileName);
+    } else {
+      return inputStream;
     }
   }
 
@@ -122,114 +172,5 @@ public class BootstrapThemeService {
   public static boolean isValidColor(final String colorCode) {
     Matcher matcher = pattern.matcher(colorCode);
     return matcher.matches();
-  }
-
-  /**
-   * Resolve the target file for an {@code @import} directive.
-   *
-   * @param fileName The {@code import} fileName.
-   * @param previousFile The file that contains the {@code import} directive.
-   * @return The resolve import objects or {@code null} if the import file was not found.
-   */
-  private static Collection<Import> doScssImport(String fileName, Import previousFile) {
-    try {
-      final Path importPath = getImportPath(previousFile);
-      Path targetPath = importPath.resolve(fileName);
-      return resolveImport(targetPath);
-    } catch (URISyntaxException | IOException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
-  @NotNull
-  private static Path getImportPath(Import previous) {
-    Path previousParentPath = getPreviousParentPath(previous);
-    return Objects.requireNonNullElseGet(previousParentPath, () -> Path.of("theme"));
-  }
-
-  private static Path getPreviousParentPath(Import previous) {
-    String previousPath = getPreviousPath(previous);
-    return Paths.get(previousPath).getParent();
-  }
-
-  @NotNull
-  private static String getPreviousPath(Import previous) {
-    String absoluteUri = previous.getAbsoluteUri().toString();
-    if (absoluteUri.contains("!")) {
-      return absoluteUri.split("!/")[1];
-    } else {
-      return absoluteUri;
-    }
-  }
-
-  /**
-   * Try to determine the import object for a given path.
-   *
-   * @param path The path to resolve.
-   * @return The import object or {@code null} if the file was not found.
-   */
-  private static Collection<Import> resolveImport(Path path)
-      throws IOException, URISyntaxException {
-    URL resource = resolveResource(path);
-    final String source = IOUtils.toString(resource, StandardCharsets.UTF_8);
-    final Import scssImport = new Import(resource.toURI(), resource.toURI(), source);
-    return Collections.singleton(scssImport);
-  }
-
-  /**
-   * Try to find a resource for this path.
-   *
-   * <p>A sass import like {@code @import "foo"} does not contain the partial prefix (underscore) or
-   * file extension. This method will try the following namings to find the import file {@code foo}:
-   *
-   * <ul>
-   *   <li>_foo.scss
-   *   <li>_foo.css
-   *   <li>_foo
-   *   <li>foo.scss
-   *   <li>foo.css
-   *   <li>foo
-   * </ul>
-   *
-   * @param path The path to resolve.
-   * @return The resource URL of the resolved file or {@code null} if the file was not found.
-   */
-  private static URL resolveResource(Path path)
-      throws FileNotFoundException, MalformedURLException {
-    final Path dir = path.getParent();
-    final String basename = path.getFileName().toString();
-
-    for (String prefix : new String[] {"_", ""}) {
-      for (String suffix : new String[] {".scss", ".css", ""}) {
-        final Path target = dir.resolve(prefix + basename + suffix);
-        URL resource = getResource(target);
-        if (resource != null) {
-          return resource;
-        }
-      }
-    }
-    throw new FileNotFoundException(basename);
-  }
-
-  private static URL getResource(Path target) throws MalformedURLException {
-    URL resourceUrl =
-        BootstrapThemeService.class
-            .getClassLoader()
-            .getResource(target.toString().replace('\\', '/'));
-
-    if (resourceUrl == null) {
-      return getNonJarUrlForTest(target);
-    } else {
-      return resourceUrl;
-    }
-  }
-
-  private static URL getNonJarUrlForTest(Path target) throws MalformedURLException {
-    Path fullPath = Paths.get(target.toString());
-    if (Files.exists(fullPath)) {
-      return Paths.get(target.toString()).toUri().toURL();
-    } else {
-      return null;
-    }
   }
 }


### PR DESCRIPTION
The deprecated `io.bit3.jsass.Compiler` was replaced with the actively maintained `de.larsgrefer.sass.embedded.SassCompiler`. This compiler works on modern systems, gives stylesheet deprecation warnings, and allows compression of the served CSS. Tested and working under:

- MacOS 12.4 on M1 processor, running on IntelliJ IDE
- MacOS 12.4 on M1 processor, running on fat JAR distribution
- Windows 10, running on fat JAR distribution