### PR TITLE
Add API version to request meta for compliance

### DIFF
--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/beaconv2/requests/BeaconRequestMeta.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/beaconv2/requests/BeaconRequestMeta.java
@@ -1,3 +1,8 @@
 package org.molgenis.emx2.beaconv2.requests;
 
-public class BeaconRequestMeta {}
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+
+@JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
+public class BeaconRequestMeta {
+  private String apiVersion;
+}


### PR DESCRIPTION
Added 'apiVersion' field to BeaconRequestMeta for compliance with https://github.com/ejp-rd-vp/vp-api-specs. Right now, requests as defined by the spec fail because they have apiVersion which cannot be parsed into the object structure.