### PR TITLE
fix(client): graphql query expansion bring server to its knees

### DIFF
--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -414,7 +414,7 @@ const columnNames = (
        if (
         //we always can expand singular refs
         ["REF", "ONTOLOGY"].includes(col.columnType)
-        //but we only expand list refs if we are on root level to not break server (keys should't contain these)
+        //but we only expand *_array refs if we are on root level to not break server (keys should't contain these)
         || (rootLevel && ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType))
        ) {
         result =

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -402,6 +402,7 @@ const columnNames = (
   schemaName: string,
   tableName: string,
   metaData: ISchemaMetaData,
+  //allows expansion of ref fields to add their next layer of details. 
   expandLevel: number,
   //default is rootLevel listing of columnNames
   rootLevel: boolean = true

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -408,6 +408,7 @@ const columnNames = (
 ) => {
   let result = "";
   getTable(schemaName, tableName, metaData.tables)?.columns?.forEach((col) => {
+    //we always expand the subfields of key=1, but other 'ref' fields only if they do not break server
     if (expandLevel > 0 || col.key == 1) {
        if (
         //we always can expand singular refs

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -412,7 +412,7 @@ const columnNames = (
        if (
         //we always can expand singular refs
         ["REF", "ONTOLOGY"].includes(col.columnType)
-        //but we only expand list refs if we are on root level to not break server
+        //but we only expand list refs if we are on root level to not break server (keys should't contain these)
         || (rootLevel && ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType))
        ) {
         result =

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -407,7 +407,10 @@ const columnNames = (
   let result = "";
   getTable(schemaName, tableName, metaData.tables)?.columns?.forEach((col) => {
     if (expandLevel > 0 || col.key == 1) {
-      if (isRefType(col.columnType)) {
+      if (["REF_ARRAY", "REFBACK","ONTOLOGY_ARRAY"].includes(col.columnType)) {
+        //we don't expand these otherwise server will break down!
+      }
+      else if (["REF", "ONTOLOGY"].includes(col.columnType)) {
         result =
           result +
           " " +

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -6,6 +6,7 @@ import { ITableMetaData } from "../Interfaces/ITableMetaData";
 import { IQueryMetaData } from "./IQueryMetaData";
 import { ISetting } from "../Interfaces/ISetting";
 import { IClient, INewClient } from "./IClient";
+import { columnNames } from "./queryBuilder";
 
 export { request };
 const client: IClient = {
@@ -387,71 +388,6 @@ const request = async (url: string, graphql: string, variables?: any) => {
         .join(". ");
       throw detailedErrorMessage || error.message;
     });
-};
-
-/**
- * @param {String} schemaName - schema where initial table is in
- * @param {String} tableName
- * @param {Object} metaData - object that contains all schema meta data
- * @param {Number} expandLevel - how many levels of grahpql should be expanded
- * @returns String of fields for use in gql query.
- * key=1 fields will always be expanded.
- * Other fields until level is reached
- */
-const columnNames = (
-  schemaName: string,
-  tableName: string,
-  metaData: ISchemaMetaData,
-  //allows expansion of ref fields to add their next layer of details. 
-  expandLevel: number,
-  //default is rootLevel listing of columnNames
-  rootLevel: boolean = true
-) => {
-  let result = "";
-  getTable(schemaName, tableName, metaData.tables)?.columns?.forEach((col) => {
-    //we always expand the subfields of key=1, but other 'ref' fields only if they do not break server
-    if (expandLevel > 0 || col.key == 1) {
-       if (
-        //we always can expand singular refs
-        ["REF", "ONTOLOGY"].includes(col.columnType)
-        //but we only expand *_array refs if we are on root level to not break server (keys should't contain these)
-        || (rootLevel && ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType))
-       ) {
-        result =
-          result +
-          " " +
-          col.id +
-          "{" +
-          columnNames(
-            col.refSchema ? col.refSchema : schemaName,
-            col.refTable,
-            metaData,
-            expandLevel - 1,
-            //indicate that subqueries should not be expanded on ref_array, refback, ontology_array
-            false
-          ) +
-          "}";
-      } else if (col.columnType === "FILE") {
-        result = result + " " + col.id + "{id,size,extension,url}";
-      } else if (col.columnType !== "HEADING") {
-        result = result + " " + col.id;
-      }
-    }
-  });
-  return result;
-};
-
-const getTable = (
-  schemaName: string,
-  tableName: string,
-  tableStore: ITableMetaData[]
-) => {
-  const result = tableStore.find(
-    (table) =>
-      table.id === convertToPascalCase(tableName) &&
-      table.externalSchema === schemaName
-  );
-  return result;
 };
 
 const isFileValue = (value: File) => {

--- a/apps/molgenis-components/src/client/queryBuilder.test.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.test.ts
@@ -2,381 +2,240 @@ import { describe, assert, test } from "vitest";
 import { columnNames } from "./queryBuilder";
 
 describe("columnNames", () => {
-
-  const expand = 2
+  const expand = 2;
   test("it should return the column names", () => {
     const expectedResult =
-      " name category { name } photoUrls status tags{ order name label parent{ name } codesystem code ontologyTermURI definition children { name } } weight orders { orderId pet{ name } quantity price complete status }";
-    const result = columnNames("pet store", "Pet", metaData, expand)
+      " name category { name } tags { order name label parent { name } children { name } } weight orders { orderId pet { name } }";
+    const result = columnNames("pet store", "Pet", metaData, expand);
     assert.equal(result, expectedResult);
   });
 });
 
-// test meta data with mg_columns removed 
+// test meta data with mg_columns removed
 const metaData = {
-    "name": "pet store",
-    "tables": [
+  name: "pet store",
+  tables: [
+    {
+      name: "Category",
+      tableType: "DATA",
+      id: "Category",
+      externalSchema: "pet store",
+      columns: [
         {
-            "name": "Category",
-            "tableType": "DATA",
-            "id": "Category",
-            "externalSchema": "pet store",
-            "columns": [
-                {
-                    "name": "name",
-                    "id": "name",
-                    "columnType": "STRING",
-                    "key": 1,
-                    "required": true
-                },
-            ]
+          name: "name",
+          id: "name",
+          columnType: "STRING",
+          key: 1,
+          required: true,
+        },
+      ],
+    },
+    {
+      name: "Order",
+      tableType: "DATA",
+      id: "Order",
+      externalSchema: "pet store",
+      columns: [
+        {
+          name: "orderId",
+          id: "orderId",
+          columnType: "STRING",
+          key: 1,
+          required: true,
         },
         {
-            "name": "Order",
-            "tableType": "DATA",
-            "id": "Order",
-            "externalSchema": "pet store",
-            "columns": [
-                {
-                    "name": "orderId",
-                    "id": "orderId",
-                    "columnType": "STRING",
-                    "key": 1,
-                    "required": true
-                },
-                {
-                    "name": "pet",
-                    "id": "pet",
-                    "columnType": "REF",
-                    "refTable": "Pet",
-                    "refLabelDefault": "${name}",
-                    "position": 1
-                },
-                {
-                    "name": "quantity",
-                    "id": "quantity",
-                    "columnType": "LONG",
-                    "position": 2,
-                    "validation": "if(quantity < 1) 'quantity should be >= 1'"
-                },
-                {
-                    "name": "price",
-                    "id": "price",
-                    "columnType": "DECIMAL",
-                    "position": 3,
-                    "validation": "price >= 1"
-                },
-                {
-                    "name": "complete",
-                    "id": "complete",
-                    "columnType": "BOOL",
-                    "position": 4
-                },
-                {
-                    "name": "status",
-                    "id": "status",
-                    "columnType": "STRING",
-                    "position": 5
-                },
-            ]
+          name: "pet",
+          id: "pet",
+          columnType: "REF",
+          refTable: "Pet",
+          refLabelDefault: "${name}",
+          position: 1,
+        },
+      ],
+    },
+    {
+      name: "Pet",
+      tableType: "DATA",
+      id: "Pet",
+      descriptions: [
+        {
+          locale: "en",
+          value: "My pet store example table",
+        },
+      ],
+      externalSchema: "pet store",
+      columns: [
+        {
+          name: "name",
+          id: "name",
+          columnType: "STRING",
+          key: 1,
+          required: true,
+          descriptions: [
+            {
+              locale: "en",
+              value: "the name",
+            },
+          ],
         },
         {
-            "name": "Pet",
-            "tableType": "DATA",
-            "id": "Pet",
-            "descriptions": [
-                {
-                    "locale": "en",
-                    "value": "My pet store example table"
-                }
-            ],
-            "externalSchema": "pet store",
-            "columns": [
-                {
-                    "name": "name",
-                    "id": "name",
-                    "columnType": "STRING",
-                    "key": 1,
-                    "required": true,
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "the name"
-                        }
-                    ]
-                },
-                {
-                    "name": "category",
-                    "id": "category",
-                    "columnType": "REF",
-                    "refTable": "Category",
-                    "refLabelDefault": "${name}",
-                    "required": true,
-                    "position": 1
-                },
-                {
-                    "name": "photoUrls",
-                    "id": "photoUrls",
-                    "columnType": "STRING_ARRAY",
-                    "position": 2
-                },
-                {
-                    "name": "details",
-                    "id": "details",
-                    "columnType": "HEADING",
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "Details"
-                        }
-                    ],
-                    "position": 3
-                },
-                {
-                    "name": "status",
-                    "id": "status",
-                    "columnType": "STRING",
-                    "position": 4
-                },
-                {
-                    "name": "tags",
-                    "id": "tags",
-                    "columnType": "ONTOLOGY_ARRAY",
-                    "refTable": "Tag",
-                    "refLabelDefault": "${name}",
-                    "position": 5
-                },
-                {
-                    "name": "weight",
-                    "id": "weight",
-                    "columnType": "DECIMAL",
-                    "required": true,
-                    "position": 6
-                },
-                {
-                    "name": "orders",
-                    "id": "orders",
-                    "columnType": "REFBACK",
-                    "refTable": "Order",
-                    "refLabelDefault": "${orderId}",
-                    "refBack": "pet",
-                    "position": 7
-                },
-            ]
+          name: "category",
+          id: "category",
+          columnType: "REF",
+          refTable: "Category",
+          refLabelDefault: "${name}",
+          required: true,
+          position: 1,
+        },
+
+        {
+          name: "tags",
+          id: "tags",
+          columnType: "ONTOLOGY_ARRAY",
+          refTable: "Tag",
+          refLabelDefault: "${name}",
+          position: 5,
         },
         {
-            "name": "Tag",
-            "tableType": "ONTOLOGIES",
-            "id": "Tag",
-            "externalSchema": "pet store",
-            "columns": [
-                {
-                    "name": "order",
-                    "id": "order",
-                    "columnType": "INT",
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C42680"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "Order of this term within the code system"
-                        }
-                    ]
-                },
-                {
-                    "name": "name",
-                    "id": "name",
-                    "columnType": "STRING",
-                    "key": 1,
-                    "required": true,
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C42614"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "Unique name of the term within this table"
-                        }
-                    ],
-                    "position": 1
-                },
-                {
-                    "name": "label",
-                    "id": "label",
-                    "columnType": "STRING",
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C45561"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "User-friendly label for this term. Should be unique in parent"
-                        }
-                    ],
-                    "position": 2
-                },
-                {
-                    "name": "parent",
-                    "id": "parent",
-                    "columnType": "REF",
-                    "refTable": "Tag",
-                    "refLabelDefault": "${name}",
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C80013"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "The parent term, in case this code exists in a hierarchy"
-                        }
-                    ],
-                    "position": 3
-                },
-                {
-                    "name": "codesystem",
-                    "id": "codesystem",
-                    "columnType": "STRING",
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C70895"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "Abbreviation of the code system/ontology this term belongs to"
-                        }
-                    ],
-                    "position": 4
-                },
-                {
-                    "name": "code",
-                    "id": "code",
-                    "columnType": "STRING",
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C25162"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "Identifier used for this term within this code system/ontology"
-                        }
-                    ],
-                    "position": 5
-                },
-                {
-                    "name": "ontologyTermURI",
-                    "id": "ontologyTermURI",
-                    "columnType": "HYPERLINK",
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C114456"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "Reference to structured definition of this term"
-                        }
-                    ],
-                    "position": 6
-                },
-                {
-                    "name": "definition",
-                    "id": "definition",
-                    "columnType": "TEXT",
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C42777"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "A concise explanation of the meaning of this term"
-                        }
-                    ],
-                    "position": 7
-                },
-                {
-                    "name": "children",
-                    "id": "children",
-                    "columnType": "REFBACK",
-                    "refTable": "Tag",
-                    "refLabelDefault": "${name}",
-                    "refBack": "parent",
-                    "semantics": [
-                        "http://purl.obolibrary.org/obo/NCIT_C90504"
-                    ],
-                    "descriptions": [
-                        {
-                            "locale": "en",
-                            "value": "Child terms, in case this term is the parent of other terms"
-                        }
-                    ],
-                    "position": 8
-                },
-            ]
+          name: "weight",
+          id: "weight",
+          columnType: "DECIMAL",
+          required: true,
+          position: 6,
         },
         {
-            "name": "User",
-            "tableType": "DATA",
-            "id": "User",
-            "externalSchema": "pet store",
-            "columns": [
-                {
-                    "name": "username",
-                    "id": "username",
-                    "columnType": "STRING",
-                    "key": 1,
-                    "required": true
-                },
-                {
-                    "name": "firstName",
-                    "id": "firstName",
-                    "columnType": "STRING",
-                    "position": 1
-                },
-                {
-                    "name": "lastName",
-                    "id": "lastName",
-                    "columnType": "STRING",
-                    "position": 2
-                },
-                {
-                    "name": "picture",
-                    "id": "picture",
-                    "columnType": "FILE",
-                    "position": 3
-                },
-                {
-                    "name": "email",
-                    "id": "email",
-                    "columnType": "EMAIL",
-                    "position": 4
-                },
-                {
-                    "name": "password",
-                    "id": "password",
-                    "columnType": "STRING",
-                    "position": 5
-                },
-                {
-                    "name": "phone",
-                    "id": "phone",
-                    "columnType": "STRING",
-                    "position": 6
-                },
-                {
-                    "name": "userStatus",
-                    "id": "userStatus",
-                    "columnType": "INT",
-                    "position": 7
-                },
-                {
-                    "name": "pets",
-                    "id": "pets",
-                    "columnType": "REF_ARRAY",
-                    "refTable": "Pet",
-                    "refLabelDefault": "${name}",
-                    "position": 8
-                },
-            ]
-        }
-    ]
-}
+          name: "orders",
+          id: "orders",
+          columnType: "REFBACK",
+          refTable: "Order",
+          refLabelDefault: "${orderId}",
+          refBack: "pet",
+          position: 7,
+        },
+      ],
+    },
+    {
+      name: "Tag",
+      tableType: "ONTOLOGIES",
+      id: "Tag",
+      externalSchema: "pet store",
+      columns: [
+        {
+          name: "order",
+          id: "order",
+          columnType: "INT",
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C42680"],
+          descriptions: [
+            {
+              locale: "en",
+              value: "Order of this term within the code system",
+            },
+          ],
+        },
+        {
+          name: "name",
+          id: "name",
+          columnType: "STRING",
+          key: 1,
+          required: true,
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C42614"],
+          descriptions: [
+            {
+              locale: "en",
+              value: "Unique name of the term within this table",
+            },
+          ],
+          position: 1,
+        },
+        {
+          name: "label",
+          id: "label",
+          columnType: "STRING",
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C45561"],
+          descriptions: [
+            {
+              locale: "en",
+              value:
+                "User-friendly label for this term. Should be unique in parent",
+            },
+          ],
+          position: 2,
+        },
+        {
+          name: "parent",
+          id: "parent",
+          columnType: "REF",
+          refTable: "Tag",
+          refLabelDefault: "${name}",
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C80013"],
+          descriptions: [
+            {
+              locale: "en",
+              value: "The parent term, in case this code exists in a hierarchy",
+            },
+          ],
+          position: 3,
+        },
+
+        {
+          name: "children",
+          id: "children",
+          columnType: "REFBACK",
+          refTable: "Tag",
+          refLabelDefault: "${name}",
+          refBack: "parent",
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C90504"],
+          descriptions: [
+            {
+              locale: "en",
+              value:
+                "Child terms, in case this term is the parent of other terms",
+            },
+          ],
+          position: 8,
+        },
+      ],
+    },
+    {
+      name: "User",
+      tableType: "DATA",
+      id: "User",
+      externalSchema: "pet store",
+      columns: [
+        {
+          name: "username",
+          id: "username",
+          columnType: "STRING",
+          key: 1,
+          required: true,
+        },
+        {
+          name: "firstName",
+          id: "firstName",
+          columnType: "STRING",
+          position: 1,
+        },
+        {
+          name: "lastName",
+          id: "lastName",
+          columnType: "STRING",
+          position: 2,
+        },
+        {
+          name: "picture",
+          id: "picture",
+          columnType: "FILE",
+          position: 3,
+        },
+        {
+          name: "pets",
+          id: "pets",
+          columnType: "REF_ARRAY",
+          refTable: "Pet",
+          refLabelDefault: "${name}",
+          position: 8,
+        },
+      ],
+    },
+  ],
+};

