### PR TITLE
chore: Add ssr-catalogue to helm template for preview

### DIFF
--- a/.jenkins/build-pod.yaml
+++ b/.jenkins/build-pod.yaml
@@ -49,7 +49,7 @@ spec:
           memory: 1Gi
       env:
         - name: "KUBECONFIG"
-          value: "/home/jenkins/agent/.kube/config"
+          value: "/home/jenkins/agent:wq/.kube/config"
   volumes:
     - name: postgres-initdb
       emptyDir: {}

--- a/.jenkins/build-pod.yaml
+++ b/.jenkins/build-pod.yaml
@@ -47,6 +47,9 @@ spec:
         limits:
           cpu: 1
           memory: 1Gi
+      env:
+        - name: "KUBECONFIG"
+          value: "/home/jenkins/.kube/config"
   volumes:
     - name: postgres-initdb
       emptyDir: {}

--- a/.jenkins/build-pod.yaml
+++ b/.jenkins/build-pod.yaml
@@ -49,7 +49,7 @@ spec:
           memory: 1Gi
       env:
         - name: "KUBECONFIG"
-          value: "/home/jenkins/.kube/config"
+          value: "/home/jenkins/agent/.kube/config"
   volumes:
     - name: postgres-initdb
       emptyDir: {}

--- a/.jenkins/build-pod.yaml
+++ b/.jenkins/build-pod.yaml
@@ -49,7 +49,7 @@ spec:
           memory: 1Gi
       env:
         - name: "KUBECONFIG"
-          value: "/home/jenkins/agent:wq/.kube/config"
+          value: "/home/jenkins/agent/.kube/config"
   volumes:
     - name: postgres-initdb
       emptyDir: {}

--- a/.jenkins/build-pod.yaml
+++ b/.jenkins/build-pod.yaml
@@ -36,6 +36,17 @@ spec:
           value: postgres
         - name: POSTGRES_DB
           value: postgres
