### PR TITLE
Fix/streamrdf

### DIFF
--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/RDFService.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/RDFService.java
@@ -11,7 +11,7 @@ import static org.molgenis.emx2.semantics.rdf.ValueToRDF.describeValues;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.util.StdDateFormat;
-import java.io.PrintWriter;
+import java.io.OutputStream;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.List;
@@ -115,12 +115,12 @@ public class RDFService {
    * The number of schemas, tables, and rows returned depend on the input parameters.
    *
    * @param schemas
-   * @param writer
+   * @param outputStream
    * @param request
    * @param response
    */
   public static void describeAsRDF(
-      PrintWriter writer,
+      OutputStream outputStream,
       Request request,
       Response response,
       String rdfApiLocation,
@@ -154,7 +154,7 @@ public class RDFService {
 
       Rio.write(
           rdfService.getBuilder().build(),
-          writer,
+          outputStream,
           rdfService.getRdfFormat(),
           rdfService.getConfig());
 

--- a/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/RDFTest.java
+++ b/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/RDFTest.java
@@ -5,8 +5,8 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.molgenis.emx2.semantics.rdf.StringsForRDFTest.*;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import java.io.ByteArrayOutputStream;
+import java.io.OutputStream;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.molgenis.emx2.Database;
@@ -42,10 +42,10 @@ public class RDFTest {
     Request request = mock(Request.class);
     Response response = mock(Response.class);
     when(request.url()).thenReturn("http://localhost:8080/api/fdp");
-    StringWriter sw = new StringWriter();
+    OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        new PrintWriter(sw), request, response, RDF_API_LOCATION, null, null, petStoreSchemas);
-    String result = sw.getBuffer().toString();
+        outputStream, request, response, RDF_API_LOCATION, null, null, petStoreSchemas);
+    String result = outputStream.toString();
     assertTrue(result.contains(TTL_PREFIX_1));
     assertTrue(result.contains(TTL_PREFIX_2));
     assertTrue(result.contains(TTL_ROOT));
@@ -75,10 +75,10 @@ public class RDFTest {
     Request request = mock(Request.class);
     Response response = mock(Response.class);
     when(request.url()).thenReturn("http://localhost:8080/petStoreNr1/api/fdp");
-    StringWriter sw = new StringWriter();
+    OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        new PrintWriter(sw), request, response, RDF_API_LOCATION, null, null, petStoreSchemas[0]);
-    String result = sw.getBuffer().toString();
+        outputStream, request, response, RDF_API_LOCATION, null, null, petStoreSchemas[0]);
+    String result = outputStream.toString();
     assertTrue(result.contains(TTL_PREFIX_1));
     assertFalse(result.contains(TTL_PREFIX_2));
     assertTrue(result.contains(TTL_ROOT));
@@ -109,10 +109,10 @@ public class RDFTest {
     Response response = mock(Response.class);
     when(request.url()).thenReturn("http://localhost:8080/petStore/api/fdp/Category");
     Table table = petStoreSchemas[0].getTable("Category");
-    StringWriter sw = new StringWriter();
+    OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        new PrintWriter(sw), request, response, RDF_API_LOCATION, table, null, table.getSchema());
-    String result = sw.getBuffer().toString();
+        outputStream, request, response, RDF_API_LOCATION, table, null, table.getSchema());
+    String result = outputStream.toString();
     assertTrue(result.contains(TTL_PREFIX_1));
     assertFalse(result.contains(TTL_PREFIX_2));
     assertTrue(result.contains(TTL_ROOT));
@@ -144,10 +144,10 @@ public class RDFTest {
     when(request.url()).thenReturn("http://localhost:8080/petStore/api/fdp/Category/cat");
     Table table = petStoreSchemas[0].getTable("Category");
     String rowId = "cat";
-    StringWriter sw = new StringWriter();
+    OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        new PrintWriter(sw), request, response, RDF_API_LOCATION, table, rowId, table.getSchema());
-    String result = sw.getBuffer().toString();
+        outputStream, request, response, RDF_API_LOCATION, table, rowId, table.getSchema());
+    String result = outputStream.toString();
     assertTrue(result.contains(TTL_PREFIX_1));
     assertFalse(result.contains(TTL_PREFIX_2));
     assertTrue(result.contains(TTL_ROOT));
@@ -181,10 +181,10 @@ public class RDFTest {
     when(request.queryParams("format")).thenReturn("xml");
     Table table = petStoreSchemas[0].getTable("Category");
     String rowId = "cat";
-    StringWriter sw = new StringWriter();
+    OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        new PrintWriter(sw), request, response, RDF_API_LOCATION, table, rowId, table.getSchema());
-    String result = sw.getBuffer().toString();
+        outputStream, request, response, RDF_API_LOCATION, table, rowId, table.getSchema());
+    String result = outputStream.toString();
     assertTrue(result.contains("xmlns:emx0=\"http://localhost:8080/petStoreNr1/api/rdf/\">"));
     assertTrue(result.contains("<rdf:Description rdf:about=\"http://localhost:8080\">"));
     assertTrue(


### PR DESCRIPTION
RDF API now immediately streams its response instead of first buffering everything in memory first. This prevents the server from spending minutes to hours preparing results for even relatively small data sets.