### PR TITLE
fix: column IRI in RDF API is now retrievable

### DIFF
--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/RDFService.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/RDFService.java
@@ -125,6 +125,7 @@ public class RDFService {
       String rdfApiLocation,
       Table table,
       String rowId,
+      String columnName,
       Schema... schemas) {
     try {
 
@@ -139,13 +140,17 @@ public class RDFService {
         List<Table> tables = table != null ? Arrays.asList(table) : schema.getTablesSorted();
         for (Table tableToDescribe : tables) {
           describeTable(rdfService.getBuilder(), tableToDescribe, schemaRdfApiContext);
-          describeColumns(rdfService.getBuilder(), tableToDescribe, schemaRdfApiContext);
-          describeValues(
-              rdfService.getJsonMapper(),
-              rdfService.getBuilder(),
-              tableToDescribe,
-              rowId,
-              schemaRdfApiContext);
+          describeColumns(
+              rdfService.getBuilder(), columnName, tableToDescribe, schemaRdfApiContext);
+          // if a column name is provided then only provide column metadata, no row values
+          if (columnName == null) {
+            describeValues(
+                rdfService.getJsonMapper(),
+                rdfService.getBuilder(),
+                tableToDescribe,
+                rowId,
+                schemaRdfApiContext);
+          }
         }
       }
 

--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/rdf/ColumnToRDF.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/rdf/ColumnToRDF.java
@@ -16,10 +16,14 @@ public class ColumnToRDF {
 
   // todo: unit is missing (which would also be a sdmx-attribute:unitMeasure, typed as an
   // qb:AttributeProperty)
-  public static void describeColumns(ModelBuilder builder, Table table, String schemaContext)
-      throws Exception {
+  public static void describeColumns(
+      ModelBuilder builder, String columnName, Table table, String schemaContext) throws Exception {
     String tableContext = schemaContext + "/" + table.getName();
     for (Column c : table.getMetadata().getColumns()) {
+      // allow selecting one particular column by ignoring the rest
+      if (columnName != null && !c.getName().equals(columnName)) {
+        continue;
+      }
       String columnContext = tableContext + "/column/" + c.getName();
       // SIO:000757 = database column
       builder.add(columnContext, RDF.TYPE, iri("http://semanticscience.org/resource/SIO_000757"));

--- a/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/OntologyTableSemantics.java
+++ b/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/OntologyTableSemantics.java
@@ -43,7 +43,7 @@ public class OntologyTableSemantics {
     when(request.url()).thenReturn("http://localhost:8080/petStore/api/fdp");
     OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, null, null, petStoreSchema);
+        outputStream, request, response, RDF_API_LOCATION, null, null, null, petStoreSchema);
     String result = outputStream.toString();
 
     /**
@@ -66,7 +66,7 @@ public class OntologyTableSemantics {
 
     outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, null, null, petStoreSchema);
+        outputStream, request, response, RDF_API_LOCATION, null, null, null, petStoreSchema);
     result = outputStream.toString();
 
     /**

--- a/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/RDFTest.java
+++ b/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/RDFTest.java
@@ -44,7 +44,7 @@ public class RDFTest {
     when(request.url()).thenReturn("http://localhost:8080" + RDF_API_LOCATION);
     OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, null, null, petStoreSchemas);
+        outputStream, request, response, RDF_API_LOCATION, null, null, null, petStoreSchemas);
     String result = outputStream.toString();
     assertTrue(result.contains(TTL_PREFIX_1));
     assertTrue(result.contains(TTL_PREFIX_2));
@@ -55,10 +55,12 @@ public class RDFTest {
     assertTrue(result.contains(TTL_TABLE_CATEGORY_2));
     assertTrue(result.contains(TTL_TABLE_PET_1));
     assertTrue(result.contains(TTL_TABLE_PET_2));
-    assertTrue(result.contains(TTL_COL_CATEGORY_1));
-    assertTrue(result.contains(TTL_COL_CATEGORY_2));
-    assertTrue(result.contains(TTL_COL_PET_1));
-    assertTrue(result.contains(TTL_COL_PET_2));
+    assertTrue(result.contains(TTL_COL_CATEGORY_NAME_1));
+    assertTrue(result.contains(TTL_COL_CATEGORY_NAME_2));
+    assertTrue(result.contains(TTL_COL_PET_NAME_1));
+    assertTrue(result.contains(TTL_COL_PET_NAME_2));
+    assertTrue(result.contains(TTL_COL_PET_DETAILS_1));
+    assertTrue(result.contains(TTL_COL_PET_DETAILS_2));
     assertTrue(result.contains(TTL_ROW_POOKY_1));
     assertTrue(result.contains(TTL_ROW_SPIKE_1));
     assertTrue(result.contains(TTL_ROW_POOKY_2));
@@ -76,7 +78,7 @@ public class RDFTest {
     when(request.url()).thenReturn("http://localhost:8080/petStoreNr1" + RDF_API_LOCATION);
     OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, null, null, petStoreSchemas[0]);
+        outputStream, request, response, RDF_API_LOCATION, null, null, null, petStoreSchemas[0]);
     String result = outputStream.toString();
     assertTrue(result.contains(TTL_PREFIX_1));
     assertFalse(result.contains(TTL_PREFIX_2));
@@ -87,10 +89,12 @@ public class RDFTest {
     assertFalse(result.contains(TTL_TABLE_CATEGORY_2));
     assertTrue(result.contains(TTL_TABLE_PET_1));
     assertFalse(result.contains(TTL_TABLE_PET_2));
-    assertTrue(result.contains(TTL_COL_CATEGORY_1));
-    assertFalse(result.contains(TTL_COL_CATEGORY_2));
-    assertTrue(result.contains(TTL_COL_PET_1));
-    assertFalse(result.contains(TTL_COL_PET_2));
+    assertTrue(result.contains(TTL_COL_CATEGORY_NAME_1));
+    assertFalse(result.contains(TTL_COL_CATEGORY_NAME_2));
+    assertTrue(result.contains(TTL_COL_PET_NAME_1));
+    assertFalse(result.contains(TTL_COL_PET_NAME_2));
+    assertTrue(result.contains(TTL_COL_PET_DETAILS_1));
+    assertFalse(result.contains(TTL_COL_PET_DETAILS_2));
     assertTrue(result.contains(TTL_ROW_POOKY_1));
     assertTrue(result.contains(TTL_ROW_SPIKE_1));
     assertFalse(result.contains(TTL_ROW_POOKY_2));
@@ -110,7 +114,7 @@ public class RDFTest {
     Table table = petStoreSchemas[0].getTable("Category");
     OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, table, null, table.getSchema());
+        outputStream, request, response, RDF_API_LOCATION, table, null, null, table.getSchema());
     String result = outputStream.toString();
     assertTrue(result.contains(TTL_PREFIX_1));
     assertFalse(result.contains(TTL_PREFIX_2));
@@ -121,16 +125,61 @@ public class RDFTest {
     assertFalse(result.contains(TTL_TABLE_CATEGORY_2));
     assertFalse(result.contains(TTL_TABLE_PET_1));
     assertFalse(result.contains(TTL_TABLE_PET_2));
-    assertTrue(result.contains(TTL_COL_CATEGORY_1));
-    assertFalse(result.contains(TTL_COL_CATEGORY_2));
-    assertFalse(result.contains(TTL_COL_PET_1));
-    assertFalse(result.contains(TTL_COL_PET_2));
+    assertTrue(result.contains(TTL_COL_CATEGORY_NAME_1));
+    assertFalse(result.contains(TTL_COL_CATEGORY_NAME_2));
+    assertFalse(result.contains(TTL_COL_PET_NAME_1));
+    assertFalse(result.contains(TTL_COL_PET_NAME_2));
+    assertFalse(result.contains(TTL_COL_PET_DETAILS_1));
+    assertFalse(result.contains(TTL_COL_PET_DETAILS_2));
     assertFalse(result.contains(TTL_ROW_POOKY_1));
     assertFalse(result.contains(TTL_ROW_SPIKE_1));
     assertFalse(result.contains(TTL_ROW_POOKY_2));
     assertFalse(result.contains(TTL_ROW_SPIKE_2));
     assertTrue(result.contains(TTL_ROW_CAT_1));
     assertTrue(result.contains(TTL_ROW_DOG_1));
+    assertFalse(result.contains(TTL_ROW_CAT_2));
+    assertFalse(result.contains(TTL_ROW_DOG_2));
+  }
+
+  @Test
+  public void RDFForOneColumnAsTTL() {
+    Request request = mock(Request.class);
+    Response response = mock(Response.class);
+    when(request.url())
+        .thenReturn("http://localhost:8080/petStore" + RDF_API_LOCATION + "/Pet/column/details");
+    Table table = petStoreSchemas[0].getTable("Pet");
+    OutputStream outputStream = new ByteArrayOutputStream();
+    RDFService.describeAsRDF(
+        outputStream,
+        request,
+        response,
+        RDF_API_LOCATION,
+        table,
+        null,
+        "details",
+        table.getSchema());
+    String result = outputStream.toString();
+    assertTrue(result.contains(TTL_PREFIX_1));
+    assertFalse(result.contains(TTL_PREFIX_2));
+    assertTrue(result.contains(TTL_ROOT));
+    assertTrue(result.contains(TTL_SCHEMA_1));
+    assertFalse(result.contains(TTL_SCHEMA_2));
+    assertFalse(result.contains(TTL_TABLE_CATEGORY_1));
+    assertFalse(result.contains(TTL_TABLE_CATEGORY_2));
+    assertTrue(result.contains(TTL_TABLE_PET_1));
+    assertFalse(result.contains(TTL_TABLE_PET_2));
+    assertFalse(result.contains(TTL_COL_CATEGORY_NAME_1));
+    assertFalse(result.contains(TTL_COL_CATEGORY_NAME_2));
+    assertFalse(result.contains(TTL_COL_PET_NAME_1));
+    assertFalse(result.contains(TTL_COL_PET_NAME_2));
+    assertTrue(result.contains(TTL_COL_PET_DETAILS_1));
+    assertFalse(result.contains(TTL_COL_PET_DETAILS_2));
+    assertFalse(result.contains(TTL_ROW_POOKY_1));
+    assertFalse(result.contains(TTL_ROW_SPIKE_1));
+    assertFalse(result.contains(TTL_ROW_POOKY_2));
+    assertFalse(result.contains(TTL_ROW_SPIKE_2));
+    assertFalse(result.contains(TTL_ROW_CAT_1));
+    assertFalse(result.contains(TTL_ROW_DOG_1));
     assertFalse(result.contains(TTL_ROW_CAT_2));
     assertFalse(result.contains(TTL_ROW_DOG_2));
   }
@@ -145,7 +194,7 @@ public class RDFTest {
     String rowId = "cat";
     OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, table, rowId, table.getSchema());
+        outputStream, request, response, RDF_API_LOCATION, table, rowId, null, table.getSchema());
     String result = outputStream.toString();
     assertTrue(result.contains(TTL_PREFIX_1));
     assertFalse(result.contains(TTL_PREFIX_2));
@@ -156,10 +205,12 @@ public class RDFTest {
     assertFalse(result.contains(TTL_TABLE_CATEGORY_2));
     assertFalse(result.contains(TTL_TABLE_PET_1));
     assertFalse(result.contains(TTL_TABLE_PET_2));
-    assertTrue(result.contains(TTL_COL_CATEGORY_1));
-    assertFalse(result.contains(TTL_COL_CATEGORY_2));
-    assertFalse(result.contains(TTL_COL_PET_1));
-    assertFalse(result.contains(TTL_COL_PET_2));
+    assertTrue(result.contains(TTL_COL_CATEGORY_NAME_1));
+    assertFalse(result.contains(TTL_COL_CATEGORY_NAME_2));
+    assertFalse(result.contains(TTL_COL_PET_NAME_1));
+    assertFalse(result.contains(TTL_COL_PET_NAME_2));
+    assertFalse(result.contains(TTL_COL_PET_DETAILS_1));
+    assertFalse(result.contains(TTL_COL_PET_DETAILS_2));
     assertFalse(result.contains(TTL_ROW_POOKY_1));
     assertFalse(result.contains(TTL_ROW_SPIKE_1));
     assertFalse(result.contains(TTL_ROW_POOKY_2));
@@ -182,7 +233,7 @@ public class RDFTest {
     String rowId = "cat";
     OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, table, rowId, table.getSchema());
+        outputStream, request, response, RDF_API_LOCATION, table, rowId, null, table.getSchema());
     String result = outputStream.toString();
     assertTrue(result.contains("xmlns:emx0=\"http://localhost:8080/petStoreNr1/api/rdf/\">"));
     assertTrue(result.contains("<rdf:Description rdf:about=\"http://localhost:8080\">"));
@@ -205,7 +256,7 @@ public class RDFTest {
     Table table = petStoreSchemas[0].getTable("Tag");
     OutputStream outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, table, null, table.getSchema());
+        outputStream, request, response, RDF_API_LOCATION, table, null, null, table.getSchema());
     String result = outputStream.toString();
 
     // expect the default tag ("Controlled Vocabulary") but not NCIT_C25586 ("New")
@@ -217,7 +268,7 @@ public class RDFTest {
     System.out.println("getSem = " + table.getMetadata().getSemantics()[0]);
     outputStream = new ByteArrayOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, table, null, table.getSchema());
+        outputStream, request, response, RDF_API_LOCATION, table, null, null, table.getSchema());
     result = outputStream.toString();
 
     // expect NCIT_C25586 ("New") and no longer the default tag ("Controlled Vocabulary")

--- a/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/StringsForRDFTest.java
+++ b/backend/molgenis-emx2-semantics/src/test/java/org/molgenis/emx2/semantics/rdf/StringsForRDFTest.java
@@ -12,14 +12,18 @@ public class StringsForRDFTest {
   static final String TTL_TABLE_CATEGORY_2 = "emx1:Category a owl:Class";
   static final String TTL_TABLE_PET_1 = "emx0:Pet a owl:Class";
   static final String TTL_TABLE_PET_2 = "emx1:Pet a owl:Class";
-  static final String TTL_COL_CATEGORY_1 =
+  static final String TTL_COL_CATEGORY_NAME_1 =
       "<http://localhost:8080/petStoreNr1/api/rdf/Category/column/name> a sio:SIO_000757";
-  static final String TTL_COL_CATEGORY_2 =
+  static final String TTL_COL_CATEGORY_NAME_2 =
       "<http://localhost:8080/petStoreNr2/api/rdf/Category/column/name> a sio:SIO_000757";
-  static final String TTL_COL_PET_1 =
+  static final String TTL_COL_PET_NAME_1 =
       "<http://localhost:8080/petStoreNr1/api/rdf/Pet/column/name> a sio:SIO_000757";
-  static final String TTL_COL_PET_2 =
+  static final String TTL_COL_PET_NAME_2 =
       "<http://localhost:8080/petStoreNr2/api/rdf/Pet/column/name> a sio:SIO_000757";
+  static final String TTL_COL_PET_DETAILS_1 =
+      "<http://localhost:8080/petStoreNr1/api/rdf/Pet/column/details> a sio:SIO_000757";
+  static final String TTL_COL_PET_DETAILS_2 =
+      "<http://localhost:8080/petStoreNr2/api/rdf/Pet/column/details> a sio:SIO_000757";
   static final String TTL_ROW_POOKY_1 =
       "<http://localhost:8080/petStoreNr1/api/rdf/Pet/pooky> a emx0:Pet";
   static final String TTL_ROW_SPIKE_1 =

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
@@ -27,6 +27,7 @@ public class RDFApi {
     get("/:schema" + RDF_API_LOCATION, RDFApi::rdfForSchema);
     get("/:schema" + RDF_API_LOCATION + "/:table", RDFApi::rdfForTable);
     get("/:schema" + RDF_API_LOCATION + "/:table/:row", RDFApi::rdfForRow);
+    get("/:schema" + RDF_API_LOCATION + "/:table/column/:column", RDFApi::rdfForColumn);
   }
 
   private static int rdfForDatabase(Request request, Response response) throws IOException {
@@ -38,7 +39,7 @@ public class RDFApi {
     }
     OutputStream outputStream = response.raw().getOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, null, null, schemas);
+        outputStream, request, response, RDF_API_LOCATION, null, null, null, schemas);
     outputStream.flush();
     outputStream.close();
     return 200;
@@ -47,7 +48,8 @@ public class RDFApi {
   private static int rdfForSchema(Request request, Response response) throws IOException {
     Schema schema = getSchema(request);
     OutputStream outputStream = response.raw().getOutputStream();
-    RDFService.describeAsRDF(outputStream, request, response, RDF_API_LOCATION, null, null, schema);
+    RDFService.describeAsRDF(
+        outputStream, request, response, RDF_API_LOCATION, null, null, null, schema);
     outputStream.flush();
     outputStream.close();
     return 200;
@@ -57,7 +59,7 @@ public class RDFApi {
     Table table = getTable(request);
     OutputStream outputStream = response.raw().getOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, table, null, table.getSchema());
+        outputStream, request, response, RDF_API_LOCATION, table, null, null, table.getSchema());
     outputStream.flush();
     outputStream.close();
     return 200;
@@ -68,7 +70,25 @@ public class RDFApi {
     String rowId = sanitize(request.params("row"));
     OutputStream outputStream = response.raw().getOutputStream();
     RDFService.describeAsRDF(
-        outputStream, request, response, RDF_API_LOCATION, table, rowId, table.getSchema());
+        outputStream, request, response, RDF_API_LOCATION, table, rowId, null, table.getSchema());
+    outputStream.flush();
+    outputStream.close();
+    return 200;
+  }
+
+  private static int rdfForColumn(Request request, Response response) throws IOException {
+    Table table = getTable(request);
+    String columnName = sanitize(request.params("column"));
+    OutputStream outputStream = response.raw().getOutputStream();
+    RDFService.describeAsRDF(
+        outputStream,
+        request,
+        response,
+        RDF_API_LOCATION,
+        table,
+        null,
+        columnName,
+        table.getSchema());
     outputStream.flush();
     outputStream.close();
     return 200;

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -712,6 +712,12 @@ public class WebApiSmokeTests {
         .expect()
         .statusCode(200)
         .when()
+        .get("http://localhost:8080/pet store/api/rdf/Category/column/name");
+    given()
+        .sessionId(SESSION_ID)
+        .expect()
+        .statusCode(200)
+        .when()
         .get("http://localhost:8080/pet store/api/rdf/Category/cat");
     given()
         .sessionId(SESSION_ID)


### PR DESCRIPTION
Columns were defined in RDF export, like so:
```
<https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category/column/name> a sio:SIO_000757,
    qb:MeasureProperty, owl:DatatypeProperty;
  rdfs:range "http://www.w3.org/2001/XMLSchema#string";
  rdfs:label "name";
  rdfs:domain <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category> .
```

Where `https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category/column/name` is the IRI that identifies this column (_name_) for this table (_Category_). 

This IRI is then used to express row values, e.g. where _cat_ is an instance of _Category_:
```
<https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category/cat> a <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category>,
    sio:SIO_001187, qb:Observation;
  qb:dataSet <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category>;
  <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category/column/name> "cat";
```

But this column IRI was not resolvable! This limits or breaks metadata traversal. This PR fixes that by now allowing column IRIs to resolve.

For instance,

`https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category/column/name`

Would (after merge and update) resolve to this minimal RDF to describe this column:
- EMX2 location
- Schema within EMX2
- Table within schema
- Column within table

```
@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
@prefix owl: <http://www.w3.org/2002/07/owl#> .
@prefix sio: <http://semanticscience.org/resource/> .
@prefix qb: <http://purl.org/linked-data/cube#> .
@prefix dcterms: <http://purl.org/dc/terms/> .
@prefix emx0: <https://joeri.molgeniscloud.org/pet%20store/api/rdf/> .

<https://joeri.molgeniscloud.org> a sio:SIO_000750;
  rdfs:label "EMX2";
  dcterms:description "MOLGENIS EMX2 database at https://joeri.molgeniscloud.org";
  dcterms:creator <https://molgenis.org> .

<https://joeri.molgeniscloud.org/pet%20store/api/rdf> a rdfs:Container;
  rdfs:label "pet store";
  dcterms:isPartOf <https://joeri.molgeniscloud.org>;
  <http://www.w3.org/ns/ldp#contains> <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Tag>,
    <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category>, <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Pet>,
    <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Order>, <https://joeri.molgeniscloud.org/pet%20store/api/rdf/User> .

<https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category> a owl:Class, qb:DataSet, sio:SIO_000754;
  rdfs:isDefinedBy sio:SIO_001055;
  rdfs:label "Category";
  rdfs:range <http://purl.obolibrary.org/obo/NCIT_C25474> .

<https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category/column/name> a sio:SIO_000757,
    qb:MeasureProperty, owl:DatatypeProperty;
  rdfs:range "http://www.w3.org/2001/XMLSchema#string";
  rdfs:label "name";
  rdfs:domain <https://joeri.molgeniscloud.org/pet%20store/api/rdf/Category>;
  <http://purl.org/dc/elements/1.1/description> "{}" .
```
