### PR TITLE
feat: can define ontology labels

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -14,7 +14,7 @@
     >
       <div
         class="border-0 text-left form-control"
-        style="height: auto"
+        style="height: auto;"
         @click="toggleFocus"
       >
         <span
@@ -28,7 +28,7 @@
         </span>
         <i
           class="p-2 fa fa-times"
-          style="vertical-align: middle"
+          style="vertical-align: middle;"
           @click.stop="clearSelection"
           v-if="showExpanded && selectionWithoutChildren.length > 0"
         />
@@ -57,13 +57,13 @@
         <span class="d-inline-block float-right">
           <i
             class="p-2 fa fa-times"
-            style="vertical-align: middle"
+            style="vertical-align: middle;"
             @click.stop="clearSelection"
             v-if="!showExpanded && selectionWithoutChildren.length > 0"
           />
           <i
             class="p-2 fa fa-caret-down"
-            style="vertical-align: middle"
+            style="vertical-align: middle;"
             v-if="!showExpanded"
           />
         </span>
@@ -85,7 +85,7 @@
         <InputOntologySubtree
           :key="key"
           v-if="rootTerms.length > 0"
-          style="max-height: 100vh"
+          style="max-height: 100vh;"
           class="pt-2 pl-0 dropdown-item"
           :terms="rootTerms"
           :isMultiSelect="isMultiSelect"
