### PR TITLE
feat: expand ontology search to not only search on name

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -405,7 +405,7 @@ export default {
           .map((s) => s.toLowerCase());
         //check every term if it matches all search terms
         Object.values(this.terms).forEach((term) => {
-          if (searchTerms.every((s) => term.name.toLowerCase().includes(s))) {
+          if (searchTerms.every((s) => term.name.toLowerCase().includes(s) || term.label?.toLowerCase().includes(s) ||  term.definition?.toLowerCase().includes(s) ||  term.code?.toLowerCase().includes(s)  )) {
             term.visible = true;
             this.searchResultCount++;
 

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -400,7 +400,7 @@ export default {
         //split and sanitize search terms
         let searchTerms = this.search
           .trim()
-          .split(/:| /)
+          .split(/[\s,:]+/)
           .filter((s) => s.trim().length > 0)
           .map((s) => s.toLowerCase());
         //check every term if it matches all search terms

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -460,6 +460,7 @@ export default {
             terms[e.name].definition = e.definition;
             terms[e.name].label = e.label;
             terms[e.name].code = e.code;
+            terms[e.name].codesystem = e.codesystem;
           } else {
             //else simply add the record
             terms[e.name] = {
@@ -468,6 +469,7 @@ export default {
               selected: false,
               definition: e.definition,
               code: e.code,
+              codesystem: e.codesystem,
               label: e.label
             };
           }

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -405,7 +405,7 @@ export default {
           .map((s) => s.toLowerCase());
         //check every term if it matches all search terms
         Object.values(this.terms).forEach((term) => {
-          if (searchTerms.every((s) => term.name.toLowerCase().includes(s) || term.label?.toLowerCase().includes(s) ||  term.definition?.toLowerCase().includes(s) ||  term.code?.toLowerCase().includes(s)  )) {
+          if (searchTerms.every((s) => term.name.toLowerCase().includes(s) || term.label?.toLowerCase().includes(s) ||  term.definition?.toLowerCase().includes(s) ||  term.code?.toLowerCase().includes(s))) {
             term.visible = true;
             this.searchResultCount++;
 

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -459,6 +459,7 @@ export default {
             //then copy properties, currently only definition and label
             terms[e.name].definition = e.definition;
             terms[e.name].label = e.label;
+            terms[e.name].code = e.code;
           } else {
             //else simply add the record
             terms[e.name] = {
@@ -466,6 +467,7 @@ export default {
               visible: true,
               selected: false,
               definition: e.definition,
+              code: e.code,
               label: e.label
             };
           }

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -400,7 +400,7 @@ export default {
         //split and sanitize search terms
         let searchTerms = this.search
           .trim()
-          .split(" ")
+          .split(/:| /)
           .filter((s) => s.trim().length > 0)
           .map((s) => s.toLowerCase());
         //check every term if it matches all search terms

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -405,7 +405,7 @@ export default {
           .map((s) => s.toLowerCase());
         //check every term if it matches all search terms
         Object.values(this.terms).forEach((term) => {
-          if (searchTerms.every((s) => term.name.toLowerCase().includes(s) || term.label?.toLowerCase().includes(s) ||  term.definition?.toLowerCase().includes(s) ||  term.code?.toLowerCase().includes(s))) {
+          if (searchTerms.every((s) => term.name.toLowerCase().includes(s) || term.label?.toLowerCase().includes(s) ||  term.definition?.toLowerCase().includes(s) ||  term.code?.toLowerCase().includes(s) ||  term.codesystem?.toLowerCase().includes(s))) {
             term.visible = true;
             this.searchResultCount++;
 

--- a/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
@@ -22,7 +22,8 @@
         class="flex-grow-1 pl-2"
         role="button"
       >
-        {{ term.label ? term.label : term.name }}
+        {{ term.label ? term.label : term.name }} 
+        <span v-if="term.code">({{term.code}})</span>
         <small v-if="term.definition" class="text-muted">
           <i> - {{ term.definition }}</i></small
         >

--- a/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
@@ -22,8 +22,12 @@
         class="flex-grow-1 pl-2"
         role="button"
       >
-        {{ term.label ? term.label : term.name }} 
-        <span v-if="term.code">({{term.code}})</span>
+        {{ term.label ? term.label : term.name }}
+        <span v-if="term.codesystem || term.code">(</span>
+        <span v-if="term.codesystem">{{term.codesystem}}</span>
+        <span v-if="term.codesystem && term.code">:</span>
+        <span v-if="term.code">{{term.code}}</span>
+        <span v-if="term.codesystem || term.code">)</span>
         <small v-if="term.definition" class="text-muted">
           <i> - {{ term.definition }}</i></small
         >

--- a/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
@@ -23,11 +23,7 @@
         role="button"
       >
         {{ term.label ? term.label : term.name }}
-        <span v-if="term.codesystem || term.code">(</span>
-        <span v-if="term.codesystem">{{term.codesystem}}</span>
-        <span v-if="term.codesystem && term.code">:</span>
-        <span v-if="term.code">{{term.code}}</span>
-        <span v-if="term.codesystem || term.code">)</span>
+        <span v-if="term.code"> (<span v-if="term.codesystem">{{term.codesystem}}:</span>{{term.code}})</span>
         <small v-if="term.definition" class="text-muted">
           <i> - {{ term.definition }}</i></small
         >


### PR DESCRIPTION
Issue:
* when you now open ontology dialogue and search, only matches on 'name' are shown

new:
* also matching label, definition, code are shown