### PR TITLE
Revert "chore(deps): update plugin com.github.node-gradle.node to v3.4.0"

### DIFF
--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -2,7 +2,7 @@
 
 plugins {
     id "base"
-    id "com.github.node-gradle.node" version "3.4.0"
+    id "com.github.node-gradle.node" version "3.3.0"
 }
 
 def nodeSpec = {


### PR DESCRIPTION
Reverts molgenis/molgenis-emx2#1384

Motivation: see if this leads to more stability in the build to get rid of "finished with non-zero exit value 127" errors.