--- a/apps/molgenis-components/src/client/queryBuilder.test.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.test.ts
@@ -1,241 +1,241 @@
-import { describe, assert, test } from "vitest";
-import { columnNames } from "./queryBuilder";
+import {describe, assert, test} from "vitest";
+import {columnNames} from "./queryBuilder";
 
 describe("columnNames", () => {
-  const expand = 2;
-  test("it should return the column names", () => {
-    const expectedResult =
-      " name category { name } tags { order name label parent { name } children { name } } weight orders { orderId pet { name } }";
-    const result = columnNames("pet store", "Pet", metaData, expand);
-    assert.equal(result, expectedResult);
-  });
+    const expand = 2;
+    test("it should return the column names", () => {
+        const expectedResult =
+            " name category { name } tags { order name label parent { name } } weight orders { orderId pet { name } }";
+        const result = columnNames("pet store", "Pet", metaData, expand);
+        assert.equal(result, expectedResult);
+    });
 });
 
 // test meta data with mg_columns removed
 const metaData = {
-  name: "pet store",
-  tables: [
-    {
-      name: "Category",
-      tableType: "DATA",
-      id: "Category",
-      externalSchema: "pet store",
-      columns: [
+    name: "pet store",
+    tables: [
         {
-          name: "name",
-          id: "name",
-          columnType: "STRING",
-          key: 1,
-          required: true,
-        },
-      ],
-    },
-    {
-      name: "Order",
-      tableType: "DATA",
-      id: "Order",
-      externalSchema: "pet store",
-      columns: [
-        {
-          name: "orderId",
-          id: "orderId",
-          columnType: "STRING",
-          key: 1,
-          required: true,
+            name: "Category",
+            tableType: "DATA",
+            id: "Category",
+            externalSchema: "pet store",
+            columns: [
+                {
+                    name: "name",
+                    id: "name",
+                    columnType: "STRING",
+                    key: 1,
+                    required: true,
+                },
+            ],
         },
         {
-          name: "pet",
-          id: "pet",
-          columnType: "REF",
-          refTable: "Pet",
-          refLabelDefault: "${name}",
-          position: 1,
-        },
-      ],
-    },
-    {
-      name: "Pet",
-      tableType: "DATA",
-      id: "Pet",
-      descriptions: [
-        {
-          locale: "en",
-          value: "My pet store example table",
-        },
-      ],
-      externalSchema: "pet store",
-      columns: [
-        {
-          name: "name",
-          id: "name",
-          columnType: "STRING",
-          key: 1,
-          required: true,
-          descriptions: [
-            {
-              locale: "en",
-              value: "the name",
-            },
-          ],
+            name: "Order",
+            tableType: "DATA",
+            id: "Order",
+            externalSchema: "pet store",
+            columns: [
+                {
+                    name: "orderId",
+                    id: "orderId",
+                    columnType: "STRING",
+                    key: 1,
+                    required: true,
+                },
+                {
+                    name: "pet",
+                    id: "pet",
+                    columnType: "REF",
+                    refTable: "Pet",
+                    refLabelDefault: "${name}",
+                    position: 1,
+                },
+            ],
         },
         {
-          name: "category",
-          id: "category",
-          columnType: "REF",
-          refTable: "Category",
-          refLabelDefault: "${name}",
-          required: true,
-          position: 1,
-        },
+            name: "Pet",
+            tableType: "DATA",
+            id: "Pet",
+            descriptions: [
+                {
+                    locale: "en",
+                    value: "My pet store example table",
+                },
+            ],
+            externalSchema: "pet store",
+            columns: [
+                {
+                    name: "name",
+                    id: "name",
+                    columnType: "STRING",
+                    key: 1,
+                    required: true,
+                    descriptions: [
+                        {
+                            locale: "en",
+                            value: "the name",
+                        },
+                    ],
+                },
+                {
+                    name: "category",
+                    id: "category",
+                    columnType: "REF",
+                    refTable: "Category",
+                    refLabelDefault: "${name}",
+                    required: true,
+                    position: 1,
+                },
 
-        {
-          name: "tags",
-          id: "tags",
-          columnType: "ONTOLOGY_ARRAY",
-          refTable: "Tag",
-          refLabelDefault: "${name}",
-          position: 5,
+                {
+                    name: "tags",
+                    id: "tags",
+                    columnType: "ONTOLOGY_ARRAY",
+                    refTable: "Tag",
+                    refLabelDefault: "${name}",
+                    position: 5,
+                },
+                {
+                    name: "weight",
+                    id: "weight",
+                    columnType: "DECIMAL",
+                    required: true,
+                    position: 6,
+                },
+                {
+                    name: "orders",
+                    id: "orders",
+                    columnType: "REFBACK",
+                    refTable: "Order",
+                    refLabelDefault: "${orderId}",
+                    refBack: "pet",
+                    position: 7,
+                },
+            ],
         },
         {
-          name: "weight",
-          id: "weight",
-          columnType: "DECIMAL",
-          required: true,
-          position: 6,
-        },
-        {
-          name: "orders",
-          id: "orders",
-          columnType: "REFBACK",
-          refTable: "Order",
-          refLabelDefault: "${orderId}",
-          refBack: "pet",
-          position: 7,
-        },
-      ],
-    },
-    {
-      name: "Tag",
-      tableType: "ONTOLOGIES",
-      id: "Tag",
-      externalSchema: "pet store",
-      columns: [
-        {
-          name: "order",
-          id: "order",
-          columnType: "INT",
-          semantics: ["http://purl.obolibrary.org/obo/NCIT_C42680"],
-          descriptions: [
-            {
-              locale: "en",
-              value: "Order of this term within the code system",
-            },
-          ],
-        },
-        {
-          name: "name",
-          id: "name",
-          columnType: "STRING",
-          key: 1,
-          required: true,
-          semantics: ["http://purl.obolibrary.org/obo/NCIT_C42614"],
-          descriptions: [
-            {
-              locale: "en",
-              value: "Unique name of the term within this table",
-            },
-          ],
-          position: 1,
-        },
-        {
-          name: "label",
-          id: "label",
-          columnType: "STRING",
-          semantics: ["http://purl.obolibrary.org/obo/NCIT_C45561"],
-          descriptions: [
-            {
-              locale: "en",
-              value:
-                "User-friendly label for this term. Should be unique in parent",
-            },
-          ],
-          position: 2,
-        },
-        {
-          name: "parent",
-          id: "parent",
-          columnType: "REF",
-          refTable: "Tag",
-          refLabelDefault: "${name}",
-          semantics: ["http://purl.obolibrary.org/obo/NCIT_C80013"],
-          descriptions: [
-            {
-              locale: "en",
-              value: "The parent term, in case this code exists in a hierarchy",
-            },
-          ],
-          position: 3,
-        },
+            name: "Tag",
+            tableType: "ONTOLOGIES",
+            id: "Tag",
+            externalSchema: "pet store",
+            columns: [
+                {
+                    name: "order",
+                    id: "order",
+                    columnType: "INT",
+                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C42680"],
+                    descriptions: [
+                        {
+                            locale: "en",
+                            value: "Order of this term within the code system",
+                        },
+                    ],
+                },
+                {
+                    name: "name",
+                    id: "name",
+                    columnType: "STRING",
+                    key: 1,
+                    required: true,
+                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C42614"],
+                    descriptions: [
+                        {
+                            locale: "en",
+                            value: "Unique name of the term within this table",
+                        },
+                    ],
+                    position: 1,
+                },
+                {
+                    name: "label",
+                    id: "label",
+                    columnType: "STRING",
+                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C45561"],
+                    descriptions: [
+                        {
+                            locale: "en",
+                            value:
+                                "User-friendly label for this term. Should be unique in parent",
+                        },
+                    ],
+                    position: 2,
+                },
+                {
+                    name: "parent",
+                    id: "parent",
+                    columnType: "REF",
+                    refTable: "Tag",
+                    refLabelDefault: "${name}",
+                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C80013"],
+                    descriptions: [
+                        {
+                            locale: "en",
+                            value: "The parent term, in case this code exists in a hierarchy",
+                        },
+                    ],
+                    position: 3,
+                },
 
-        {
-          name: "children",
-          id: "children",
-          columnType: "REFBACK",
-          refTable: "Tag",
-          refLabelDefault: "${name}",
-          refBack: "parent",
-          semantics: ["http://purl.obolibrary.org/obo/NCIT_C90504"],
-          descriptions: [
-            {
-              locale: "en",
-              value:
-                "Child terms, in case this term is the parent of other terms",
-            },
-          ],
-          position: 8,
-        },
-      ],
-    },
-    {
-      name: "User",
-      tableType: "DATA",
-      id: "User",
-      externalSchema: "pet store",
-      columns: [
-        {
-          name: "username",
-          id: "username",
-          columnType: "STRING",
-          key: 1,
-          required: true,
+                {
+                    name: "children",
+                    id: "children",
+                    columnType: "REFBACK",
+                    refTable: "Tag",
+                    refLabelDefault: "${name}",
+                    refBack: "parent",
+                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C90504"],
+                    descriptions: [
+                        {
+                            locale: "en",
+                            value:
+                                "Child terms, in case this term is the parent of other terms",
+                        },
+                    ],
+                    position: 8,
+                },
+            ],
         },
         {
-          name: "firstName",
-          id: "firstName",
-          columnType: "STRING",
-          position: 1,
+            name: "User",
+            tableType: "DATA",
+            id: "User",
+            externalSchema: "pet store",
+            columns: [
+                {
+                    name: "username",
+                    id: "username",
+                    columnType: "STRING",
+                    key: 1,
+                    required: true,
+                },
+                {
+                    name: "firstName",
+                    id: "firstName",
+                    columnType: "STRING",
+                    position: 1,
+                },
+                {
+                    name: "lastName",
+                    id: "lastName",
+                    columnType: "STRING",
+                    position: 2,
+                },
+                {
+                    name: "picture",
+                    id: "picture",
+                    columnType: "FILE",
+                    position: 3,
+                },
+                {
+                    name: "pets",
+                    id: "pets",
+                    columnType: "REF_ARRAY",
+                    refTable: "Pet",
+                    refLabelDefault: "${name}",
+                    position: 8,
+                },
+            ],
         },
-        {
-          name: "lastName",
-          id: "lastName",
-          columnType: "STRING",
-          position: 2,
-        },
-        {
-          name: "picture",
-          id: "picture",
-          columnType: "FILE",
-          position: 3,
-        },
-        {
-          name: "pets",
-          id: "pets",
-          columnType: "REF_ARRAY",
-          refTable: "Pet",
-          refLabelDefault: "${name}",
-          position: 8,
-        },
-      ],
-    },
-  ],
+    ],
 };

