### PR TITLE
fix: Fix boolean filer sync with filter-wells

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputRadio.vue
+++ b/apps/molgenis-components/src/components/forms/InputRadio.vue
@@ -70,6 +70,9 @@ export default {
     radioValue() {
       this.$emit("input", this.radioValue);
     },
+    value(newValue) {
+      this.radioValue = newValue
+    }
   },
   computed: {
     isClearShown() {


### PR DESCRIPTION
sync back radio value on value update ( radioValue is not reactive to avoid prop mutation ), 
make the radio ui react to updating the value from outside after input creation ( for example the filter conditions)

Closes #1797