### PR TITLE
fix: fetch missing tree parts work-around

### DIFF
--- a/apps/nuxt3-ssr/gql/fragments/ontology.js
+++ b/apps/nuxt3-ssr/gql/fragments/ontology.js
@@ -8,6 +8,52 @@ export default gql`
     ontologyTermURI
     parent {
       name
+      code
+      order
+      definition
+      ontologyTermURI
+      parent {
+        name
+        code
+        order
+        definition
+        ontologyTermURI
+        parent {
+          name
+          code
+          order
+          definition
+          ontologyTermURI
+          parent {
+            name
+            code
+            order
+            definition
+            ontologyTermURI
+            parent {
+              name
+              code
+              order
+              definition
+              ontologyTermURI
+              parent {
+                name
+                code
+                order
+                definition
+                ontologyTermURI
+                parent {
+                  name
+                  code
+                  order
+                  definition
+                  ontologyTermURI
+                }
+              }
+            }
+          }
+        }
+      }
     }
     children {
       name


### PR DESCRIPTION
Due to the lack of recursive query possibilities the partial tree can not be reconstructed from the selected ontology items. This change works around this missing feature by fetching up to 8 levels up (from the selected ontology item). This is sufficient for the current ontologies used but does not solve te general case.

Closes https://github.com/molgenis/molgenis-emx2/issues/2044
Related to: https://github.com/molgenis/molgenis-emx2/issues/2047