--- a/apps/molgenis-components/src/client/queryBuilder.test.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.test.ts
@@ -1,0 +1,382 @@
+import { describe, assert, test } from "vitest";
+import { columnNames } from "./queryBuilder";
+
+describe("columnNames", () => {
+
+  const expand = 2
+  test("it should return the column names", () => {
+    const expectedResult =
+      " name category { name } photoUrls status tags{ order name label parent{ name } codesystem code ontologyTermURI definition children { name } } weight orders { orderId pet{ name } quantity price complete status }";
+    const result = columnNames("pet store", "Pet", metaData, expand)
+    assert.equal(result, expectedResult);
+  });
+});
+
+// test meta data with mg_columns removed 
+const metaData = {
+    "name": "pet store",
+    "tables": [
+        {
+            "name": "Category",
+            "tableType": "DATA",
+            "id": "Category",
+            "externalSchema": "pet store",
+            "columns": [
+                {
+                    "name": "name",
+                    "id": "name",
+                    "columnType": "STRING",
+                    "key": 1,
+                    "required": true
+                },
+            ]
+        },
+        {
+            "name": "Order",
+            "tableType": "DATA",
+            "id": "Order",
+            "externalSchema": "pet store",
+            "columns": [
+                {
+                    "name": "orderId",
+                    "id": "orderId",
+                    "columnType": "STRING",
+                    "key": 1,
+                    "required": true
+                },
+                {
+                    "name": "pet",
+                    "id": "pet",
+                    "columnType": "REF",
+                    "refTable": "Pet",
+                    "refLabelDefault": "${name}",
+                    "position": 1
+                },
+                {
+                    "name": "quantity",
+                    "id": "quantity",
+                    "columnType": "LONG",
+                    "position": 2,
+                    "validation": "if(quantity < 1) 'quantity should be >= 1'"
+                },
+                {
+                    "name": "price",
+                    "id": "price",
+                    "columnType": "DECIMAL",
+                    "position": 3,
+                    "validation": "price >= 1"
+                },
+                {
+                    "name": "complete",
+                    "id": "complete",
+                    "columnType": "BOOL",
+                    "position": 4
+                },
+                {
+                    "name": "status",
+                    "id": "status",
+                    "columnType": "STRING",
+                    "position": 5
+                },
+            ]
+        },
+        {
+            "name": "Pet",
+            "tableType": "DATA",
+            "id": "Pet",
+            "descriptions": [
+                {
+                    "locale": "en",
+                    "value": "My pet store example table"
+                }
+            ],
+            "externalSchema": "pet store",
+            "columns": [
+                {
+                    "name": "name",
+                    "id": "name",
+                    "columnType": "STRING",
+                    "key": 1,
+                    "required": true,
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "the name"
+                        }
+                    ]
+                },
+                {
+                    "name": "category",
+                    "id": "category",
+                    "columnType": "REF",
+                    "refTable": "Category",
+                    "refLabelDefault": "${name}",
+                    "required": true,
+                    "position": 1
+                },
+                {
+                    "name": "photoUrls",
+                    "id": "photoUrls",
+                    "columnType": "STRING_ARRAY",
+                    "position": 2
+                },
+                {
+                    "name": "details",
+                    "id": "details",
+                    "columnType": "HEADING",
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Details"
+                        }
+                    ],
+                    "position": 3
+                },
+                {
+                    "name": "status",
+                    "id": "status",
+                    "columnType": "STRING",
+                    "position": 4
+                },
+                {
+                    "name": "tags",
+                    "id": "tags",
+                    "columnType": "ONTOLOGY_ARRAY",
+                    "refTable": "Tag",
+                    "refLabelDefault": "${name}",
+                    "position": 5
+                },
+                {
+                    "name": "weight",
+                    "id": "weight",
+                    "columnType": "DECIMAL",
+                    "required": true,
+                    "position": 6
+                },
+                {
+                    "name": "orders",
+                    "id": "orders",
+                    "columnType": "REFBACK",
+                    "refTable": "Order",
+                    "refLabelDefault": "${orderId}",
+                    "refBack": "pet",
+                    "position": 7
+                },
+            ]
+        },
+        {
+            "name": "Tag",
+            "tableType": "ONTOLOGIES",
+            "id": "Tag",
+            "externalSchema": "pet store",
+            "columns": [
+                {
+                    "name": "order",
+                    "id": "order",
+                    "columnType": "INT",
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C42680"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Order of this term within the code system"
+                        }
+                    ]
+                },
+                {
+                    "name": "name",
+                    "id": "name",
+                    "columnType": "STRING",
+                    "key": 1,
+                    "required": true,
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C42614"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Unique name of the term within this table"
+                        }
+                    ],
+                    "position": 1
+                },
+                {
+                    "name": "label",
+                    "id": "label",
+                    "columnType": "STRING",
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C45561"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "User-friendly label for this term. Should be unique in parent"
+                        }
+                    ],
+                    "position": 2
+                },
+                {
+                    "name": "parent",
+                    "id": "parent",
+                    "columnType": "REF",
+                    "refTable": "Tag",
+                    "refLabelDefault": "${name}",
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C80013"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "The parent term, in case this code exists in a hierarchy"
+                        }
+                    ],
+                    "position": 3
+                },
+                {
+                    "name": "codesystem",
+                    "id": "codesystem",
+                    "columnType": "STRING",
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C70895"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Abbreviation of the code system/ontology this term belongs to"
+                        }
+                    ],
+                    "position": 4
+                },
+                {
+                    "name": "code",
+                    "id": "code",
+                    "columnType": "STRING",
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C25162"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Identifier used for this term within this code system/ontology"
+                        }
+                    ],
+                    "position": 5
+                },
+                {
+                    "name": "ontologyTermURI",
+                    "id": "ontologyTermURI",
+                    "columnType": "HYPERLINK",
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C114456"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Reference to structured definition of this term"
+                        }
+                    ],
+                    "position": 6
+                },
+                {
+                    "name": "definition",
+                    "id": "definition",
+                    "columnType": "TEXT",
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C42777"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "A concise explanation of the meaning of this term"
+                        }
+                    ],
+                    "position": 7
+                },
+                {
+                    "name": "children",
+                    "id": "children",
+                    "columnType": "REFBACK",
+                    "refTable": "Tag",
+                    "refLabelDefault": "${name}",
+                    "refBack": "parent",
+                    "semantics": [
+                        "http://purl.obolibrary.org/obo/NCIT_C90504"
+                    ],
+                    "descriptions": [
+                        {
+                            "locale": "en",
+                            "value": "Child terms, in case this term is the parent of other terms"
+                        }
+                    ],
+                    "position": 8
+                },
+            ]
+        },
+        {
+            "name": "User",
+            "tableType": "DATA",
+            "id": "User",
+            "externalSchema": "pet store",
+            "columns": [
+                {
+                    "name": "username",
+                    "id": "username",
+                    "columnType": "STRING",
+                    "key": 1,
+                    "required": true
+                },
+                {
+                    "name": "firstName",
+                    "id": "firstName",
+                    "columnType": "STRING",
+                    "position": 1
+                },
+                {
+                    "name": "lastName",
+                    "id": "lastName",
+                    "columnType": "STRING",
+                    "position": 2
+                },
+                {
+                    "name": "picture",
+                    "id": "picture",
+                    "columnType": "FILE",
+                    "position": 3
+                },
+                {
+                    "name": "email",
+                    "id": "email",
+                    "columnType": "EMAIL",
+                    "position": 4
+                },
+                {
+                    "name": "password",
+                    "id": "password",
+                    "columnType": "STRING",
+                    "position": 5
+                },
+                {
+                    "name": "phone",
+                    "id": "phone",
+                    "columnType": "STRING",
+                    "position": 6
+                },
+                {
+                    "name": "userStatus",
+                    "id": "userStatus",
+                    "columnType": "INT",
+                    "position": 7
+                },
+                {
+                    "name": "pets",
+                    "id": "pets",
+                    "columnType": "REF_ARRAY",
+                    "refTable": "Pet",
+                    "refLabelDefault": "${name}",
+                    "position": 8
+                },
+            ]
+        }
+    ]
+}

