### PR TITLE
fix: replace graphql-request with client call

### DIFF
--- a/apps/molgenis-components/src/components/task/Task.vue
+++ b/apps/molgenis-components/src/components/task/Task.vue
@@ -7,7 +7,7 @@
 </template>
 
 <script>
-import { request } from "graphql-request";
+import { request } from "../../client/client.js";
 import SubTask from "./SubTask.vue";
 import Spinner from "../layout/Spinner.vue";
 

--- a/apps/molgenis-components/src/components/task/TaskList.vue
+++ b/apps/molgenis-components/src/components/task/TaskList.vue
@@ -25,7 +25,7 @@
 </template>
 
 <script>
-import { request } from "graphql-request";
+import { request } from "../../client/client.js";
 import MessageError from "../forms/MessageError.vue";
 
 export default {


### PR DESCRIPTION
Closes #1649

graphql-request uses code that can not run the server side ( window.FormData call )