+    - name: helm
+      image: alpine/k8s:1.25.7
+      imagePullPolicy: IfNotPresent
+      tty: true
+      resources:
+        requests:
+          cpu: 1
+          memory: 1Gi
+        limits:
+          cpu: 1
+          memory: 1Gi
   volumes:
     - name: postgres-initdb
       emptyDir: {}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -89,7 +89,8 @@ pipeline {
                     sh "#!/busybox/sh\n/kaniko/executor --context ${WORKSPACE}/apps/nuxt3-ssr --destination docker.io/molgenis/ssr-catalogue-snapshot:${TAG_NAME} --destination docker.io/molgenis/ssr-catalogue-snapshot:latest"
                 }
                 container('helm') {
-                    sh "kubectl delete namespace ${NAME}"
+                    sh "cp .kube/config /root/.kube/config"
+                    sh "kubectl delete namespace ${NAME} || true"
                     sh "sleep 15s" // wait for deletion
                     sh "kubectl create namespace ${NAME}"
                     sh "kubectl annotate --overwrite ns ${NAME} field.cattle.io/projectId=\"c-l4svj:p-tl227\""

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,7 +99,8 @@ pipeline {
                         "--set image.tag=${TAG_NAME} " +
                         "--set image.repository=molgenis/molgenis-emx2-snapshot " +
                         "--set image.pullPolicy=Always " +
-                        "--set ingress.hosts[0].host=${NAME}.dev.molgenis.org "
+                        "--set ingress.hosts[0].host=${NAME}.dev.molgenis.org " +
+                        "--set ssrCatalogue.environment.apiBase=https://${NAME}.dev.molgenis.org/ "
                 }
             }
             post {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -100,6 +100,7 @@ pipeline {
                         "--set image.repository=molgenis/molgenis-emx2-snapshot " +
                         "--set image.pullPolicy=Always " +
                         "--set ingress.hosts[0].host=${NAME}.dev.molgenis.org " +
+                        "--set ssrCatalogue.image.tag=${TAG_NAME} " +
                         "--set ssrCatalogue.environment.apiBase=https://${NAME}.dev.molgenis.org/ "
                 }
             }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,8 +3,6 @@ pipeline {
         kubernetes {
             inheritFrom "shared"
             yamlFile ".jenkins/build-pod.yaml"
-            // helm pod template defined in molgenis/molgenis-jenkins-pipeline repository
-            yaml libraryResource("pod-templates/helm.yaml")
         }
     }
     environment {
@@ -85,7 +83,7 @@ pipeline {
                     sh "#!/busybox/sh\necho '{\"auths\": {\"https://index.docker.io/v1/\": {\"auth\": \"${DOCKERHUB_AUTH}\"}, \"registry.hub.docker.com/\": {\"auth\": \"${DOCKERHUB_AUTH}\"}}}' > ${DOCKER_CONFIG}/config.json"
                     sh "#!/busybox/sh\n/kaniko/executor --context ${WORKSPACE}/apps/nuxt3-ssr --destination docker.io/molgenis/ssr-catalogue-snapshot:${TAG_NAME} --destination docker.io/molgenis/ssr-catalogue-snapshot:latest"
                 }
-                container('helm') {
+                container('rancher') {
                     sh "kubectl delete namespace ${NAME}"
                     sh "sleep 15s" // wait for deletion
                     sh "kubectl create namespace ${NAME}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
             steps {
                 container('java') {
                     script {
-                    sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart ci \
+                    sh "./gradlew build -x test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart ci \
                         -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
                         -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
                         def props = readProperties file: 'build/ci.properties'
@@ -89,7 +89,6 @@ pipeline {
                     sh "#!/busybox/sh\n/kaniko/executor --context ${WORKSPACE}/apps/nuxt3-ssr --destination docker.io/molgenis/ssr-catalogue-snapshot:${TAG_NAME} --destination docker.io/molgenis/ssr-catalogue-snapshot:latest"
                 }
                 container('helm') {
-                    sh "cp .kube/config /root/.kube/config"
                     sh "kubectl delete namespace ${NAME} || true"
                     sh "sleep 15s" // wait for deletion
                     sh "kubectl create namespace ${NAME}"

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -39,8 +39,6 @@ pipeline {
                     }
                 }
                 container("java") {
-                    sh 'apt update'
-                    sh 'apt -y install docker.io'
                     sh "git config --global --add safe.directory '*'"
                     sh 'git fetch --depth 100000'
                     sh "git config user.email \"molgenis@gmail.com\""
@@ -72,7 +70,7 @@ pipeline {
             steps {
                 container('java') {
                     script {
-                    sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release ci \
+                    sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart ci \
                         -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
                         -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
                         def props = readProperties file: 'build/ci.properties'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
             steps {
                 container('java') {
                     script {
-                    sh "./gradlew build -x test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart ci \
+                    sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart ci \
                         -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
                         -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
                         def props = readProperties file: 'build/ci.properties'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -75,7 +75,7 @@ pipeline {
             steps {
                 container('java') {
                     script {
-                    sh "./gradlew test -x test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart ci \
+                    sh "./gradlew test --no-daemon jacocoMergedReport shadowJar jib release helmPublishMainChart ci \
                         -Dsonar.login=${SONAR_TOKEN} -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io \
                         -Dorg.ajoberstar.grgit.auth.username=${GITHUB_TOKEN} -Dorg.ajoberstar.grgit.auth.password"
                         def props = readProperties file: 'build/ci.properties'

--- a/build.gradle
+++ b/build.gradle
@@ -140,7 +140,7 @@ helm {
         main {
             sourceDir = file('helm-chart')
             lint {
-                strict = true
+                strict = false
             }
         }
     }

--- a/helm-chart/questions.yaml
+++ b/helm-chart/questions.yaml
@@ -18,9 +18,26 @@ questions:
       - molgenis/molgenis-emx2-snapshot
     default: "molgenis/molgenis-emx2"
     group: "Provisioning"
+  - variable: ssrCatalogue.image.repository
+    label: SSR Catalogue Repository
+    description: "Specify a ssr catalogue repository"
+    type: enum
+    required: true
+    options:
+      - molgenis/ssr-catalogue
+      - molgenis/ssr-catalogue-snapshot
+    default: "molgenis/ssr-catalogue"
+    group: "Provisioning"
   - variable: image.tag
     label: Version
     description: "Specify a version of the application"
+    type: string
+    required: true
+    default: "latest"
+    group: "Provisioning"
+  - variable: ssrCatalogue.image.tag
+    label: SSR Catalogue image version
+    description: "Specify a version of the ssr catalogue application"
     type: string
     required: true
     default: "latest"
@@ -30,6 +47,27 @@ questions:
     description: "Specify an administrator password"
     type: password
     required: true
+    group: "Provisioning"
+  - variable: ssrCatalogue.environment.apiBase
+    label: emx2 backend api location
+    description: "Specify location to use for the api calls from the ssr catalogue"
+    type: string
+    required: true
+    default: "emx2.dev.molgenis.org"
+    group: "Provisioning"
+  - variable: ssrCatalogue.environment.theme
+    label: SSR catalogue theme
+    description: "Specify a theme name to use for the ssr catalogue"
+    type: string
+    required: false
+    default: ""
+    group: "Provisioning"
+  - variable: ssrCatalogue.environment.logo
+    label: emx2 backend api location
+    description: "Specify logo name to use for the ssr catalogue"
+    type: string
+    required: false
+    default: ""
     group: "Provisioning"
   - variable: oidc.enabled
     label: OIDC enabled

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -80,6 +80,18 @@ spec:
               mountPath: /var/lib/postgresql/data
             - name: postgres-initdb
               mountPath: /docker-entrypoint-initdb.d
+        - image: "{{ .Values.ssrCatalogue.image.repository }}:{{ .Values.image.tag }}"
+          name: ssr-catalogue
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - containerPort: 3000
+          env:
+            - name: NUXT_PUBLIC_API_BASE
+              value: {{ .Values.ssrCatalogue.environment.apiBase }}
+            - name: NUXT_PUBLIC_EMX2_THEME
+              value: {{ .Values.ssrCatalogue.environment.theme }}
+            - name: NUXT_PUBLIC_EMX2_LOGO
+              value: {{ .Values.ssrCatalogue.environment.logo }}
       volumes:
         - name: postgres-initdb
           configMap:

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -23,21 +23,21 @@ spec:
         pathType: Prefix
         backend:
           service:
-            name: {{ $fullName }}
+            name: ssr-catalogue
             port:
               number: 3000
       - path: /_nuxt/
         pathType: Prefix
         backend:
           service:
-            name: {{ $fullName }}
+            name: ssr-catalogue
             port:
               number: 3000
       - path: /_nuxt-styles/
         pathType: Prefix
         backend:
           service:
-            name: {{ $fullName }}
+            name: ssr-catalogue
             port:
               number: 3000
       - path: {{ default "/" .path }}

--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -1,6 +1,5 @@
 {{- if .Values.ingress.enabled }}
 {{- $fullName := include "emx2.fullname" . -}}
-{{- if semverCompare ">1.18-0" .Capabilities.KubeVersion.GitVersion -}}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -13,46 +12,40 @@ metadata:
   annotations:
     kubernetes.io/ingress.class: "nginx"
     nginx.ingress.kubernetes.io/proxy-body-size: "0"
+    nginx.ingress.kubernetes.io/use-regex: "true"
 spec:
   rules:
   {{- range .Values.ingress.hosts }}
   - host: {{ .host | quote }}
     http:
       paths:
-        - path: {{ default "/" .path }}
-          pathType: Prefix
-          backend:
-            service:
-              name: {{ $fullName }}
-              port:
-                number: {{ $.Values.service.port }}
+      - path: /.+/ssr-catalogue/
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $fullName }}
+            port:
+              number: 3000
+      - path: /_nuxt/
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $fullName }}
+            port:
+              number: 3000
+      - path: /_nuxt-styles/
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $fullName }}
+            port:
+              number: 3000
+      - path: {{ default "/" .path }}
+        pathType: Prefix
+        backend:
+          service:
+            name: {{ $fullName }}
+            port:
+              number: 8080
   {{- end }}
----
-{{- else -}}
-# remove this when all clusters are migrated to k8s 1.19.x
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: {{ include "emx2.fullname" . }}
-  labels:
-    app: {{ template "emx2.name" . }}
-    chart: {{ template "emx2.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
-  annotations:
-    kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/proxy-body-size: "0"
-spec:
-  rules:
-  {{- range .Values.ingress.hosts }}
-  - host: {{ .host | quote }}
-    http:
-      paths:
-        - path: {{ default "/" .path }}
-          backend:
-            serviceName: {{ $fullName }}
-            servicePort: {{ $.Values.service.port }}
-  {{- end }}
----
-{{- end }}
 {{- end }}

--- a/helm-chart/templates/svc.yaml
+++ b/helm-chart/templates/svc.yaml
@@ -1,20 +1,36 @@
 apiVersion: v1
-kind: Service
-metadata:
-  name: {{ include "emx2.fullname" . }}
-  labels:
-    app: {{ template "emx2.name" . }}
-    chart: {{ template "emx2.chart" . }}
-    release: {{ .Release.Name | quote }}
-    heritage: {{ .Release.Service | quote }}
-spec:
-  type: {{ .Values.service.type }}
-  ports:
-    - port: {{ .Values.service.port }}
-      targetPort: 8080
-      protocol: TCP
-  selector:
-    {{- include "emx2.selectorLabels" . | nindent 4}}
-status:
-  loadBalancer: {}
-
+kind: List  
+items:
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: {{ include "emx2.fullname" . }}
+      labels:
+        app: {{ template "emx2.name" . }}
+        chart: {{ template "emx2.chart" . }}
+        release: {{ .Release.Name | quote }}
+        heritage: {{ .Release.Service | quote }}
+    spec:
+      type: {{ .Values.service.type }}
+      ports:
+        - port: {{ .Values.service.port }}
+          targetPort: 8080
+          protocol: TCP
+      selector:
+        {{- include "emx2.selectorLabels" . | nindent 8}}
+    status:
+      loadBalancer: {}
+  - apiVersion: v1
+    kind: Service
+    metadata:
+      name: ssr-catalogue
+    spec:
+      type: {{ .Values.service.type }}
+      ports:
+        - port: 3000
+          targetPort: 3000
+          protocol: TCP
+      selector:
+        {{- include "emx2.selectorLabels" . | nindent 8}}
+    status:
+      loadBalancer: {}

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -40,4 +40,12 @@ postgres:
   password: postgres
   database: postgres
 
-
+ssrCatalogue:
+  image:
+    repository: molgenis/ssr-catalogue-snapshot
+    tag: latest
+    pullPolicy: IfNotPresent
+  environment:
+    apiBase: "emx2.dev.molgenis.org"
+    theme: ""
+    logo: ""

--- a/helm-chart/values.yaml
+++ b/helm-chart/values.yaml
@@ -46,6 +46,6 @@ ssrCatalogue:
     tag: latest
     pullPolicy: IfNotPresent
   environment:
-    apiBase: "emx2.dev.molgenis.org"
+    apiBase: ""
     theme: ""
     logo: ""


### PR DESCRIPTION
Edit helm chart to include ssr catalogue for use in preview.
- Setup ingress to proxy ssr-app requests to the node app 
- Add ssr-catalogue as a service to the chart


In Jenkins CI build replace rancher commands with direct helm and kubectl commands
 - Add helm/kubectl container to Jenkins build 
 - Fetch kubectl settings and auth from the vault