--- a/apps/molgenis-components/src/client/queryBuilder.test.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.test.ts
@@ -1,241 +1,275 @@
-import {describe, assert, test} from "vitest";
-import {columnNames} from "./queryBuilder";
+import { describe, assert, test } from "vitest";
+import { columnNames } from "./queryBuilder";
 
 describe("columnNames", () => {
-    const expand = 2;
-    test("it should return the column names", () => {
-        const expectedResult =
-            " name category { name } tags { order name label parent { name } } weight orders { orderId pet { name } }";
-        const result = columnNames("pet store", "Pet", metaData, expand);
-        assert.equal(result, expectedResult);
-    });
+  const EXPAND_ONE = 1;
+  const EXPAND_TWO = 2;
+
+  //Pet
+  //expand 1
+  test("it should return the pet columns expanded, children are not expanded, expect primary keys", () => {
+    const expectedResult =
+      " name category { name } tags { name } weight orders { orderId }";
+    const result = columnNames("pet store", "Pet", metaData, EXPAND_ONE);
+    assert.equal(result, expectedResult);
+  });
+  //expand 2
+  test("it should return the pet columns expanded", () => {
+    const expectedResult =
+      " name category { name } tags { order name label parent { name } } weight orders { orderId pet { name } }";
+    const result = columnNames("pet store", "Pet", metaData, EXPAND_TWO);
+    assert.equal(result, expectedResult);
+  });
+
+  //expand 2
+  test("it should return the order columns expanded, only arrays are not expanded beyond level 0 (so 'pet.tags' is missing)", () => {
+    const expectedResult = " orderId pet { name category { name } weight }";
+    const result = columnNames("pet store", "Order", metaData, EXPAND_TWO);
+    assert.equal(result, expectedResult);
+  });
+
+  //ontology
+  //expand 1
+  test("it should return the ontology columns expanded, only children array are not expanded beyond level 0", () => {
+    const expectedResult =
+      " order name label parent { name } children { name }";
+    const result = columnNames("pet store", "Tag", metaData, EXPAND_ONE);
+    assert.equal(result, expectedResult);
+  });
+  //expand 2
+  test("it should return the ontology columns expanded, only children array are not expanded beyond level 0", () => {
+    const expectedResult =
+      " order name label parent { order name label parent { name } } children { order name label parent { name } }";
+    const result = columnNames("pet store", "Tag", metaData, EXPAND_TWO);
+    assert.equal(result, expectedResult);
+  });
 });
 
 // test meta data with mg_columns removed
 const metaData = {
-    name: "pet store",
-    tables: [
+  name: "pet store",
+  tables: [
+    {
+      name: "Category",
+      tableType: "DATA",
+      id: "Category",
+      externalSchema: "pet store",
+      columns: [
         {
-            name: "Category",
-            tableType: "DATA",
-            id: "Category",
-            externalSchema: "pet store",
-            columns: [
-                {
-                    name: "name",
-                    id: "name",
-                    columnType: "STRING",
-                    key: 1,
-                    required: true,
-                },
-            ],
+          name: "name",
+          id: "name",
+          columnType: "STRING",
+          key: 1,
+          required: true,
+        },
+      ],
+    },
+    {
+      name: "Order",
+      tableType: "DATA",
+      id: "Order",
+      externalSchema: "pet store",
+      columns: [
+        {
+          name: "orderId",
+          id: "orderId",
+          columnType: "STRING",
+          key: 1,
+          required: true,
         },
         {
-            name: "Order",
-            tableType: "DATA",
-            id: "Order",
-            externalSchema: "pet store",
-            columns: [
-                {
-                    name: "orderId",
-                    id: "orderId",
-                    columnType: "STRING",
-                    key: 1,
-                    required: true,
-                },
-                {
-                    name: "pet",
-                    id: "pet",
-                    columnType: "REF",
-                    refTable: "Pet",
-                    refLabelDefault: "${name}",
-                    position: 1,
-                },
-            ],
+          name: "pet",
+          id: "pet",
+          columnType: "REF",
+          refTable: "Pet",
+          refLabelDefault: "${name}",
+          position: 1,
+        },
+      ],
+    },
+    {
+      name: "Pet",
+      tableType: "DATA",
+      id: "Pet",
+      descriptions: [
+        {
+          locale: "en",
+          value: "My pet store example table",
+        },
+      ],
+      externalSchema: "pet store",
+      columns: [
+        {
+          name: "name",
+          id: "name",
+          columnType: "STRING",
+          key: 1,
+          required: true,
+          descriptions: [
+            {
+              locale: "en",
+              value: "the name",
+            },
+          ],
         },
         {
-            name: "Pet",
-            tableType: "DATA",
-            id: "Pet",
-            descriptions: [
-                {
-                    locale: "en",
-                    value: "My pet store example table",
-                },
-            ],
-            externalSchema: "pet store",
-            columns: [
-                {
-                    name: "name",
-                    id: "name",
-                    columnType: "STRING",
-                    key: 1,
-                    required: true,
-                    descriptions: [
-                        {
-                            locale: "en",
-                            value: "the name",
-                        },
-                    ],
-                },
-                {
-                    name: "category",
-                    id: "category",
-                    columnType: "REF",
-                    refTable: "Category",
-                    refLabelDefault: "${name}",
-                    required: true,
-                    position: 1,
-                },
+          name: "category",
+          id: "category",
+          columnType: "REF",
+          refTable: "Category",
+          refLabelDefault: "${name}",
+          required: true,
+          position: 1,
+        },
 
-                {
-                    name: "tags",
-                    id: "tags",
-                    columnType: "ONTOLOGY_ARRAY",
-                    refTable: "Tag",
-                    refLabelDefault: "${name}",
-                    position: 5,
-                },
-                {
-                    name: "weight",
-                    id: "weight",
-                    columnType: "DECIMAL",
-                    required: true,
-                    position: 6,
-                },
-                {
-                    name: "orders",
-                    id: "orders",
-                    columnType: "REFBACK",
-                    refTable: "Order",
-                    refLabelDefault: "${orderId}",
-                    refBack: "pet",
-                    position: 7,
-                },
-            ],
+        {
+          name: "tags",
+          id: "tags",
+          columnType: "ONTOLOGY_ARRAY",
+          refTable: "Tag",
+          refLabelDefault: "${name}",
+          position: 5,
         },
         {
-            name: "Tag",
-            tableType: "ONTOLOGIES",
-            id: "Tag",
-            externalSchema: "pet store",
-            columns: [
-                {
-                    name: "order",
-                    id: "order",
-                    columnType: "INT",
-                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C42680"],
-                    descriptions: [
-                        {
-                            locale: "en",
-                            value: "Order of this term within the code system",
-                        },
-                    ],
-                },
-                {
-                    name: "name",
-                    id: "name",
-                    columnType: "STRING",
-                    key: 1,
-                    required: true,
-                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C42614"],
-                    descriptions: [
-                        {
-                            locale: "en",
-                            value: "Unique name of the term within this table",
-                        },
-                    ],
-                    position: 1,
-                },
-                {
-                    name: "label",
-                    id: "label",
-                    columnType: "STRING",
-                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C45561"],
-                    descriptions: [
-                        {
-                            locale: "en",
-                            value:
-                                "User-friendly label for this term. Should be unique in parent",
-                        },
-                    ],
-                    position: 2,
-                },
-                {
-                    name: "parent",
-                    id: "parent",
-                    columnType: "REF",
-                    refTable: "Tag",
-                    refLabelDefault: "${name}",
-                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C80013"],
-                    descriptions: [
-                        {
-                            locale: "en",
-                            value: "The parent term, in case this code exists in a hierarchy",
-                        },
-                    ],
-                    position: 3,
-                },
+          name: "weight",
+          id: "weight",
+          columnType: "DECIMAL",
+          required: true,
+          position: 6,
+        },
+        {
+          name: "orders",
+          id: "orders",
+          columnType: "REFBACK",
+          refTable: "Order",
+          refLabelDefault: "${orderId}",
+          refBack: "pet",
+          position: 7,
+        },
+      ],
+    },
+    {
+      name: "Tag",
+      tableType: "ONTOLOGIES",
+      id: "Tag",
+      externalSchema: "pet store",
+      columns: [
+        {
+          name: "order",
+          id: "order",
+          columnType: "INT",
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C42680"],
+          descriptions: [
+            {
+              locale: "en",
+              value: "Order of this term within the code system",
+            },
+          ],
+        },
+        {
+          name: "name",
+          id: "name",
+          columnType: "STRING",
+          key: 1,
+          required: true,
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C42614"],
+          descriptions: [
+            {
+              locale: "en",
+              value: "Unique name of the term within this table",
+            },
+          ],
+          position: 1,
+        },
+        {
+          name: "label",
+          id: "label",
+          columnType: "STRING",
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C45561"],
+          descriptions: [
+            {
+              locale: "en",
+              value:
+                "User-friendly label for this term. Should be unique in parent",
+            },
+          ],
+          position: 2,
+        },
+        {
+          name: "parent",
+          id: "parent",
+          columnType: "REF",
+          refTable: "Tag",
+          refLabelDefault: "${name}",
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C80013"],
+          descriptions: [
+            {
+              locale: "en",
+              value: "The parent term, in case this code exists in a hierarchy",
+            },
+          ],
+          position: 3,
+        },
 
-                {
-                    name: "children",
-                    id: "children",
-                    columnType: "REFBACK",
-                    refTable: "Tag",
-                    refLabelDefault: "${name}",
-                    refBack: "parent",
-                    semantics: ["http://purl.obolibrary.org/obo/NCIT_C90504"],
-                    descriptions: [
-                        {
-                            locale: "en",
-                            value:
-                                "Child terms, in case this term is the parent of other terms",
-                        },
-                    ],
-                    position: 8,
-                },
-            ],
+        {
+          name: "children",
+          id: "children",
+          columnType: "REFBACK",
+          refTable: "Tag",
+          refLabelDefault: "${name}",
+          refBack: "parent",
+          semantics: ["http://purl.obolibrary.org/obo/NCIT_C90504"],
+          descriptions: [
+            {
+              locale: "en",
+              value:
+                "Child terms, in case this term is the parent of other terms",
+            },
+          ],
+          position: 8,
+        },
+      ],
+    },
+    {
+      name: "User",
+      tableType: "DATA",
+      id: "User",
+      externalSchema: "pet store",
+      columns: [
+        {
+          name: "username",
+          id: "username",
+          columnType: "STRING",
+          key: 1,
+          required: true,
         },
         {
-            name: "User",
-            tableType: "DATA",
-            id: "User",
-            externalSchema: "pet store",
-            columns: [
-                {
-                    name: "username",
-                    id: "username",
-                    columnType: "STRING",
-                    key: 1,
-                    required: true,
-                },
-                {
-                    name: "firstName",
-                    id: "firstName",
-                    columnType: "STRING",
-                    position: 1,
-                },
-                {
-                    name: "lastName",
-                    id: "lastName",
-                    columnType: "STRING",
-                    position: 2,
-                },
-                {
-                    name: "picture",
-                    id: "picture",
-                    columnType: "FILE",
-                    position: 3,
-                },
-                {
-                    name: "pets",
-                    id: "pets",
-                    columnType: "REF_ARRAY",
-                    refTable: "Pet",
-                    refLabelDefault: "${name}",
-                    position: 8,
-                },
-            ],
+          name: "firstName",
+          id: "firstName",
+          columnType: "STRING",
+          position: 1,
         },
-    ],
+        {
+          name: "lastName",
+          id: "lastName",
+          columnType: "STRING",
+          position: 2,
+        },
+        {
+          name: "picture",
+          id: "picture",
+          columnType: "FILE",
+          position: 3,
+        },
+        {
+          name: "pets",
+          id: "pets",
+          columnType: "REF_ARRAY",
+          refTable: "Pet",
+          refLabelDefault: "${name}",
+          position: 8,
+        },
+      ],
+    },
+  ],
 };

