### PR TITLE
fix: response MIME types for FDP and Beacon 

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
@@ -20,6 +20,7 @@ import spark.Response;
 public class BeaconApi {
 
   private static MolgenisSessionManager sessionManager;
+  private static final String applicationJsonMimeType = "application/json";
 
   public static void create(MolgenisSessionManager sm) {
     sessionManager = sm;
@@ -55,36 +56,36 @@ public class BeaconApi {
   }
 
   private static String getInfo(Request req, Response response) throws JsonProcessingException {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     return getWriter().writeValueAsString(new Info());
   }
 
   private static String getServiceInfo(Request request, Response response)
       throws JsonProcessingException {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     return getWriter().writeValueAsString(new Info());
   }
 
   private static Object getConfiguration(Request request, Response response)
       throws JsonProcessingException {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     return getWriter().writeValueAsString(new Configuration());
   }
 
   private static Object getMap(Request request, Response response) throws JsonProcessingException {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     return getWriter().writeValueAsString(new Map(request));
   }
 
   private static Object getEntryTypes(Request request, Response response)
       throws JsonProcessingException {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     return getWriter().writeValueAsString(new EntryTypes());
   }
 
   private static String getFilteringTerms(Request request, Response response)
       throws JsonProcessingException {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     String skip = request.queryParams("skip");
     String limit = request.queryParams("limit");
     // TODO handle skip and limit
@@ -93,7 +94,7 @@ public class BeaconApi {
 
   private static String getDatasets(Request request, Response response)
       throws JsonProcessingException {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     String skip = request.queryParams("skip");
     String limit = request.queryParams("limit");
 
@@ -103,37 +104,37 @@ public class BeaconApi {
   }
 
   private static String getAnalyses(Request request, Response response) throws Exception {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     List<Table> tables = getTableFromAllSchemas("Analyses", request);
     return getWriter().writeValueAsString(new Analyses(request, tables));
   }
 
   private static String getBiosamples(Request request, Response response) throws Exception {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     List<Table> tables = getTableFromAllSchemas("Biosamples", request);
     return getWriter().writeValueAsString(new Biosamples(request, tables));
   }
 
   private static String getCohorts(Request request, Response response) throws Exception {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     List<Table> tables = getTableFromAllSchemas("Cohorts", request);
     return getWriter().writeValueAsString(new Cohorts(request, tables));
   }
 
   private static String getIndividuals(Request request, Response response) throws Exception {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     List<Table> tables = getTableFromAllSchemas("Individuals", request);
     return getWriter().writeValueAsString(new Individuals(request, tables));
   }
 
   private static String getRuns(Request request, Response response) throws Exception {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     List<Table> tables = getTableFromAllSchemas("Runs", request);
     return getWriter().writeValueAsString(new Runs(request, tables));
   }
 
   private static String getGenomicVariants(Request request, Response response) throws Exception {
-    response.type("application/json");
+    response.type(applicationJsonMimeType);
     List<Table> tables = getTableFromAllSchemas("GenomicVariations", request);
     return getWriter().writeValueAsString(new GenomicVariants(request, tables));
   }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
@@ -20,7 +20,7 @@ import spark.Response;
 public class BeaconApi {
 
   private static MolgenisSessionManager sessionManager;
-  private static final String applicationJsonMimeType = "application/json";
+  private static final String APPLICATION_JSON_MIME_TYPE = "application/json";
 
   public static void create(MolgenisSessionManager sm) {
     sessionManager = sm;
@@ -56,36 +56,36 @@ public class BeaconApi {
   }
 
   private static String getInfo(Request req, Response response) throws JsonProcessingException {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     return getWriter().writeValueAsString(new Info());
   }
 
   private static String getServiceInfo(Request request, Response response)
       throws JsonProcessingException {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     return getWriter().writeValueAsString(new Info());
   }
 
   private static Object getConfiguration(Request request, Response response)
       throws JsonProcessingException {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     return getWriter().writeValueAsString(new Configuration());
   }
 
   private static Object getMap(Request request, Response response) throws JsonProcessingException {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     return getWriter().writeValueAsString(new Map(request));
   }
 
   private static Object getEntryTypes(Request request, Response response)
       throws JsonProcessingException {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     return getWriter().writeValueAsString(new EntryTypes());
   }
 
   private static String getFilteringTerms(Request request, Response response)
       throws JsonProcessingException {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     String skip = request.queryParams("skip");
     String limit = request.queryParams("limit");
     // TODO handle skip and limit
@@ -94,7 +94,7 @@ public class BeaconApi {
 
   private static String getDatasets(Request request, Response response)
       throws JsonProcessingException {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     String skip = request.queryParams("skip");
     String limit = request.queryParams("limit");
 
@@ -104,37 +104,37 @@ public class BeaconApi {
   }
 
   private static String getAnalyses(Request request, Response response) throws Exception {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     List<Table> tables = getTableFromAllSchemas("Analyses", request);
     return getWriter().writeValueAsString(new Analyses(request, tables));
   }
 
   private static String getBiosamples(Request request, Response response) throws Exception {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     List<Table> tables = getTableFromAllSchemas("Biosamples", request);
     return getWriter().writeValueAsString(new Biosamples(request, tables));
   }
 
   private static String getCohorts(Request request, Response response) throws Exception {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     List<Table> tables = getTableFromAllSchemas("Cohorts", request);
     return getWriter().writeValueAsString(new Cohorts(request, tables));
   }
 
   private static String getIndividuals(Request request, Response response) throws Exception {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     List<Table> tables = getTableFromAllSchemas("Individuals", request);
     return getWriter().writeValueAsString(new Individuals(request, tables));
   }
 
   private static String getRuns(Request request, Response response) throws Exception {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     List<Table> tables = getTableFromAllSchemas("Runs", request);
     return getWriter().writeValueAsString(new Runs(request, tables));
   }
 
   private static String getGenomicVariants(Request request, Response response) throws Exception {
-    response.type(applicationJsonMimeType);
+    response.type(APPLICATION_JSON_MIME_TYPE);
     List<Table> tables = getTableFromAllSchemas("GenomicVariations", request);
     return getWriter().writeValueAsString(new GenomicVariants(request, tables));
   }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
@@ -54,32 +54,37 @@ public class BeaconApi {
     //    post("/:schema/api/beacon/datasets/:table", BeaconApi::postDatasetsForTable);
   }
 
-  private static String getInfo(Request req, Response res) throws JsonProcessingException {
-
+  private static String getInfo(Request req, Response response) throws JsonProcessingException {
+    response.type("application/json");
     return getWriter().writeValueAsString(new Info());
   }
 
   private static String getServiceInfo(Request request, Response response)
       throws JsonProcessingException {
+    response.type("application/json");
     return getWriter().writeValueAsString(new Info());
   }
 
   private static Object getConfiguration(Request request, Response response)
       throws JsonProcessingException {
+    response.type("application/json");
     return getWriter().writeValueAsString(new Configuration());
   }
 
   private static Object getMap(Request request, Response response) throws JsonProcessingException {
+    response.type("application/json");
     return getWriter().writeValueAsString(new Map(request));
   }
 
   private static Object getEntryTypes(Request request, Response response)
       throws JsonProcessingException {
+    response.type("application/json");
     return getWriter().writeValueAsString(new EntryTypes());
   }
 
   private static String getFilteringTerms(Request request, Response response)
       throws JsonProcessingException {
+    response.type("application/json");
     String skip = request.queryParams("skip");
     String limit = request.queryParams("limit");
     // TODO handle skip and limit
@@ -88,6 +93,7 @@ public class BeaconApi {
 
   private static String getDatasets(Request request, Response response)
       throws JsonProcessingException {
+    response.type("application/json");
     String skip = request.queryParams("skip");
     String limit = request.queryParams("limit");
 
@@ -97,31 +103,37 @@ public class BeaconApi {
   }
 
   private static String getAnalyses(Request request, Response response) throws Exception {
+    response.type("application/json");
     List<Table> tables = getTableFromAllSchemas("Analyses", request);
     return getWriter().writeValueAsString(new Analyses(request, tables));
   }
 
   private static String getBiosamples(Request request, Response response) throws Exception {
+    response.type("application/json");
     List<Table> tables = getTableFromAllSchemas("Biosamples", request);
     return getWriter().writeValueAsString(new Biosamples(request, tables));
   }
 
   private static String getCohorts(Request request, Response response) throws Exception {
+    response.type("application/json");
     List<Table> tables = getTableFromAllSchemas("Cohorts", request);
     return getWriter().writeValueAsString(new Cohorts(request, tables));
   }
 
   private static String getIndividuals(Request request, Response response) throws Exception {
+    response.type("application/json");
     List<Table> tables = getTableFromAllSchemas("Individuals", request);
     return getWriter().writeValueAsString(new Individuals(request, tables));
   }
 
   private static String getRuns(Request request, Response response) throws Exception {
+    response.type("application/json");
     List<Table> tables = getTableFromAllSchemas("Runs", request);
     return getWriter().writeValueAsString(new Runs(request, tables));
   }
 
   private static String getGenomicVariants(Request request, Response response) throws Exception {
+    response.type("application/json");
     List<Table> tables = getTableFromAllSchemas("GenomicVariations", request);
     return getWriter().writeValueAsString(new GenomicVariants(request, tables));
   }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FAIRDataPointApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FAIRDataPointApi.java
@@ -13,7 +13,7 @@ import spark.Response;
 public class FAIRDataPointApi {
 
   private static MolgenisSessionManager sessionManager;
-  private static final String textTurtleMimeType = "text/turtle";
+  private static final String TEXT_TURTLE_MIME_TYPE = "text/turtle";
 
   public static void create(MolgenisSessionManager sm) {
     sessionManager = sm;
@@ -35,48 +35,48 @@ public class FAIRDataPointApi {
   }
 
   private static String getFDP(Request request, Response res) throws Exception {
-    res.type(textTurtleMimeType);
+    res.type(TEXT_TURTLE_MIME_TYPE);
     Schema[] schemas = getSchemasHavingTable("FDP_Catalog", request);
     return new FAIRDataPoint(request, schemas).getResult();
   }
 
   private static String getCatalog(Request request, Response res) throws Exception {
-    res.type(textTurtleMimeType);
+    res.type(TEXT_TURTLE_MIME_TYPE);
     Schema schema = getSchema(request);
     Table table = schema.getTable("FDP_Catalog");
     return new FAIRDataPointCatalog(request, table).getResult();
   }
 
   private static String getDataset(Request request, Response res) throws Exception {
-    res.type(textTurtleMimeType);
+    res.type(TEXT_TURTLE_MIME_TYPE);
     Schema schema = getSchema(request);
     Table table = schema.getTable("FDP_Dataset");
     return new FAIRDataPointDataset(request, table).getResult();
   }
 
   private static String getDistribution(Request request, Response res) throws Exception {
-    res.type(textTurtleMimeType);
+    res.type(TEXT_TURTLE_MIME_TYPE);
     return new FAIRDataPointDistribution(request, sessionManager.getSession(request).getDatabase())
         .getResult();
   }
 
   private static String getFDPProfile(Request request, Response res) {
-    res.type(textTurtleMimeType);
+    res.type(TEXT_TURTLE_MIME_TYPE);
     return FAIRDataPointProfile.FDP_SHACL;
   }
 
   private static String getCatalogProfile(Request request, Response res) {
-    res.type(textTurtleMimeType);
+    res.type(TEXT_TURTLE_MIME_TYPE);
     return FAIRDataPointProfile.CATALOG_SHACL;
   }
 
   private static String getDatasetProfile(Request request, Response res) {
-    res.type(textTurtleMimeType);
+    res.type(TEXT_TURTLE_MIME_TYPE);
     return FAIRDataPointProfile.DATASET_SHACL;
   }
 
   private static String getDistributionProfile(Request request, Response res) {
-    res.type(textTurtleMimeType);
+    res.type(TEXT_TURTLE_MIME_TYPE);
     return FAIRDataPointProfile.DISTRIBUTION_SHACL;
   }
 }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FAIRDataPointApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FAIRDataPointApi.java
@@ -13,6 +13,7 @@ import spark.Response;
 public class FAIRDataPointApi {
 
   private static MolgenisSessionManager sessionManager;
+  private static final String textTurtleMimeType = "text/turtle";
 
   public static void create(MolgenisSessionManager sm) {
     sessionManager = sm;
@@ -34,48 +35,48 @@ public class FAIRDataPointApi {
   }
 
   private static String getFDP(Request request, Response res) throws Exception {
-    res.type("text/turtle");
+    res.type(textTurtleMimeType);
     Schema[] schemas = getSchemasHavingTable("FDP_Catalog", request);
     return new FAIRDataPoint(request, schemas).getResult();
   }
 
   private static String getCatalog(Request request, Response res) throws Exception {
-    res.type("text/turtle");
+    res.type(textTurtleMimeType);
     Schema schema = getSchema(request);
     Table table = schema.getTable("FDP_Catalog");
     return new FAIRDataPointCatalog(request, table).getResult();
   }
 
   private static String getDataset(Request request, Response res) throws Exception {
-    res.type("text/turtle");
+    res.type(textTurtleMimeType);
     Schema schema = getSchema(request);
     Table table = schema.getTable("FDP_Dataset");
     return new FAIRDataPointDataset(request, table).getResult();
   }
 
   private static String getDistribution(Request request, Response res) throws Exception {
-    res.type("text/turtle");
+    res.type(textTurtleMimeType);
     return new FAIRDataPointDistribution(request, sessionManager.getSession(request).getDatabase())
         .getResult();
   }
 
   private static String getFDPProfile(Request request, Response res) {
-    res.type("text/turtle");
+    res.type(textTurtleMimeType);
     return FAIRDataPointProfile.FDP_SHACL;
   }
 
   private static String getCatalogProfile(Request request, Response res) {
-    res.type("text/turtle");
+    res.type(textTurtleMimeType);
     return FAIRDataPointProfile.CATALOG_SHACL;
   }
 
   private static String getDatasetProfile(Request request, Response res) {
-    res.type("text/turtle");
+    res.type(textTurtleMimeType);
     return FAIRDataPointProfile.DATASET_SHACL;
   }
 
   private static String getDistributionProfile(Request request, Response res) {
-    res.type("text/turtle");
+    res.type(textTurtleMimeType);
     return FAIRDataPointProfile.DISTRIBUTION_SHACL;
   }
 }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FAIRDataPointApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FAIRDataPointApi.java
@@ -34,40 +34,48 @@ public class FAIRDataPointApi {
   }
 
   private static String getFDP(Request request, Response res) throws Exception {
+    res.type("text/turtle");
     Schema[] schemas = getSchemasHavingTable("FDP_Catalog", request);
     return new FAIRDataPoint(request, schemas).getResult();
   }
 
   private static String getCatalog(Request request, Response res) throws Exception {
+    res.type("text/turtle");
     Schema schema = getSchema(request);
     Table table = schema.getTable("FDP_Catalog");
     return new FAIRDataPointCatalog(request, table).getResult();
   }
 
   private static String getDataset(Request request, Response res) throws Exception {
+    res.type("text/turtle");
     Schema schema = getSchema(request);
     Table table = schema.getTable("FDP_Dataset");
     return new FAIRDataPointDataset(request, table).getResult();
   }
 
   private static String getDistribution(Request request, Response res) throws Exception {
+    res.type("text/turtle");
     return new FAIRDataPointDistribution(request, sessionManager.getSession(request).getDatabase())
         .getResult();
   }
 
-  private static String getFDPProfile(Request request, Response res) throws Exception {
+  private static String getFDPProfile(Request request, Response res) {
+    res.type("text/turtle");
     return FAIRDataPointProfile.FDP_SHACL;
   }
 
-  private static String getCatalogProfile(Request request, Response res) throws Exception {
+  private static String getCatalogProfile(Request request, Response res) {
+    res.type("text/turtle");
     return FAIRDataPointProfile.CATALOG_SHACL;
   }
 
-  private static String getDatasetProfile(Request request, Response res) throws Exception {
+  private static String getDatasetProfile(Request request, Response res) {
+    res.type("text/turtle");
     return FAIRDataPointProfile.DATASET_SHACL;
   }
 
-  private static String getDistributionProfile(Request request, Response res) throws Exception {
+  private static String getDistributionProfile(Request request, Response res) {
+    res.type("text/turtle");
     return FAIRDataPointProfile.DISTRIBUTION_SHACL;
   }
 }


### PR DESCRIPTION
FAIR Data Point API responses are now MIME typed as `text/turtle` and Beacon v2 API responses are types as `application/json`. This informs clients on how to handle the response and allows better rendering.