### PR TITLE
Feat/model 3.1

### DIFF
--- a/data/datacatalogue3/CatalogueOntologies/Areas of information ds.csv
+++ b/data/datacatalogue3/CatalogueOntologies/Areas of information ds.csv
@@ -1,4 +1,4 @@
-name,label,description,parent
+name,label,definition,parent
 Geographic regions,,Are data on geographic region available?,
 Family linkage,,Is any linkage available in the data bank between any of the following persons?,
 Family linkage routinely,,Is familial linkage created routinely?,

--- a/data/datacatalogue3/CatalogueOntologies/Document types.csv
+++ b/data/datacatalogue3/CatalogueOntologies/Document types.csv
@@ -1,4 +1,4 @@
-name,code,order,description,comments,parent,ontologyTermURI
+name,code,order,definition,comments,parent,ontologyTermURI
 Harmonisation protocol,HP,,,,,
 Informed consent,IC,,,,,
 Standard operating protocol,SOP,,,,,

--- a/data/datacatalogue3/CatalogueOntologies/Network features.csv
+++ b/data/datacatalogue3/CatalogueOntologies/Network features.csv
@@ -1,4 +1,4 @@
-name,parent,description
+name,parent,definition
 ENCePP network,,Do you want to become an ENCePP partner?
 Primary therapeutic area,,Please specify the primary therapeutic/disease area of your Network. Multiple values can be selected.
 Anaesthesia,Primary therapeutic area,

--- a/data/datacatalogue3/CatalogueOntologies/Organisation features.csv
+++ b/data/datacatalogue3/CatalogueOntologies/Organisation features.csv
@@ -1,4 +1,4 @@
-name,parent,description
+name,parent,definition
 Research interest,,Are you interested in research directly funded by pharmaceutical companies?
 ENCePP center,,Do you want to become an ENCePP partner?
 Experience,,Do you have experience in collecting data directly from individual patients/respondents?

--- a/data/datacatalogue3/CatalogueOntologies/Study design classification.csv
+++ b/data/datacatalogue3/CatalogueOntologies/Study design classification.csv
@@ -1,4 +1,4 @@
-name,description,parent
+name,definition,parent
 Clinical Trial Randomisation
 Randomised clinical trial,,Clinical Trial Randomisation
 Non-randomised clinical trial,,Clinical Trial Randomisation

--- a/data/datacatalogue3/CatalogueOntologies/Study features.csv
+++ b/data/datacatalogue3/CatalogueOntologies/Study features.csv
@@ -1,4 +1,4 @@
-name,label,description,parent
+name,label,definition,parent
 Data characterisation conducted,,Was a data characterisation or quality check process completed?,
 Data characterisation conducted: No,No,,Data characterisation conducted
 Data characterisation conducted: Yes,Yes,,Data characterisation conducted

--- a/data/datacatalogue3/CatalogueOntologies/Study quality marks.csv
+++ b/data/datacatalogue3/CatalogueOntologies/Study quality marks.csv
@@ -1,3 +1,3 @@
-name,description
+name,definition
 ENCePP seal,Are you requesting the ENCePP seal for this study?
 ENCePP code of conduct,Is this study performed in line with the ENCePP Code of conduct?

--- a/data/datacatalogue3/CatalogueOntologies/Study requirements.csv
+++ b/data/datacatalogue3/CatalogueOntologies/Study requirements.csv
@@ -1,4 +1,4 @@
-name,label,description,parent
+name,label,definition,parent
 Required by regulator,,Was the study requested by a regulatory body?,
 Yes,,,Required by regulator
 No,,,Required by regulator

--- a/data/datacatalogue3/molgenis.csv
+++ b/data/datacatalogue3/molgenis.csv
@@ -71,7 +71,6 @@ Data sources,,population exit other,text,,,,,,,,,"If other, specify the causes o
 Data sources,,population disease,ontology_array,,,CatalogueOntologies,Diseases,,,,,"Does the data bank collect information on a specific disease subpopulation (e.g., as in a disease-specific registry)?",EMA,,
 Data sources,,population coverage,text,,,,,,,,,Estimated percentage of the population covered by the data source in the catchment area. Please describe the denominator.,EMA,,
 Data sources,,population not covered,text,,,,,,,,,"Description of the population covered by the data source in the catchment area whose data are not collected, where applicable (e.g.: people who are registered only for private care) ",EMA,,
-Data sources,,population size,int,,,,,,,,,Total number of unique individuals with records captured in the data source (most recent count).,EMA,,
 Data sources,,quantantitative information,refback,,,,Quantitative information,,resource,,,Numerical summaries describing data bank population,EMA,,
 Data resources,,contents,heading,,,,,,,,,Data model and contents,,,
 Data sources,,areas of information,ontology_array,,,CatalogueOntologies,Areas of information ds,,,,,Areas of information that were collected,EMA,Databanks,areasOfInformation

--- a/data/datacatalogue3/molgenis.csv
+++ b/data/datacatalogue3/molgenis.csv
@@ -81,6 +81,7 @@ Data sources,,genetic data vocabulary other,text,,,,,,,,,"If 'other,' what genet
 Data sources,,care setting other,text,,,,,,,,,"If 'other,' description of the setting of care",EMA,Databanks,careSettingOther
 Data sources,,data dictionary available,bool,,,,,,,,,Are a data dictionary and a data model available?,,,
 Data sources,,disease details,ontology_array,,,CatalogueOntologies,MedDRA,,,,,"If data on a specific disease is collected, which diseases does the data source collect information on",EMA,,