--- a/apps/molgenis-components/src/client/queryBuilder.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.ts
@@ -1,6 +1,6 @@
-import {convertToPascalCase} from "../components/utils";
-import {ISchemaMetaData} from "../Interfaces/IMetaData";
-import {ITableMetaData} from "../Interfaces/ITableMetaData";
+import { convertToPascalCase } from "../components/utils";
+import { ISchemaMetaData } from "../Interfaces/IMetaData";
+import { ITableMetaData } from "../Interfaces/ITableMetaData";
 
 /**
  * @param {String} schemaName - schema where initial table is in
@@ -12,54 +12,61 @@ import {ITableMetaData} from "../Interfaces/ITableMetaData";
  * Other fields until level is reached
  */
 export const columnNames = (
-    schemaName: string,
-    tableName: string,
-    metaData: ISchemaMetaData,
-    //allows expansion of ref fields to add their next layer of details.
-    expandLevel: number,
-    //rootLevel
-    rootLevel = true
+  schemaName: string,
+  tableName: string,
+  metaData: ISchemaMetaData,
+  //allows expansion of ref fields to add their next layer of details.
+  expandLevel: number,
+  //rootLevel
+  rootLevel = true
 ) => {
-    let result = "";
-    getTable(schemaName, tableName, metaData.tables)?.columns?.forEach((col) => {
-        //we always expand the subfields of key=1, but other 'ref' fields only if they do not break server
-        if (expandLevel > 0 || col.key == 1) {
-            if (!rootLevel && ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)) {
-                //skip
-            } else if (["REF", "ONTOLOGY", "REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)) {
-                result =
-                    result +
-                    " " +
-                    col.id +
-                    " {" +
-                    columnNames(
-                        col.refSchema ? col.refSchema : schemaName,
-                        col.refTable,
-                        metaData,
-                        //indicate that sub queries should not be expanded on ref_array, refback, ontology_array
-                        expandLevel - 1,
-                        false
-                    ) +
-                    " }";
-            } else if (col.columnType === "FILE") {
-                result += ` ${col.id} { id, size, extension, url }`;
-            } else if (col.columnType !== "HEADING") {
-                result += ` ${col.id}`;
-            }
-        }
-    });
-    return result;
+  let result = "";
+  getTable(schemaName, tableName, metaData.tables)?.columns?.forEach((col) => {
+    //we always expand the subfields of key=1, but other 'ref' fields only if they do not break server
+    if (expandLevel > 0 || col.key == 1) {
+      if (
+        !rootLevel &&
+        ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)
+      ) {
+        //skip
+      } else if (
+        ["REF", "ONTOLOGY", "REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(
+          col.columnType
+        )
+      ) {
+        result =
+          result +
+          " " +
+          col.id +
+          " {" +
+          columnNames(
+            col.refSchema ? col.refSchema : schemaName,
+            col.refTable,
+            metaData,
+            //indicate that sub queries should not be expanded on ref_array, refback, ontology_array
+            expandLevel - 1,
+            false
+          ) +
+          " }";
+      } else if (col.columnType === "FILE") {
+        result += ` ${col.id} { id, size, extension, url }`;
+      } else if (col.columnType !== "HEADING") {
+        result += ` ${col.id}`;
+      }
+    }
+  });
+  return result;
 };
 
 const getTable = (
-    schemaName: string,
-    tableName: string,
-    tableStore: ITableMetaData[]
+  schemaName: string,
+  tableName: string,
+  tableStore: ITableMetaData[]
 ) => {
-    const result = tableStore.find(
-        (table) =>
-            table.id === convertToPascalCase(tableName) &&
-            table.externalSchema === schemaName
-    );
-    return result;
+  const result = tableStore.find(
+    (table) =>
+      table.id === convertToPascalCase(tableName) &&
+      table.externalSchema === schemaName
+  );
+  return result;
 };

