### PR TITLE
fix: session in graphql-playground

### DIFF
--- a/apps/graphql-playground/src/main.js
+++ b/apps/graphql-playground/src/main.js
@@ -6,6 +6,7 @@ window.addEventListener("load", function (event) {
     endpoint: "./graphql",
     settings: {
       "schema.polling.enable": false,
+      "request.credentials": "include",
     },
     // options as 'endpoint' belong here
   });


### PR DESCRIPTION
motivation: if you have private schema then you can't use graphql-playground, even if you have signed in.

It seems session is not included. This draft PR tries to fix it. But it is working locally so that doesn't help for the testing