+Data sources,,disease details other,text,,,,,,,,,Specify disease details if not present in MedDRA,,,
 Data sources,,biospecimen collected,ontology_array,,,CatalogueOntologies,Informed consents,,,,,"If the data bank contains biospecimens, what types of specimen",,,
 Data sources,,languages,ontology_array,,,CatalogueOntologies,Languages,,,,,"Languages in which that the records are recorded (in ISO 639, https://en.wikipedia.org/wiki/List_of_ISO_639-1_codes)",EMA,,
 Data sources,,record trigger,text,,,,,,,,,"What triggers the creation of a record in the data bank? e.g., hospital discharge, specialist encounter, dispensation of a medicinal product, recording of a congenital anomaly",EMA,,

--- a/data/datacatalogue3/molgenis.csv
+++ b/data/datacatalogue3/molgenis.csv
@@ -57,13 +57,13 @@ Data resources,,number of participants with samples,int,,,,,,,,,Number of indivi
 Data sources,,underlying population,text,,,,,,,,,Provide a summary description of the underlying population (maximum 100 words) or URL to a description,,Databanks,underlyingPopulation
 Extended resources,,countries,ontology_array,,,CatalogueOntologies,Countries,,,,,Countries where data from this resource largely originate from,,,
 Data resources,,regions,ontology_array,,,CatalogueOntologies,Regions,,,,,Geographical regions where data from this resource largely originate from,EMA,Resources,regions
+Data resources,,population age groups,ontology_array,,,CatalogueOntologies,Age groups,,,,,Which population age groups are captured in this resource? Select all that are relevant.,EMA,Databanks,populationAgeGroups
 Cohorts,,inclusion criteria,text,,,,Inclusion criteria,,,,,Inclusion criteria applied to the participants of this resource,,,
 Cohorts,,start year,int,,,,,,,,,Year when first data was collected,,,
 Cohorts,,end year,int,,,,,,,,,Year when last data was collected. Leave empty if collection is ongoing,,,
 Networks,,start year,int,,,,,,,,,Year when the network was created,,,
 Networks,,end year,int,,,,,,,,,Year when the network ended,,,
 Cohorts,,subcohorts,refback,,,,Subcohorts,,resource,,,List of subcohorts or subpopulations for this resource,,,
-Data sources,,population age groups,ontology_array,,,CatalogueOntologies,Age groups,,,,,Which population age groups are captured in the data source? Select all that are relevant.,EMA,Databanks,populationAgeGroups
 Data sources,,population entry,ontology_array,,,CatalogueOntologies,Population entry,,,,,Select the possible causes / events that trigger the registration of a person in the data source,EMA,Databanks,populationEntry
 Data sources,,population entry other,text,,,,,,,,,"If other, specify the causes of entry to the underlying population",EMA,Databanks,populationEntryOther
 Data sources,,population exit,ontology_array,,,CatalogueOntologies,Population exit,,,,,Select the possible causes / events that trigger the de-registration of a person in the data source,EMA,Databanks,populationExit

--- a/data/datacatalogue3/molgenis.csv
+++ b/data/datacatalogue3/molgenis.csv
@@ -1,5 +1,5 @@
 tableName,tableExtends,columnName,columnType,key,required,refSchema,refTable,refLink,refBack,validation,semantics,description,profiles,tableName_old,columnName_old
-Version,,,,,,,,,,,,3,,,
+Version,,,,,,,,,,,,3.1,,,
 Resources,,,,,,,,,,,,"Generic listing of all resources. Should not be used directly, instead use specific types such as Databanks and Studies",,,
 Organisations,Resources,,,,,,,,,,,Research departments and research groups,,,
 Extended resources,Resources,,,,,,,,,,,,,,

--- a/data/datacatalogue3/molgenis.csv
+++ b/data/datacatalogue3/molgenis.csv
@@ -209,6 +209,7 @@ Resource organisations,,reason access other,text,,,,,,,,,"If reasonAccess is 'ot
 Linked data sources,,,,,,,,,,,,Links between datasource and databank,,,
 Linked data sources,,main datasource,ref,1,,,Data sources,,,,,,,DatasourceDatabanks,datasource
 Linked data sources,,linked datasource,ref,1,,,Data sources,,,,,,,DatasourceDatabanks,databank
+Linked data sources,,other linked data source,text,,,,,,,,,"If other linked data source, enter the name of the data source",,,
 Linked data sources,,linkage description,text,,,,,,,,,Provide a high-level description of the linkages that are either currently available between data sources in the data source (when pre-linked = yes) or linkages that are possible when using the data source,,,
 Linked data sources,,linkage strategy,ontology,,,CatalogueOntologies,Linkage strategies,,,,,The linkage method that was used to link data banks. One entry per data bank,,DatasourceDatabanks,linkageStrategy
 Linked data sources,,linkage variable,text,,,,,,,,,"If a single variable (or linkage key) is used to link a data bank to others, a name and description of the variable is provided. One entry per data bank",,DatasourceDatabanks,linkageVariable


### PR DESCRIPTION
add:
-Linked datasources.other linked data source (text) - Meant for when data source that is linked is not in list of data sources entered into the database. The field Linked datasources.linked data source should contain an option 'Other' and the data source name can then be specified in the new field. Just entering the other data source into the Data sources table is not preferred by EMA, because this may create ownership problems.
-Data sources.disease details other (text)

moved:
-Data sources.population age groups to Data resources.population age groups - data item also used by UMCG cohorts

delete:
-Data sources.population size - is duplicate of Data recources.number of participants


change:
-column names in ontologies description to definition

