### PR TITLE
Feat: added HGVS notations to Beacon

### DIFF
--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/beaconv2/endpoints/genomicvariants/GenomicVariantsResponse.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/beaconv2/endpoints/genomicvariants/GenomicVariantsResponse.java
@@ -165,6 +165,9 @@ public class GenomicVariantsResponse {
                   + "position__start,"
                   + "position__end,"
                   + "geneId,"
+                  + "genomicHGVSId,"
+                  + "proteinHGVSIds,"
+                  + "transcriptHGVSIds,"
                   + "clinicalInterpretations{"
                   + "   category{name,codesystem,code},"
                   + "   clinicalRelevance{name,codesystem,code},"
@@ -188,6 +191,15 @@ public class GenomicVariantsResponse {
           genomicVariantsItem.setReferenceBases((String) map.get("referenceBases"));
           genomicVariantsItem.setAlternateBases((String) map.get("alternateBases"));
           genomicVariantsItem.setGeneId((String) map.get("geneId"));
+          genomicVariantsItem.setGenomicHGVSId((String) map.get("genomicHGVSId"));
+          if (map.get("proteinHGVSIds") != null) {
+            genomicVariantsItem.setProteinHGVSIds(
+                ((ArrayList<String>) map.get("proteinHGVSIds")).toArray(new String[0]));
+          }
+          if (map.get("transcriptHGVSIds") != null) {
+            genomicVariantsItem.setTranscriptHGVSIds(
+                ((ArrayList<String>) map.get("transcriptHGVSIds")).toArray(new String[0]));
+          }
           genomicVariantsItem.setPosition(
               new Position(
                   TypeUtils.toString(map.get("position__assemblyId")),

--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/beaconv2/endpoints/genomicvariants/GenomicVariantsResultSetsItem.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/beaconv2/endpoints/genomicvariants/GenomicVariantsResultSetsItem.java
@@ -11,6 +11,9 @@ public class GenomicVariantsResultSetsItem {
   private String alternateBases;
   private Position position;
   private String geneId;
+  private String genomicHGVSId;
+  private String[] proteinHGVSIds;
+  private String[] transcriptHGVSIds;
   private VariantLevelData variantLevelData;
 
   public void setVariantInternalId(String variantInternalId) {
@@ -43,5 +46,29 @@ public class GenomicVariantsResultSetsItem {
 
   public void setVariantLevelData(VariantLevelData variantLevelData) {
     this.variantLevelData = variantLevelData;
+  }
+
+  public String getGenomicHGVSId() {
+    return genomicHGVSId;
+  }
+
+  public void setGenomicHGVSId(String genomicHGVSId) {
+    this.genomicHGVSId = genomicHGVSId;
+  }
+
+  public String[] getProteinHGVSIds() {
+    return proteinHGVSIds;
+  }
+
+  public void setProteinHGVSIds(String[] proteinHGVSIds) {
+    this.proteinHGVSIds = proteinHGVSIds;
+  }
+
+  public String[] getTranscriptHGVSIds() {
+    return transcriptHGVSIds;
+  }
+
+  public void setTranscriptHGVSIds(String[] transcriptHGVSIds) {
+    this.transcriptHGVSIds = transcriptHGVSIds;
   }
 }

--- a/data/fairdatahub/beaconv2/demodata/GenomicVariations.csv
+++ b/data/fairdatahub/beaconv2/demodata/GenomicVariations.csv
@@ -1,5 +1,5 @@
-variantInternalId,variantType,referenceBases,alternateBases,position_assemblyId,position_refseqId,position_start,position_end,geneId,clinicalInterpretations
-20:2447951..2447952c>g,SNP,c,g,GRCh37,20,2447951,2447952,SNRPB,"Var001_CI001,Var001_CI002"
+variantInternalId,variantType,referenceBases,alternateBases,position_assemblyId,position_refseqId,position_start,position_end,geneId,clinicalInterpretations,genomicHGVSId,proteinHGVSIds,transcriptHGVSIds
+20:2447951..2447952c>g,SNP,c,g,GRCh37,20,2447951,2447952,SNRPB,"Var001_CI001,Var001_CI002",NC_000017.11:g.43057063G>A,NP_009225.1:p.Glu1817Ter,NC_000023.10(NM004006.2):c.357+1G
 20:2447955..2447958c>g,SNP,c,g,GRCh37,20,2447955,2447958,SNRPB,Var002_CI001
 20:2447946..2447950c>g,SNP,c,g,GRCh37,20,2447946,2447950,SNRPB
 20:2447961..2447963c>g,SNP,c,g,GRCh37,20,2447961,2447963,SNORD119

--- a/data/fairdatahub/beaconv2/molgenis.csv
+++ b/data/fairdatahub/beaconv2/molgenis.csv
@@ -9,6 +9,9 @@ GenomicVariations,,position_refseqId,string,,,,,,,,http://purl.obolibrary.org/ob
 GenomicVariations,,position_start,long,,,,,,,,http://purl.obolibrary.org/obo/GENO_0000894,E.g. 2447955
 GenomicVariations,,position_end,long,,,,,,,,http://purl.obolibrary.org/obo/GENO_0000895,E.g. 2447958
 GenomicVariations,,geneId,string,,,,,,,,http://purl.obolibrary.org/obo/NCIT_C20826,E.g. TTN
+GenomicVariations,,genomicHGVSId,string,,,,,,,,http://purl.obolibrary.org/obo/NCIT_C172243,E.g. NC_000017.11:g.43057063G>A
+GenomicVariations,,proteinHGVSIds,string_array,,,,,,,,http://ensembl.org/glossary/ENSGLOSSARY_0000274,E.g. NP_009225.1:p.Glu1817Ter
+GenomicVariations,,transcriptHGVSIds,string_array,,,,,,,,http://purl.obolibrary.org/obo/NCIT_C172244,E.g. NC_000023.10(NM004006.2):c.357+1G
 GenomicVariations,,clinicalInterpretations,ref_array,,,,GenomicVariationsClinInterpr,,,,http://purl.obolibrary.org/obo/NCIT_C125009,E.g. Var001_CI001
 GenomicVariationsClinInterpr,,,,,,,,,,,http://purl.obolibrary.org/obo/NCIT_C125009,Beacon v2 GenomicVariations Clinical Interpretations
 GenomicVariationsClinInterpr,,id,string,1,TRUE,,,,,,http://purl.obolibrary.org/obo/NCIT_C87853,E.g. Var001_CI001


### PR DESCRIPTION
Added HGVS notations for genomic variants for Beacon, used in various places. The fields:

- genomicHGVSId, string
- proteinHGVSIds, string_array
- transcriptHGVSIds, string_array