### PR TITLE
fix: only update table metadata fields if present

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
@@ -290,8 +290,13 @@ public class SqlSchema implements Schema {
         if (!mergeTable.getSettings().isEmpty()) {
           oldTable.setSettings(mergeTable.getSettings());
         }
-        oldTable.setDescription(mergeTable.getDescription());
-        oldTable.setSemantics(mergeTable.getSemantics());
+        if (mergeTable.getDescription() != null) {
+          oldTable.setDescription(mergeTable.getDescription());
+        }
+        if (mergeTable.getSemantics() != null) {
+          oldTable.setSemantics(mergeTable.getSemantics());
+        }
+        // TableType is DATA by default and therefore never null
         oldTable.setTableType(mergeTable.getTableType());
         MetadataUtils.saveTableMetadata(targetSchema.getMetadata().getJooq(), oldTable);
 


### PR DESCRIPTION
Before, if the table metadata `semantics` or `description` was left empty in CSV import into an existing table, the existing values for these fields were overwritten by empty values.

Now, you can update specific table fields without having to re-supply the old values lest they were emptied.

For instance, this is a table I want to update:

```
tableName,semantics,description
MyTable,http://myOLDsemantics.nl,My OLD description
```

With perhaps only new semantics:

```
tableName,semantics
MyTable,http://myNEWsemantics.nl
```

The result will then be

```
tableName,semantics,description
MyTable,http://myNEWsemantics.nl,My OLD description
```

And then description:

tableName,description
MyTable,My description