--- a/apps/molgenis-components/src/client/queryBuilder.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.ts
@@ -49,16 +49,21 @@ export const columnNames = (
         ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)
       ) {
         // only list the keys but down not expand further
-        const refColumns = getTable(
-          col.refSchema ? col.refSchema : schemaName,
-          col.refTable,
-          metaData.tables
-        )?.columns;
-        const refColumnsIdString = refColumns
-          ?.filter((c) => c.key === 1)
-          .map((col) => col.id)
-          .join(" ");
-        result += ` ${col.id} { ${refColumnsIdString} }`;
+        result =
+          result +
+          " " +
+          col.id +
+          " {" +
+          columnNames(
+            col.refSchema ? col.refSchema : schemaName,
+            col.refTable,
+            metaData,
+            //should only include the keys by setting level to 0
+            0,
+            //indicate that sub queries should not be expanded on ref_array, refback, ontology_array
+            false
+          ) +
+          " }";
       } else if (col.columnType === "FILE") {
         result += ` ${col.id} { id, size, extension, url }`;
       } else if (col.columnType !== "HEADING") {

--- a/apps/molgenis-components/src/client/queryBuilder.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.ts
@@ -41,14 +41,28 @@ export const columnNames = (
             col.refTable,
             metaData,
             expandLevel - 1,
-            //indicate that subqueries should not be expanded on ref_array, refback, ontology_array
+            //indicate that sub queries should not be expanded on ref_array, refback, ontology_array
             false
           ) +
           " }";
+      } else if (
+        ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)
+      ) {
+        // only list the keys but down not expand further
+        const refColumns = getTable(
+          col.refSchema ? col.refSchema : schemaName,
+          col.refTable,
+          metaData.tables
+        )?.columns;
+        const refColumnsIdString = refColumns
+          ?.filter((c) => c.key === 1)
+          .map((col) => col.id)
+          .join(" ");
+        result += ` ${col.id} { ${refColumnsIdString} }`;
       } else if (col.columnType === "FILE") {
-        result = result + " " + col.id + "{id,size,extension,url}";
+        result += ` ${col.id} { id, size, extension, url }`;
       } else if (col.columnType !== "HEADING") {
-        result = result + " " + col.id;
+        result += ` ${col.id}`;
       }
     }
   });

