### PR TITLE
feat: Return to location after OIDC login

### DIFF
--- a/apps/molgenis-components/src/components/account/MolgenisSession.vue
+++ b/apps/molgenis-components/src/components/account/MolgenisSession.vue
@@ -26,7 +26,7 @@
           :error="error"
           @close="closeSignupForm"
         />
-        <ButtonOutline v-if="isOidcEnabled" href="/_login" :light="true">
+        <ButtonOutline v-if="isOidcEnabled" :href="oidcLoginUrl" :light="true">
           Sign in</ButtonOutline
         >
         <ButtonOutline v-else @click="showSigninForm = true" :light="true">
@@ -110,6 +110,12 @@ export default defineComponent({
   computed: {
     isOidcEnabled() {
       return this.session?.settings?.isOidcEnabled === "true";
+    },
+    oidcLoginUrl() {
+      const redirectParam = window?.location?.href
+        ? `?redirect=${window.location.href}`
+        : "";
+      return "/_login" + redirectParam;
     },
     locales() {
       if (this.session?.settings?.locales) {

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/controllers/OIDCController.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/controllers/OIDCController.java
@@ -17,6 +17,7 @@ import org.pac4j.core.http.adapter.HttpActionAdapter;
 import org.pac4j.core.profile.ProfileManager;
 import org.pac4j.core.profile.UserProfile;
 import org.pac4j.core.util.FindBest;
+import org.pac4j.core.util.Pac4jConstants;
 import org.pac4j.jee.context.session.JEESessionStore;
 import org.pac4j.sparkjava.SparkHttpActionAdapter;
 import org.pac4j.sparkjava.SparkWebContext;
@@ -41,6 +42,7 @@ public class OIDCController {
 
   public Object handleLoginRequest(Request request, Response response) {
     final SparkWebContext context = new SparkWebContext(request, response);
+    sessionStore.set(context, Pac4jConstants.REQUESTED_URL, request.queryParams("redirect"));
     final var client =
         securityConfig
             .getClients()
@@ -102,7 +104,6 @@ public class OIDCController {
     logger.info("OIDC sign in for user: {}", user);
 
     response.status(302);
-    response.redirect("/");
     return response;
   }
 }


### PR DESCRIPTION
related to [#9924](https://trac.molgeniscloud.org/ticket/9924) [new](https://trac.molgeniscloud.org/query?status=new&order=position&col=id&col=position&col=summary&col=status&col=type&col=milestone) [story](https://trac.molgeniscloud.org/query?status=accepted&status=assigned&status=new&status=reopened&type=story&order=position&col=id&col=position&col=summary&col=status&col=type&col=milestone)
_As data manager I want to be redirected to the schema overview when logging in with OIDC_

this pr sets up the 'default' behaviour, other PR can extend with passing a redirect location from (schema)settings 