### PR TITLE
chore: fix jenkins build 

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -60,7 +60,7 @@ pipeline {
             steps {
                 container('java') {
                     script {
-                    sh "./gradlew test jacocoMergedReport shadowJar jib release ci \
+                    sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release ci \
                         -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
                         -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
                         def props = readProperties file: 'build/ci.properties'
@@ -96,7 +96,7 @@ pipeline {
             steps {
                 container('java') {
                     script {
-                        sh "./gradlew test jacocoMergedReport shadowJar jib release helmPublishMainChart sonarqube ci \
+                        sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart sonarqube ci \
                             -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
                             -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
                         def props = readProperties file: 'build/ci.properties'

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 def nodeSpec = {
     version = '16.16.0'
-    yarnVersion = '1.22.19'
+    yarnVersion = '1.17.3' // lock verison to avoid https://github.com/yarnpkg/yarn/issues/6977
     npmVersion = "8.17.0"
     download = true
 }

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -7,7 +7,7 @@ plugins {
 
 def nodeSpec = {
     version = '16.16.0'
-    yarnVersion = '1.17.3' // lock verison to avoid https://github.com/yarnpkg/yarn/issues/6977
+    yarnVersion = '1.22.19'
     npmVersion = "8.17.0"
     download = true
 }

--- a/apps/package.json
+++ b/apps/package.json
@@ -13,5 +13,6 @@
     "molgenis-components",
     "helloworld",
     "gendecs"
-  ]
+   ],
+  "nohoist": ["**/**/**"]
 }


### PR DESCRIPTION
Workaround for gradle/yarn-workspace interaction issue. 
gradle does parallel runs of the apps build ,  yarn-workspace hoists up the dependancies to the app/node_modules folder , but yarn does not expect parallel build and then throws a file already exists exception. 

seems like a yarn issue to me , as a work around we can stop hoisting  