### PR TITLE
fix: table create and drop order for tests now repeatable

### DIFF
--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlCrossSchemaRefs.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlCrossSchemaRefs.java
@@ -27,8 +27,10 @@ public class TestGraphqlCrossSchemaRefs {
   @BeforeClass
   public static void setup() {
     Database database = TestDatabaseFactory.getTestDatabase();
-    schema1 = database.dropCreateSchema(schemaName1);
-    schema2 = database.dropCreateSchema(schemaName2);
+    database.dropSchemaIfExists(schemaName2);
+    database.dropSchemaIfExists(schemaName1);
+    schema1 = database.createSchema(schemaName1);
+    schema2 = database.createSchema(schemaName2);
 
     CrossSchemaReferenceExample.create(schema1, schema2);
     graphql = new GraphqlApiFactory().createGraphqlForSchema(schema2);

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestCrossSchemaForeignKeysAndInheritance.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestCrossSchemaForeignKeysAndInheritance.java
@@ -12,6 +12,12 @@ import org.molgenis.emx2.Schema;
 import org.molgenis.emx2.datamodels.test.CrossSchemaReferenceExample;
 
 public class TestCrossSchemaForeignKeysAndInheritance {
+
+  private static final String schemaName1 =
+      TestCrossSchemaForeignKeysAndInheritance.class.getSimpleName() + "1";
+  private static final String schemaName2 =
+      TestCrossSchemaForeignKeysAndInheritance.class.getSimpleName() + "2";
+
   static Schema schema1;
   static Schema schema2;
   static Database db;
@@ -19,11 +25,10 @@ public class TestCrossSchemaForeignKeysAndInheritance {
   @BeforeClass
   public static void setUp() {
     db = TestDatabaseFactory.getTestDatabase();
-    schema1 =
-        db.dropCreateSchema(TestCrossSchemaForeignKeysAndInheritance.class.getSimpleName() + "1");
-    schema2 =
-        db.dropCreateSchema(TestCrossSchemaForeignKeysAndInheritance.class.getSimpleName() + "2");
-
+    db.dropSchemaIfExists(schemaName2);
+    db.dropSchemaIfExists(schemaName1);
+    schema1 = db.createSchema(schemaName1);
+    schema2 = db.createSchema(schemaName2);
     CrossSchemaReferenceExample.create(schema1, schema2);
   }
 


### PR DESCRIPTION
TestGraphqlCrossSchemaRefs and TestCrossSchemaForeignKeysAndInheritance would only successfully run once on a clean database, but fail when attempted more than once. What happened:

__Run 1__
Start from a clean database.
Schema 1 does not exist, no dropping needed, is created empty.
Schema 2 does not exist, no dropping needed, is created empty.
Schemas are filled with data, including Schema 2 receiving data with a dependency on Schema 1.
Test succeeds.

__Run 2__
Start from a dirty database.
Schema 1 already exists, is therefore dropped, and created empty.
Schema 2 already exists, is therefore dropped, but this fails because there is still an existing data dependency on Schema 1, which no longer exists.
Test fails.

So we have to first drop Schema 2 and then Schema 1, and then create them again. After this fix:

__Run ∞__
Start from either a clean or dirty database.
Schema 2 if it exists, is dropped.
Schema 1 if it exists, is dropped.
Schema 1 is created empty.
Schema 2 is created empty.
Schemas are filled with data, including Schema 2 receiving data with a dependency on Schema 1.
Test succeeds.
