### PR TITLE
build: try to have build only run in case of 'master' or when PR

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -58,9 +58,9 @@ pipeline {
         }
         stage("Pull request") {
             when {
-                anyOf {
+                allOf {
+                    changeRequest()
                     branch 'PR-*'
-                    branch 'master'
                }
             }
             environment {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,107 +13,109 @@ pipeline {
         MOLGENIS_POSTGRES_URI = 'jdbc:postgresql://localhost/molgenis'
     }
     stages {
-        stage('Prepare') {
-            steps {
-                checkout scm
-                container('vault') {
-                    script {
-                        sh "mkdir ${JENKINS_AGENT_WORKDIR}/.m2"
-                        sh "mkdir ${JENKINS_AGENT_WORKDIR}/.rancher"
-                        sh(script: "vault read -field=value secret/ops/jenkins/rancher/cli2.json > ${JENKINS_AGENT_WORKDIR}/.rancher/cli2.json")
-                        sh(script: "vault read -field=value secret/ops/jenkins/maven/settings.xml > ${JENKINS_AGENT_WORKDIR}/.m2/settings.xml")
-                        env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/ops/token/sonar', returnStdout: true)
-                        env.GITHUB_TOKEN = sh(script: 'vault read -field=token-emx2 secret/ops/token/github', returnStdout: true)
-                        env.DOCKERHUB_AUTH = sh(script: 'vault read -field=value secret/gcc/token/dockerhub', returnStdout: true)
-                        env.NEXUS_USER = sh(script: 'vault read -field=username secret/ops/account/nexus', returnStdout: true)
-                        env.NEXUS_PWD = sh(script: 'vault read -field=password secret/ops/account/nexus', returnStdout: true)
+        if(env.BRANCH_NAME == 'master') {
+            stage('Prepare') {
+                steps {
+                    checkout scm
+                    container('vault') {
+                        script {
+                            sh "mkdir ${JENKINS_AGENT_WORKDIR}/.m2"
+                            sh "mkdir ${JENKINS_AGENT_WORKDIR}/.rancher"
+                            sh(script: "vault read -field=value secret/ops/jenkins/rancher/cli2.json > ${JENKINS_AGENT_WORKDIR}/.rancher/cli2.json")
+                            sh(script: "vault read -field=value secret/ops/jenkins/maven/settings.xml > ${JENKINS_AGENT_WORKDIR}/.m2/settings.xml")
+                            env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/ops/token/sonar', returnStdout: true)
+                            env.GITHUB_TOKEN = sh(script: 'vault read -field=token-emx2 secret/ops/token/github', returnStdout: true)
+                            env.DOCKERHUB_AUTH = sh(script: 'vault read -field=value secret/gcc/token/dockerhub', returnStdout: true)
+                            env.NEXUS_USER = sh(script: 'vault read -field=username secret/ops/account/nexus', returnStdout: true)
+                            env.NEXUS_PWD = sh(script: 'vault read -field=password secret/ops/account/nexus', returnStdout: true)
+                        }
+                    }
+                    container("java") {
+                        sh 'apt update'
+                        sh 'apt -y install docker.io'
+                        sh "git config --global --add safe.directory '*'"
+                        sh 'git fetch --depth 100000'
+                        sh "git config user.email \"molgenis@gmail.com\""
+                        sh "git config user.name \"molgenis-jenkins\""
+                        sh 'git config url.https://.insteadOf git://'
+                        sh "mkdir -p ${DOCKER_CONFIG}"
+                        sh "echo '{\"auths\": {\"https://index.docker.io/v1/\": {\"auth\": \"${DOCKERHUB_AUTH}\"}, \"registry.hub.docker.com\": {\"auth\": \"${DOCKERHUB_AUTH}\"}}}' > ${DOCKER_CONFIG}/config.json"
+                        sh "apt-get update && apt-get install postgresql-client -y"
+                        sh "psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql"
+                    }
+                    dir("${JENKINS_AGENT_WORKDIR}/.m2") {
+                        stash includes: 'settings.xml', name: 'maven-settings'
+                    }
+                    dir("${JENKINS_AGENT_WORKDIR}/.rancher") {
+                        stash includes: 'cli2.json', name: 'rancher-config'
                     }
                 }
-                container("java") {
-                    sh 'apt update'
-                    sh 'apt -y install docker.io'
-                    sh "git config --global --add safe.directory '*'"
-                    sh 'git fetch --depth 100000'
-                    sh "git config user.email \"molgenis@gmail.com\""
-                    sh "git config user.name \"molgenis-jenkins\""
-                    sh 'git config url.https://.insteadOf git://'
-                    sh "mkdir -p ${DOCKER_CONFIG}"
-                    sh "echo '{\"auths\": {\"https://index.docker.io/v1/\": {\"auth\": \"${DOCKERHUB_AUTH}\"}, \"registry.hub.docker.com\": {\"auth\": \"${DOCKERHUB_AUTH}\"}}}' > ${DOCKER_CONFIG}/config.json"
-                    sh "apt-get update && apt-get install postgresql-client -y"
-                    sh "psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql"
-                }
-                dir("${JENKINS_AGENT_WORKDIR}/.m2") {
-                    stash includes: 'settings.xml', name: 'maven-settings'
-                }
-                dir("${JENKINS_AGENT_WORKDIR}/.rancher") {
-                    stash includes: 'cli2.json', name: 'rancher-config'
-                }
             }
-        }
-        stage("Pull request") {
-            when {
-                changeRequest()
-            }
-            environment {
-                NAME = "preview-emx2-pr-${CHANGE_ID.toLowerCase()}"
-            }
-            steps {
-                container('java') {
-                    script {
-                    sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release ci \
-                        -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
-                        -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
-                        def props = readProperties file: 'build/ci.properties'
-                        env.TAG_NAME = props.tagName
-                        sh "./gradlew --no-daemon helmLintMainChart --info"
-                    }
+            stage("Pull request") {
+                when {
+                    changeRequest()
                 }
-                container('rancher') {
-                    sh "rancher apps delete ${NAME} || true"
-                    sh "sleep 15s" // wait for deletion
-                    sh "rancher apps install " +
-                        "-n ${NAME} " +
-                        "c-l4svj:molgenis-helm3-emx2 " +
-                        "${NAME} " +
-                        "--no-prompt " +
-                        "--set adminPassword=admin " +
-                        "--set image.tag=${TAG_NAME} " +
-                        "--set image.repository=molgenis/molgenis-emx2-snapshot " +
-                        "--set image.pullPolicy=Always " +
-                        "--set ingress.hosts[0].host=${NAME}.dev.molgenis.org"
+                environment {
+                    NAME = "preview-emx2-pr-${CHANGE_ID.toLowerCase()}"
                 }
-            }
-            post {
-                success {
-                    molgenisSlack(message: "PR Preview available on https://${NAME}.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
-                }
-            }
-        }
-        stage('Master') {
-            when {
-                branch 'master'
-            }
-            steps {
-                container('java') {
-                    script {
-                        sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart sonarqube ci \
+                steps {
+                    container('java') {
+                        script {
+                        sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release ci \
                             -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
                             -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
-                        def props = readProperties file: 'build/ci.properties'
-                        env.TAG_NAME = props.tagName
+                            def props = readProperties file: 'build/ci.properties'
+                            env.TAG_NAME = props.tagName
+                            sh "./gradlew --no-daemon helmLintMainChart --info"
+                        }
+                    }
+                    container('rancher') {
+                        sh "rancher apps delete ${NAME} || true"
+                        sh "sleep 15s" // wait for deletion
+                        sh "rancher apps install " +
+                            "-n ${NAME} " +
+                            "c-l4svj:molgenis-helm3-emx2 " +
+                            "${NAME} " +
+                            "--no-prompt " +
+                            "--set adminPassword=admin " +
+                            "--set image.tag=${TAG_NAME} " +
+                            "--set image.repository=molgenis/molgenis-emx2-snapshot " +
+                            "--set image.pullPolicy=Always " +
+                            "--set ingress.hosts[0].host=${NAME}.dev.molgenis.org"
                     }
                 }
-                container('rancher') {
-                    script {
-                        sh 'rancher context switch dev-molgenis'
-                        env.REPOSITORY = env.TAG_NAME.toString().contains('-SNAPSHOT') ? 'molgenis/molgenis-emx2-snapshot' : 'molgenis/molgenis-emx2'
-                        sh "rancher apps upgrade --set image.tag=${TAG_NAME} --set image.repository=${REPOSITORY} p-tl227:emx2 ${TAG_NAME}"
+                post {
+                    success {
+                        molgenisSlack(message: "PR Preview available on https://${NAME}.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
                     }
                 }
             }
-            post {
-                success {
-                    molgenisSlack(message: "EMX2 version: ${TAG_NAME} is released. Check it out: https://emx2.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
+            stage('Master') {
+                when {
+                    branch 'master'
+                }
+                steps {
+                    container('java') {
+                        script {
+                            sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart sonarqube ci \
+                                -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
+                                -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
+                            def props = readProperties file: 'build/ci.properties'
+                            env.TAG_NAME = props.tagName
+                        }
+                    }
+                    container('rancher') {
+                        script {
+                            sh 'rancher context switch dev-molgenis'
+                            env.REPOSITORY = env.TAG_NAME.toString().contains('-SNAPSHOT') ? 'molgenis/molgenis-emx2-snapshot' : 'molgenis/molgenis-emx2'
+                            sh "rancher apps upgrade --set image.tag=${TAG_NAME} --set image.repository=${REPOSITORY} p-tl227:emx2 ${TAG_NAME}"
+                        }
+                    }
+                }
+                post {
+                    success {
+                        molgenisSlack(message: "EMX2 version: ${TAG_NAME} is released. Check it out: https://emx2.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
+                    }
                 }
             }
         }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,10 @@ pipeline {
         stage('Prepare') {
             when {
                 anyOf {
-                    branch 'PR-*'
+                    allOf {
+                        changeRequest()
+                        branch 'PR-*'
+                    }
                     branch 'master'
                }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -52,7 +52,8 @@ pipeline {
         }
         stage("Pull request") {
             when {
-                branch 'PR-*' || branch 'master'
+                branch 'PR-*'
+                branch 'master'
             }
             environment {
                 NAME = "preview-emx2-pr-${CHANGE_ID.toLowerCase()}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -14,6 +14,12 @@ pipeline {
     }
     stages {
         stage('Prepare') {
+            when {
+                anyOf {
+                    branch 'PR-*'
+                    branch 'master'
+               }
+            }
             steps {
                 checkout scm
                 container('vault') {
@@ -52,8 +58,10 @@ pipeline {
         }
         stage("Pull request") {
             when {
-                branch 'PR-*'
-                branch 'master'
+                anyOf {
+                    branch 'PR-*'
+                    branch 'master'
+               }
             }
             environment {
                 NAME = "preview-emx2-pr-${CHANGE_ID.toLowerCase()}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,111 +13,110 @@ pipeline {
         MOLGENIS_POSTGRES_URI = 'jdbc:postgresql://localhost/molgenis'
     }
     stages {
-        if(env.BRANCH_NAME == 'master') {
-            stage('Prepare') {
-                steps {
-                    checkout scm
-                    container('vault') {
-                        script {
-                            sh "mkdir ${JENKINS_AGENT_WORKDIR}/.m2"
-                            sh "mkdir ${JENKINS_AGENT_WORKDIR}/.rancher"
-                            sh(script: "vault read -field=value secret/ops/jenkins/rancher/cli2.json > ${JENKINS_AGENT_WORKDIR}/.rancher/cli2.json")
-                            sh(script: "vault read -field=value secret/ops/jenkins/maven/settings.xml > ${JENKINS_AGENT_WORKDIR}/.m2/settings.xml")
-                            env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/ops/token/sonar', returnStdout: true)
-                            env.GITHUB_TOKEN = sh(script: 'vault read -field=token-emx2 secret/ops/token/github', returnStdout: true)
-                            env.DOCKERHUB_AUTH = sh(script: 'vault read -field=value secret/gcc/token/dockerhub', returnStdout: true)
-                            env.NEXUS_USER = sh(script: 'vault read -field=username secret/ops/account/nexus', returnStdout: true)
-                            env.NEXUS_PWD = sh(script: 'vault read -field=password secret/ops/account/nexus', returnStdout: true)
-                        }
-                    }
-                    container("java") {
-                        sh 'apt update'
-                        sh 'apt -y install docker.io'
-                        sh "git config --global --add safe.directory '*'"
-                        sh 'git fetch --depth 100000'
-                        sh "git config user.email \"molgenis@gmail.com\""
-                        sh "git config user.name \"molgenis-jenkins\""
-                        sh 'git config url.https://.insteadOf git://'
-                        sh "mkdir -p ${DOCKER_CONFIG}"
-                        sh "echo '{\"auths\": {\"https://index.docker.io/v1/\": {\"auth\": \"${DOCKERHUB_AUTH}\"}, \"registry.hub.docker.com\": {\"auth\": \"${DOCKERHUB_AUTH}\"}}}' > ${DOCKER_CONFIG}/config.json"
-                        sh "apt-get update && apt-get install postgresql-client -y"
-                        sh "psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql"
-                    }
-                    dir("${JENKINS_AGENT_WORKDIR}/.m2") {
-                        stash includes: 'settings.xml', name: 'maven-settings'
-                    }
-                    dir("${JENKINS_AGENT_WORKDIR}/.rancher") {
-                        stash includes: 'cli2.json', name: 'rancher-config'
+        stage('Prepare') {
+            steps {
+                checkout scm
+                container('vault') {
+                    script {
+                        sh "mkdir ${JENKINS_AGENT_WORKDIR}/.m2"
+                        sh "mkdir ${JENKINS_AGENT_WORKDIR}/.rancher"
+                        sh(script: "vault read -field=value secret/ops/jenkins/rancher/cli2.json > ${JENKINS_AGENT_WORKDIR}/.rancher/cli2.json")
+                        sh(script: "vault read -field=value secret/ops/jenkins/maven/settings.xml > ${JENKINS_AGENT_WORKDIR}/.m2/settings.xml")
+                        env.SONAR_TOKEN = sh(script: 'vault read -field=value secret/ops/token/sonar', returnStdout: true)
+                        env.GITHUB_TOKEN = sh(script: 'vault read -field=token-emx2 secret/ops/token/github', returnStdout: true)
+                        env.DOCKERHUB_AUTH = sh(script: 'vault read -field=value secret/gcc/token/dockerhub', returnStdout: true)
+                        env.NEXUS_USER = sh(script: 'vault read -field=username secret/ops/account/nexus', returnStdout: true)
+                        env.NEXUS_PWD = sh(script: 'vault read -field=password secret/ops/account/nexus', returnStdout: true)
                     }
                 }
-            }
-            stage("Pull request") {
-                when {
-                    changeRequest()
+                container("java") {
+                    sh 'apt update'
+                    sh 'apt -y install docker.io'
+                    sh "git config --global --add safe.directory '*'"
+                    sh 'git fetch --depth 100000'
+                    sh "git config user.email \"molgenis@gmail.com\""
+                    sh "git config user.name \"molgenis-jenkins\""
+                    sh 'git config url.https://.insteadOf git://'
+                    sh "mkdir -p ${DOCKER_CONFIG}"
+                    sh "echo '{\"auths\": {\"https://index.docker.io/v1/\": {\"auth\": \"${DOCKERHUB_AUTH}\"}, \"registry.hub.docker.com\": {\"auth\": \"${DOCKERHUB_AUTH}\"}}}' > ${DOCKER_CONFIG}/config.json"
+                    sh "apt-get update && apt-get install postgresql-client -y"
+                    sh "psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql"
                 }
-                environment {
-                    NAME = "preview-emx2-pr-${CHANGE_ID.toLowerCase()}"
+                dir("${JENKINS_AGENT_WORKDIR}/.m2") {
+                    stash includes: 'settings.xml', name: 'maven-settings'
                 }
-                steps {
-                    container('java') {
-                        script {
-                        sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release ci \
-                            -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
-                            -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
-                            def props = readProperties file: 'build/ci.properties'
-                            env.TAG_NAME = props.tagName
-                            sh "./gradlew --no-daemon helmLintMainChart --info"
-                        }
-                    }
-                    container('rancher') {
-                        sh "rancher apps delete ${NAME} || true"
-                        sh "sleep 15s" // wait for deletion
-                        sh "rancher apps install " +
-                            "-n ${NAME} " +
-                            "c-l4svj:molgenis-helm3-emx2 " +
-                            "${NAME} " +
-                            "--no-prompt " +
-                            "--set adminPassword=admin " +
-                            "--set image.tag=${TAG_NAME} " +
-                            "--set image.repository=molgenis/molgenis-emx2-snapshot " +
-                            "--set image.pullPolicy=Always " +
-                            "--set ingress.hosts[0].host=${NAME}.dev.molgenis.org"
-                    }
-                }
-                post {
-                    success {
-                        molgenisSlack(message: "PR Preview available on https://${NAME}.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
-                    }
-                }
-            }
-            stage('Master') {
-                when {
-                    branch 'master'
-                }
-                steps {
-                    container('java') {
-                        script {
-                            sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart sonarqube ci \
-                                -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
-                                -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
-                            def props = readProperties file: 'build/ci.properties'
-                            env.TAG_NAME = props.tagName
-                        }
-                    }
-                    container('rancher') {
-                        script {
-                            sh 'rancher context switch dev-molgenis'
-                            env.REPOSITORY = env.TAG_NAME.toString().contains('-SNAPSHOT') ? 'molgenis/molgenis-emx2-snapshot' : 'molgenis/molgenis-emx2'
-                            sh "rancher apps upgrade --set image.tag=${TAG_NAME} --set image.repository=${REPOSITORY} p-tl227:emx2 ${TAG_NAME}"
-                        }
-                    }
-                }
-                post {
-                    success {
-                        molgenisSlack(message: "EMX2 version: ${TAG_NAME} is released. Check it out: https://emx2.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
-                    }
+                dir("${JENKINS_AGENT_WORKDIR}/.rancher") {
+                    stash includes: 'cli2.json', name: 'rancher-config'
                 }
             }
         }
+        stage("Pull request") {
+            when {
+                branch 'PR-*' || branch 'master'
+            }
+            environment {
+                NAME = "preview-emx2-pr-${CHANGE_ID.toLowerCase()}"
+            }
+            steps {
+                container('java') {
+                    script {
+                    sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release ci \
+                        -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
+                        -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
+                        def props = readProperties file: 'build/ci.properties'
+                        env.TAG_NAME = props.tagName
+                        sh "./gradlew --no-daemon helmLintMainChart --info"
+                    }
+                }
+                container('rancher') {
+                    sh "rancher apps delete ${NAME} || true"
+                    sh "sleep 15s" // wait for deletion
+                    sh "rancher apps install " +
+                        "-n ${NAME} " +
+                        "c-l4svj:molgenis-helm3-emx2 " +
+                        "${NAME} " +
+                        "--no-prompt " +
+                        "--set adminPassword=admin " +
+                        "--set image.tag=${TAG_NAME} " +
+                        "--set image.repository=molgenis/molgenis-emx2-snapshot " +
+                        "--set image.pullPolicy=Always " +
+                        "--set ingress.hosts[0].host=${NAME}.dev.molgenis.org"
+                }
+            }
+            post {
+                success {
+                    molgenisSlack(message: "PR Preview available on https://${NAME}.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
+                }
+            }
+        }
+        stage('Master') {
+            when {
+                branch 'master'
+            }
+            steps {
+                container('java') {
+                    script {
+                        sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart sonarqube ci \
+                            -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
+                            -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
+                        def props = readProperties file: 'build/ci.properties'
+                        env.TAG_NAME = props.tagName
+                    }
+                }
+                container('rancher') {
+                    script {
+                        sh 'rancher context switch dev-molgenis'
+                        env.REPOSITORY = env.TAG_NAME.toString().contains('-SNAPSHOT') ? 'molgenis/molgenis-emx2-snapshot' : 'molgenis/molgenis-emx2'
+                        sh "rancher apps upgrade --set image.tag=${TAG_NAME} --set image.repository=${REPOSITORY} p-tl227:emx2 ${TAG_NAME}"
+                    }
+                }
+            }
+            post {
+                success {
+                    molgenisSlack(message: "EMX2 version: ${TAG_NAME} is released. Check it out: https://emx2.dev.molgenis.org", status:'INFO', channel: '#pr-emx2')
+                }
+            }
+        }
+        
     }
 }

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![OpenSSF Scorecard](https://api.securityscorecards.dev/projects/github.com/molgenis/molgenis-emx2/badge)](https://api.securityscorecards.dev/projects/github.com/molgenis/molgenis-emx2)
 
 
-# MOLGENIS EMX2 FAIR scientific data platform
+# MOLGENIS EMX2 FAIR scientific data platform 
 
 The world's most customizable platform for (scientific) data and FAIR principles (findability, accessibility,
 interoperability and reusability). 


### PR DESCRIPTION
Motivation is to reduce Jenkins builds, that currently builds every PR twice (once for the PR and once for the source branch).

Solution is that only the 'PR' and 'master' branches have steps to execute (I couldn't see how to prevent the jenkinsfile to run at all, unless changing the jenkins config server side).

The other branches should skip all steps.