--- a/apps/molgenis-components/src/client/queryBuilder.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.ts
@@ -1,6 +1,6 @@
-import { convertToPascalCase } from "../components/utils";
-import { ISchemaMetaData } from "../Interfaces/IMetaData";
-import { ITableMetaData } from "../Interfaces/ITableMetaData";
+import {convertToPascalCase} from "../components/utils";
+import {ISchemaMetaData} from "../Interfaces/IMetaData";
+import {ITableMetaData} from "../Interfaces/ITableMetaData";
 
 /**
  * @param {String} schemaName - schema where initial table is in
@@ -12,77 +12,54 @@ import { ITableMetaData } from "../Interfaces/ITableMetaData";
  * Other fields until level is reached
  */
 export const columnNames = (
-  schemaName: string,
-  tableName: string,
-  metaData: ISchemaMetaData,
-  //allows expansion of ref fields to add their next layer of details.
-  expandLevel: number,
-  //default is rootLevel listing of columnNames
-  rootLevel: boolean = true
+    schemaName: string,
+    tableName: string,
+    metaData: ISchemaMetaData,
+    //allows expansion of ref fields to add their next layer of details.
+    expandLevel: number,
+    //rootLevel
+    rootLevel = true
 ) => {
-  let result = "";
-  getTable(schemaName, tableName, metaData.tables)?.columns?.forEach((col) => {
-    //we always expand the subfields of key=1, but other 'ref' fields only if they do not break server
-    if (expandLevel > 0 || col.key == 1) {
-      if (
-        //we always can expand singular refs
-        ["REF", "ONTOLOGY"].includes(col.columnType) ||
-        //but we only expand *_array refs if we are on root level to not break server (keys shouldn't contain these)
-        (rootLevel &&
-          ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType))
-      ) {
-        result =
-          result +
-          " " +
-          col.id +
-          " {" +
-          columnNames(
-            col.refSchema ? col.refSchema : schemaName,
-            col.refTable,
-            metaData,
-            expandLevel - 1,
-            //indicate that sub queries should not be expanded on ref_array, refback, ontology_array
-            false
-          ) +
-          " }";
-      } else if (
-        ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)
-      ) {
-        // only list the keys but down not expand further
-        result =
-          result +
-          " " +
-          col.id +
-          " {" +
-          columnNames(
-            col.refSchema ? col.refSchema : schemaName,
-            col.refTable,
-            metaData,
-            //should only include the keys by setting level to 0
-            0,
-            //indicate that sub queries should not be expanded on ref_array, refback, ontology_array
-            false
-          ) +
-          " }";
-      } else if (col.columnType === "FILE") {
-        result += ` ${col.id} { id, size, extension, url }`;
-      } else if (col.columnType !== "HEADING") {
-        result += ` ${col.id}`;
-      }
-    }
-  });
-  return result;
+    let result = "";
+    getTable(schemaName, tableName, metaData.tables)?.columns?.forEach((col) => {
+        //we always expand the subfields of key=1, but other 'ref' fields only if they do not break server
+        if (expandLevel > 0 || col.key == 1) {
+            if (!rootLevel && ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)) {
+                //skip
+            } else if (["REF", "ONTOLOGY", "REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)) {
+                result =
+                    result +
+                    " " +
+                    col.id +
+                    " {" +
+                    columnNames(
+                        col.refSchema ? col.refSchema : schemaName,
+                        col.refTable,
+                        metaData,
+                        //indicate that sub queries should not be expanded on ref_array, refback, ontology_array
+                        expandLevel - 1,
+                        false
+                    ) +
+                    " }";
+            } else if (col.columnType === "FILE") {
+                result += ` ${col.id} { id, size, extension, url }`;
+            } else if (col.columnType !== "HEADING") {
+                result += ` ${col.id}`;
+            }
+        }
+    });
+    return result;
 };
 
 const getTable = (
-  schemaName: string,
-  tableName: string,
-  tableStore: ITableMetaData[]
+    schemaName: string,
+    tableName: string,
+    tableStore: ITableMetaData[]
 ) => {
-  const result = tableStore.find(
-    (table) =>
-      table.id === convertToPascalCase(tableName) &&
-      table.externalSchema === schemaName
-  );
-  return result;
+    const result = tableStore.find(
+        (table) =>
+            table.id === convertToPascalCase(tableName) &&
+            table.externalSchema === schemaName
+    );
+    return result;
 };

