### PR TITLE
fix: load table settings with metaData

### DIFF
--- a/apps/molgenis-components/src/client/client.js
+++ b/apps/molgenis-components/src/client/client.js
@@ -126,6 +126,10 @@ _schema {
       visible,
       validation
     }
+    settings { 
+      key,
+      value 
+    }
   }
 }}`;
 


### PR DESCRIPTION
Fixes issue where card settings where not loaded as part of the table meta data, resulting in card template not being used.