### PR TITLE
chore: fix kaniko run

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,8 @@ FROM node:18.13.0-alpine
 WORKDIR /
 
 ## Copy the files need from the contaxt into to image
-COPY ./nuxt3-ssr/.nuxt /.nuxt
-COPY ./nuxt3-ssr/.output /.output
+COPY ./.nuxt /.nuxt
+COPY ./.output /.output
 
 # Expose $PORT on container.
 # We use a varibale here as the port is something that can differ on the environment.


### PR DESCRIPTION
Kaniko does not to be run from app folder ( like gradle) therefore run it from nuxt3 folder and update the file path for the copy