@@ -332,7 +332,7 @@ export default {
     },
     emitValue() {
       let selectedTerms = Object.values(this.terms)
-        .filter((term) => term.selected === "complete")
+        .filter((term) => term.selected === "complete" && !term.children)
         .map((term) => {
           return { name: term.name };
         });
@@ -353,7 +353,10 @@ export default {
         value.forEach((v) => {
           let term = this.terms[v.name];
           if (term) {
-            term.selected = "complete";
+            //select if doesn't have children
+            if (this.getAllChildren(term).length == 0) {
+              term.selected = "complete";
+            }
             if (this.isMultiSelect) {
               //if list also select its children
               this.getAllChildren(term).forEach(
@@ -430,10 +433,14 @@ export default {
       }
       this.key++;
     },
-    value() {
-      if (this.terms.size > 0) {
+    modelValue: {
+      deep: true,
+      handler() {
         this.applySelection(this.modelValue);
-      }
+        //vue has problem to react on changes deep changes in selection tree
+        //therefore we use this key to force updates in this component
+        this.key++;
+      },
     },
     data() {
       if (this.data) {
@@ -445,8 +452,9 @@ export default {
         this.data.forEach((e) => {
           // did we see it maybe as parent before?
           if (terms[e.name]) {
-            //then copy properties, currently only definition
+            //then copy properties, currently only definition and label
             terms[e.name].definition = e.definition;
+            terms[e.name].label = e.label;
           } else {
             //else simply add the record
             terms[e.name] = {
@@ -454,6 +462,7 @@ export default {
               visible: true,
               selected: false,
               definition: e.definition,
+              label: e.label
             };
           }
           if (e.parent) {

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -560,8 +560,8 @@ export default {
           description="please choose your options in tree below"
           v-model="value"
           :isMultiSelect="false"
-          tableName="AreasOfInformation"
-          graphqlURL="/CatalogueOntologies/graphql"
+          tableName="Tag"
+          graphqlURL="/pet store/graphql"
       />
     </demo-item>
 

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -573,8 +573,8 @@ export default {
           description="please choose your options in tree below"
           v-model="value"
           :isMultiSelect="true"
-          tableName="AreasOfInformation"
-          graphqlURL="/CatalogueOntologies/graphql"
+          tableName="Tag"
+          graphqlURL="/pet store/graphql"
       />
     </demo-item>
   </div>

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -560,8 +560,8 @@ export default {
           description="please choose your options in tree below"
           v-model="value"
           :isMultiSelect="false"
-          tableName="Tag"
-          graphqlURL="/pet store/graphql"
+          tableName="AreasOfInformation"
+          graphqlURL="/CatalogueOntologies/graphql"
       />
     </demo-item>
 
@@ -573,8 +573,8 @@ export default {
           description="please choose your options in tree below"
           v-model="value"
           :isMultiSelect="true"
-          tableName="Tag"
-          graphqlURL="/pet store/graphql"
+          tableName="AreasOfInformation"
+          graphqlURL="/CatalogueOntologies/graphql"
       />
     </demo-item>
   </div>

--- a/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
@@ -22,7 +22,7 @@
         class="flex-grow-1 pl-2"
         role="button"
       >
-        {{ term.name }}
+        {{ term.label ? term.label : term.name }}
         <small v-if="term.definition" class="text-muted">
           <i> - {{ term.definition }}</i></small
         >

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -551,6 +551,11 @@
     semver "^7.3.5"
     tar "^6.1.11"
 
+"@molgenis/expressions@0.21.2":
+  version "0.21.2"
+  resolved "https://registry.yarnpkg.com/@molgenis/expressions/-/expressions-0.21.2.tgz#eceb57c294f49a7ac4bee7db5f1957fc83401d3c"
+  integrity sha512-iL6MgMoKp8fbYqPTz1M6EYWTM3EYusSLugsqM4ddpmVttwNVImzpFNmA70Hl+SjaKtPPmobCpHNkgr6xTEWTbQ==
+
 "@netlify/functions@^1.2.0":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@netlify/functions/-/functions-1.3.0.tgz#4305a3fb6b49caf56cd2be88d4b8534b1d5aff4f"

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
@@ -293,7 +293,7 @@ public class SqlColumnExecutor {
                 // .setKey(2) when we upgrade to psql 15 so we can allow parent == null in
                 // constraint so we can ensure unique labels on each level
                 .setDescription("User-friendly label for this term. Should be unique in parent")
-                .setSemantics("http://purl.obolibrary.org/obo/NCIT_C42614"),
+                .setSemantics("http://purl.obolibrary.org/obo/NCIT_C45561"),
             column("parent")
                 // .setKey(2)  when we upgrade to psql 15 so we can allow parent == null in
                 // constraint

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
@@ -287,26 +287,33 @@ public class SqlColumnExecutor {
             column("name")
                 .setPkey()
                 .setRequired(true)
-                .setDescription("Short but user-friendly name for this term")
+                .setDescription("Unique name of the term within this table")
                 .setSemantics("http://purl.obolibrary.org/obo/NCIT_C42614"),
-            column("codesystem")
-                // .setKey(2) //todo: ideally, combination of code+codesystem has a unique
-                // check
-                .setRequired(false)
-                .setSemantics("http://purl.obolibrary.org/obo/NCIT_C70895")
-                .setDescription("Abbreviation of the code system/ontology this term belongs to"),
-            column("code")
-                // .setKey(2)
-                .setRequired(false)
-                .setSemantics("http://purl.obolibrary.org/obo/NCIT_C25162")
-                .setDescription("Identifier used for this term within this code system/ontology"),
+            column("label")
+                // .setKey(2) when we upgrade to psql 15 so we can allow parent == null in
+                // constraint so we can ensure unique labels on each level
+                .setDescription("User-friendly label for this term. Should be unique in parent")
+                .setSemantics("http://purl.obolibrary.org/obo/NCIT_C42614"),
             column("parent")
+                // .setKey(2)  when we upgrade to psql 15 so we can allow parent == null in
+                // constraint
                 .setType(REF)
                 .setSemantics("http://purl.obolibrary.org/obo/NCIT_C80013")
                 .setRefTable(name)
                 .setDescription("The parent term, in case this code exists in a hierarchy"),
+            column("codesystem")
+                // we allow that multiple terms link to same code
+                // however, in principle we might have cases where we need multiple codes or even
+                // more complex semantics?
+                .setRequired(false)
+                .setSemantics("http://purl.obolibrary.org/obo/NCIT_C70895")
+                .setDescription("Abbreviation of the code system/ontology this term belongs to"),
+            column("code")
+                .setRequired(false)
+                .setSemantics("http://purl.obolibrary.org/obo/NCIT_C25162")
+                .setDescription("Identifier used for this term within this code system/ontology"),
             column("ontologyTermURI")
-                // .setKey(3) //todo: ideally, has a unique check
+                // we allow that multiple terms link to same purl
                 .setType(HYPERLINK)
                 .setSemantics("http://purl.obolibrary.org/obo/NCIT_C114456")
                 .setRequired(false)

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
@@ -236,9 +236,22 @@ class SqlTableMetadataExecutor {
       DSLContext jooq, TableMetadata table, Integer index, List<Field<?>> keyFields) {
     Name uniqueName = name(table.getTableName() + "_KEY" + index);
     jooq.execute("ALTER TABLE {0} DROP CONSTRAINT IF EXISTS {1}", getJooqTable(table), uniqueName);
+    // when we upgrade to psql 15 we can enable this
+    //    if (keyFields.size() > 1) {
+    //      // in composite keys allow nulls
+    //      jooq.execute(
+    //          "ALTER TABLE {0} ADD CONSTRAINT {1} UNIQUE NULLS NOT DISTINCT  ({2})",
+    //          table.getJooqTable(),
+    //          name(uniqueName),
+    //          keyword(
+    //              keyFields.stream()
+    //                  .map(field -> name(field.getName()).toString())
+    //                  .collect(Collectors.joining(","))));
+    //    } else {
     jooq.alterTable(getJooqTable(table))
         .add(constraint(name(uniqueName)).unique(keyFields.toArray(new Field[keyFields.size()])))
         .execute();
+    //    }
   }
 
   static void executeDropTable(DSLContext jooq, TableMetadata table) {

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -387,7 +387,7 @@ public class WebApiSmokeTests {
     String path = "/pet store/api/csv/Tag";
 
     String result = given().sessionId(SESSION_ID).accept(ACCEPT_CSV).when().get(path).asString();
-    assertTrue(result.contains("green,,,colors"));
+    assertTrue(result.contains("green,,colors"));
 
     String update = "name,parent\r\nyellow,colors\r\n";
     given().sessionId(SESSION_ID).body(update).when().post(path).then().statusCode(200);
@@ -398,7 +398,7 @@ public class WebApiSmokeTests {
     given().sessionId(SESSION_ID).body(update).when().delete(path).then().statusCode(200);
 
     result = given().sessionId(SESSION_ID).accept(ACCEPT_CSV).when().get(path).asString();
-    assertTrue(result.contains("green,,,colors"));
+    assertTrue(result.contains("green,,colors"));
   }
 
   @Test

--- a/docs/molgenis/use_schema.md
+++ b/docs/molgenis/use_schema.md
@@ -138,6 +138,27 @@ the example below.
 Schema allows for some magic for columns of type 'ontology' and 'ontology_array'. For these columns, the referred table
 is automatically created, using refTable as the name.
 
+The ontology table minimaly needs the following content
+
+| name |
+|------|
+|term1 |
+|term2 |
+
+A more advanced example
+
+| name       | parent | label  |description |ontologyURI|
+|------------|--------|--------|------------|-----------|
+| term1      |        |        |            |           |
+| term1.a    | term1  |        |            |           |
+| term1.b    | term1  | b      |this will show 'b' instead of term1.b| 
+
+Explanation:
+* parent - will show terms in a hierarchy
+* label - Note that by default the 'label' will be same a name. However in user interface tree input it can be desirable to show another label.
+* ontologyTermURI - hyperlink to persistent identifier
+* order - use this to change the order, otherwise insertion order will be used
+
 ## Expressions
 
 You can further fine tune the behaviour of tables using molgenis expressions. For more information on the expression


### PR DESCRIPTION
Motivation: 
- sometimes same names must be used in multiple sub hierarchies; this would require prefix. To keep UI clean you can now use a shorter label.

For example:
- prescriptions:xyz 
- dispensings:xyz
in both places you would like to show 'xyz' on in the form. (in the filter statements you would like to see the prescriptions:xyz)

N.B. only works on newly created ontology tables; do we want a migration?