### PR TITLE
fix: Orderby on non 'root' table column fails #2175

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -581,7 +581,9 @@ public class GraphqlTableFieldFactory {
               sc.setOffset((int) args.get(GraphqlConstants.OFFSET));
             }
             if (args.containsKey(GraphqlConstants.ORDERBY)) {
-              sc.setOrderBy(convertOrderByIdsToNames(aTable, args));
+              TableMetadata orderByTable =
+                  column.get().isReference() ? column.get().getRefTable() : column.get().getTable();
+              sc.setOrderBy(convertOrderByIdsToNames(orderByTable, args));
             }
             result.add(sc);
           } else if (agg_fields.contains(s.getName())) {

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqSchemaFields.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqSchemaFields.java
@@ -241,6 +241,13 @@ public class TestGraphqSchemaFields {
     TestCase.assertEquals(
         "tweety", execute("{Pet(orderby:{name:DESC}){name}}").at("/Pet/0/name").textValue());
 
+    // order by on non-root column
+    TestCase.assertEquals(
+        "delivered",
+        execute("{Pet {orders(orderby: {orderId: ASC}) {status}}}")
+            .at("/Pet/0/orders/0/status")
+            .textValue());
+
     // filter nested
     TestCase.assertEquals(
         "red",


### PR DESCRIPTION
If column is ref type column use the reference column to find the name

Closes #2175