### PR TITLE
feat: enable build time compression of asset files

### DIFF
--- a/apps/nuxt3-ssr/nuxt.config.ts
+++ b/apps/nuxt3-ssr/nuxt.config.ts
@@ -21,7 +21,10 @@ const config = {
       emx2Theme: '',
       emx2Logo: '',
     }
-  }
+  },
+  nitro: {
+    compressPublicAssets: { brotli: true },
+  },
 }
 
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
Compress assets using brotli

Longer build times due to compression 
Smaller assets ( css in particular ) leading to 25% increase on lighthouse performance for 'empty' page 