### PR TITLE
fix: refSchema references were broken when table names overlapped

### DIFF
--- a/apps/molgenis-components/src/ClientView.vue
+++ b/apps/molgenis-components/src/ClientView.vue
@@ -52,7 +52,7 @@ export default {
     },
   },
   async mounted() {
-    this.client = Client.newClient("/pet store/graphql", this.$axios);
+    this.client = Client.newClient("pet store", this.$axios);
     this.fetchData();
   },
   watch: {

--- a/apps/molgenis-components/src/client/client.js
+++ b/apps/molgenis-components/src/client/client.js
@@ -4,7 +4,7 @@ import { deepClone, convertToPascalCase } from "../components/utils";
 export { request };
 
 export default {
-  newClient: (graphqlURL, externalAxios) => {
+  newClient: (schemaName, externalAxios) => {
     const myAxios = externalAxios || axios;
     // use closure to have metaData cache private to client
     let metaData = null;
@@ -12,60 +12,73 @@ export default {
       insertDataRow,
       updateDataRow,
       deleteRow: async (rowKey, tableName) => {
-        return deleteRow(rowKey, tableName, graphqlURL);
+        return deleteRow(rowKey, tableName, schemaName);
       },
       deleteAllTableData: async (tableName) => {
-        return deleteAllTableData(tableName, graphqlURL);
+        return deleteAllTableData(tableName);
       },
       fetchMetaData: async () => {
-        const schema = await fetchMetaData(myAxios, graphqlURL);
-        metaData = schema;
+        metaData = await fetchMetaData(myAxios, schemaName);
+        if (!schemaName) {
+          schemaName = metaData.name;
+        }
         return deepClone(metaData);
       },
       fetchTableMetaData: async (tableName) => {
         if (metaData === null) {
-          const schema = await fetchMetaData(myAxios, graphqlURL);
-          metaData = schema;
+          metaData = await fetchMetaData(myAxios, schemaName);
+          if (!schemaName) {
+            schemaName = metaData.name;
+          }
         }
         return deepClone(metaData).tables.find(
-          (table) => table.id === convertToPascalCase(tableName)
+          (table) =>
+            table.id === convertToPascalCase(tableName) &&
+            table.externalSchema === schemaName
         );
       },
       fetchTableData: async (tableId, properties) => {
         if (metaData === null) {
-          metaData = await fetchMetaData(myAxios, graphqlURL);
+          metaData = await fetchMetaData(myAxios, schemaName);
+          if (!schemaName) {
+            schemaName = metaData.name;
+          }
         }
         return fetchTableData(
           tableId,
           properties,
           metaData,
           myAxios,
-          graphqlURL
+          schemaName
         );
       },
       fetchTableDataValues: async (tableName, properties) => {
         const tableId = convertToPascalCase(tableName);
         if (metaData === null) {
-          const schema = await fetchMetaData(myAxios, graphqlURL);
-          metaData = schema;
+          metaData = await fetchMetaData(myAxios, schemaName);
+          if (!schemaName) {
+            schemaName = metaData.name;
+          }
         }
         const dataResp = await fetchTableData(
           tableId,
           properties,
           metaData,
           myAxios,
-          graphqlURL
+          schemaName
         );
         return dataResp[tableId];
       },
       fetchRowData: async (tableName, rowId) => {
         const tableId = convertToPascalCase(tableName);
         if (metaData === null) {
-          const schema = await fetchMetaData(myAxios, graphqlURL);
-          metaData = schema;
+          metaData = await fetchMetaData(myAxios, schemaName);
+          if (!schemaName) {
+            schemaName = metaData.name;
+          }
         }
         const tableMetaData = metaData.tables.find(
-          (table) => table.id === tableId
+          (table) => table.id === tableId && table.externalSchema === schemaName
         );
         const filter = tableMetaData.columns
           .filter((column) => column.key === 1)
@@ -82,7 +95,7 @@ export default {
             },
             metaData,
             myAxios,
-            graphqlURL
+            schemaName
           )
         )[tableId];
 
@@ -94,13 +107,13 @@ export default {
       },
       saveTableSettings: async (settings) => {
         return request(
-          graphqlURL ? graphqlURL : "graphql",
+          graphqlURL(schemaName),
           `mutation change($settings:[MolgenisSettingsInput]){change(settings:$settings){message}}`,
           { settings: settings }
         );
       },
       fetchSettings: async () => {
-        return fetchSettings(graphqlURL ? graphqlURL : "graphql");
+        return fetchSettings(schemaName);
       },
       fetchSettingValue: async (name) => {
         const settings = await fetchSettings();
@@ -123,9 +136,11 @@ export default {
           },
         };
 
-        await request("graphql", createMutation, variables).catch((e) => {
-          console.error(e);
-        });
+        await request(graphqlURL(schemaName), createMutation, variables).catch(
+          (e) => {
+            console.error(e);
+          }
+        );
       },
     };
   },
@@ -147,6 +162,7 @@ _schema {
       columnType,
       key,
       refTable,
+      refSchema,
       refLink,
       refLabel,
       refBack,
@@ -165,39 +181,42 @@ _schema {
   }
 }}`;
 
-const insertDataRow = (rowData, tableName, graphqlURL) => {
+const graphqlURL = (schemaName) => {
+  return schemaName ? "/" + schemaName + "/graphql" : "graphql";
+};
+
+const insertDataRow = (rowData, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
   const formData = toFormData(rowData);
   const query = `mutation insert($value:[${tableId}Input]){insert(${tableId}:$value){message}}`;
   formData.append("query", query);
-  return axios.post(graphqlURL, formData);
+  return axios.post(graphqlURL(schemaName), formData);
 };
 
-const updateDataRow = (rowData, tableName, graphqlURL) => {
+const updateDataRow = (rowData, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
   const formData = toFormData(rowData);
   const query = `mutation update($value:[${tableId}Input]){update(${tableId}:$value){message}}`;
   formData.append("query", query);
-  return axios.post(graphqlURL, formData);
+  return axios.post(graphqlURL(schemaName), formData);
 };
 
-const deleteRow = (key, tableName, graphqlURL) => {
+const deleteRow = (key, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
   const query = `mutation delete($pkey:[${tableId}Input]){delete(${tableId}:$pkey){message}}`;
   const variables = { pkey: [key] };
-  return axios.post(graphqlURL, { query, variables });
+  return axios.post(graphqlURL(schemaName), { query, variables });
 };
 
-const deleteAllTableData = (tableName, graphqlURL) => {
+const deleteAllTableData = (tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
   const query = `mutation {truncate(tables:"${tableId}"){message}}`;
-  return axios.post(graphqlURL, { query });
+  return axios.post(graphqlURL(schemaName), { query });
 };
 
-const fetchMetaData = async (axios, graphqlURL, onError) => {
-  const url = graphqlURL ? graphqlURL : "graphql";
+const fetchMetaData = async (axios, schemaName, onError) => {
   const resp = await axios
-    .post(url, { query: metaDataQuery })
+    .post(graphqlURL(schemaName), { query: metaDataQuery })
     .catch((error) => {
       console.log(error);
       if (typeof onError === "function") {
@@ -212,11 +231,10 @@ const fetchTableData = async (
   properties,
   metaData,
   axios,
-  graphqlURL,
+  schemaName,
   onError
 ) => {
   const tableId = convertToPascalCase(tableName);
-  const url = graphqlURL ? graphqlURL : "graphql";
   const limit =
     properties && Object.prototype.hasOwnProperty.call(properties, "limit")
       ? properties.limit
@@ -234,7 +252,7 @@ const fetchTableData = async (
       ? ',search:"' + properties.searchTerms.trim() + '"'
       : "";
 
-  const cNames = columnNames(tableId, metaData);
+  const cNames = columnNames(schemaName, tableId, metaData);
   const tableDataQuery = `query ${tableId}( $filter:${tableId}Filter, $orderby:${tableId}orderby ) {
         ${tableId}(
           filter:$filter,
@@ -259,7 +277,10 @@ const fetchTableData = async (
       ? properties.orderby
       : {};
   const resp = await axios
-    .post(url, { query: tableDataQuery, variables: { filter, orderby } })
+    .post(graphqlURL(schemaName), {
+      query: tableDataQuery,
+      variables: { filter, orderby },
+    })
     .catch((error) => {
       console.log(error);
       if (typeof onError === "function") {
@@ -271,13 +292,9 @@ const fetchTableData = async (
   return resp.data.data;
 };
 
-const fetchSettings = async (graphqlURL) => {
-  return (
-    await request(
-      graphqlURL ? graphqlURL : "graphql",
-      "{_settings{key, value}}"
-    )
-  )._settings;
+const fetchSettings = async (schemaName) => {
+  return (await request(graphqlURL(schemaName), "{_settings{key, value}}"))
+    ._settings;
 };
 
 const request = async (url, graphql, variables) => {
@@ -301,15 +318,21 @@ const request = async (url, graphql, variables) => {
  * @param {Object} metaData - object that contains all schema meta data
  * @returns String of fields for use in gql query
  */
-const columnNames = (tableName, metaData) => {
+const columnNames = (schemaName, tableName, metaData) => {
   let result = "";
-  getTable(tableName, metaData.tables).columns.forEach((col) => {
+  getTable(schemaName, tableName, metaData.tables).columns.forEach((col) => {
     if (
       ["REF", "REF_ARRAY", "REFBACK", "ONTOLOGY", "ONTOLOGY_ARRAY"].includes(
         col.columnType
       ) > 0
     ) {
-      result = result + " " + col.id + "{" + refGraphql(col, metaData) + "}";
+      result =
+        result +
+        " " +
+        col.id +
+        "{" +
+        refGraphql(schemaName, col, metaData) +
+        "}";
     } else if (col.columnType === "FILE") {
       result = result + " " + col.id + "{id,size,extension,url}";
     } else if (col.columnType !== "HEADING") {
@@ -320,9 +343,10 @@ const columnNames = (tableName, metaData) => {
   return result;
 };
 
-const refGraphql = (column, metaData) => {
+const refGraphql = (schemaName, column, metaData) => {
   let graphqlString = "";
-  const refTable = getTable(column.refTable, metaData.tables);
+  schemaName = column.refSchema ? column.refSchema : schemaName;
+  const refTable = getTable(schemaName, column.refTable, metaData.tables);
   refTable.columns.forEach((c) => {
     if (c.key == 1) {
       graphqlString += c.id + " ";
@@ -331,17 +355,20 @@ const refGraphql = (column, metaData) => {
           c.columnType
         ) > 0
       ) {
-        graphqlString += "{" + refGraphql(c, metaData) + "}";
+        graphqlString += "{" + refGraphql(schemaName, c, metaData) + "}";
       }
     }
   });
   return graphqlString;
 };
 
-const getTable = (tableName, tableStore) => {
-  return tableStore.find(
-    (table) => table.id === convertToPascalCase(tableName)
+const getTable = (schemaName, tableName, tableStore) => {
+  const result = tableStore.find(
+    (table) =>
+      table.id === convertToPascalCase(tableName) &&
+      table.externalSchema === schemaName
   );
+  return result;
 };
 
 const isFileValue = (value) => {

--- a/apps/molgenis-components/src/client/client.js
+++ b/apps/molgenis-components/src/client/client.js
@@ -187,26 +187,23 @@ const graphqlURL = (schemaName) => {
 
 const insertDataRow = (rowData, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
-  const schemaId = convertToPascalCase(schemaName);
   const formData = toFormData(rowData);
-  const query = `mutation insert($value:[${schemaId}_${tableId}Input]){insert(${tableId}:$value){message}}`;
+  const query = `mutation insert($value:[${tableId}Input]){insert(${tableId}:$value){message}}`;
   formData.append("query", query);
   return axios.post(graphqlURL(schemaName), formData);
 };
 
 const updateDataRow = (rowData, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
-  const schemaId = convertToPascalCase(schemaName);
   const formData = toFormData(rowData);
-  const query = `mutation update($value:[${schemaId}_${tableId}Input]){update(${tableId}:$value){message}}`;
+  const query = `mutation update($value:[${tableId}Input]){update(${tableId}:$value){message}}`;
   formData.append("query", query);
   return axios.post(graphqlURL(schemaName), formData);
 };
 
 const deleteRow = (key, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
-  const schemaId = convertToPascalCase(schemaName);
-  const query = `mutation delete($pkey:[${schemaId}_${tableId}Input]){delete(${tableId}:$pkey){message}}`;
+  const query = `mutation delete($pkey:[${tableId}Input]){delete(${tableId}:$pkey){message}}`;
   const variables = { pkey: [key] };
   return axios.post(graphqlURL(schemaName), { query, variables });
 };
@@ -256,8 +253,7 @@ const fetchTableData = async (
       : "";
 
   const cNames = columnNames(schemaName, tableId, metaData);
-  const schemaId = convertToPascalCase(schemaName);
-  const tableDataQuery = `query ${tableId}( $filter:${schemaId}_${tableId}Filter, $orderby:${schemaId}_${tableId}orderby ) {
+  const tableDataQuery = `query ${tableId}( $filter:${tableId}Filter, $orderby:${tableId}orderby ) {
         ${tableId}(
           filter:$filter,
           limit:${limit}, 

--- a/apps/molgenis-components/src/client/client.js
+++ b/apps/molgenis-components/src/client/client.js
@@ -187,23 +187,26 @@ const graphqlURL = (schemaName) => {
 
 const insertDataRow = (rowData, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
+  const schemaId = convertToPascalCase(schemaName);
   const formData = toFormData(rowData);
-  const query = `mutation insert($value:[${tableId}Input]){insert(${tableId}:$value){message}}`;
+  const query = `mutation insert($value:[${schemaId}_${tableId}Input]){insert(${tableId}:$value){message}}`;
   formData.append("query", query);
   return axios.post(graphqlURL(schemaName), formData);
 };
 
 const updateDataRow = (rowData, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
+  const schemaId = convertToPascalCase(schemaName);
   const formData = toFormData(rowData);
-  const query = `mutation update($value:[${tableId}Input]){update(${tableId}:$value){message}}`;
+  const query = `mutation update($value:[${schemaId}_${tableId}Input]){update(${tableId}:$value){message}}`;
   formData.append("query", query);
   return axios.post(graphqlURL(schemaName), formData);
 };
 
 const deleteRow = (key, tableName, schemaName) => {
   const tableId = convertToPascalCase(tableName);
-  const query = `mutation delete($pkey:[${tableId}Input]){delete(${tableId}:$pkey){message}}`;
+  const schemaId = convertToPascalCase(schemaName);
+  const query = `mutation delete($pkey:[${schemaId}_${tableId}Input]){delete(${tableId}:$pkey){message}}`;
   const variables = { pkey: [key] };
   return axios.post(graphqlURL(schemaName), { query, variables });
 };
@@ -253,7 +256,8 @@ const fetchTableData = async (
       : "";
 
   const cNames = columnNames(schemaName, tableId, metaData);
-  const tableDataQuery = `query ${tableId}( $filter:${tableId}Filter, $orderby:${tableId}orderby ) {
+  const schemaId = convertToPascalCase(schemaName);
+  const tableDataQuery = `query ${tableId}( $filter:${schemaId}_${tableId}Filter, $orderby:${schemaId}_${tableId}orderby ) {
         ${tableId}(
           filter:$filter,
           limit:${limit}, 

--- a/apps/molgenis-components/src/components/filters/FilterInput.vue
+++ b/apps/molgenis-components/src/components/filters/FilterInput.vue
@@ -7,7 +7,7 @@
           :condition="conditions"
           @updateCondition="updateCondition(index - 1, $event)"
           :tableName="tableName"
-          :graphqlURL="graphqlURL"
+          :schemaName="schemaName"
       ></component>
    </div>
     <div v-else v-for="index in fieldCount" :key="index">
@@ -20,7 +20,7 @@
         @addCondition="fieldCount++"
         :showAddButton="index === conditions.length"
         :tableName="tableName"
-        :graphqlURL="graphqlURL"
+        :schemaName="schemaName"
       ></component>
     </div>
   </div>
@@ -102,7 +102,7 @@ export default {
       type: String,
       required: false,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
       required: false,
     },
@@ -239,7 +239,7 @@ export default {
             id="filter-input-ontology"
             columnType="ONTOLOGY"
             tableName="Tag"
-            graphqlURL="/pet store/graphql"
+            schemaName="pet store"
             :conditions="conditions6"
             @updateConditions="conditions6 = $event"
         />
@@ -253,7 +253,7 @@ export default {
             id="filter-input-ref"
             columnType="REF"
             tableName="Tag"
-            graphqlURL="/pet store/graphql"
+            schemaName="pet store"
             :conditions="conditions7"
             @updateConditions="conditions7 = $event"
         />
@@ -267,7 +267,7 @@ export default {
             id="filter-input-reflist"
             columnType="REF_ARRAY"
             tableName="Tag"
-            graphqlURL="/pet store/graphql"
+            schemaName="pet store"
             :conditions="conditions8"
             @updateConditions="conditions8 = $event"
         />

--- a/apps/molgenis-components/src/components/filters/FilterSidebar.vue
+++ b/apps/molgenis-components/src/components/filters/FilterSidebar.vue
@@ -12,7 +12,7 @@
         @updateConditions="handleUpdateFilter(index, $event)"
         :columnType="filter.columnType"
         :tableName="filter.refTable"
-        :graphqlURL="graphqlURL"
+        :schemaName="filter.refSchema ? filter.refSchema : schemaName"
       />
     </FilterContainer>
   </div>
@@ -39,9 +39,9 @@ export default {
       type: Array,
       default: () => [],
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
-      default: () => "graphql",
+      required: false,
     },
   },
   computed: {
@@ -66,10 +66,10 @@ export default {
   <demo-item>
     <div class="row">
       <div class="col-4">
-        <FilterSidebar :filters="filters" graphqlURL="/pet store/graphql" @updateFilters="onUpdate"/>
+        <FilterSidebar :filters="filters" schemaName="pet store" @updateFilters="onUpdate"/>
       </div>
       <div class="col-8">
-        <FilterWells :filters="filters" graphqlURL="/pet store/graphql" @updateFilters="onUpdate"/>
+        <FilterWells :filters="filters" schemaName="pet store" @updateFilters="onUpdate"/>
         <pre>{{ filters }}</pre>
       </div>
     </div>

--- a/apps/molgenis-components/src/components/filters/OntologyFilter.vue
+++ b/apps/molgenis-components/src/components/filters/OntologyFilter.vue
@@ -4,7 +4,7 @@
     :modelValue="condition"
     @update:modelValue="onUpdateCondition"
     :tableName="tableName"
-    :graphqlURL="graphqlURL"
+    :schemaName="schemaName"
     :isMultiSelect="true"
     :showExpanded="true"
   />
@@ -25,7 +25,7 @@ export default {
       type: Object,
       required: false,
     },
-    graphqlURL: {
+    schemaName: {
       required: false,
       type: String,
     },

--- a/apps/molgenis-components/src/components/filters/RefFilter.vue
+++ b/apps/molgenis-components/src/components/filters/RefFilter.vue
@@ -4,7 +4,7 @@
     :modelValue="condition"
     @update:modelValue="onUpdateCondition"
     :tableName="tableName"
-    :graphqlURL="graphqlURL"
+    :schemaName="schemaName"
   />
 </template>
 
@@ -23,7 +23,7 @@ export default {
       type: Object,
       required: false,
     },
-    graphqlURL: {
+    schemaName: {
       required: false,
       type: String,
     },

--- a/apps/molgenis-components/src/components/filters/RefListFilter.vue
+++ b/apps/molgenis-components/src/components/filters/RefListFilter.vue
@@ -4,7 +4,7 @@
     :modelValue="condition"
     @update:modelValue="onUpdateCondition"
     :tableName="tableName"
-    :graphqlURL="graphqlURL"
+    :schemaName="schemaName"
   />
 </template>
 
@@ -23,7 +23,7 @@ export default {
       type: Object,
       required: false,
     },
-    graphqlURL: {
+    schemaName: {
       required: false,
       type: String,
     },

--- a/apps/molgenis-components/src/components/forms/EditModal.vue
+++ b/apps/molgenis-components/src/components/forms/EditModal.vue
@@ -9,7 +9,7 @@
           :pkey="pkey"
           :tableName="tableName"
           :tableMetaData="tableMetaData"
-          :graphqlURL="graphqlURL"
+          :schemaName="schemaName"
           :visibleColumns="visibleColumns"
           :clone="clone"
           :page="currentPage"
@@ -23,7 +23,7 @@
           :pkey="pkey"
           :tableName="tableName"
           :tableMetaData="tableMetaData"
-          :graphqlURL="graphqlURL"
+          :schemaName="schemaName"
           :visibleColumns="visibleColumns"
           :clone="clone"
           class="flex-grow-1"
@@ -123,10 +123,9 @@ export default {
       type: Boolean,
       required: true,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
       required: false,
-      default: () => "graphql",
     },
     pkey: {
       type: Object,
@@ -187,7 +186,7 @@ export default {
       const result = await this.client[action](
         formData,
         this.tableName,
-        this.graphqlURL
+        this.schemaName
       ).catch(this.handleSaveError);
       if (result) {
         this.handleClose();
@@ -218,8 +217,8 @@ export default {
   },
   async mounted() {
     this.loaded = false;
-    this.client = Client.newClient(this.graphqlURL);
-    const settings = await this.client.fetchSettings(this.graphqlURL);
+    this.client = Client.newClient(this.schemaName);
+    const settings = await this.client.fetchSettings();
 
     this.useChapters =
       settings.find((item) => item.key === IS_CHAPTERS_ENABLED_FIELD_NAME)
@@ -311,7 +310,7 @@ export default {
       :pkey="demoKey"
       :clone="demoMode === 'clone'"
       :isModalShown="isModalShown"
-      :graphqlURL="graphqlURL"
+      :schemaName="schemaName"
       @close="isModalShown = false"
     />
   </DemoItem>
@@ -321,21 +320,21 @@ export default {
 export default {
   data: function () {
     return {
+      schemaName: "pet store",
       tableName: "Pet",
       demoMode: "insert", // one of [insert, update, clone]
       demoKey: null, // empty in case of insert
       isModalShown: false,
-      graphqlURL: "/pet store/graphql",
       useChapters: true
     };
   },
   methods: {
     async reload() {
-      const client = this.$Client.newClient(this.graphqlURL);
+      const client = this.$Client.newClient(this.schemaName);
       const tableMetaData = await client.fetchTableMetaData(this.tableName);
       const rowData = await client.fetchTableDataValues(this.tableName);
       this.demoKey = this.$utils.getPrimaryKey(rowData[0], tableMetaData);
-      const settings = await client.fetchSettings(this.graphqlURL);
+      const settings = await client.fetchSettings();
       this.useChapters =
         settings.find((item) => item.key === IS_CHAPTERS_ENABLED_FIELD_NAME)?.value !==
         "false";

--- a/apps/molgenis-components/src/components/forms/EditModal.vue
+++ b/apps/molgenis-components/src/components/forms/EditModal.vue
@@ -9,7 +9,7 @@
           :pkey="pkey"
           :tableName="tableName"
           :tableMetaData="tableMetaData"
-          :schemaName="schemaName"
+          :schemaMetaData="schemaMetaData"
           :visibleColumns="visibleColumns"
           :clone="clone"
           :page="currentPage"
@@ -23,7 +23,7 @@
           :pkey="pkey"
           :tableName="tableName"
           :tableMetaData="tableMetaData"
-          :schemaName="schemaName"
+          :schemaMetadata="schemaMetaData"
           :visibleColumns="visibleColumns"
           :clone="clone"
           class="flex-grow-1"
@@ -102,6 +102,7 @@ export default {
     return {
       rowData: {},
       tableMetaData: null,
+      schemaMetaData: null,
       client: null,
       errorMessage: null,
       loaded: true,
@@ -218,6 +219,7 @@ export default {
   async mounted() {
     this.loaded = false;
     this.client = Client.newClient(this.schemaName);
+    this.schemaMetaData = await this.client.fetchMetaData();
     const settings = await this.client.fetchSettings();
 
     this.useChapters =

--- a/apps/molgenis-components/src/components/forms/EditModalWizard.vue
+++ b/apps/molgenis-components/src/components/forms/EditModalWizard.vue
@@ -7,7 +7,7 @@
       :pkey="pkey"
       :tableName="tableName"
       :tableMetaData="tableMetaData"
-      :graphqlURL="graphqlURL"
+      :schemaName="schemaName"
       :visibleColumns="columnsSplitByHeadings[page - 1]"
       :clone="clone"
       @update:modelValue="$emit('update:modelValue', $event)"
@@ -54,9 +54,9 @@ export default {
       type: Array,
       required: false,
     },
-    graphqlURL: {
-      default: "graphql",
+    schemaName: {
       type: String,
+      required: false
     },
   },
   mounted() {

--- a/apps/molgenis-components/src/components/forms/EditModalWizard.vue
+++ b/apps/molgenis-components/src/components/forms/EditModalWizard.vue
@@ -7,7 +7,7 @@
       :pkey="pkey"
       :tableName="tableName"
       :tableMetaData="tableMetaData"
-      :schemaName="schemaName"
+      :schemaMetaData="schemaMetaData"
       :visibleColumns="columnsSplitByHeadings[page - 1]"
       :clone="clone"
       @update:modelValue="$emit('update:modelValue', $event)"
@@ -54,8 +54,8 @@ export default {
       type: Array,
       required: false,
     },
-    schemaName: {
-      type: String,
+    schemaMetaData: {
+      type: Object,
       required: false
     },
   },

--- a/apps/molgenis-components/src/components/forms/FormInput.vue
+++ b/apps/molgenis-components/src/components/forms/FormInput.vue
@@ -88,8 +88,8 @@ export default {
       type: Object,
       required: false,
     },
-    graphqlURL: {
-      default: "graphql",
+    schemaName: {
+      required: false,
       type: String,
     },
     pkey: {
@@ -363,7 +363,7 @@ export default {
           label="Example ref input"
           tableName="Pet"
           :defaultValue="{ name: 'spike' }"
-          :graphqlURL="graphqlUrl"
+          :schemaName="schemaName"
           v-model="refValue"
         />
       </div>
@@ -377,7 +377,7 @@ export default {
           label="Example ref array input"
           tableName="Pet"
           :defaultValue="[{ name: 'spike' }]"
-          :graphqlURL="graphqlUrl"
+          :schemaName="schemaName"
           v-model="refValueArray"
         />
       </div>
@@ -391,7 +391,7 @@ export default {
           label="Example ontology input"
           tableName="Category"
           v-model="ontologyValue"
-          :graphqlURL="graphqlUrl"
+          :schemaName="schemaName"
         />
       </div>
       <div>You selected: {{ JSON.stringify(ontologyValue, null, 2) }}</div>
@@ -404,7 +404,7 @@ export default {
           label="Example ontology array input"
           tableName="Category"
           v-model="ontologyArrayValue"
-          :graphqlURL="graphqlUrl"
+          :schemaName="schemaName"
         />
       </div>
       <div>You selected: {{ JSON.stringify(ontologyArrayValue, null, 2) }}</div>
@@ -435,11 +435,11 @@ export default {
   </div>
 </template>
 <script>
-const graphqlUrl = "/pet store/graphql";
+const schemaName = "pet store";
 export default {
   data: function () {
     return {
-      graphqlUrl,
+      schemaName,
       stringValue: "test",
       stringValueInplace: "inplace",
       stringValueArray: ["value1", "value2"],

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -154,9 +154,9 @@ export default {
       type: String,
       required: false,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
-      default: "graphql",
+      required: false
     },
   },
   data() {
@@ -500,7 +500,7 @@ export default {
   },
   async mounted() {
     if (this.tableName) {
-      const client = Client.newClient(this.graphqlURL);
+      const client = Client.newClient(this.schemaName);
       this.data = (
         await client.fetchTableData(this.tableName, { limit: this.limit || 20 })
       )[this.tableId];
@@ -568,7 +568,7 @@ export default {
           description="please choose your options in tree below"
           v-model="value3"
           tableName="Tag"
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
       />
       <div>You selected: {{ value3 }}</div>
     </demo-item>
@@ -582,7 +582,7 @@ export default {
           v-model="value4"
           :isMultiSelect="true"
           tableName="Tag"
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
       />
       <div>You selected: {{ value4 }}</div>
     </demo-item>

--- a/apps/molgenis-components/src/components/forms/InputRef.vue
+++ b/apps/molgenis-components/src/components/forms/InputRef.vue
@@ -176,6 +176,11 @@ export default {
       this.count = response[this.tableId + "_agg"].count;
     },
   },
+  watch: {
+    filter() {
+      this.loadOptions();
+    }
+  },
   async mounted() {
     this.client = Client.newClient(this.schemaName);
     this.tableMetaData = await this.client.fetchTableMetaData(this.tableName);

--- a/apps/molgenis-components/src/components/forms/InputRef.vue
+++ b/apps/molgenis-components/src/components/forms/InputRef.vue
@@ -65,7 +65,7 @@
             @select="select($event)"
             @deselect="clearValue"
             @close="loadOptions"
-            :graphqlURL="graphqlURL"
+            :schemaName="schemaName"
             :showSelect="true"
             :limit="10"
             :canEdit="canEdit"
@@ -98,8 +98,8 @@ export default {
     ButtonAlt,
   },
   props: {
-    graphqlURL: {
-      default: "graphql",
+    schemaName: {
+      required: false,
       type: String,
     },
     filter: Object,
@@ -177,10 +177,8 @@ export default {
     },
   },
   async mounted() {
-    this.client = Client.newClient(this.graphqlURL);
-    this.tableMetaData = (await this.client.fetchMetaData()).tables.find(
-      (table) => table.id === this.tableId
-    );
+    this.client = Client.newClient(this.schemaName);
+    this.tableMetaData = await this.client.fetchTableMetaData(this.tableName);
     this.loadOptions();
   },
 };
@@ -206,7 +204,7 @@ export default {
         v-model="value"
         tableName="Pet"
         description="Standard input"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
         :canEdit="canEdit"
       />
       Selection: {{ value }}
@@ -219,7 +217,7 @@ export default {
         tableName="Pet"
         description="This is a default value"
         :defaultValue="defaultValue"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
         :canEdit="canEdit"
       />
       Selection: {{ defaultValue }}
@@ -232,7 +230,7 @@ export default {
         tableName="Pet"
         description="Filter by name"
         :filter="{ category: { name: { equals: 'cat' } } }"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
         :canEdit="canEdit"
       />
       Selection: {{ filterValue }}
@@ -244,7 +242,7 @@ export default {
         v-model="multiColumnValue"
         tableName="Pet"
         description="This is a multi column input"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
         multipleColumns
         :itemsPerColumn="3"
         :canEdit="canEdit"

--- a/apps/molgenis-components/src/components/forms/InputRefBack.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefBack.vue
@@ -14,7 +14,7 @@
           v-bind="$props"
           :canEdit="canEdit"
           :reload="reload"
-          :grapqlURL="graphqlURL"
+          :schemaName="schemaName"
         />
         <RowButton
           v-if="canEdit"
@@ -34,7 +34,7 @@
           v-if="canEdit"
           type="edit"
           :table="tableName"
-          :graphqlURL="graphqlURL"
+          :schemaName="schemaName"
           :visible-columns="visibleColumnNames"
           :refTablePrimaryKeyObject="
             getPrimaryKey(slotProps.row, tableMetadata)
@@ -48,7 +48,7 @@
           v-if="canEdit"
           type="clone"
           :table="tableName"
-          :graphqlURL="graphqlURL"
+          :schemaName="schemaName"
           :pkey="getPrimaryKey(slotProps.row, tableMetadata)"
           :visible-columns="visibleColumnNames"
           :default-value="defaultValue"
@@ -81,7 +81,7 @@
       :pkey="editRowPrimaryKey"
       :visibleColumns="visibleColumns"
       :clone="editMode === 'clone'"
-      :graphqlURL="graphqlURL"
+      :schemaName="schemaName"
       :defaultValue="defaultValue"
       @close="handleModalClose"
     />
@@ -142,9 +142,9 @@ export default {
       type: Object,
       required: false,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
-      default: "graphql",
+      required: false,
     },
     /**
      * if table (that has a column that is referred to by this table) can be edited
@@ -235,7 +235,7 @@ export default {
     },
   },
   mounted: async function () {
-    this.client = Client.newClient(this.graphqlURL);
+    this.client = Client.newClient(this.schemaName);
     this.isLoading = true;
     this.tableMetadata = await this.client.fetchTableMetaData(this.tableName).catch(error => this.errorMessage = error.message);
     await this.reload();
@@ -260,7 +260,7 @@ export default {
           tableName="Order"
           refBack="pet"
           :refTablePrimaryKeyObject=null
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
       />
     </div>
 
@@ -274,7 +274,7 @@ export default {
           tableName="Order"
           refBack="pet"
           :refTablePrimaryKeyObject="{name:'spike'}"
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
       />
     </div>
 
@@ -287,7 +287,7 @@ export default {
           tableName="Order"
           refBack="pet"
           :refTablePrimaryKeyObject="{name:'spike'}"
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
       />
     </div>
   </div>

--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -168,6 +168,9 @@ export default {
       const options = {
         limit: this.maxNum,
       };
+      if(this.filter) {
+        options['filter'] = this.filter;
+      }
       const response = await this.client.fetchTableData(
         this.tableId,
         options
@@ -179,6 +182,9 @@ export default {
   watch: {
     modelValue() {
       this.selection = this.modelValue;
+    },
+    filter() {
+      this.loadOptions();
     }
   },
   async mounted() {

--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -67,7 +67,7 @@
             :filter="filter"
             @select="emitSelection"
             @deselect="deselect"
-            :graphqlURL="graphqlURL"
+            :schemaName="schemaName"
             :showSelect="true"
             :limit="10"
             :canEdit="canEdit"
@@ -111,9 +111,9 @@ export default {
     ButtonAlt,
   },
   props: {
-    graphqlURL: {
-      default: "graphql",
+    schemaName: {
       type: String,
+      required: false,
     },
     filter: Object,
     multipleColumns: Boolean,
@@ -182,14 +182,9 @@ export default {
     }
   },
   async mounted() {
-    this.client = Client.newClient(this.graphqlURL);
-    const allMetaData = await this.client.fetchMetaData();
-    this.tableMetaData = allMetaData.tables.find(
-      (table) => table.id === this.tableId
-    );
-
+    this.client = Client.newClient(this.schemaName);
+    this.tableMetaData = await this.client.fetchTableMetaData(this.tableName);
     await this.loadOptions();
-
     if (!this.modelValue) {
       this.selection = [];
     }
@@ -210,14 +205,14 @@ export default {
         <p class="font-italic">view in table mode to see edit action buttons</p>
     </div>
     <DemoItem>
-      <!-- normally you don't need graphqlURL, default url = 'graphql' just works -->
+      <!-- normally you don't need schemaName, it will use graphql on current path-->
       <InputRefList
         id="input-ref-list"
         label="Standard ref input list"
         v-model="value"
         tableName="Pet"
         description="Standard input"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
         :canEdit="canEdit"
       />
       Selection: {{ value }}
@@ -230,7 +225,7 @@ export default {
         tableName="Pet"
         description="This is a default value"
         :defaultValue="defaultValue"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
         :canEdit="canEdit"
       />
       Selection: {{ defaultValue }}
@@ -243,7 +238,7 @@ export default {
         tableName="Pet"
         description="Filter by name"
         :filter="{ category: { name: { equals: 'pooky' } } }"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
         :canEdit="canEdit"
       />
       Selection: {{ filterValue }}
@@ -255,7 +250,7 @@ export default {
         v-model="multiColumnValue"
         tableName="Pet"
         description="This is a multi column input"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
         multipleColumns
         :canEdit="canEdit"
       />

--- a/apps/molgenis-components/src/components/forms/InputRefSelect.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefSelect.vue
@@ -32,7 +32,7 @@
           <TableSearch
             :lookupTableName="tableName"
             :filter="filter"
-            :graphqlURL="graphqlURL"
+            :schemaName="schemaName"
             :canEdit="canEdit"
             @select="select($event)"
             @deselect="deselect(selectIdx)"
@@ -80,9 +80,9 @@ export default {
   },
   props: {
     tableName: String,
-    graphqlURL: {
-      default: "graphql",
+    schemaName: {
       type: String,
+      required: false,
     },
     filter: Object,
     refLabel: String,
@@ -146,8 +146,8 @@ export default {
       id="input-ref-select-1" 
       v-model="value1" 
       tableName="Pet" 
-      graphqlURL="/pet store/graphql
-    "/>
+      schemaName="pet store"
+    />
     Selection: {{ value1 }}
   </div>
 
@@ -157,7 +157,7 @@ export default {
         id="input-ref-select-2"
         v-model="value2"
         tableName="Pet"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
     />
     Selection: {{ value2 }}
   </div>
@@ -169,7 +169,7 @@ export default {
         v-model="value3"
         tableName="Pet"
         :filter="{category:{name: {equals:'dog'}}}"
-        graphqlURL="/pet store/graphql"
+        schemaName="pet store"
     />
     Selection: {{ value3 }}
   </div>

--- a/apps/molgenis-components/src/components/tables/RoutedTableExplorer.vue
+++ b/apps/molgenis-components/src/components/tables/RoutedTableExplorer.vue
@@ -2,7 +2,7 @@
   <div>
     <TableExplorer
       :tableName="tableName"
-      :graphqlURL="graphqlURL"
+      :schemaName="schemaName"
       :canEdit="canEdit"
       :canManage="canManage"
       @updateConditions="updateConditions"
@@ -42,9 +42,9 @@ export default {
       type: String,
       required: true,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
-      default: () => "graphql",
+      required: false,
     },
     canEdit: {
       type: Boolean,

--- a/apps/molgenis-components/src/components/tables/RowButtonAdd.vue
+++ b/apps/molgenis-components/src/components/tables/RowButtonAdd.vue
@@ -6,7 +6,7 @@
       :id="id + 'add-modal'"
       :tableName="tableName"
       :isModalShown="isModalShown"
-      :graphqlURL="graphqlURL"
+      :schemaName="schemaName"
       @close="handleClose"
     />
   </span>
@@ -27,10 +27,9 @@ export default {
       type: String,
       required: true,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
       required: false,
-      default: () => "graphql",
     },
   },
   data() {
@@ -55,7 +54,7 @@ export default {
         <RowButtonAdd 
           id="row-add-btn-sample" 
           tableName="Pet"
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
         />
       </div>
     </div>

--- a/apps/molgenis-components/src/components/tables/RowButtonClone.vue
+++ b/apps/molgenis-components/src/components/tables/RowButtonClone.vue
@@ -8,7 +8,7 @@
       :pkey="pkey"
       :clone="true"
       :isModalShown="isModalShown"
-      :graphqlURL="graphqlURL"
+      :schemaName="schemaName"
       @close="handleClose"
     />
   </div>
@@ -34,10 +34,9 @@ export default {
       type: Object,
       required: true,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
       required: false,
-      default: () => "graphql",
     },
   },
   data() {
@@ -63,7 +62,7 @@ export default {
           id="row-clone-btn-sample"
           tableName="Pet"
           :pkey="{name: 'pooky'}"
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
       />
     </div>
   </div>

--- a/apps/molgenis-components/src/components/tables/RowButtonDelete.vue
+++ b/apps/molgenis-components/src/components/tables/RowButtonDelete.vue
@@ -34,10 +34,9 @@ export default {
     pkey: {
       type: Object,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
       required: false,
-      default: () => "graphql",
     },
   },
   data() {
@@ -49,9 +48,9 @@ export default {
   methods: {
     async handleExecuteDelete() {
       if (!this.client) {
-        this.client = Client.newClient(this.graphqlURL);
+        this.client = Client.newClient(this.schemaName);
       }
-      this.client
+      await this.client
         .deleteRow(this.pkey, this.tableName)
         .then(() => {
           this.$emit("success", {
@@ -87,7 +86,7 @@ export default {
           id="row-delete-btn-sample"
           tableName="Pet"
           :pkey="{name: 'pooky'}"
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
           @error="handleError"
           @success="handleSuccess"
       />

--- a/apps/molgenis-components/src/components/tables/RowButtonEdit.vue
+++ b/apps/molgenis-components/src/components/tables/RowButtonEdit.vue
@@ -6,7 +6,7 @@
       :tableName="tableName"
       :pkey="pkey"
       :isModalShown="isModalShown"
-      :graphqlURL="graphqlURL"
+      :schemaName="schemaName"
       @close="handleClose"
     />
   </span>
@@ -26,10 +26,9 @@ export default {
       type: String,
       required: true,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
       required: false,
-      default: () => "graphql",
     },
     pkey: {
       type: Object,
@@ -58,7 +57,7 @@ export default {
           id="row-edit-btn-sample" 
           tableName="Pet"
           :pkey="{name: 'pooky'}"
-          graphqlURL="/pet store/graphql"
+          schemaName="pet store"
         />
       </div>
     </div>

--- a/apps/molgenis-components/src/components/tables/ShowHide.vue
+++ b/apps/molgenis-components/src/components/tables/ShowHide.vue
@@ -146,7 +146,7 @@ export default {
     },
   },
   mounted: async function () {
-    const client = this.$Client.newClient("/pet store/graphql");
+    const client = this.$Client.newClient("pet store");
     const tableMetaData = await client.fetchTableMetaData("Pet");
     this.columns = tableMetaData.columns;
   },

--- a/apps/molgenis-components/src/components/tables/TableExplorer.vue
+++ b/apps/molgenis-components/src/components/tables/TableExplorer.vue
@@ -702,10 +702,17 @@ function getCondition(columnType, condition) {
       <label>Read only example</label>
       <table-explorer
         id="my-table-explorer"
-        tableName="Cohorts"
-        schemaName="DataCatalogue"
+        tableName="Pet"
+        graphqlURL="/pet store/graphql"
+        :showColumns="showColumns"
+        :showFilters="showFilters"
+        :urlConditions="urlConditions"
+        :showPage="page"
+        :showLimit="limit"
+        :showOrderBy="showOrderBy"
+        :showOrder="showOrder"
         :canEdit="canEdit"
-
+        :canManage="canManage"
       />
       <div class="border mt-3 p-2">
         <h5>synced props: </h5>

--- a/apps/molgenis-components/src/components/tables/TableExplorer.vue
+++ b/apps/molgenis-components/src/components/tables/TableExplorer.vue
@@ -98,7 +98,7 @@
       <div class="btn-group" v-if="canManage">
         <TableSettings v-if="tableMetadata"
           :tableMetadata="tableMetadata"
-          :graphqlURL="graphqlURL"
+          :schemaName="schemaName"
           @update:settings="reloadMetadata"
         />
 
@@ -113,7 +113,7 @@
         <FilterSidebar
           :filters="columns"
           @updateFilters="emitConditions"
-          :graphqlURL="graphqlURL"
+          :schemaName="schemaName"
         />
       </div>
       <div
@@ -175,7 +175,7 @@
               v-if="canEdit"
               type="add"
               :table="tableName"
-              :graphqlURL="graphqlURL"
+              :schemaName="schemaName"
               @add="handleRowAction('add')"
               class="d-inline p-0"
             />
@@ -229,7 +229,7 @@
       :tableName="tableName"
       :pkey="editRowPrimaryKey"
       :clone="editMode === 'clone'"
-      :graphqlURL="graphqlURL"
+      :schemaName="schemaName"
       @close="handleModalClose"
     />
 
@@ -343,9 +343,9 @@ export default {
       type: String,
       required: true,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
-      default: () => "graphql",
+      required: false,
     },
     showSelect: {
       type: Boolean,
@@ -603,7 +603,7 @@ export default {
       this.tableMetadata = newTableMetadata;
     },
     async reloadMetadata() {
-      this.client = Client.newClient(this.graphqlURL);
+      this.client = Client.newClient(this.schemaName);
       const newTableMetadata = await this.client.fetchTableMetaData(this.tableName).catch(this.handleError);
       this.setTableMetadata(newTableMetadata);
       this.reload();
@@ -702,17 +702,10 @@ function getCondition(columnType, condition) {
       <label>Read only example</label>
       <table-explorer
         id="my-table-explorer"
-        tableName="Pet"
-        graphqlURL="/pet store/graphql"
-        :showColumns="showColumns"
-        :showFilters="showFilters"
-        :urlConditions="urlConditions"
-        :showPage="page" 
-        :showLimit="limit"
-        :showOrderBy="showOrderBy" 
-        :showOrder="showOrder"
+        tableName="Cohorts"
+        schemaName="DataCatalogue"
         :canEdit="canEdit"
-        :canManage="canManage"
+
       />
       <div class="border mt-3 p-2">
         <h5>synced props: </h5>

--- a/apps/molgenis-components/src/components/tables/TableMolgenis.vue
+++ b/apps/molgenis-components/src/components/tables/TableMolgenis.vue
@@ -312,7 +312,7 @@ export default {
     },
   },
   async mounted() {
-    const client = Client.newClient("/pet store/graphql", this.$axios);
+    const client = Client.newClient("pet store", this.$axios);
     const remoteMetaData = await client.fetchMetaData();
     const petColumns = remoteMetaData.tables.find(
       (t) => t.name === "Pet"

--- a/apps/molgenis-components/src/components/tables/TableSearch.vue
+++ b/apps/molgenis-components/src/components/tables/TableSearch.vue
@@ -34,7 +34,7 @@
               v-if="canEdit"
               :id="'row-button-add-' + lookupTableName"
               :tableName="lookupTableName"
-              :graphqlURL="graphqlURL"
+              :schemaName="schemaName"
               @close="loadData"
               class="d-inline p-0"
             />
@@ -45,7 +45,7 @@
               v-bind="$props"
               :canEdit="canEdit"
               :reload="loadData"
-              :grapqlURL="graphqlURL"
+              :schemaName="schemaName"
             />
           </template>
           <template v-slot:rowheader="slotProps">
@@ -59,7 +59,7 @@
               v-if="canEdit"
               :id="'row-button-edit-' + lookupTableName"
               :tableName="lookupTableName"
-              :graphqlURL="graphqlURL"
+              :schemaName="schemaName"
               :pkey="slotProps.rowkey"
               @close="loadData"
               class="text-left"
@@ -68,7 +68,7 @@
               v-if="canEdit"
               :id="'row-button-del-' + lookupTableName"
               :tableName="lookupTableName"
-              :graphqlURL="graphqlURL"
+              :schemaName="schemaName"
               :pkey="slotProps.rowkey"
               @close="loadData"
             />
@@ -109,7 +109,7 @@ export default {
       type: String,
       required: true,
     },
-    graphqlURL: {
+    schemaName: {
       type: String,
       required: true,
     },
@@ -177,17 +177,11 @@ export default {
         filter: this.filter,
       };
 
-      const client = Client.newClient(this.graphqlURL);
-      const remoteMetaData = await client
-        .fetchMetaData()
-        .catch(() => (this.graphqlError = "Failed to load meta data"));
+      const client = Client.newClient(this.schemaName);
       const gqlResponse = await client
-        .fetchTableData(this.lookupTableIdentifier, queryOptions)
+        .fetchTableData(this.lookupTableName, queryOptions)
         .catch(() => (this.graphqlError = "Failed to load data"));
-
-      this.tableMetadata = remoteMetaData.tables.find(
-        (table) => table.id === this.lookupTableIdentifier
-      );
+      this.tableMetadata = await client.fetchTableMetaData(this.lookupTableName);
       this.data = gqlResponse[this.lookupTableIdentifier];
       this.count = gqlResponse[`${this.lookupTableIdentifier}_agg`].count;
       this.loading = false;
@@ -223,7 +217,7 @@ export default {
         :columns.sync="columns"
         :lookupTableName="'Pet'"
         :showSelect="false"
-        :graphqlURL="'/pet store/graphql'"
+        schemaName="pet store"
         :canEdit="canEdit"
         @select="click"
         @deselect="click"

--- a/apps/molgenis-components/src/components/tables/TableSettings.vue
+++ b/apps/molgenis-components/src/components/tables/TableSettings.vue
@@ -58,9 +58,9 @@ export default {
     ButtonAlt,
   },
   props: {
-    graphqlURL: {
+    schemaName: {
       type: String,
-      default: "graphql",
+      required: false,
     },
     tableMetadata: {type: Object, required: true}
   },
@@ -103,7 +103,7 @@ export default {
       this.loading = true;
       this.graphqlError = null;
       this.success = null;
-      const resp = await request(this.graphqlURL, `mutation change($tables:[MolgenisTableInput]){change(tables:$tables){message}}`, {tables:[this.tableMetadata]})
+      const resp = await request(this.schemaName ? "/"+this.schemaName+"/graphql":"graphql", `mutation change($tables:[MolgenisTableInput]){change(tables:$tables){message}}`, {tables:[this.tableMetadata]})
         .catch((error) => {
           this.graphqlError = error.errors[0].message;
         });

--- a/apps/molgenis-components/src/components/utils.js
+++ b/apps/molgenis-components/src/components/utils.js
@@ -102,29 +102,33 @@ export function isInvalidBigInt(value) {
 }
 
 export function convertToCamelCase(string) {
-  const words = string.trim().split(/\s+/);
-  let result = "";
-  words.forEach((word, index) => {
-    if (index === 0) {
-      result += word.charAt(0).toLowerCase();
-    } else {
-      result += word.charAt(0).toUpperCase();
-    }
-    if (word.length > 1) {
-      result += word.slice(1);
-    }
-  });
-  return result;
+  if (string) {
+    const words = string.trim().split(/\s+/);
+    let result = "";
+    words.forEach((word, index) => {
+      if (index === 0) {
+        result += word.charAt(0).toLowerCase();
+      } else {
+        result += word.charAt(0).toUpperCase();
+      }
+      if (word.length > 1) {
+        result += word.slice(1);
+      }
+    });
+    return result;
+  }
 }
 
 export function convertToPascalCase(string) {
-  const words = string.trim().split(/\s+/);
-  let result = "";
-  words.forEach((word, index) => {
-    result += word.charAt(0).toUpperCase();
-    if (word.length > 1) {
-      result += word.slice(1);
-    }
-  });
-  return result;
+  if (string) {
+    const words = string.trim().split(/\s+/);
+    let result = "";
+    words.forEach((word, index) => {
+      result += word.charAt(0).toUpperCase();
+      if (word.length > 1) {
+        result += word.slice(1);
+      }
+    });
+    return result;
+  }
 }

--- a/apps/schema/src/components/Schema.vue
+++ b/apps/schema/src/components/Schema.vue
@@ -214,7 +214,7 @@ export default {
           : schema.tables.filter(
               (table) =>
                 table.tableType !== "ONTOLOGIES" &&
-                table.externalSchema === undefined
+                table.externalSchema === schema.name
             );
         tables.forEach((t) => {
           t.oldName = t.name;

--- a/apps/settings/package.json
+++ b/apps/settings/package.json
@@ -13,7 +13,7 @@
     "graphql-request": "5.1.0",
     "vue": "3.2.45",
     "vue-router": "4.1.6",
-    "vue3-swatches": "1.2.3",
+    "vue3-colorpicker": "2.1.2",
     "vuedraggable": "4.1.0"
   },
   "devDependencies": {

--- a/apps/settings/src/components/Theme.vue
+++ b/apps/settings/src/components/Theme.vue
@@ -5,8 +5,9 @@
     <div v-else>
       <p>Use settings below to change look and feel:</p>
       <MessageSuccess v-if="success">{{ success }}</MessageSuccess>
-      <label>Choose primary color</label><br />
-      <v-swatches class="mb-2" v-model="primaryColor" show-fallback />
+      <label><b>Choose primary color</b></label><br />
+      <ColorPicker class="mb-2" v-model:pureColor="primaryColor" format="hex6" shape="circle" />
+     {{primaryColor}}
       <InputString
         id="theme-url-input"
         label="Set logo url"
@@ -27,7 +28,8 @@ import {
   MessageSuccess,
   Spinner,
 } from "molgenis-components";
-import VSwatches from "vue3-swatches";
+import {ColorPicker} from "vue3-colorpicker";
+import "vue3-colorpicker/style.css";
 import { request } from "graphql-request";
 
 export default {
@@ -36,7 +38,7 @@ export default {
     ButtonAction,
     MessageError,
     MessageSuccess,
-    VSwatches,
+    ColorPicker,
     Spinner,
   },
   props: {

--- a/apps/tables/src/components/ListTables.vue
+++ b/apps/tables/src/components/ListTables.vue
@@ -64,7 +64,7 @@ export default {
       if (this.search && this.search.trim().length > 0) {
         let terms = this.search.toLowerCase().split(" ");
         return this.schema.tables
-          .filter((table) => !table.externalSchema)
+          .filter((table) => table.externalSchema === this.schema.name)
           .filter((table) =>
             terms.every(
               (term) =>
@@ -74,7 +74,7 @@ export default {
             )
           );
       } else {
-        return this.schema.tables.filter((table) => !table.externalSchema);
+        return this.schema.tables.filter((table) => table.externalSchema === this.schema.name);
       }
     },
     tables() {

--- a/apps/tables/src/components/ViewTable.vue
+++ b/apps/tables/src/components/ViewTable.vue
@@ -1,10 +1,11 @@
 <template>
-  <div>
+  <div v-if="schema">
     <router-link v-if="schema" to="/">
       &lt; Back to {{ schema.name }}
     </router-link>
     <RoutedTableExplorer
       :tableName="table"
+      :schemaName="schema.name"
       :canEdit="canEdit"
       :canManage="canManage"
     />

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2,6 +2,11 @@
 # yarn lockfile v1
 
 
+"@aesoper/normal-utils@^0.1.5":
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/@aesoper/normal-utils/-/normal-utils-0.1.5.tgz#82b7c899ab9670c55515f949a3766d24260b8039"
+  integrity sha512-LFF/6y6h5mfwhnJaWqqxuC8zzDaHCG62kMRkd8xhDtq62TQj9dM17A9DhE87W7DhiARJsHLgcina/9P4eNCN1w==
+
 "@ampproject/remapping@^2.1.0":
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/@ampproject/remapping/-/remapping-2.2.0.tgz#56c133824780de3174aed5ab6834f3026790154d"
@@ -1095,6 +1100,11 @@
     tslib "^2.4.0"
     webcrypto-core "^1.7.4"
 
+"@popperjs/core@^2.10.1":
+  version "2.11.6"
+  resolved "https://registry.yarnpkg.com/@popperjs/core/-/core-2.11.6.tgz#cee20bd55e68a1720bdab363ecf0c821ded4cd45"
+  integrity sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==
+
 "@redux-saga/core@^1.2.1":
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/@redux-saga/core/-/core-1.2.1.tgz#3680989621517d075a2cc85e0d2744b682990ed8"
@@ -1545,6 +1555,14 @@
     quill "^1.3.7"
     quill-delta "^4.2.2"
 
+"@vueuse/core@^6.5.3":
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/core/-/core-6.9.2.tgz#76b16d01f33cf367dd1a2d7f2e31d106443ceb8a"
+  integrity sha512-FRwl4ccSFuHZBHLGgS9TMv/+Dd6XFaL4o9nph2qtgQIV+z29RBFokw08XjHfykiENRzB01MjYHJ7iRUnsIFQXg==
+  dependencies:
+    "@vueuse/shared" "6.9.2"
+    vue-demi "*"
+
 "@vueuse/head@^1.0.15":
   version "1.0.16"
   resolved "https://registry.yarnpkg.com/@vueuse/head/-/head-1.0.16.tgz#24db98a74f7727332e37f258273be7e2393e0702"
@@ -1554,6 +1572,13 @@
     "@unhead/schema" "^1.0.1"
     "@unhead/ssr" "^1.0.1"
     "@unhead/vue" "^1.0.1"
+
+"@vueuse/shared@6.9.2":
+  version "6.9.2"
+  resolved "https://registry.yarnpkg.com/@vueuse/shared/-/shared-6.9.2.tgz#97e4369fa7262ebc96fe1d6e210268f30b037005"
+  integrity sha512-lAiMh6XROs0kSKVd0Yb/6GKoQMxC1fYrFDi6opvQWISPtcqRNluRrQxLUZ3WTI78ovtoKRLktjhkFAtydcfFDg==
+  dependencies:
+    vue-demi "*"
 
 "@whatwg-node/fetch@^0.5.0":
   version "0.5.1"
@@ -2524,6 +2549,11 @@ copy-to-clipboard@^3.0.8, copy-to-clipboard@^3.2.0, copy-to-clipboard@^3.3.1:
   integrity sha512-Vme1Z6RUDzrb6xAI7EZlVZ5uvOk2F//GaxKUxajDqm9LhOVM1inxNAD2vy+UZDYsd0uyA9s7b3/FVZPSxqrCfg==
   dependencies:
     toggle-selection "^1.0.6"
+
+core-js@3.27.0:
+  version "3.27.0"
+  resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.27.0.tgz#a343bc614f29d9dcffa7616e65e10f9001cdd332"
+  integrity sha512-wY6cKosevs430KRkHUIsvepDXHGjlXOZO3hYXNyqpD6JvB0X28aXyv0t1Y1vZMwE7SoKmtfa6IASHCPN52FwBQ==
 
 core-js@3.27.1:
   version "3.27.1"
@@ -3955,6 +3985,11 @@ graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.4, 
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.10.tgz#147d3a006da4ca3ce14728c7aefc287c367d7a6c"
   integrity sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==
 
+gradient-parser@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/gradient-parser/-/gradient-parser-1.0.2.tgz#d283b80390386e2613c992bb0e5abb259aedf25f"
+  integrity sha512-gR6nY33xC9yJoH4wGLQtZQMXDi6RI3H37ERu7kQCVUzlXjNedpZM7xcA489Opwbq0BSGohtWGsWsntupmxelMg==
+
 graphiql@^0.17.5:
   version "0.17.5"
   resolved "https://registry.yarnpkg.com/graphiql/-/graphiql-0.17.5.tgz#76c553fc0d8936f77e33114ac3374f1807a718ff"
@@ -4568,6 +4603,11 @@ is-plain-obj@^3.0.0:
   resolved "https://registry.yarnpkg.com/is-plain-obj/-/is-plain-obj-3.0.0.tgz#af6f2ea14ac5a646183a5bbdb5baabbc156ad9d7"
   integrity sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==
 
+is-plain-object@5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/is-plain-object/-/is-plain-object-5.0.0.tgz#4427f50ab3429e9025ea7d52e9043a9ef4159344"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
+
 is-primitive@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/is-primitive/-/is-primitive-3.0.1.tgz#98c4db1abff185485a657fc2905052b940524d05"
@@ -4895,6 +4935,11 @@ local-pkg@^0.4.2:
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/local-pkg/-/local-pkg-0.4.2.tgz#13107310b77e74a0e513147a131a2ba288176c2f"
   integrity sha512-mlERgSPrbxU3BP4qBqAvvwlgW4MTg78iwJdGGnv7kibKjWcJksrG3t6LB5lXI93wXRDvG4NpUgJFmTG4T6rdrg==
+
+lodash-es@^4.17.21:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.21.tgz#43e626c46e6591b7750beb2b50117390c609e3ee"
+  integrity sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==
 
 lodash._getnative@^3.0.0:
   version "3.9.1"
@@ -5875,6 +5920,11 @@ perfect-debounce@^0.1.3:
   resolved "https://registry.yarnpkg.com/perfect-debounce/-/perfect-debounce-0.1.3.tgz#ff6798ea543a3ba1f0efeeaf97c0340f5c8871ce"
   integrity sha512-NOT9AcKiDGpnV/HBhI22Str++XWcErO/bALvHCuhv33owZW/CjH8KAFLZDCmu3727sihe0wTxpDhyGc6M8qacQ==
 
+performance-now@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
+  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
+
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -6437,6 +6487,13 @@ radix3@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/radix3/-/radix3-1.0.0.tgz#d1c760b850206a6bd5dfd26820c25903cb20eccc"
   integrity sha512-6n3AEXth91ASapMVKiEh2wrbFJmI+NBilrWE0AbiGgfm0xet0QXC8+a3K19r1UVYjUjctUgB053c3V/J6V0kCQ==
+
+raf@^3.4.1:
+  version "3.4.1"
+  resolved "https://registry.yarnpkg.com/raf/-/raf-3.4.1.tgz#0742e99a4a6552f445d73e3ee0328af0ff1ede39"
+  integrity sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==
+  dependencies:
+    performance-now "^2.1.0"
 
 randombytes@^2.1.0:
   version "2.1.0"
@@ -7528,6 +7585,11 @@ tinybench@^2.3.1:
   resolved "https://registry.yarnpkg.com/tinybench/-/tinybench-2.3.1.tgz#14f64e6b77d7ef0b1f6ab850c7a808c6760b414d"
   integrity sha512-hGYWYBMPr7p4g5IarQE7XhlyWveh1EKhy4wUBS1LrHXCKYgvz+4/jCqgmJqZxxldesn05vccrtME2RLLZNW7iA==
 
+tinycolor2@^1.4.2:
+  version "1.5.2"
+  resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.5.2.tgz#7d30b4584d8b7d62b9a94dacc505614a6516a95f"
+  integrity sha512-h80m9GPFGbcLzZByXlNSEhp1gf8Dy+VX/2JCGUZsWLo7lV1mnE/XlxGYgRBoMLJh1lIDXP0EMC4RPTjlRaV+Bg==
+
 tinypool@^0.3.0:
   version "0.3.0"
   resolved "https://registry.yarnpkg.com/tinypool/-/tinypool-0.3.0.tgz#c405d8b743509fc28ea4ca358433190be654f819"
@@ -8118,6 +8180,11 @@ vue-bundle-renderer@^1.0.0:
   dependencies:
     ufo "^1.0.0"
 
+vue-demi@*:
+  version "0.13.11"
+  resolved "https://registry.yarnpkg.com/vue-demi/-/vue-demi-0.13.11.tgz#7d90369bdae8974d87b1973564ad390182410d99"
+  integrity sha512-IR8HoEEGM65YY3ZJYAjMlKygDQn25D5ajNFNoKh9RSDMQtlzCxtfQjdQgv9jjK+m3377SsJXY8ysq8kLCZL25A==
+
 vue-devtools-stub@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/vue-devtools-stub/-/vue-devtools-stub-0.1.0.tgz#a65b9485edecd4273cedcb8102c739b83add2c81"
@@ -8154,12 +8221,44 @@ vue-tabler-icons@2.17.0:
   resolved "https://registry.yarnpkg.com/vue-tabler-icons/-/vue-tabler-icons-2.17.0.tgz#e339f2c314197b4f076e923296f77ae3a44d399c"
   integrity sha512-VEgm9tBwQ96asVVOp3+10zJvOLWg/kY5oV3/n4cAHPVPpsJrj/3z76JBm8WrRxTk9WNwnYl1JqzeCnhChGSFqw==
 
-vue3-swatches@1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/vue3-swatches/-/vue3-swatches-1.2.3.tgz#69c20521470e2c5f3f4de052e8776a313d2333a5"
-  integrity sha512-UC4pzu2eFXvkjsIDmprLaOKiJ/bblBlP2PIrENK0gnhH0BFsvhSVCH3AGOK8m/8ZMai4r2Vyjr/ETeEjW5p3VA==
+vue-types@^4.1.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/vue-types/-/vue-types-4.2.1.tgz#f8f7e5fb42d4a6acda6d92c9736b510e5534c753"
+  integrity sha512-DNQZmJuOvovLUIp0BENRkdnZHbI0V4e2mNvjAZOAXKD56YGvRchtUYOXA/XqTxdv7Ng5SJLZqRKRpAhm5NLaPQ==
+  dependencies:
+    is-plain-object "5.0.0"
 
-vue@3.2.45, vue@^3.2.45:
+vue3-angle@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/vue3-angle/-/vue3-angle-0.1.6.tgz#cd99ececdb175543537d5b058319347225949cab"
+  integrity sha512-XbGG4xWhbbbB4Ujj17wyy5GjfsvTQL8+P00eRj3Y2W239l1CvKGehemrr0f1+IJa+aJpHaPn4hB22ahLy67Iqw==
+
+vue3-colorpicker@2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/vue3-colorpicker/-/vue3-colorpicker-2.1.2.tgz#fefb29040d9c0bf63a4f9c56553415dbd305325c"
+  integrity sha512-ojCug0yVj5KOxoQo4GjhLXLsQ3P+y9UdNBKWD+ZRbeuswfdVVGsiL21BmIw+fVuLmrXJ1KC2y8nyskjsViBHRA==
+  dependencies:
+    "@aesoper/normal-utils" "^0.1.5"
+    "@popperjs/core" "^2.10.1"
+    "@vueuse/core" "^6.5.3"
+    gradient-parser "^1.0.2"
+    lodash-es "^4.17.21"
+    tinycolor2 "^1.4.2"
+    vue-types "^4.1.0"
+    vue3-angle "^0.1.6"
+    vue3-normal-library "^0.1.6"
+
+vue3-normal-library@^0.1.6:
+  version "0.1.6"
+  resolved "https://registry.yarnpkg.com/vue3-normal-library/-/vue3-normal-library-0.1.6.tgz#f8731f861e325ebe39ab3df5af934d76b6998fe7"
+  integrity sha512-TSqCeD092ETnjqamNKtXencLnG4a+NVWFZgalmyPtFH1FHvpxLP7eptT8krOL2sZVspficic8DghfDakw3tKRQ==
+  dependencies:
+    lodash-es "^4.17.21"
+    raf "^3.4.1"
+    vue "^3.2.6"
+    vue-types "^4.1.0"
+
+vue@3.2.45, vue@^3.2.45, vue@^3.2.6:
   version "3.2.45"
   resolved "https://registry.yarnpkg.com/vue/-/vue-3.2.45.tgz#94a116784447eb7dbd892167784619fef379b3c8"
   integrity sha512-9Nx/Mg2b2xWlXykmCwiTUCWHbWIj53bnkizBxKai1g61f2Xit700A1ljowpTIM11e3uipOeiPcSqnmBg6gyiaA==

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlApiFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlApiFactory.java
@@ -211,12 +211,12 @@ public class GraphqlApiFactory {
     }
 
     // table
-    GraphqlTableFieldFactory tableField = new GraphqlTableFieldFactory();
-    for (TableMetadata table : schema.getMetadata().getTablesIncludingExternal()) {
+    GraphqlTableFieldFactory tableField = new GraphqlTableFieldFactory(schema);
+    for (TableMetadata table : schema.getMetadata().getTables()) {
       if (table.getColumns().size() > 0) {
-        queryBuilder.field(tableField.tableQueryField(table.getTable()));
-        queryBuilder.field(tableField.tableAggField(table.getTable()));
-        queryBuilder.field(tableField.tableGroupByField(table.getTable()));
+        queryBuilder.field(tableField.tableQueryField(table));
+        queryBuilder.field(tableField.tableAggField(table));
+        queryBuilder.field(tableField.tableGroupByField(table));
       }
     }
     mutationBuilder.field(tableField.insertMutation(schema));

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -53,8 +53,13 @@ public class GraphqlTableFieldFactory {
 
   // helper to generate globally unique identifiers
   private String getTableTypeIdentifier(TableMetadata table) {
-    // refschema types we prefix with schema so unique for whole database
-    return table.getSchema().getIdentifier() + "_" + table.getIdentifier();
+    if (table.getSchemaName().equals(schema.getName())) {
+      // local types we keep as was before
+      return table.getIdentifier();
+    } else {
+      // refschema types we prefix with schema
+      return table.getSchema().getIdentifier() + "_" + table.getIdentifier();
+    }
   }
 
   // schema specific types

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -6,7 +6,6 @@ import static org.molgenis.emx2.graphql.GraphqlApiMutationResult.Status.SUCCESS;
 import static org.molgenis.emx2.graphql.GraphqlApiMutationResult.typeForMutationResult;
 import static org.molgenis.emx2.graphql.GraphqlConstants.*;
 import static org.molgenis.emx2.sql.SqlQuery.*;
-import static org.molgenis.emx2.utils.TypeUtils.convertToPascalCase;
 
 import graphql.Scalars;
 import graphql.schema.*;
@@ -35,16 +34,37 @@ public class GraphqlTableFieldFactory {
               GraphQLFieldDefinition.newFieldDefinition().name("url").type(Scalars.GraphQLString))
           .build();
   final List<String> agg_fields = List.of("max", "min", "sum", "avg");
-  // cache so we can reuse filter input types between tables
-  private Map<String, GraphQLInputObjectType> tableFilterInputTypes = new LinkedHashMap<>();
-  // cache so we can reuse filter input types between tables
+  private final Schema schema;
+
+  // cache so we can reuse types between tables
   private Map<ColumnType, GraphQLInputObjectType> columnFilterInputTypes = new LinkedHashMap<>();
-  private Map<String, GraphQLInputObjectType> rowInputTypes = new LinkedHashMap<>();
-  private Map<String, GraphQLInputObjectType> refTypes = new LinkedHashMap<>();
+  private Map<String, GraphQLNamedOutputType> tableTypes = new LinkedHashMap<>();
+  private Map<String, GraphQLNamedOutputType> tableAggTypes = new LinkedHashMap<>();
+  private Map<String, GraphQLNamedOutputType> tableOrderByTypes = new LinkedHashMap<>();
+  private Map<String, GraphQLNamedOutputType> tableGroupByTypes = new LinkedHashMap();
+  private Map<String, GraphQLNamedInputType> tableFilterInputTypes = new LinkedHashMap<>();
+  private Map<String, GraphQLNamedInputType> tableOrderByInputTypes = new LinkedHashMap<>();
+  private Map<String, GraphQLNamedInputType> rowInputTypes = new LinkedHashMap<>();
+  private Map<String, GraphQLNamedInputType> refTypes = new LinkedHashMap<>();
+
+  public GraphqlTableFieldFactory(Schema schema) {
+    this.schema = schema;
+  }
+
+  // helper to generate globally unique identifiers
+  private String getTableTypeIdentifier(TableMetadata table) {
+    if (table.getSchemaName().equals(schema.getName())) {
+      // local types we keep as was before
+      return table.getIdentifier();
+    } else {
+      // refschema types we prefix with schema
+      return table.getSchema().getName() + "_" + table.getIdentifier();
+    }
+  }
 
   // schema specific types
-  public GraphQLFieldDefinition tableQueryField(Table table) {
-    GraphQLObjectType tableType = createTableObjectType(table);
+  public GraphQLFieldDefinition tableQueryField(TableMetadata table) {
+    GraphQLNamedOutputType tableType = createTableObjectType(table);
     return GraphQLFieldDefinition.newFieldDefinition()
         .name(table.getIdentifier())
         .type(GraphQLList.list(tableType))
@@ -52,7 +72,7 @@ public class GraphqlTableFieldFactory {
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.FILTER_ARGUMENT)
-                .type(getTableFilterInputObjectType(table.getMetadata()))
+                .type(getTableFilterInputType(table))
                 .build())
         .argument(
             GraphQLArgument.newArgument()
@@ -72,12 +92,12 @@ public class GraphqlTableFieldFactory {
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.ORDERBY)
-                .type(createTableOrderByInputObjectType(table.getMetadata()))
+                .type(createTableOrderByInputType(table))
                 .build())
         .build();
   }
 
-  public GraphQLFieldDefinition tableGroupByField(Table table) {
+  public GraphQLFieldDefinition tableGroupByField(TableMetadata table) {
     return GraphQLFieldDefinition.newFieldDefinition()
         .name(table.getIdentifier() + "_groupBy")
         .type(GraphQLList.list(createTableGroupByType(table)))
@@ -85,7 +105,7 @@ public class GraphqlTableFieldFactory {
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.FILTER_ARGUMENT)
-                .type(getTableFilterInputObjectType(table.getMetadata()))
+                .type(getTableFilterInputType(table))
                 .build())
         .argument(
             GraphQLArgument.newArgument()
@@ -95,7 +115,7 @@ public class GraphqlTableFieldFactory {
         .build();
   }
 
-  public GraphQLFieldDefinition tableAggField(Table table) {
+  public GraphQLFieldDefinition tableAggField(TableMetadata table) {
     return GraphQLFieldDefinition.newFieldDefinition()
         .name(table.getIdentifier() + "_agg")
         .type(createTableAggregationType(table))
@@ -103,7 +123,7 @@ public class GraphqlTableFieldFactory {
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.FILTER_ARGUMENT)
-                .type(getTableFilterInputObjectType(table.getMetadata()))
+                .type(getTableFilterInputType(table))
                 .build())
         .argument(
             GraphQLArgument.newArgument()
@@ -113,199 +133,219 @@ public class GraphqlTableFieldFactory {
         .build();
   }
 
-  private GraphQLObjectType createTableObjectType(Table table) {
-    GraphQLObjectType.Builder tableBuilder =
-        GraphQLObjectType.newObject().name(table.getIdentifier());
-    for (Column col : table.getMetadata().getColumnsWithoutHeadings()) {
-      String id = col.getIdentifier();
-      switch (col.getColumnType().getBaseType()) {
-        case HEADING:
-          // nothing to do
-          break;
-        case FILE:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition().name(id).type(fileDownload));
-          break;
-        case BOOL:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLBoolean));
-          break;
-        case BOOL_ARRAY:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(id)
-                  .type(GraphQLList.list(Scalars.GraphQLBoolean)));
-          break;
-        case STRING:
-        case TEXT:
-        case LONG:
-        case UUID:
-        case DATE:
-        case DATETIME:
-        case EMAIL:
-        case HYPERLINK:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLString));
-          break;
-        case STRING_ARRAY:
-        case EMAIL_ARRAY:
-        case HYPERLINK_ARRAY:
-        case TEXT_ARRAY:
-        case LONG_ARRAY:
-        case DATE_ARRAY:
-        case DATETIME_ARRAY:
-        case UUID_ARRAY:
-        case JSONB_ARRAY:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(id)
-                  .type(GraphQLList.list(Scalars.GraphQLString)));
-          break;
-        case DECIMAL:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLFloat));
-          break;
-        case DECIMAL_ARRAY:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(id)
-                  .type(GraphQLList.list(Scalars.GraphQLBigDecimal)));
-          break;
-        case INT:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLInt));
-          break;
-        case INT_ARRAY:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(id)
-                  .type(GraphQLList.list(Scalars.GraphQLInt)));
-          break;
-        case REF:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(id)
-                  .type(GraphQLTypeReference.typeRef(col.getRefTableIdentifier())));
-          break;
-        case REF_ARRAY:
-        case REFBACK:
-          // case MREF:
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(id)
-                  .type(GraphQLList.list(GraphQLTypeReference.typeRef(col.getRefTableIdentifier())))
-                  .argument(
-                      GraphQLArgument.newArgument()
-                          .name(GraphqlConstants.FILTER_ARGUMENT)
-                          .type(getTableFilterInputObjectType(col.getRefTable()))
-                          .build())
-                  .argument(
-                      GraphQLArgument.newArgument()
-                          .name(GraphqlConstants.LIMIT)
-                          .type(Scalars.GraphQLInt)
-                          .build())
-                  .argument(
-                      GraphQLArgument.newArgument()
-                          .name(GraphqlConstants.OFFSET)
-                          .type(Scalars.GraphQLInt)
-                          .build())
-                  .argument(
-                      GraphQLArgument.newArgument()
-                          .name(GraphqlConstants.ORDERBY)
-                          .type(
-                              GraphQLTypeReference.typeRef(
-                                  col.getRefTable().getIdentifier() + GraphqlConstants.ORDERBY))
-                          .build()));
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(id + "_agg")
-                  .type(GraphQLTypeReference.typeRef(col.getRefTableIdentifier() + "Aggregate")));
-          tableBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(id + "_groupBy")
-                  .type(GraphQLTypeReference.typeRef(col.getRefTableIdentifier() + "GroupBy")));
-          break;
-        default:
-          throw new UnsupportedOperationException(
-              "Not yet implemented type " + col.getColumnType());
+  private GraphQLNamedOutputType createTableObjectType(TableMetadata table) {
+    String tableObjectType = getTableTypeIdentifier(table);
+    if (!tableTypes.containsKey(tableObjectType)) {
+      // put reference in case of cyclic references
+      tableTypes.put(tableObjectType, GraphQLTypeReference.typeRef(tableObjectType));
+      // build the object
+      GraphQLObjectType.Builder tableBuilder = GraphQLObjectType.newObject().name(tableObjectType);
+      for (Column col : table.getColumnsWithoutHeadings()) {
+        String id = col.getIdentifier();
+        switch (col.getColumnType().getBaseType()) {
+          case HEADING:
+            // nothing to do
+            break;
+          case FILE:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition().name(id).type(fileDownload));
+            break;
+          case BOOL:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLBoolean));
+            break;
+          case BOOL_ARRAY:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name(id)
+                    .type(GraphQLList.list(Scalars.GraphQLBoolean)));
+            break;
+          case STRING:
+          case TEXT:
+          case LONG:
+          case UUID:
+          case DATE:
+          case DATETIME:
+          case EMAIL:
+          case HYPERLINK:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLString));
+            break;
+          case STRING_ARRAY:
+          case EMAIL_ARRAY:
+          case HYPERLINK_ARRAY:
+          case TEXT_ARRAY:
+          case LONG_ARRAY:
+          case DATE_ARRAY:
+          case DATETIME_ARRAY:
+          case UUID_ARRAY:
+          case JSONB_ARRAY:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name(id)
+                    .type(GraphQLList.list(Scalars.GraphQLString)));
+            break;
+          case DECIMAL:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLFloat));
+            break;
+          case DECIMAL_ARRAY:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name(id)
+                    .type(GraphQLList.list(Scalars.GraphQLBigDecimal)));
+            break;
+          case INT:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLInt));
+            break;
+          case INT_ARRAY:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name(id)
+                    .type(GraphQLList.list(Scalars.GraphQLInt)));
+            break;
+          case REF:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name(id)
+                    .type(createTableObjectType(col.getRefTable())));
+            break;
+          case REF_ARRAY:
+          case REFBACK:
+            // case MREF:
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name(id)
+                    .type(GraphQLList.list(createTableObjectType(col.getRefTable())))
+                    .argument(
+                        GraphQLArgument.newArgument()
+                            .name(GraphqlConstants.FILTER_ARGUMENT)
+                            .type(getTableFilterInputType(col.getRefTable()))
+                            .build())
+                    .argument(
+                        GraphQLArgument.newArgument()
+                            .name(GraphqlConstants.LIMIT)
+                            .type(Scalars.GraphQLInt)
+                            .build())
+                    .argument(
+                        GraphQLArgument.newArgument()
+                            .name(GraphqlConstants.OFFSET)
+                            .type(Scalars.GraphQLInt)
+                            .build())
+                    .argument(
+                        GraphQLArgument.newArgument()
+                            .name(GraphqlConstants.ORDERBY)
+                            .type(createTableOrderByInputType(col.getRefTable()))
+                            .build()));
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name(id + "_agg")
+                    .type(createTableAggregationType(col.getRefTable())));
+            tableBuilder.field(
+                GraphQLFieldDefinition.newFieldDefinition()
+                    .name(id + "_groupBy")
+                    .type(createTableGroupByType(col.getRefTable())));
+            break;
+          default:
+            throw new UnsupportedOperationException(
+                "Not yet implemented type " + col.getColumnType());
+        }
       }
+      tableTypes.put(tableObjectType, tableBuilder.build());
     }
-    return tableBuilder.build();
+    return tableTypes.get(tableObjectType);
   }
 
-  private GraphQLObjectType createTableGroupByType(Table table) {
-    String tableName = table.getIdentifier();
-
-    // group by options, for now only ref, refArray
-    GraphQLObjectType.Builder groupByBuilder =
-        GraphQLObjectType.newObject().name(tableName + "GroupBy");
-    groupByBuilder.field(
-        GraphQLFieldDefinition.newFieldDefinition().name("count").type(Scalars.GraphQLInt));
-    for (Column column : table.getMetadata().getColumns()) {
-      // for now only 'ref' types. We might want to have truncating actions for the other types.
-      if (column.isRef() || column.isRefArray()) {
-        groupByBuilder.field(
-            GraphQLFieldDefinition.newFieldDefinition()
-                .name(column.getIdentifier())
-                .type(GraphQLTypeReference.typeRef(column.getRefTableIdentifier())));
+  private GraphQLNamedOutputType createTableGroupByType(TableMetadata table) {
+    String tableGroupByType = table.getIdentifier() + "GroupBy";
+    if (!tableGroupByTypes.containsKey(tableGroupByType)) {
+      // add reference in case of self reference
+      tableGroupByTypes.put(tableGroupByType, GraphQLTypeReference.typeRef(tableGroupByType));
+      // group by options, for now only ref, refArray
+      GraphQLObjectType.Builder groupByBuilder =
+          GraphQLObjectType.newObject().name(tableGroupByType);
+      groupByBuilder.field(
+          GraphQLFieldDefinition.newFieldDefinition().name("count").type(Scalars.GraphQLInt));
+      for (Column column : table.getColumns()) {
+        // for now only 'ref' types. We might want to have truncating actions for the other types.
+        if (column.isRef() || column.isRefArray()) {
+          groupByBuilder.field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name(column.getIdentifier())
+                  .type(createTableObjectType(column.getRefTable())));
+        }
       }
+      tableGroupByTypes.put(tableGroupByType, groupByBuilder.build());
     }
-    return groupByBuilder.build();
+    return tableGroupByTypes.get(tableGroupByType);
   }
 
-  private GraphQLObjectType createTableAggregationType(Table table) {
-    String tableName = table.getIdentifier();
-    GraphQLObjectType.Builder builder = GraphQLObjectType.newObject().name(tableName + "Aggregate");
-    builder.field(
-        GraphQLFieldDefinition.newFieldDefinition().name("count").type(Scalars.GraphQLInt));
-    List<Column> aggCols =
-        table.getMetadata().getColumns().stream()
-            .filter(
-                c ->
-                    ColumnType.INT.equals(c.getColumnType())
-                        || ColumnType.DECIMAL.equals(c.getColumnType())
-                        || ColumnType.LONG.equals(c.getColumnType()))
-            .toList();
+  private GraphQLNamedOutputType createTableAggregationType(TableMetadata table) {
+    String tableAggregationType = getTableTypeIdentifier(table) + "Aggregate";
+    if (!tableAggTypes.containsKey(tableAggregationType)) {
+      // put reference in case of self reference
+      tableAggTypes.put(tableAggregationType, GraphQLTypeReference.typeRef(tableAggregationType));
+      // aggregate type
+      GraphQLObjectType.Builder builder = GraphQLObjectType.newObject().name(tableAggregationType);
+      builder.field(
+          GraphQLFieldDefinition.newFieldDefinition().name("count").type(Scalars.GraphQLInt));
+      List<Column> aggCols =
+          table.getColumns().stream()
+              .filter(
+                  c ->
+                      ColumnType.INT.equals(c.getColumnType())
+                          || ColumnType.DECIMAL.equals(c.getColumnType())
+                          || ColumnType.LONG.equals(c.getColumnType()))
+              .toList();
 
-    if (aggCols.size() > 0) {
-      GraphQLObjectType.Builder max = GraphQLObjectType.newObject().name(tableName + "_max");
-      GraphQLObjectType.Builder min = GraphQLObjectType.newObject().name(tableName + "_min");
-      GraphQLObjectType.Builder sum = GraphQLObjectType.newObject().name(tableName + "_sum");
-      GraphQLObjectType.Builder avg = GraphQLObjectType.newObject().name(tableName + "_avg");
-      for (Column col : aggCols) {
-        max.field(
-            GraphQLFieldDefinition.newFieldDefinition()
-                .name(col.getIdentifier())
-                .type(graphQLTypeOf(col)));
-        min.field(
-            GraphQLFieldDefinition.newFieldDefinition()
-                .name(col.getIdentifier())
-                .type(graphQLTypeOf(col)));
-        avg.field(
-            GraphQLFieldDefinition.newFieldDefinition()
-                .name(col.getIdentifier())
-                .type(Scalars.GraphQLFloat));
-        sum.field(
-            GraphQLFieldDefinition.newFieldDefinition()
-                .name(col.getIdentifier())
-                .type(graphQLTypeOf(col)));
+      if (aggCols.size() > 0) {
+        GraphQLObjectType.Builder max =
+            GraphQLObjectType.newObject().name(tableAggregationType + "_max");
+        GraphQLObjectType.Builder min =
+            GraphQLObjectType.newObject().name(tableAggregationType + "_min");
+        GraphQLObjectType.Builder sum =
+            GraphQLObjectType.newObject().name(tableAggregationType + "_sum");
+        GraphQLObjectType.Builder avg =
+            GraphQLObjectType.newObject().name(tableAggregationType + "_avg");
+        for (Column col : aggCols) {
+          max.field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name(col.getIdentifier())
+                  .type(graphQLTypeOf(col)));
+          min.field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name(col.getIdentifier())
+                  .type(graphQLTypeOf(col)));
+          avg.field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name(col.getIdentifier())
+                  .type(Scalars.GraphQLFloat));
+          sum.field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name(col.getIdentifier())
+                  .type(graphQLTypeOf(col)));
+        }
+        builder
+            .field(GraphQLFieldDefinition.newFieldDefinition().name(MAX_FIELD).type(max))
+            .field(GraphQLFieldDefinition.newFieldDefinition().name(MIN_FIELD).type(min))
+            .field(GraphQLFieldDefinition.newFieldDefinition().name(AVG_FIELD).type(avg))
+            .field(GraphQLFieldDefinition.newFieldDefinition().name(SUM_FIELD).type(sum));
       }
-      builder
-          .field(GraphQLFieldDefinition.newFieldDefinition().name(MAX_FIELD).type(max))
-          .field(GraphQLFieldDefinition.newFieldDefinition().name(MIN_FIELD).type(min))
-          .field(GraphQLFieldDefinition.newFieldDefinition().name(AVG_FIELD).type(avg))
-          .field(GraphQLFieldDefinition.newFieldDefinition().name(SUM_FIELD).type(sum));
-    }
 
-    return builder.build();
+      tableAggTypes.put(tableAggregationType, builder.build());
+    }
+    return tableAggTypes.get(tableAggregationType);
   }
 
-  private GraphQLInputObjectType getTableFilterInputObjectType(TableMetadata table) {
-    String tableName = table.getIdentifier();
-    if (!tableFilterInputTypes.containsKey(tableName)) {
-      String typeName = tableName + FILTER;
+  private GraphQLNamedInputType getTableFilterInputType(TableMetadata table) {
+    String tableFilterInputType = table.getIdentifier() + FILTER;
+    if (!tableFilterInputTypes.containsKey(tableFilterInputType)) {
+      // put reference in case of self reference\
+      tableFilterInputTypes.put(
+          tableFilterInputType, GraphQLTypeReference.typeRef(tableFilterInputType));
       GraphQLInputObjectType.Builder filterBuilder =
-          GraphQLInputObjectType.newInputObject().name(typeName);
+          GraphQLInputObjectType.newInputObject().name(tableFilterInputType);
       if (table.getPrimaryKeyColumns().size() > 0) {
         filterBuilder.field(
             GraphQLInputObjectField.newInputObjectField()
@@ -321,49 +361,55 @@ public class GraphqlTableFieldFactory {
       filterBuilder.field(
           GraphQLInputObjectField.newInputObjectField()
               .name(FILTER_OR)
-              .type(GraphQLList.list(GraphQLTypeReference.typeRef(typeName)))
+              .type(GraphQLList.list(GraphQLTypeReference.typeRef(tableFilterInputType)))
               .build());
       filterBuilder.field(
           GraphQLInputObjectField.newInputObjectField()
               .name(FILTER_AND)
-              .type(GraphQLList.list(GraphQLTypeReference.typeRef(typeName)))
+              .type(GraphQLList.list(GraphQLTypeReference.typeRef(tableFilterInputType)))
               .build());
       for (Column col : table.getColumns()) {
         if (col.isReference()) {
           filterBuilder.field(
               GraphQLInputObjectField.newInputObjectField()
                   .name(col.getIdentifier())
-                  .type(
-                      GraphQLTypeReference.typeRef(
-                          convertToPascalCase(col.getRefTableName()) + FILTER))
+                  .type(getTableFilterInputType(col.getRefTable()))
                   .build());
         } else if (col.getColumnType().getOperators().length > 0) {
           filterBuilder.field(
               GraphQLInputObjectField.newInputObjectField()
                   .name(col.getIdentifier())
-                  .type(getColumnFilterInputObjectType(col))
+                  .type(getColumnFilterInputType(col))
                   .build());
         }
       }
-      tableFilterInputTypes.put(tableName, filterBuilder.build());
+      // replace reference with the actual thing
+      tableFilterInputTypes.put(tableFilterInputType, filterBuilder.build());
     }
-    return tableFilterInputTypes.get(tableName);
+    return tableFilterInputTypes.get(tableFilterInputType);
   }
 
-  private GraphQLInputObjectType createTableOrderByInputObjectType(TableMetadata table) {
-    GraphQLInputObjectType.Builder orderByBuilder =
-        GraphQLInputObjectType.newInputObject()
-            .name(table.getIdentifier() + GraphqlConstants.ORDERBY);
-    for (Column col : table.getColumns()) {
-      orderByBuilder.field(
-          GraphQLInputObjectField.newInputObjectField()
-              .name(col.getIdentifier())
-              .type(orderByEnum));
+  private GraphQLNamedInputType createTableOrderByInputType(TableMetadata table) {
+    String tableOrderByInputType = getTableTypeIdentifier(table) + GraphqlConstants.ORDERBY;
+    if (!tableOrderByInputTypes.containsKey(tableOrderByInputType)) {
+      // put reference in case of self reference
+      tableOrderByInputTypes.put(
+          tableOrderByInputType, GraphQLTypeReference.typeRef(tableOrderByInputType));
+      // build the type
+      GraphQLInputObjectType.Builder orderByBuilder =
+          GraphQLInputObjectType.newInputObject().name(tableOrderByInputType);
+      for (Column col : table.getColumns()) {
+        orderByBuilder.field(
+            GraphQLInputObjectField.newInputObjectField()
+                .name(col.getIdentifier())
+                .type(orderByEnum));
+      }
+      tableOrderByInputTypes.put(tableOrderByInputType, orderByBuilder.build());
     }
-    return orderByBuilder.build();
+    return tableOrderByInputTypes.get(tableOrderByInputType);
   }
 
-  private GraphQLInputObjectType getColumnFilterInputObjectType(Column column) {
+  private GraphQLInputObjectType getColumnFilterInputType(Column column) {
     ColumnType type = column.getColumnType();
     // singleton
     if (this.columnFilterInputTypes.get(type) == null) {
@@ -561,9 +607,9 @@ public class GraphqlTableFieldFactory {
     }
   }
 
-  private DataFetcher fetcherForTableQueryField(Table aTable) {
+  private DataFetcher fetcherForTableQueryField(TableMetadata aTable) {
     return dataFetchingEnvironment -> {
-      Table table = aTable;
+      Table table = aTable.getTable();
       Query q = table.query();
       String fieldName = dataFetchingEnvironment.getField().getName();
       if (fieldName.endsWith("_agg")) {
@@ -571,8 +617,7 @@ public class GraphqlTableFieldFactory {
       } else if (fieldName.endsWith("_groupBy")) {
         q = table.groupBy();
       }
-      q.select(
-          convertMapSelection(aTable.getMetadata(), dataFetchingEnvironment.getSelectionSet()));
+      q.select(convertMapSelection(aTable, dataFetchingEnvironment.getSelectionSet()));
       Map<String, Object> args = dataFetchingEnvironment.getArguments();
       if (dataFetchingEnvironment.getArgument(GraphqlConstants.FILTER_ARGUMENT) != null) {
         q.where(
@@ -590,7 +635,7 @@ public class GraphqlTableFieldFactory {
         Map<String, Order> orderBy = (Map<String, Order>) args.get(ORDERBY);
         Map<String, Order> unescapedMap = new HashMap<>();
         for (var entry : orderBy.entrySet()) {
-          Optional<Column> column = findColumnById(aTable.getMetadata(), entry.getKey());
+          Optional<Column> column = findColumnById(aTable, entry.getKey());
           if (column.isPresent()) {
             unescapedMap.put(column.get().getName(), entry.getValue());
           } else {
@@ -621,12 +666,12 @@ public class GraphqlTableFieldFactory {
             .name(type.name().toLowerCase())
             .type(typeForMutationResult)
             .dataFetcher(fetcher(schema, type));
-    for (TableMetadata table : schema.getMetadata().getTablesIncludingExternal()) {
+    for (TableMetadata table : schema.getMetadata().getTables()) {
       if (table.getColumnsWithoutHeadings().size() > 0) {
         fieldBuilder.argument(
             GraphQLArgument.newArgument()
                 .name(table.getIdentifier())
-                .type(GraphQLList.list(rowInputType(table.getTable()))));
+                .type(GraphQLList.list(rowInputType(table))));
       }
     }
     return fieldBuilder.build();
@@ -669,7 +714,7 @@ public class GraphqlTableFieldFactory {
     return dataFetchingEnvironment -> {
       StringBuilder result = new StringBuilder();
       boolean any = false;
-      for (TableMetadata tableMetadata : schema.getMetadata().getTablesIncludingExternal()) {
+      for (TableMetadata tableMetadata : schema.getMetadata().getTables()) {
         List<Map<String, Object>> rowsAslistOfMaps =
             dataFetchingEnvironment.getArgument(tableMetadata.getIdentifier());
         if (rowsAslistOfMaps != null) {
@@ -710,12 +755,14 @@ public class GraphqlTableFieldFactory {
     };
   }
 
-  private GraphQLInputObjectType rowInputType(Table table) {
-    String tableName = table.getIdentifier();
-    if (rowInputTypes.get(tableName) == null) {
+  private GraphQLNamedInputType rowInputType(TableMetadata table) {
+    String rowInputType = getTableTypeIdentifier(table);
+    if (rowInputTypes.get(rowInputType) == null) {
+      // in case of self reference
+      rowInputTypes.put(rowInputType, GraphQLTypeReference.typeRef(rowInputType));
       GraphQLInputObjectType.Builder inputBuilder =
-          GraphQLInputObjectType.newInputObject().name(tableName + INPUT);
-      for (Column col : table.getMetadata().getColumnsWithoutHeadings()) {
+          GraphQLInputObjectType.newInputObject().name(rowInputType + INPUT);
+      for (Column col : table.getColumnsWithoutHeadings()) {
         GraphQLInputType type;
         if (col.isReference()) {
           if (col.isRef()) {
@@ -730,18 +777,20 @@ public class GraphqlTableFieldFactory {
         inputBuilder.field(
             GraphQLInputObjectField.newInputObjectField().name(col.getIdentifier()).type(type));
       }
-      rowInputTypes.put(tableName, inputBuilder.build());
+      rowInputTypes.put(rowInputType, inputBuilder.build());
     }
-    return rowInputTypes.get(tableName);
+    return rowInputTypes.get(rowInputType);
   }
 
-  public GraphQLInputObjectType getPrimaryKeyInput(TableMetadata table) {
-    GraphQLInputType type;
-    String name = table.getIdentifier() + "PkeyInput";
-    if (refTypes.get(name) == null) {
+  public GraphQLNamedInputType getPrimaryKeyInput(TableMetadata table) {
+    String primaryKeyInput = getTableTypeIdentifier(table) + "PkeyInput";
+    if (!refTypes.containsKey(primaryKeyInput)) {
+      // in case circular reference
+      refTypes.put(primaryKeyInput, GraphQLTypeReference.typeRef(primaryKeyInput));
       GraphQLInputObjectType.Builder refTypeBuilder =
-          GraphQLInputObjectType.newInputObject().name(name);
+          GraphQLInputObjectType.newInputObject().name(primaryKeyInput);
       for (Column ref : table.getPrimaryKeyColumns()) {
+        GraphQLInputType type;
         ColumnType columnType = ref.getColumnType();
         if (ref.isReference()) {
           type = getPrimaryKeyInput(ref.getRefTable());
@@ -751,9 +800,9 @@ public class GraphqlTableFieldFactory {
         refTypeBuilder.field(
             GraphQLInputObjectField.newInputObjectField().name(ref.getIdentifier()).type(type));
       }
-      refTypes.put(name, refTypeBuilder.build());
+      refTypes.put(primaryKeyInput, refTypeBuilder.build());
     }
-    return refTypes.get(name);
+    return refTypes.get(primaryKeyInput);
   }
 
   private GraphQLInputType getGraphQLInputType(ColumnType columnType) {

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -53,13 +53,8 @@ public class GraphqlTableFieldFactory {
 
   // helper to generate globally unique identifiers
   private String getTableTypeIdentifier(TableMetadata table) {
-    if (table.getSchemaName().equals(schema.getName())) {
-      // local types we keep as was before
-      return table.getIdentifier();
-    } else {
-      // refschema types we prefix with schema
-      return table.getSchema().getName() + "_" + table.getIdentifier();
-    }
+    // refschema types we prefix with schema so unique for whole database
+    return table.getSchema().getIdentifier() + "_" + table.getIdentifier();
   }
 
   // schema specific types
@@ -339,7 +334,7 @@ public class GraphqlTableFieldFactory {
   }
 
   private GraphQLNamedInputType getTableFilterInputType(TableMetadata table) {
-    String tableFilterInputType = table.getIdentifier() + FILTER;
+    String tableFilterInputType = getTableTypeIdentifier(table) + FILTER;
     if (!tableFilterInputTypes.containsKey(tableFilterInputType)) {
       // put reference in case of self reference\
       tableFilterInputTypes.put(
@@ -704,7 +699,9 @@ public class GraphqlTableFieldFactory {
                 .name(table.getIdentifier())
                 // reuse same input as insert
                 .type(
-                    GraphQLList.list(GraphQLTypeReference.typeRef(table.getIdentifier() + INPUT))));
+                    GraphQLList.list(
+                        GraphQLTypeReference.typeRef(
+                            getTableTypeIdentifier(table.getMetadata()) + INPUT))));
       }
     }
     return fieldBuilder.build();

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Table.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Table.java
@@ -42,9 +42,7 @@ public class Table {
         tableMetadata.getSettings().entrySet().stream()
             .map(entry -> new Setting(entry.getKey(), entry.getValue()))
             .toList();
-    if (!tableMetadata.getSchemaName().equals(schema.getName())) {
-      this.externalSchema = tableMetadata.getSchemaName();
-    }
+    this.externalSchema = tableMetadata.getSchemaName();
     for (org.molgenis.emx2.Column column : tableMetadata.getColumns()) {
       this.columns.add(new Column(column, tableMetadata, minimal));
     }

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlCrossSchemaRefs.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlCrossSchemaRefs.java
@@ -44,12 +44,6 @@ public class TestGraphqlCrossSchemaRefs {
     Assert.assertEquals(
         "dog", execute("{PetLover{name,pets{species}}}").at("/PetLover/0/pets/1/species").asText());
 
-    Assert.assertTrue(
-        execute("{_schema{tables{name}}}")
-            .at("/_schema/tables")
-            .findValuesAsText("name")
-            .contains("Parent"));
-
     // checks for a reported bug that ChildInput were not created
     Assert.assertTrue(
         execute("mutation{save(Child:{name:\"test\"}){message}}")

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/ChangeLogUtilsTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/ChangeLogUtilsTest.java
@@ -2,8 +2,10 @@ package org.molgenis.emx2.sql;
 
 import static junit.framework.TestCase.assertEquals;
 
+import org.junit.Ignore;
 import org.junit.Test;
 
+@Ignore
 public class ChangeLogUtilsTest {
   @Test
   public void testBuildProcessAuditFunction() {

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/ChangeLogUtilsTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/ChangeLogUtilsTest.java
@@ -5,7 +5,6 @@ import static junit.framework.TestCase.assertEquals;
 import org.junit.Ignore;
 import org.junit.Test;
 
-@Ignore
 public class ChangeLogUtilsTest {
   @Test
   public void testBuildProcessAuditFunction() {

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/ChangeLogUtilsTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/ChangeLogUtilsTest.java
@@ -2,7 +2,6 @@ package org.molgenis.emx2.sql;
 
 import static junit.framework.TestCase.assertEquals;
 
-import org.junit.Ignore;
 import org.junit.Test;
 
 public class ChangeLogUtilsTest {

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -285,7 +285,7 @@ public class WebApiSmokeTests {
     String schemaJson2 =
         given().sessionId(SESSION_ID).when().get("/pet store json/api/json").asString();
 
-    assertEquals(schemaJson, schemaJson2);
+    assertEquals(schemaJson, schemaJson2.replace("pet store json", "pet store"));
 
     String schemaYaml = given().sessionId(SESSION_ID).when().get("/pet store/api/yaml").asString();
 
@@ -302,7 +302,7 @@ public class WebApiSmokeTests {
     String schemaYaml2 =
         given().sessionId(SESSION_ID).when().get("/pet store yaml/api/yaml").asString();
 
-    assertEquals(schemaYaml, schemaYaml2);
+    assertEquals(schemaYaml, schemaYaml2.replace("pet store yaml", "pet store"));
   }
 
   @Test

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaMetadata.java
@@ -2,6 +2,7 @@ package org.molgenis.emx2;
 
 import static org.molgenis.emx2.Constants.OIDC_CALLBACK_PATH;
 import static org.molgenis.emx2.Constants.OIDC_LOGIN_PATH;
+import static org.molgenis.emx2.utils.TypeUtils.convertToPascalCase;
 
 import java.util.*;
 import org.molgenis.emx2.utils.TableSort;
@@ -50,6 +51,10 @@ public class SchemaMetadata extends HasSettings<SchemaMetadata> {
 
   public String getName() {
     return name;
+  }
+
+  public String getIdentifier() {
+    return convertToPascalCase(getName());
   }
 
   public void setName(String name) {

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SchemaMetadata.java
@@ -137,14 +137,26 @@ public class SchemaMetadata extends HasSettings<SchemaMetadata> {
 
   private void addExternalTablesRecursive(
       Map<String, TableMetadata> tables, TableMetadata current) {
-    if (current.getInheritedTable() != null && !tables.containsKey(current.getInherit())) {
-      tables.put(current.getInherit(), current.getInheritedTable());
-      addExternalTablesRecursive(tables, current.getInheritedTable());
+    if (current.getInheritedTable() != null) {
+      String scopeTableName = current.getInherit();
+      if (!current.getInheritedTable().getSchemaName().equals(getName())) {
+        scopeTableName = current.getInheritedTable().getSchemaName() + "_" + scopeTableName;
+      }
+      if (!tables.containsKey(scopeTableName)) {
+        tables.put(scopeTableName, current.getInheritedTable());
+        addExternalTablesRecursive(tables, current.getInheritedTable());
+      }
     }
     for (Column c : current.getColumns()) {
-      if (c.isReference() && !tables.containsKey(c.getRefTableName())) {
-        tables.put(c.getRefTableName(), c.getRefTable());
-        addExternalTablesRecursive(tables, c.getRefTable());
+      if (c.isReference()) {
+        String scopeTableName = c.getRefTableName();
+        if (!getName().equals(c.getRefSchema())) {
+          scopeTableName = c.getRefSchema() + "_" + scopeTableName;
+        }
+        if (!tables.containsKey(scopeTableName)) {
+          tables.put(scopeTableName, c.getRefTable());
+          addExternalTablesRecursive(tables, c.getRefTable());
+        }
       }
     }
   }


### PR DESCRIPTION
Example:
* in catalogue staging model we have 'DataSets' but we in mappings we also refer to DataCatalogue.DataSets. 

Before:
* These references were broken because the schemas were effectively merged.

With this PR:
* References to other schemas are using actually the other graphql endpoint.

Most changes for this in the Client (using different graphql endpoint based on refSchema) and in GraphqlTableFieldFactory (moving refSchema tables out of api)

