### PR TITLE
chore: cleanup vue3 issue

### DIFF
--- a/apps/molgenis-components/src/components/filters/BooleanFilter.vue
+++ b/apps/molgenis-components/src/components/filters/BooleanFilter.vue
@@ -18,13 +18,6 @@ export default {
       type: String,
       required: true,
     },
-    name: {
-      type: String,
-      required: false,
-      default: function () {
-        return this.id;
-      },
-    },
     condition: {
       type: Boolean,
       required: false,

--- a/apps/molgenis-components/src/components/filters/DateFilter.vue
+++ b/apps/molgenis-components/src/components/filters/DateFilter.vue
@@ -32,13 +32,6 @@ export default {
       type: String,
       required: true,
     },
-    name: {
-      type: String,
-      required: false,
-      default: function () {
-        return this.id;
-      },
-    },
     condition: {
       type: Array,
       required: false,

--- a/apps/molgenis-components/src/components/filters/DateTimeFilter.vue
+++ b/apps/molgenis-components/src/components/filters/DateTimeFilter.vue
@@ -32,13 +32,6 @@ export default {
       type: String,
       required: true,
     },
-    name: {
-      type: String,
-      required: false,
-      default: function () {
-        return this.id;
-      },
-    },
     condition: {
       type: Array,
       required: false,

--- a/apps/molgenis-components/src/components/filters/DecimalFilter.vue
+++ b/apps/molgenis-components/src/components/filters/DecimalFilter.vue
@@ -22,13 +22,6 @@ export default {
       type: String,
       required: true,
     },
-    name: {
-      type: String,
-      required: false,
-      default: function () {
-        return this.id;
-      },
-    },
     condition: {
       type: Array,
       required: false,

--- a/apps/molgenis-components/src/components/filters/FilterInput.vue
+++ b/apps/molgenis-components/src/components/filters/FilterInput.vue
@@ -87,13 +87,6 @@ export default {
       type: Array,
       required: true,
     },
-    name: {
-      type: String,
-      required: false,
-      default: function () {
-        return this.id;
-      },
-    },
     tableName: {
       type: String,
       required: false,

--- a/apps/molgenis-components/src/components/filters/IntegerFilter.vue
+++ b/apps/molgenis-components/src/components/filters/IntegerFilter.vue
@@ -22,13 +22,6 @@ export default {
       type: String,
       required: true,
     },
-    name: {
-      type: String,
-      required: false,
-      default: function () {
-        return this.id;
-      },
-    },
     condition: {
       type: Array,
       required: false,

--- a/apps/molgenis-components/src/components/filters/StringFilter.vue
+++ b/apps/molgenis-components/src/components/filters/StringFilter.vue
@@ -22,13 +22,6 @@ export default {
       type: String,
       required: true,
     },
-    name: {
-      type: String,
-      required: false,
-      default: function () {
-        return this.id;
-      },
-    },
     condition: {
       type: String,
       required: false,

--- a/apps/molgenis-components/src/components/forms/FormInput.vue
+++ b/apps/molgenis-components/src/components/forms/FormInput.vue
@@ -450,7 +450,7 @@ export default {
       textValue: "example text",
       textValueArray: ["text", "more text"],
       longValue: "1337",
-      longValueArray: ["0", "1.1"],
+      longValueArray: ["0", "101"],
       decimalValue: 3.7,
       decimalValueArray: [4.2, 13.37],
       booleanValue: true,

--- a/apps/molgenis-components/src/components/forms/baseInputs/BaseInput.vue
+++ b/apps/molgenis-components/src/components/forms/baseInputs/BaseInput.vue
@@ -17,9 +17,6 @@ export default {
     name: {
       type: String,
       required: false,
-      default: function () {
-        return this.id;
-      },
     },
     value: {
       type: [String, Number, Object, Array, Boolean],

--- a/apps/molgenis-components/src/components/tables/TableMolgenis.vue
+++ b/apps/molgenis-components/src/components/tables/TableMolgenis.vue
@@ -237,8 +237,8 @@ export default {
                       :columns.sync="remoteColumns"
                       :data="remoteTableData"
                       @click="click"
-      >
-      </table-molgenis id="table-molgenis-empty" label="Empty Table Molgenis">
+      />
+      <table-molgenis id="table-molgenis-empty" label="Empty Table Molgenis"/>
     </demo-item>
     <DemoItem>
       <label class="font-italic">Example without data</label>


### PR DESCRIPTION
Clean up small issue that block moving to vue 3 

- this context can no longer be referenced from prop.default
- filter inputs do not need a name
- proper closing tags in docs example