### PR TITLE
fix: set ref key as part of cloned row data

### DIFF
--- a/apps/molgenis-components/src/components/forms/EditModal.vue
+++ b/apps/molgenis-components/src/components/forms/EditModal.vue
@@ -142,8 +142,6 @@ export default {
     this.client = Client.newClient(this.graphqlURL);
     this.tableMetaData = await this.client.fetchTableMetaData(this.tableName);
 
-    this.rowData = this.defaultValue ? deepClone(this.defaultValue) : {};
-
     if (this.pkey) {
       this.rowData = await this.fetchRowData();
 
@@ -159,6 +157,8 @@ export default {
         );
       }
     }
+
+    this.rowData = { ...this.rowData, ...deepClone(this.defaultValue) };
     this.loaded = true;
   },
 };


### PR DESCRIPTION
Use the default data prop to reset ref key in case of clone

solves issue in clone via inputRefback , the key from the parent table should stil be set on the clone data set.
Row data if first fetched based on clone origin id, then the keys are removed , then the ref key from the parent is put back . This pr adds the part where the ref key is put back