### PR TITLE
fix: graph genome API now only requires variant start positions

### DIFF
--- a/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/graphgenome/Semantics.java
+++ b/backend/molgenis-emx2-semantics/src/main/java/org/molgenis/emx2/semantics/graphgenome/Semantics.java
@@ -85,13 +85,16 @@ public class Semantics {
       }
     }
     if (variant != null && type.equals(ALTERNATIVE)) {
-
       builder.add(
           nodeId,
           "http://purl.obolibrary.org/obo/GENO_0000894",
           variant.getPosition().getStart()[0]);
-      builder.add(
-          nodeId, "http://purl.obolibrary.org/obo/GENO_0000895", variant.getPosition().getEnd()[0]);
+      if (variant.getPosition().getEnd() != null) {
+        builder.add(
+            nodeId,
+            "http://purl.obolibrary.org/obo/GENO_0000895",
+            variant.getPosition().getEnd()[0]);
+      }
       String variantIRI =
           host
               + "/"


### PR DESCRIPTION
End positions are not always provided, now it works with only start positions. End is now determined by latest start + longest variant reference sequence, to be on the safe side. Could still be optimised by using all available information...