### PR TITLE
fix: Clicking 'show more' in a table takes you back to tables overview

### DIFF
--- a/apps/molgenis-components/src/components/layout/ReadMore.vue
+++ b/apps/molgenis-components/src/components/layout/ReadMore.vue
@@ -4,11 +4,11 @@
     <span v-else-if="text.length <= length">{{ text }}</span>
     <span v-else-if="expand">
       {{ text }}
-      <a @click.stop="expand = false" href="#">...show less </a>
+      <a @click.stop.prevent="expand = false" href="#">...show less </a>
     </span>
     <span v-else>
       {{ text.slice(0, length) }}
-      <a @click.stop="expand = true" href="#" title="Expand text">
+      <a @click.stop.prevent="expand = true" href="#" title="Expand text">
         ...show more
       </a>
     </span>


### PR DESCRIPTION
closes #1842