### PR TITLE
Fix/rdftablemeta

### DIFF
--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/rdf/TableToRDF.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/rdf/TableToRDF.java
@@ -5,6 +5,7 @@ import static org.molgenis.emx2.semantics.rdf.IRIParsingEncoding.encodedIRI;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.util.ModelBuilder;
+import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.model.vocabulary.OWL;
 import org.eclipse.rdf4j.model.vocabulary.RDF;
 import org.eclipse.rdf4j.model.vocabulary.RDFS;
@@ -26,8 +27,16 @@ public class TableToRDF {
       builder.add(
           // NCIT:C48697 = Controlled Vocabulary
           tableContext, RDFS.ISDEFINEDBY, iri("http://purl.obolibrary.org/obo/NCIT_C48697"));
+    } else {
+      builder.add(
+          // SIO:001055 = observing (definition: observing is a process of passive interaction in
+          // which one entity makes note of attributes of one or more entities)
+          tableContext, RDFS.ISDEFINEDBY, iri("http://semanticscience.org/resource/SIO_001055"));
     }
     builder.add(tableContext, RDFS.LABEL, table.getName());
+    if (table.getMetadata().getDescription() != null) {
+      builder.add(tableContext, DCTERMS.DESCRIPTION, table.getMetadata().getDescription());
+    }
     if (table.getMetadata().getTableType() == TableType.DATA) {
       // NCIT:C25474 = Data
       builder.add(tableContext, RDFS.RANGE, iri("http://purl.obolibrary.org/obo/NCIT_C25474"));

--- a/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/RDFTest.java
+++ b/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/RDFTest.java
@@ -132,7 +132,6 @@ public class RDFTest {
     assertTrue(result.contains(TTL_ROW_DOG_1));
     assertFalse(result.contains(TTL_ROW_CAT_2));
     assertFalse(result.contains(TTL_ROW_DOG_2));
-    assertEquals(5972, result.length());
   }
 
   @Test
@@ -167,7 +166,6 @@ public class RDFTest {
     assertFalse(result.contains(TTL_ROW_DOG_1));
     assertFalse(result.contains(TTL_ROW_CAT_2));
     assertFalse(result.contains(TTL_ROW_DOG_2));
-    assertEquals(2910, result.length());
   }
 
   @Test
@@ -194,6 +192,5 @@ public class RDFTest {
     assertTrue(
         result.contains(
             "<rdf:Description rdf:about=\"http://localhost:8080/petStoreNr1/api/rdf/Category/column/name\">"));
-    assertEquals(6285, result.length());
   }
 }


### PR DESCRIPTION
Added description to table metadata exported in RDF format. Also added a default definition for `DATA` tables. JUnit test was updated by removing exact character counts which is a poor and brittle metric.