### PR TITLE
Linked hashmap to fix language order

### DIFF
--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointCatalog.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointCatalog.java
@@ -188,7 +188,7 @@ public class FAIRDataPointCatalog {
 
     if (catalogFromJSON.get("language") != null) {
       ArrayList<IRI> languages =
-          extractItemAsIRI((List<Map>) catalogFromJSON.get("language"), "ontologyTermURI");
+          extractItemAsIRI((List<LinkedHashMap>) catalogFromJSON.get("language"), "ontologyTermURI");
       for (IRI language : languages) {
         builder.add(reqUrl, DCTERMS.LANGUAGE, language);
       }
@@ -249,9 +249,9 @@ public class FAIRDataPointCatalog {
    * @param item
    * @return
    */
-  public static ArrayList<IRI> extractItemAsIRI(List<Map> object, String item) {
+  public static ArrayList<IRI> extractItemAsIRI(List<LinkedHashMap> object, String item) {
     ArrayList<IRI> values = new ArrayList<>();
-    for (Map map : object) {
+    for (LinkedHashMap map : object) {
       IRI iri = iri(TypeUtils.toString(map.get(item)));
       values.add(iri);
     }

--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointDataset.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointDataset.java
@@ -134,7 +134,7 @@ public class FAIRDataPointDataset {
     }
     if (datasetFromJSON.get("spatial") != null) {
       ArrayList<IRI> spatials =
-          extractItemAsIRI((List<Map>) datasetFromJSON.get("spatial"), "ontologyTermURI");
+          extractItemAsIRI((List<LinkedHashMap>) datasetFromJSON.get("spatial"), "ontologyTermURI");
       for (IRI spatial : spatials) {
         builder.add(reqUrl, DCTERMS.SPATIAL, spatial);
       }
@@ -190,7 +190,7 @@ public class FAIRDataPointDataset {
     }
     if (datasetFromJSON.get("language") != null) {
       ArrayList<IRI> languages =
-          extractItemAsIRI((List<Map>) datasetFromJSON.get("language"), "ontologyTermURI");
+          extractItemAsIRI((List<LinkedHashMap>) datasetFromJSON.get("language"), "ontologyTermURI");
       for (IRI language : languages) {
         builder.add(reqUrl, DCTERMS.LANGUAGE, language);
       }


### PR DESCRIPTION
Maybe this fixes the test problem where languages appear in a different order. Cannot reproduce locally, it never fails.

```
org.molgenis.emx2.semantics.fairdatapoint.FAIRDataPointTest > FDPDataset FAILED
    org.junit.ComparisonFailure: expected:<...terms:language lang:[eng, lang:nld];
      dcterms:relation...> but was:<...terms:language lang:[nld, lang:eng];
```