--- a/apps/molgenis-components/src/client/queryBuilder.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.ts
@@ -1,0 +1,69 @@
+import { convertToPascalCase } from "../components/utils";
+import { ISchemaMetaData } from "../Interfaces/IMetaData";
+import { ITableMetaData } from "../Interfaces/ITableMetaData";
+
+/**
+ * @param {String} schemaName - schema where initial table is in
+ * @param {String} tableName
+ * @param {Object} metaData - object that contains all schema meta data
+ * @param {Number} expandLevel - how many levels of grahpql should be expanded
+ * @returns String of fields for use in gql query.
+ * key=1 fields will always be expanded.
+ * Other fields until level is reached
+ */
+export const columnNames = (
+  schemaName: string,
+  tableName: string,
+  metaData: ISchemaMetaData,
+  //allows expansion of ref fields to add their next layer of details.
+  expandLevel: number,
+  //default is rootLevel listing of columnNames
+  rootLevel: boolean = true
+) => {
+  let result = "";
+  getTable(schemaName, tableName, metaData.tables)?.columns?.forEach((col) => {
+    //we always expand the subfields of key=1, but other 'ref' fields only if they do not break server
+    if (expandLevel > 0 || col.key == 1) {
+      if (
+        //we always can expand singular refs
+        ["REF", "ONTOLOGY"].includes(col.columnType) ||
+        //but we only expand *_array refs if we are on root level to not break server (keys shouldn't contain these)
+        (rootLevel &&
+          ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType))
+      ) {
+        result =
+          result +
+          " " +
+          col.id +
+          " {" +
+          columnNames(
+            col.refSchema ? col.refSchema : schemaName,
+            col.refTable,
+            metaData,
+            expandLevel - 1,
+            //indicate that subqueries should not be expanded on ref_array, refback, ontology_array
+            false
+          ) +
+          " }";
+      } else if (col.columnType === "FILE") {
+        result = result + " " + col.id + "{id,size,extension,url}";
+      } else if (col.columnType !== "HEADING") {
+        result = result + " " + col.id;
+      }
+    }
+  });
+  return result;
+};
+
+const getTable = (
+  schemaName: string,
+  tableName: string,
+  tableStore: ITableMetaData[]
+) => {
+  const result = tableStore.find(
+    (table) =>
+      table.id === convertToPascalCase(tableName) &&
+      table.externalSchema === schemaName
+  );
+  return result;
+};


### PR DESCRIPTION
This fixes issue with graphql creating queries that kills server, by removing query expansion into fields that may return large lists of data (i.e. ref_array, ontology_array).

We still might choose to reduce default expandLevel from '2' to '1' to be safe, but I think we might be fine this way.