### PR TITLE
chore: wait for chart publish

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -106,6 +106,7 @@ pipeline {
                 container('rancher') {
                     script {
                         sh 'rancher context switch dev-molgenis'
+                        sh "sleep 30s" // wait for chart publish
                         env.REPOSITORY = env.TAG_NAME.toString().contains('-SNAPSHOT') ? 'molgenis/molgenis-emx2-snapshot' : 'molgenis/molgenis-emx2'
                         sh "rancher apps upgrade --set image.tag=${TAG_NAME} --set image.repository=${REPOSITORY} p-tl227:emx2 ${TAG_NAME}"
                     }


### PR DESCRIPTION
the java container pushes a new chart version to the repo. the new version needs to be available before it can be used by rancher