### PR TITLE
fix: remove vue property name from title; fix: hide header behind modal

### DIFF
--- a/apps/schema/src/components/ColumnEditModal.vue
+++ b/apps/schema/src/components/ColumnEditModal.vue
@@ -231,7 +231,7 @@ export default {
     /** can be set to 'add' */
     operation: {
       type: String,
-      default: "update:modelValue",
+      default: "edit",
     },
     /** Optional tooltip*/
     tooltip: {

--- a/apps/schema/src/components/Schema.vue
+++ b/apps/schema/src/components/Schema.vue
@@ -61,11 +61,11 @@ table {
 
 /*
   Work around for bootstrap 4 interaction effect with dropdown ( from Breadcrumb )
-  Use the available space between z layers to move the sticky app header below the menu dropdown
-  1000 - 1 = 999
+  Use the available space between z layers to move the sticky app header below the menu dropdown and modals
+  1000 - 2 = 998
 */
 .sticky-top {
-  z-index: 999;
+  z-index: 998;
 }
 </style>
 


### PR DESCRIPTION
Don't show title above modal:
<img width="1406" alt="Schermafbeelding 2023-01-11 om 15 07 47" src="https://user-images.githubusercontent.com/46395349/211844110-22cb1c7f-39d1-4c53-8bb5-faa145fc5b46.png">

Don't show a vue property in the modal title
<img width="549" alt="Schermafbeelding 2023-01-11 om 15 05 13" src="https://user-images.githubusercontent.com/46395349/211844142-d055deed-1240-4b6d-8b81-4cda0468a450.png">
