### PR TITLE
fix: when refLink then error was shown for correct examples.

### DIFF
--- a/apps/styleguide/src/tables/RowEditModal.vue
+++ b/apps/styleguide/src/tables/RowEditModal.vue
@@ -235,7 +235,7 @@ export default {
           return (
             value &&
             refValue &&
-            JSON.stringify(value) !== JSON.stringify(refValue)
+            !JSON.stringify(value).includes(JSON.stringify(refValue))
           );
         }
       }


### PR DESCRIPTION
Before:
<img width="1125" alt="image" src="https://user-images.githubusercontent.com/120060/181066280-95b23170-0780-41b1-bb7b-a7dad5bf6333.png">

After:
<img width="1119" alt="image" src="https://user-images.githubusercontent.com/120060/181066340-80affaa7-c182-416a-a1ea-24ea70277641.png">
