### PR TITLE
feat: support for multiple auth token keys

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/Constants.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/Constants.java
@@ -3,7 +3,7 @@ package org.molgenis.emx2.web;
 public class Constants {
   static final String TABLE = "table";
   public static final String CONTENT_TYPE = "Content-type";
-  public static final String MOLGENIS_TOKEN = "x-molgenis-token";
+  public static final String MOLGENIS_TOKEN[] = new String[] {"x-molgenis-token", "auth-key"};
   public static final String LANDING_PAGE = "LANDING_PAGE";
 
   private Constants() {

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManager.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManager.java
@@ -48,10 +48,10 @@ public class MolgenisSessionManager {
           "Invalid session found with user == null. This should not happen so please report as a bug");
     } else {
       // check if we should apply a token
-      if (request.headers("x-molgenis-token") != null) {
+      String authTokenKey = findUsedAuthTokenKey(request);
+      if (authTokenKey != null) {
         String user =
-            JWTgenerator.getUserFromToken(
-                session.getDatabase(), request.headers("x-molgenis-token"));
+            JWTgenerator.getUserFromToken(session.getDatabase(), request.headers(authTokenKey));
         if (!session.getDatabase().getActiveUser().equals(user)) {
           session.getDatabase().setActiveUser(user);
         }
@@ -63,6 +63,22 @@ public class MolgenisSessionManager {
           request.session().id());
     }
     return session;
+  }
+
+  /**
+   * From the request, get the name of the auth token key that was used to supply the auth token in
+   * the header, or return null if none of the options are present.
+   *
+   * @param request
+   * @return
+   */
+  public String findUsedAuthTokenKey(Request request) {
+    for (String authTokenKey : Constants.MOLGENIS_TOKEN) {
+      if (request.headers(authTokenKey) != null) {
+        return authTokenKey;
+      }
+    }
+    return null;
   }
 
   /**

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/OpenApiYamlGenerator.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/OpenApiYamlGenerator.java
@@ -42,7 +42,10 @@ public class OpenApiYamlGenerator {
     api.security(securityRequirementList());
 
     // components
-    components.addSecuritySchemes("ApiKeyAuth", securityScheme());
+    for (int i = 0; i < MOLGENIS_TOKEN.length; i++) {
+      String authTokenKey = MOLGENIS_TOKEN[i];
+      components.addSecuritySchemes("ApiKeyAuth" + i, securityScheme(authTokenKey));
+    }
     components.addSchemas(PROBLEM, problemSchema());
     components.addResponses(PROBLEM, problemResponse());
 
@@ -95,11 +98,11 @@ public class OpenApiYamlGenerator {
     return tablePath;
   }
 
-  private static SecurityScheme securityScheme() {
+  private static SecurityScheme securityScheme(String authTokenKey) {
     return new SecurityScheme()
         .type(SecurityScheme.Type.APIKEY)
         .in(SecurityScheme.In.HEADER)
-        .name("x-molgenis-token");
+        .name(authTokenKey);
   }
 
   private static List<SecurityRequirement> securityRequirementList() {

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -617,7 +617,7 @@ public class WebApiSmokeTests {
     // with token we are shopmanager
     assertTrue(
         given()
-            .header(MOLGENIS_TOKEN, token)
+            .header(MOLGENIS_TOKEN[0], token)
             .body("{\"query\":\"{_session{email}}\"}")
             .post("/api/graphql")
             .getBody()
@@ -627,7 +627,7 @@ public class WebApiSmokeTests {
     // can we create a long lived token
     result =
         given()
-            .header(MOLGENIS_TOKEN, token)
+            .header(MOLGENIS_TOKEN[0], token)
             .body(
                 "{\"query\":\"mutation{createToken(email:\\\"shopmanager\\\",tokenName:\\\"mytoken\\\"){message,token}}\"}")
             .when()
@@ -637,9 +637,10 @@ public class WebApiSmokeTests {
     token = new ObjectMapper().readTree(result).at("/data/createToken/token").textValue();
 
     // with long lived token we are shopmanager
+    // also test using an alternative auth token key (should make no difference)
     assertTrue(
         given()
-            .header(MOLGENIS_TOKEN, token)
+            .header(MOLGENIS_TOKEN[1], token)
             .body("{\"query\":\"{_session{email}}\"}")
             .post("/api/graphql")
             .getBody()
@@ -660,7 +661,7 @@ public class WebApiSmokeTests {
     // as admin can we create a long lived token for others
     result =
         given()
-            .header(MOLGENIS_TOKEN, token)
+            .header(MOLGENIS_TOKEN[0], token)
             .body(
                 "{\"query\":\"mutation{createToken(email:\\\"shopmanager\\\" tokenName:\\\"mytoken\\\"){message,token}}\"}")
             .when()
@@ -670,9 +671,10 @@ public class WebApiSmokeTests {
     token = new ObjectMapper().readTree(result).at("/data/createToken/token").textValue();
 
     // with long lived token we are shopmanager
+    // also test using an alternative auth token key (should make no difference)
     assertTrue(
         given()
-            .header(MOLGENIS_TOKEN, token)
+            .header(MOLGENIS_TOKEN[1], token)
             .body("{\"query\":\"{_session{email}}\"}")
             .post("/api/graphql")
             .getBody()


### PR DESCRIPTION
Auth tokens can now be passed using different keys, defined in `Contants.MOLGENIS_TOKEN[]` (used to be `String`, now `String[]`). This enables EMX2 compatibility with Beaconized VP specs (see: https://github.com/rini21/vp-api-specs-beaconised).

For instance, in request header
```
x-molgenis-token = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiI...etc
```
would be equivalent to
```
auth-key = eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pbiI...etc
```

Solves https://github.com/molgenis/molgenis-emx2/issues/1857.