### PR TITLE
Build/upgradeyarnversion

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
       # specify the version you desire here
-      - image: gradle:jdk17
+      - image: gradle:jdk17-focal
       - image: postgres:14-alpine
         environment:
           POSTGRES_USER: postgres
@@ -62,7 +62,7 @@ jobs:
 
       - run:
           name: add packages for docker cli install
-          command: apt-get -y install gnupg lsb-release curl
+          command: apt-get -y install gnupg lsb-release
 
       - run:
           name: update packages again

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ jobs:
 
       - run:
           name: add packages for docker cli install
-          command: apt-get -y install gnupg lsb-release
+          command: apt-get -y install gnupg lsb-release curl
 
       - run:
           name: update packages again

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -33,7 +33,7 @@ pipeline {
                     sh 'apt update'
                     sh 'apt -y install docker.io'
                     sh "git config --global --add safe.directory '*'"
-                    sh 'git fetch --depth 10000'
+                    sh 'git fetch --depth 100000'
                     sh "git config user.email \"molgenis@gmail.com\""
                     sh "git config user.name \"molgenis-jenkins\""
                     sh 'git config url.https://.insteadOf git://'

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -9,38 +9,29 @@ def nodeSpec = {
     version = '16.16.0'
     yarnVersion = '1.22.19'
     npmVersion = "8.17.0"
+    download = true
 }
 
 node {
     with nodeSpec
-    download = true
+}
+
+task addCrossEnv(type: YarnTask) {
+    // add the express package only
+    args = ['global', 'add', 'cross-env']
 }
 
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    yarnSetup.configure {
-        dependsOn parent.yarnSetup
-    }
-
-    nodeSetup.configure {
-        dependsOn parent.nodeSetup
-    }
-
-    npmSetup.configure {
-        dependsOn parent.npmSetup
-    }
-
-    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.npm_install]) {
-        node {
-            with nodeSpec
-            download = false
-        }
+    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.addCrossEnv]) {
+        node { with nodeSpec }
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {
             dependsOn ":apps:styleguide:build"
             dependsOn ":apps:molgenis-components:build"
         }
+
         // set input out out put for each app type
         if (project.name == 'styleguide') {
             inputs.file('package.json')
@@ -90,10 +81,7 @@ subprojects {
 
     if (project.name == 'styleguide') {
         task buildStyleguidist(type: YarnTask, dependsOn: build) {
-            node {
-                with nodeSpec
-                download = false
-            }
+            node { with nodeSpec }
             inputs.files(fileTree('src'))
             inputs.files(fileTree('public'))
             inputs.file('package.json')
@@ -107,10 +95,7 @@ subprojects {
 
     if (project.name == 'molgenis-components') {
         task buildComponentsShowcase(type: YarnTask, dependsOn: build) {
-            node {
-                with nodeSpec
-                download = false
-            }
+            node { with nodeSpec }
             if (project.name == 'molgenis-components') {
                 inputs.file('package.json')
                 inputs.files(fileTree('src'))

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -9,18 +9,28 @@ def nodeSpec = {
     version = '16.16.0'
     yarnVersion = '1.22.19'
     npmVersion = "8.17.0"
-    download = true
 }
 
 node {
     with nodeSpec
+    download = true
+    yarnWorkDir = file("${project.projectDir}/.gradle/yarn")
+    npmWorkDir = file("${project.projectDir}/.gradle/npm")
+    workDir = file("${project.projectDir}/.gradle/nodejs")
 }
 
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
+    node {
+        with nodeSpec
+        download = false
+        yarnWorkDir = file("${parent.projectDir}/.gradle/yarn")
+        npmWorkDir = file("${parent.projectDir}/.gradle/npm")
+        workDir = file("${parent.projectDir}/.gradle/nodejs")
+    }
+
     task build(type: YarnTask, dependsOn: parent.yarn_install) {
-        node { with nodeSpec }
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {
             dependsOn ":apps:styleguide:build"
@@ -76,7 +86,6 @@ subprojects {
 
     if (project.name == 'styleguide') {
         task buildStyleguidist(type: YarnTask, dependsOn: build) {
-            node { with nodeSpec }
             inputs.files(fileTree('src'))
             inputs.files(fileTree('public'))
             inputs.file('package.json')
@@ -90,7 +99,6 @@ subprojects {
 
     if (project.name == 'molgenis-components') {
         task buildComponentsShowcase(type: YarnTask, dependsOn: build) {
-            node { with nodeSpec }
             if (project.name == 'molgenis-components') {
                 inputs.file('package.json')
                 inputs.files(fileTree('src'))

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -19,7 +19,8 @@ node {
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.npm_install]) {
+    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.addCrossEnv]) {
+        node { with nodeSpec }
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {
             dependsOn ":apps:styleguide:build"
@@ -74,6 +75,7 @@ subprojects {
 
     if (project.name == 'styleguide') {
         task buildStyleguidist(type: YarnTask, dependsOn: build) {
+            node { with nodeSpec }
             inputs.files(fileTree('src'))
             inputs.files(fileTree('public'))
             inputs.file('package.json')
@@ -87,6 +89,7 @@ subprojects {
 
     if (project.name == 'molgenis-components') {
         task buildComponentsShowcase(type: YarnTask, dependsOn: build) {
+            node { with nodeSpec }
             if (project.name == 'molgenis-components') {
                 inputs.file('package.json')
                 inputs.files(fileTree('src'))

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -14,6 +14,7 @@ def nodeSpec = {
 node {
     with nodeSpec
     download = true
+    workDir = file("${project.projectDir}/.gradle/nodejs")
     yarnWorkDir = file("${project.projectDir}/.gradle/yarn")
     npmWorkDir = file("${project.projectDir}/.gradle/npm")
     workDir = file("${project.projectDir}/.gradle/nodejs")
@@ -22,13 +23,16 @@ node {
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    yarnSetup.dependsOn parent.yarn_install
-    npmSetup.dependsOn parent.yarn_install
-    nodeSetup.dependsOn parent.yarn_install
+    yarnSetup.dependsOn parent.yarnSetup
+    npmSetup.dependsOn parent.npmSetup
+    nodeSetup.dependsOn parent.nodeSetup
+    //we use yarn workspaces, install happens on /apps level
+    yarn_install.enabled = false
 
     node {
         with nodeSpec
         download = false
+        workDir = file("${parent.projectDir}/.gradle/nodejs")
         yarnWorkDir = file("${parent.projectDir}/.gradle/yarn")
         npmWorkDir = file("${parent.projectDir}/.gradle/npm")
         workDir = file("${parent.projectDir}/.gradle/nodejs")

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -22,16 +22,18 @@ node {
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    node
-            {
-                with nodeSpec
-                download = false
-                yarnWorkDir = file("${parent.projectDir}/.gradle/yarn")
-                npmWorkDir = file("${parent.projectDir}/.gradle/npm")
-                workDir = file("${parent.projectDir}/.gradle/nodejs")
-            }
-
     yarnSetup.dependsOn parent.yarnSetup
+    npmSetup.dependsOn parent.npmSetup
+    nodeSetup.dependsOn parent.nodeSetup
+
+    node {
+        with nodeSpec
+        download = false
+        yarnWorkDir = file("${parent.projectDir}/.gradle/yarn")
+        npmWorkDir = file("${parent.projectDir}/.gradle/npm")
+        workDir = file("${parent.projectDir}/.gradle/nodejs")
+    }
+
 
     task build(type: YarnTask, dependsOn: parent.yarn_install) {
         // force build order: molgenis-components > styleguide > ...apps

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -9,18 +9,33 @@ def nodeSpec = {
     version = '16.16.0'
     yarnVersion = '1.22.19'
     npmVersion = "8.17.0"
-    download = true
 }
 
 node {
     with nodeSpec
+    download = true
 }
 
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.addCrossEnv]) {
-        node { with nodeSpec }
+    yarnSetup.configure {
+        dependsOn parent.yarnSetup
+    }
+
+    nodeSetup.configure {
+        dependsOn parent.nodeSetup
+    }
+
+    npmSetup.configure {
+        dependsOn parent.npmSetup
+    }
+
+    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.npm_install]) {
+        node {
+            with nodeSpec
+            download = false
+        }
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {
             dependsOn ":apps:styleguide:build"
@@ -75,7 +90,10 @@ subprojects {
 
     if (project.name == 'styleguide') {
         task buildStyleguidist(type: YarnTask, dependsOn: build) {
-            node { with nodeSpec }
+            node {
+                with nodeSpec
+                download = false
+            }
             inputs.files(fileTree('src'))
             inputs.files(fileTree('public'))
             inputs.file('package.json')
@@ -89,7 +107,10 @@ subprojects {
 
     if (project.name == 'molgenis-components') {
         task buildComponentsShowcase(type: YarnTask, dependsOn: build) {
-            node { with nodeSpec }
+            node {
+                with nodeSpec
+                download = false
+            }
             if (project.name == 'molgenis-components') {
                 inputs.file('package.json')
                 inputs.files(fileTree('src'))

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -6,9 +6,9 @@ plugins {
 }
 
 def nodeSpec = {
-    version = '16.13.0'
-    yarnVersion = '1.22.15'
-    npmVersion = "8.1.0"
+    version = '16.16.0'
+    yarnVersion = '1.22.19'
+    npmVersion = "8.17.0"
     download = true
 }
 
@@ -16,15 +16,10 @@ node {
     with nodeSpec
 }
 
-task addCrossEnv(type: YarnTask) {
-    // add the express package only
-    args = ['global', 'add', 'cross-env']
-}
-
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.addCrossEnv]) {
+    task build(type: YarnTask, dependsOn: parent.yarn_install) {
         node { with nodeSpec }
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -9,21 +9,15 @@ def nodeSpec = {
     version = '16.16.0'
     yarnVersion = '1.22.19'
     npmVersion = "8.17.0"
+    download = true
 }
 
 node {
     with nodeSpec
-    download = true
 }
 
 subprojects {
     apply plugin: "com.github.node-gradle.node"
-    //using from parent yarn_install
-    node {
-        with nodeSpec
-        download = false;
-    }
-
 
     task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.npm_install]) {
         // force build order: molgenis-components > styleguide > ...apps

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -9,15 +9,11 @@ def nodeSpec = {
     version = '16.16.0'
     yarnVersion = '1.22.19'
     npmVersion = "8.17.0"
+    download = true
 }
 
 node {
     with nodeSpec
-    download = true
-    workDir = file("${project.projectDir}/.gradle/nodejs")
-    yarnWorkDir = file("${project.projectDir}/.gradle/yarn")
-    npmWorkDir = file("${project.projectDir}/.gradle/npm")
-    workDir = file("${project.projectDir}/.gradle/nodejs")
 }
 
 subprojects {
@@ -29,17 +25,8 @@ subprojects {
     //we use yarn workspaces, install happens on /apps level
     yarn_install.enabled = false
 
-    node {
-        with nodeSpec
-        download = false
-        workDir = file("${parent.projectDir}/.gradle/nodejs")
-        yarnWorkDir = file("${parent.projectDir}/.gradle/yarn")
-        npmWorkDir = file("${parent.projectDir}/.gradle/npm")
-        workDir = file("${parent.projectDir}/.gradle/nodejs")
-    }
-
-
     task build(type: YarnTask, dependsOn: parent.yarn_install) {
+        node { with nodeSpec }
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {
             dependsOn ":apps:styleguide:build"
@@ -95,6 +82,7 @@ subprojects {
 
     if (project.name == 'styleguide') {
         task buildStyleguidist(type: YarnTask, dependsOn: build) {
+            node { with nodeSpec }
             inputs.files(fileTree('src'))
             inputs.files(fileTree('public'))
             inputs.file('package.json')
@@ -108,6 +96,7 @@ subprojects {
 
     if (project.name == 'molgenis-components') {
         task buildComponentsShowcase(type: YarnTask, dependsOn: build) {
+            node { with nodeSpec }
             if (project.name == 'molgenis-components') {
                 inputs.file('package.json')
                 inputs.files(fileTree('src'))

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -9,24 +9,28 @@ def nodeSpec = {
     version = '16.16.0'
     yarnVersion = '1.22.19'
     npmVersion = "8.17.0"
-    download = true
 }
 
 node {
     with nodeSpec
+    download = true
 }
 
 subprojects {
     apply plugin: "com.github.node-gradle.node"
+    //using from parent yarn_install
+    node {
+        with nodeSpec
+        download = false;
+    }
+
 
     task build(type: YarnTask, dependsOn: parent.yarn_install) {
-        node { with nodeSpec }
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {
             dependsOn ":apps:styleguide:build"
             dependsOn ":apps:molgenis-components:build"
         }
-
         // set input out out put for each app type
         if (project.name == 'styleguide') {
             inputs.file('package.json')
@@ -76,7 +80,6 @@ subprojects {
 
     if (project.name == 'styleguide') {
         task buildStyleguidist(type: YarnTask, dependsOn: build) {
-            node { with nodeSpec }
             inputs.files(fileTree('src'))
             inputs.files(fileTree('public'))
             inputs.file('package.json')
@@ -90,7 +93,6 @@ subprojects {
 
     if (project.name == 'molgenis-components') {
         task buildComponentsShowcase(type: YarnTask, dependsOn: build) {
-            node { with nodeSpec }
             if (project.name == 'molgenis-components') {
                 inputs.file('package.json')
                 inputs.files(fileTree('src'))

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -22,13 +22,16 @@ node {
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    node {
-        with nodeSpec
-        download = false
-        yarnWorkDir = file("${parent.projectDir}/.gradle/yarn")
-        npmWorkDir = file("${parent.projectDir}/.gradle/npm")
-        workDir = file("${parent.projectDir}/.gradle/nodejs")
-    }
+    node
+            {
+                with nodeSpec
+                download = false
+                yarnWorkDir = file("${parent.projectDir}/.gradle/yarn")
+                npmWorkDir = file("${parent.projectDir}/.gradle/npm")
+                workDir = file("${parent.projectDir}/.gradle/nodejs")
+            }
+
+    yarnSetup.dependsOn parent.yarnSetup
 
     task build(type: YarnTask, dependsOn: parent.yarn_install) {
         // force build order: molgenis-components > styleguide > ...apps

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -25,7 +25,7 @@ subprojects {
     }
 
 
-    task build(type: YarnTask, dependsOn: parent.yarn_install) {
+    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.npm_install]) {
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {
             dependsOn ":apps:styleguide:build"
@@ -33,7 +33,6 @@ subprojects {
         }
         // set input out out put for each app type
         if (project.name == 'styleguide') {
-            dependsOn ":apps:yarnSetup"
             inputs.file('package.json')
             inputs.files(fileTree('src'))
             inputs.files(fileTree('tests'))
@@ -43,7 +42,6 @@ subprojects {
             outputs.dir('build')
             outputs.dir('dist')
         } else if (project.name == 'molgenis-components') {
-            dependsOn ":apps:yarnSetup"
             inputs.file('package.json')
             inputs.files(fileTree('src'))
             inputs.files(fileTree('public'))

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -33,6 +33,7 @@ subprojects {
         }
         // set input out out put for each app type
         if (project.name == 'styleguide') {
+            dependsOn ":apps:yarnSetup"
             inputs.file('package.json')
             inputs.files(fileTree('src'))
             inputs.files(fileTree('tests'))
@@ -42,6 +43,7 @@ subprojects {
             outputs.dir('build')
             outputs.dir('dist')
         } else if (project.name == 'molgenis-components') {
+            dependsOn ":apps:yarnSetup"
             inputs.file('package.json')
             inputs.files(fileTree('src'))
             inputs.files(fileTree('public'))

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -22,9 +22,9 @@ node {
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    yarnSetup.dependsOn parent.yarnSetup
-    npmSetup.dependsOn parent.npmSetup
-    nodeSetup.dependsOn parent.nodeSetup
+    yarnSetup.dependsOn parent.yarn_install
+    npmSetup.dependsOn parent.yarn_install
+    nodeSetup.dependsOn parent.yarn_install
 
     node {
         with nodeSpec

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -22,8 +22,6 @@ subprojects {
     yarnSetup.dependsOn parent.yarnSetup
     npmSetup.dependsOn parent.npmSetup
     nodeSetup.dependsOn parent.nodeSetup
-    //we use yarn workspaces, install happens on /apps level
-    yarn_install.enabled = false
 
     task build(type: YarnTask, dependsOn: parent.yarn_install) {
         node { with nodeSpec }

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -16,15 +16,10 @@ node {
     with nodeSpec
 }
 
-task addCrossEnv(type: YarnTask) {
-    // add the express package only
-    args = ['global', 'add', 'cross-env']
-}
-
 subprojects {
     apply plugin: "com.github.node-gradle.node"
 
-    task build(type: YarnTask, dependsOn: [parent.yarn_install, parent.addCrossEnv]) {
+    task build(type: YarnTask, dependsOn: parent.yarn_install) {
         node { with nodeSpec }
         // force build order: molgenis-components > styleguide > ...apps
         if (project.name != 'styleguide' && project.name != 'molgenis-components') {


### PR DESCRIPTION
this PR is motivated by brittle builds of molgenis-components (esbuild error sometimes).
I hope that by have more determined order state will be more reproducible.
(might be that the gradle node plugin has become brittle, I don't know)

Typical error message: error Command failed with exit code 127.

I also noticed circleci breaking supposedly because the 'gradle:jdk17' image was changed from focal to yammie, therefore chose a more specific image.