### PR TITLE
build: refactor loaders to prevent conflicts and make sonar happy again

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -53,6 +53,8 @@ subprojects {
         //also used outside test
         implementation 'junit:junit:4.13.2'
         testImplementation 'org.mockito:mockito-core:5.1.1'
+        //allows to set environment variables in test
+        testImplementation 'com.github.stefanbirkner:system-lambda:1.2.1'
     }
 
     jacocoTestReport {
@@ -83,6 +85,11 @@ subprojects {
     } else {
         //don't cache database init
         test.outputs.upToDateWhen { false }
+    }
+
+    //enable environment variables to be set by test
+    tasks.test {
+        jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
     }
     test {
         maxParallelForks = Runtime.runtime.availableProcessors() / 2

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/AbstractDataLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/AbstractDataLoader.java
@@ -1,0 +1,40 @@
+package org.molgenis.emx2.datamodels;
+
+import java.io.InputStreamReader;
+import org.molgenis.emx2.MolgenisException;
+import org.molgenis.emx2.Schema;
+import org.molgenis.emx2.SchemaMetadata;
+import org.molgenis.emx2.io.emx2.Emx2;
+import org.molgenis.emx2.io.readers.CsvTableReader;
+
+public abstract class AbstractDataLoader {
+  // using to ensure shared schemas are not created together.
+  private static final Object lock = new Object();
+
+  public void load(Schema schema, boolean includeExampleData) {
+    // make sure only one install runs because of potential overlap with other installers
+    // e.g. shared schema
+    synchronized (lock) {
+      // make sure all installation stuff is in one tx
+      schema.tx(
+          db -> {
+            try {
+              this.loadInternalImplementation(db.getSchema(schema.getName()), includeExampleData);
+            } catch (Exception e) {
+              throw new MolgenisException(e.getMessage());
+            }
+          });
+    }
+  }
+
+  abstract void loadInternalImplementation(Schema schema, boolean includeDemoData);
+
+  public static void createSchema(Schema schema, String path) {
+    SchemaMetadata metadata =
+        Emx2.fromRowList(
+            CsvTableReader.read(
+                new InputStreamReader(
+                    DataCatalogueLoader.class.getClassLoader().getResourceAsStream(path))));
+    schema.migrate(metadata);
+  }
+}

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/AvailableDataModels.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/AvailableDataModels.java
@@ -1,7 +1,5 @@
 package org.molgenis.emx2.datamodels;
 
-import java.io.IOException;
-import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Schema;
 
 public enum AvailableDataModels {
@@ -15,25 +13,13 @@ public enum AvailableDataModels {
 
   FAIR_DATA_HUB(new FAIRDataHubLoader());
 
-  private DataModelLoader installer;
+  private AbstractDataLoader installer;
 
-  AvailableDataModels(DataModelLoader installer) {
+  AvailableDataModels(AbstractDataLoader installer) {
     this.installer = installer;
   }
 
-  public void install(Schema schema, boolean includeExampleData) {
-    schema.tx(
-        db -> {
-          try {
-            // make sure not to use schema but db because in a transaction!
-            installer.load(db.getSchema(schema.getName()), includeExampleData);
-          } catch (Exception e) {
-            throw new MolgenisException(e.getMessage());
-          }
-        });
-  }
-
-  public interface DataModelLoader {
-    void load(Schema schema, boolean includeExampleData) throws IOException;
+  public void install(Schema schema, boolean loadExampleData) {
+    this.installer.load(schema, loadExampleData);
   }
 }

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueCohortStagingLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueCohortStagingLoader.java
@@ -1,17 +1,16 @@
 package org.molgenis.emx2.datamodels;
 
-import static org.molgenis.emx2.datamodels.DataCatalogueLoader.*;
 import static org.molgenis.emx2.datamodels.DataCatalogueNetworkStagingLoader.SHARED_STAGING;
 
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.Schema;
 
-public class DataCatalogueCohortStagingLoader implements AvailableDataModels.DataModelLoader {
+public class DataCatalogueCohortStagingLoader extends AbstractDataLoader {
 
   static String DATA_CATALOGUE = "DataCatalogue";
 
   @Override
-  public void load(Schema schema, boolean includeDemoData) {
+  void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     // create shared schemas
     createSharedSchema(schema.getDatabase());
     // create the schema
@@ -22,7 +21,7 @@ public class DataCatalogueCohortStagingLoader implements AvailableDataModels.Dat
     // create DataCatalogue and CatalogueOntologies
     Schema dataCatalogueSchema = db.getSchema(DATA_CATALOGUE);
     if (dataCatalogueSchema == null) {
-      new DataCatalogueLoader().load(db.createSchema(DATA_CATALOGUE), false);
+      new DataCatalogueLoader().loadInternalImplementation(db.createSchema(DATA_CATALOGUE), false);
     }
 
     Schema sharedSchema = db.getSchema(SHARED_STAGING);

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueCohortStagingLoader3.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueCohortStagingLoader3.java
@@ -12,12 +12,12 @@ public class DataCatalogueCohortStagingLoader3 extends AbstractDataLoader {
   @Override
   void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     // create shared schemas
-    createSharedStaging(schema.getDatabase());
+    createSharedStaging3(schema.getDatabase());
     // create the schema
     createSchema(schema, "datacatalogue3/stagingCohorts/molgenis.csv");
   }
 
-  static void createSharedStaging(Database db) {
+  static void createSharedStaging3(Database db) {
     // create DataCatalogue and CatalogueOntologies
     Schema dataCatalogueSchema = db.getSchema(DATA_CATALOGUE);
     if (dataCatalogueSchema == null) {

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueCohortStagingLoader3.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueCohortStagingLoader3.java
@@ -1,35 +1,32 @@
 package org.molgenis.emx2.datamodels;
 
-import static org.molgenis.emx2.datamodels.DataCatalogueLoader.createSchema;
 import static org.molgenis.emx2.datamodels.DataCatalogueNetworkStagingLoader.SHARED_STAGING;
 
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.Schema;
 
-public class DataCatalogueCohortStagingLoader3 implements AvailableDataModels.DataModelLoader {
+public class DataCatalogueCohortStagingLoader3 extends AbstractDataLoader {
 
   static String DATA_CATALOGUE = "DataCatalogue";
 
   @Override
-  public void load(Schema schema, boolean includeDemoData) {
+  void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     // create shared schemas
-    createDataCatalogue3(schema.getDatabase());
+    createSharedStaging(schema.getDatabase());
     // create the schema
     createSchema(schema, "datacatalogue3/stagingCohorts/molgenis.csv");
   }
 
-  static void createDataCatalogue3(Database db) {
+  static void createSharedStaging(Database db) {
     // create DataCatalogue and CatalogueOntologies
     Schema dataCatalogueSchema = db.getSchema(DATA_CATALOGUE);
     if (dataCatalogueSchema == null) {
-      new DataCatalogueLoader3().load(db.createSchema(DATA_CATALOGUE), false);
+      new DataCatalogueLoader3().loadInternalImplementation(db.createSchema(DATA_CATALOGUE), false);
     }
 
     Schema sharedSchema = db.getSchema(SHARED_STAGING);
     if (sharedSchema == null) {
-      sharedSchema = db.createSchema(SHARED_STAGING);
-      // create the shared schema
-      createSchema(sharedSchema, "datacatalogue3/stagingShared/molgenis.csv");
+      createSchema(db.createSchema(SHARED_STAGING), "datacatalogue3/stagingShared/molgenis.csv");
     }
   }
 }

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueLoader.java
@@ -1,21 +1,17 @@
 package org.molgenis.emx2.datamodels;
 
-import java.io.InputStreamReader;
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.Privileges;
 import org.molgenis.emx2.Schema;
-import org.molgenis.emx2.SchemaMetadata;
 import org.molgenis.emx2.io.MolgenisIO;
-import org.molgenis.emx2.io.emx2.Emx2;
-import org.molgenis.emx2.io.readers.CsvTableReader;
 import org.molgenis.emx2.sql.SqlDatabase;
 
-public class DataCatalogueLoader implements AvailableDataModels.DataModelLoader {
+public class DataCatalogueLoader extends AbstractDataLoader {
 
   public static final String CATALOGUE_ONTOLOGIES = "CatalogueOntologies";
 
   @Override
-  public void load(Schema schema, boolean includeDemoData) {
+  void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     // create ontology schema
     Database db = schema.getDatabase();
     Schema ontologySchema = db.getSchema(CATALOGUE_ONTOLOGIES);
@@ -25,7 +21,7 @@ public class DataCatalogueLoader implements AvailableDataModels.DataModelLoader 
     }
 
     // create catalogue schema (which will create tables in ontology schema)
-    createSchema(schema, "datacatalogue/molgenis.csv");
+    this.createSchema(schema, "datacatalogue/molgenis.csv");
     schema.addMember(SqlDatabase.ANONYMOUS, Privileges.VIEWER.toString());
 
     // load data into ontology schema
@@ -35,14 +31,5 @@ public class DataCatalogueLoader implements AvailableDataModels.DataModelLoader 
     if (includeDemoData) {
       MolgenisIO.fromClasspathDirectory("datacatalogue/Cohorts", schema, false);
     }
-  }
-
-  public static void createSchema(Schema schema, String path) {
-    SchemaMetadata metadata =
-        Emx2.fromRowList(
-            CsvTableReader.read(
-                new InputStreamReader(
-                    DataCatalogueLoader.class.getClassLoader().getResourceAsStream(path))));
-    schema.migrate(metadata);
   }
 }

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueLoader3.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueLoader3.java
@@ -1,19 +1,15 @@
 package org.molgenis.emx2.datamodels;
 
-import java.io.InputStreamReader;
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.Schema;
-import org.molgenis.emx2.SchemaMetadata;
 import org.molgenis.emx2.io.MolgenisIO;
-import org.molgenis.emx2.io.emx2.Emx2;
-import org.molgenis.emx2.io.readers.CsvTableReader;
 
-public class DataCatalogueLoader3 implements AvailableDataModels.DataModelLoader {
+public class DataCatalogueLoader3 extends AbstractDataLoader {
 
   public static final String CATALOGUE_ONTOLOGIES = "CatalogueOntologies";
 
   @Override
-  public void load(Schema schema, boolean includeDemoData) {
+  void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     // create ontology schema
     Database db = schema.getDatabase();
     Schema ontologySchema = db.getSchema(CATALOGUE_ONTOLOGIES);
@@ -31,14 +27,5 @@ public class DataCatalogueLoader3 implements AvailableDataModels.DataModelLoader
     if (includeDemoData) {
       MolgenisIO.fromClasspathDirectory("datacatalogue3/Cohorts", schema, false);
     }
-  }
-
-  public static void createSchema(Schema schema, String path) {
-    SchemaMetadata metadata =
-        Emx2.fromRowList(
-            CsvTableReader.read(
-                new InputStreamReader(
-                    DataCatalogueLoader3.class.getClassLoader().getResourceAsStream(path))));
-    schema.migrate(metadata);
   }
 }

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueNetworkStagingLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueNetworkStagingLoader.java
@@ -1,16 +1,15 @@
 package org.molgenis.emx2.datamodels;
 
 import static org.molgenis.emx2.datamodels.DataCatalogueCohortStagingLoader.createSharedSchema;
-import static org.molgenis.emx2.datamodels.DataCatalogueLoader.createSchema;
 
 import org.molgenis.emx2.Schema;
 
-public class DataCatalogueNetworkStagingLoader implements AvailableDataModels.DataModelLoader {
+public class DataCatalogueNetworkStagingLoader extends AbstractDataLoader {
 
   static final String SHARED_STAGING = "SharedStaging";
 
   @Override
-  public void load(Schema schema, boolean includeDemoData) {
+  void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     // create shared schemas
     createSharedSchema(schema.getDatabase());
 

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueNetworkStagingLoader3.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueNetworkStagingLoader3.java
@@ -1,16 +1,15 @@
 package org.molgenis.emx2.datamodels;
 
-import static org.molgenis.emx2.datamodels.DataCatalogueCohortStagingLoader3.createDataCatalogue3;
-import static org.molgenis.emx2.datamodels.DataCatalogueLoader.createSchema;
+import static org.molgenis.emx2.datamodels.DataCatalogueCohortStagingLoader3.createSharedStaging;
 
 import org.molgenis.emx2.Schema;
 
-public class DataCatalogueNetworkStagingLoader3 implements AvailableDataModels.DataModelLoader {
+public class DataCatalogueNetworkStagingLoader3 extends AbstractDataLoader {
 
   @Override
-  public void load(Schema schema, boolean includeDemoData) {
+  public void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     // create shared schemas
-    createDataCatalogue3(schema.getDatabase());
+    createSharedStaging(schema.getDatabase());
 
     // create the schema
     createSchema(schema, "datacatalogue3/stagingNetworks/molgenis.csv");

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueNetworkStagingLoader3.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataCatalogueNetworkStagingLoader3.java
@@ -1,6 +1,6 @@
 package org.molgenis.emx2.datamodels;
 
-import static org.molgenis.emx2.datamodels.DataCatalogueCohortStagingLoader3.createSharedStaging;
+import static org.molgenis.emx2.datamodels.DataCatalogueCohortStagingLoader3.createSharedStaging3;
 
 import org.molgenis.emx2.Schema;
 
@@ -9,7 +9,7 @@ public class DataCatalogueNetworkStagingLoader3 extends AbstractDataLoader {
   @Override
   public void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     // create shared schemas
-    createSharedStaging(schema.getDatabase());
+    createSharedStaging3(schema.getDatabase());
 
     // create the schema
     createSchema(schema, "datacatalogue3/stagingNetworks/molgenis.csv");

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/FAIRDataHubLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/FAIRDataHubLoader.java
@@ -1,16 +1,12 @@
 package org.molgenis.emx2.datamodels;
 
-import java.io.InputStreamReader;
 import org.molgenis.emx2.Schema;
-import org.molgenis.emx2.SchemaMetadata;
 import org.molgenis.emx2.io.MolgenisIO;
-import org.molgenis.emx2.io.emx2.Emx2;
-import org.molgenis.emx2.io.readers.CsvTableReader;
 
-public class FAIRDataHubLoader implements AvailableDataModels.DataModelLoader {
+public class FAIRDataHubLoader extends AbstractDataLoader {
 
   @Override
-  public void load(Schema schema, boolean includeDemoData) {
+  void loadInternalImplementation(Schema schema, boolean includeDemoData) {
 
     // create Beacon v2 + FAIR Data Point schema (which will create tables in ontology schema)
     createSchema(schema, "fairdatahub/beaconv2/molgenis.csv");
@@ -27,14 +23,5 @@ public class FAIRDataHubLoader implements AvailableDataModels.DataModelLoader {
       MolgenisIO.fromClasspathDirectory("fairdatahub/beaconv2/demodata", schema, false);
       MolgenisIO.fromClasspathDirectory("fairdatahub/fairdatapoint/demodata", schema, false);
     }
-  }
-
-  public static void createSchema(Schema schema, String path) {
-    SchemaMetadata metadata =
-        Emx2.fromRowList(
-            CsvTableReader.read(
-                new InputStreamReader(
-                    FAIRDataHubLoader.class.getClassLoader().getResourceAsStream(path))));
-    schema.migrate(metadata);
   }
 }

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/PetStoreLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/PetStoreLoader.java
@@ -7,7 +7,7 @@ import static org.molgenis.emx2.TableMetadata.table;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.sql.SqlDatabase;
 
-public class PetStoreLoader implements AvailableDataModels.DataModelLoader {
+public class PetStoreLoader extends AbstractDataLoader {
 
   public static final String CATEGORY = "Category";
   public static final String TAG = "Tag";
@@ -80,7 +80,7 @@ public class PetStoreLoader implements AvailableDataModels.DataModelLoader {
   }
 
   @Override
-  public void load(Schema schema, boolean includeDemoData) {
+  void loadInternalImplementation(Schema schema, boolean includeDemoData) {
     schema.migrate(getSchemaMetadata());
     if (includeDemoData) {
       loadExampleData(schema);

--- a/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/TestLoaders.java
+++ b/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/TestLoaders.java
@@ -13,9 +13,6 @@ import org.molgenis.emx2.sql.TestDatabaseFactory;
 @OrderWith(Alphanumeric.class)
 public class TestLoaders {
   public static final String DATA_CATALOGUE3 = "data-catalogue";
-  public static final String RWE_CATALOGUE = "RWEcatalogue";
-  //  public static final String COHORT_STAGING = "CohortStaging";
-  //  public static final String NETWORK_STAGING = "NetworkStaging";
   public static final String COHORT_STAGING_3 = "CohortStaging3";
   public static final String NETWORK_STAGING_3 = "NetworkStaging3";
   public static final String FAIR_DATA_HUB_TEST = "FAIRDataHubTest";
@@ -26,9 +23,6 @@ public class TestLoaders {
     database = TestDatabaseFactory.getTestDatabase();
     // prevend previous dangling test results
     database.dropSchemaIfExists(DATA_CATALOGUE3);
-    // database.dropSchemaIfExists(RWE_CATALOGUE);
-    //    database.dropSchemaIfExists(COHORT_STAGING);
-    //    database.dropSchemaIfExists(NETWORK_STAGING);
     database.dropSchemaIfExists(COHORT_STAGING_3);
     database.dropSchemaIfExists(NETWORK_STAGING_3);
   }
@@ -46,28 +40,6 @@ public class TestLoaders {
     AvailableDataModels.DATA_CATALOGUE3.install(dataCatalogue, true);
     assertEquals(33, dataCatalogue.getTableNames().size());
   }
-
-  //  @Test
-  //  public void test3RWECatalogue() {
-  //    Schema rweCatalogue = database.dropCreateSchema(RWE_CATALOGUE);
-  //    AvailableDataModels.DATA_CATALOGUE3.install(rweCatalogue, false);
-  //    MolgenisIO.fromClasspathDirectory("datacatalogue/RWEcatalogue", rweCatalogue, false);
-  //  }
-
-  //  @Test
-  //  public void test4DataCatalogueCohortStagingLoader() {
-  //    Schema cohortStaging = database.dropCreateSchema(COHORT_STAGING);
-  //    AvailableDataModels.DATA_CATALOGUE_COHORT_STAGING.install(cohortStaging, true);
-  //    assertEquals(18, cohortStaging.getTableNames().size());
-  //  }
-  //
-  //  @Test
-  //  public void test5DataCatalogueNetworkStagingLoader() {
-  //    Schema networkStaging = database.dropCreateSchema(NETWORK_STAGING);
-  //    // cleanSharedSchemas();
-  //    AvailableDataModels.DATA_CATALOGUE_NETWORK_STAGING.install(networkStaging, true);
-  //    assertEquals(13, networkStaging.getTableNames().size());
-  //  }
 
   @Test
   public void test7DataCatalogueCohortStagingLoader3() {

--- a/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/TestLoaders.java
+++ b/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/TestLoaders.java
@@ -1,9 +1,6 @@
 package org.molgenis.emx2.datamodels;
 
 import static org.junit.Assert.assertEquals;
-import static org.molgenis.emx2.datamodels.DataCatalogueCohortStagingLoader.DATA_CATALOGUE;
-import static org.molgenis.emx2.datamodels.DataCatalogueLoader.CATALOGUE_ONTOLOGIES;
-import static org.molgenis.emx2.datamodels.DataCatalogueNetworkStagingLoader.SHARED_STAGING;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -11,15 +8,14 @@ import org.junit.runner.OrderWith;
 import org.junit.runner.manipulation.Alphanumeric;
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.Schema;
-import org.molgenis.emx2.io.MolgenisIO;
 import org.molgenis.emx2.sql.TestDatabaseFactory;
 
 @OrderWith(Alphanumeric.class)
 public class TestLoaders {
-  public static final String DATA_CATALOGUE1 = "data-catalogue";
+  public static final String DATA_CATALOGUE3 = "data-catalogue";
   public static final String RWE_CATALOGUE = "RWEcatalogue";
-  public static final String COHORT_STAGING = "CohortStaging";
-  public static final String NETWORK_STAGING = "NetworkStaging";
+  //  public static final String COHORT_STAGING = "CohortStaging";
+  //  public static final String NETWORK_STAGING = "NetworkStaging";
   public static final String COHORT_STAGING_3 = "CohortStaging3";
   public static final String NETWORK_STAGING_3 = "NetworkStaging3";
   public static final String FAIR_DATA_HUB_TEST = "FAIRDataHubTest";
@@ -29,10 +25,10 @@ public class TestLoaders {
   public static void setup() {
     database = TestDatabaseFactory.getTestDatabase();
     // prevend previous dangling test results
-    database.dropSchemaIfExists(DATA_CATALOGUE1);
-    database.dropSchemaIfExists(RWE_CATALOGUE);
-    database.dropSchemaIfExists(COHORT_STAGING);
-    database.dropSchemaIfExists(NETWORK_STAGING);
+    database.dropSchemaIfExists(DATA_CATALOGUE3);
+    // database.dropSchemaIfExists(RWE_CATALOGUE);
+    //    database.dropSchemaIfExists(COHORT_STAGING);
+    //    database.dropSchemaIfExists(NETWORK_STAGING);
     database.dropSchemaIfExists(COHORT_STAGING_3);
     database.dropSchemaIfExists(NETWORK_STAGING_3);
   }
@@ -46,79 +42,44 @@ public class TestLoaders {
 
   @Test
   public void test2DataCatalogueLoader() {
-    // staging catalogues will create 'DataCatalogue' and
-    Schema dataCatalogue = database.dropCreateSchema(DATA_CATALOGUE1);
-    cleanSharedSchemas();
-
-    AvailableDataModels.DATA_CATALOGUE.install(dataCatalogue, true);
-    assertEquals(37, dataCatalogue.getTableNames().size());
-
-    // cleanup because shared schema
-    database.dropSchema(DATA_CATALOGUE1);
+    Schema dataCatalogue = database.dropCreateSchema(DATA_CATALOGUE3);
+    AvailableDataModels.DATA_CATALOGUE3.install(dataCatalogue, true);
+    assertEquals(33, dataCatalogue.getTableNames().size());
   }
 
-  @Test
-  public void test3RWECatalogue() {
-    Schema rweCatalogue = database.dropCreateSchema(RWE_CATALOGUE);
+  //  @Test
+  //  public void test3RWECatalogue() {
+  //    Schema rweCatalogue = database.dropCreateSchema(RWE_CATALOGUE);
+  //    AvailableDataModels.DATA_CATALOGUE3.install(rweCatalogue, false);
+  //    MolgenisIO.fromClasspathDirectory("datacatalogue/RWEcatalogue", rweCatalogue, false);
+  //  }
 
-    cleanSharedSchemas();
-    AvailableDataModels.DATA_CATALOGUE.install(rweCatalogue, false);
-    MolgenisIO.fromClasspathDirectory("datacatalogue/RWEcatalogue", rweCatalogue, false);
-
-    // cleanup because shared schema
-    database.dropSchemaIfExists(RWE_CATALOGUE);
-  }
-
-  @Test
-  public void test4DataCatalogueCohortStagingLoader() {
-    Schema cohortStaging = database.dropCreateSchema(COHORT_STAGING);
-    cleanSharedSchemas();
-
-    AvailableDataModels.DATA_CATALOGUE_COHORT_STAGING.install(cohortStaging, true);
-    assertEquals(18, cohortStaging.getTableNames().size());
-
-    // cleanup because shared schema
-    database.dropSchemaIfExists(COHORT_STAGING);
-  }
-
-  @Test
-  public void test5DataCatalogueNetworkStagingLoader() {
-    Schema networkStaging = database.dropCreateSchema(NETWORK_STAGING);
-    cleanSharedSchemas();
-    AvailableDataModels.DATA_CATALOGUE_NETWORK_STAGING.install(networkStaging, true);
-    assertEquals(13, networkStaging.getTableNames().size());
-
-    // cleanup because shared schema
-    database.dropSchemaIfExists(NETWORK_STAGING);
-  }
+  //  @Test
+  //  public void test4DataCatalogueCohortStagingLoader() {
+  //    Schema cohortStaging = database.dropCreateSchema(COHORT_STAGING);
+  //    AvailableDataModels.DATA_CATALOGUE_COHORT_STAGING.install(cohortStaging, true);
+  //    assertEquals(18, cohortStaging.getTableNames().size());
+  //  }
+  //
+  //  @Test
+  //  public void test5DataCatalogueNetworkStagingLoader() {
+  //    Schema networkStaging = database.dropCreateSchema(NETWORK_STAGING);
+  //    // cleanSharedSchemas();
+  //    AvailableDataModels.DATA_CATALOGUE_NETWORK_STAGING.install(networkStaging, true);
+  //    assertEquals(13, networkStaging.getTableNames().size());
+  //  }
 
   @Test
   public void test7DataCatalogueCohortStagingLoader3() {
     Schema cohortStaging3 = database.dropCreateSchema(COHORT_STAGING_3);
-    cleanSharedSchemas();
-
     AvailableDataModels.DATA_CATALOGUE_COHORT_STAGING3.install(cohortStaging3, true);
     assertEquals(19, cohortStaging3.getTableNames().size());
-
-    // cleanup because shared schema
-    database.dropSchemaIfExists(COHORT_STAGING_3);
   }
 
   @Test
   public void test8DataCatalogueNetworkStagingLoader3() {
     Schema networkStaging3 = database.dropCreateSchema(NETWORK_STAGING_3);
-    cleanSharedSchemas();
-
     AvailableDataModels.DATA_CATALOGUE_NETWORK_STAGING3.install(networkStaging3, true);
     assertEquals(16, networkStaging3.getTableNames().size());
-
-    // cleanup because shared schema
-    database.dropSchemaIfExists(NETWORK_STAGING_3);
-  }
-
-  private static void cleanSharedSchemas() {
-    database.dropSchemaIfExists(DATA_CATALOGUE);
-    database.dropSchemaIfExists(SHARED_STAGING);
-    database.dropSchemaIfExists(CATALOGUE_ONTOLOGIES);
   }
 }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
@@ -348,8 +348,8 @@ public class SqlColumnExecutor {
     if (c.isReference() && !c.isOntology() && c.getRefTable() == null) {
       throw new MolgenisException(
           String.format(
-              "Add column '%s.%s' failed: 'refTable' required for columns of type REF, REF_ARRAY, REFBACK",
-              c.getTableName(), c.getName()));
+              "Add column '%s.%s' failed: 'refTable' required for columns of type REF, REF_ARRAY, REFBACK (tried to find: %s:%s)",
+              c.getTableName(), c.getName(), c.getRefSchema(), c.getRefTableName()));
     }
     if (c.getRefLink() != null) {
       if (c.getTable().getColumn(c.getRefLink()) == null) {

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/RunMolgenisEmx2.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/RunMolgenisEmx2.java
@@ -3,7 +3,7 @@ package org.molgenis.emx2;
 import static org.molgenis.emx2.ColumnType.BOOL;
 import static org.molgenis.emx2.ColumnType.INT;
 
-import org.molgenis.emx2.datamodels.DataCatalogueLoader;
+import org.molgenis.emx2.datamodels.AvailableDataModels;
 import org.molgenis.emx2.datamodels.PetStoreLoader;
 import org.molgenis.emx2.sql.SqlDatabase;
 import org.molgenis.emx2.utils.EnvironmentProperty;
@@ -45,7 +45,7 @@ public class RunMolgenisEmx2 {
 
       if (INCLUDE_CATALOGUE_DEMO && db.getSchema("catalogue") == null) {
         Schema schema = db.createSchema("catalogue");
-        new DataCatalogueLoader().load(schema, true);
+        AvailableDataModels.DATA_CATALOGUE.install(schema, true);
       }
 
     } finally {

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -1,5 +1,6 @@
 package org.molgenis.emx2.web;
 
+import static com.github.stefanbirkner.systemlambda.SystemLambda.withEnvironmentVariable;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.CoreMatchers.equalTo;
@@ -7,7 +8,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.*;
 import static org.molgenis.emx2.ColumnType.STRING;
 import static org.molgenis.emx2.Constants.MOLGENIS_HTTP_PORT;
-import static org.molgenis.emx2.RunMolgenisEmx2.INCLUDE_CATALOGUE_DEMO;
+import static org.molgenis.emx2.Constants.MOLGENIS_INCLUDE_CATALOGUE_DEMO;
 import static org.molgenis.emx2.sql.SqlDatabase.ADMIN_PW_DEFAULT;
 import static org.molgenis.emx2.sql.SqlDatabase.ANONYMOUS;
 import static org.molgenis.emx2.web.Constants.*;
@@ -44,25 +45,25 @@ public class WebApiSmokeTests {
   private static Database db;
   private static Schema schema;
   final String CSV_TEST_SCHEMA = "pet store csv";
-  static final int PORT = 8080;
+  static final int PORT = 8081; // other then default so we can see effect
 
   @BeforeClass
-  public static void before() throws IOException {
+  public static void before() throws Exception {
 
     // setup test schema
     db = TestDatabaseFactory.getTestDatabase();
 
-    // will be created by the RunMolgenisEmx2.main
+    // will be (re)created by the RunMolgenisEmx2.main
     db.dropSchemaIfExists("pet store");
+    db.dropSchemaIfExists("catalogue");
 
     // start web service for testing, including env variables
-    RunMolgenisEmx2.main(
-        new String[] {
-          "-D" + MOLGENIS_HTTP_PORT + "=" + PORT, "-D" + INCLUDE_CATALOGUE_DEMO + "=TRUE"
-        });
+    withEnvironmentVariable(MOLGENIS_HTTP_PORT, "" + PORT)
+        .and(MOLGENIS_INCLUDE_CATALOGUE_DEMO, "true")
+        .execute(() -> RunMolgenisEmx2.main(new String[] {}));
 
     // set default rest assured settings
-    RestAssured.port = Integer.valueOf(PORT);
+    RestAssured.port = PORT;
     RestAssured.baseURI = "http://localhost";
 
     // create an admin session to work with


### PR DESCRIPTION
motivation: increase test coverage, and make more robust. 

todo:
- [x] refactored the data loaders to prevent they are run in the wrong way, without using the transaction wrapper
- [x] then added environment variable option for the test so we can test also the loading of demo data at startup
- [x] stop testing with 'old' catalogue data model because we get conflicting names because 'datacatalogue' and 'sharedstaging' have same schema names (and I hope we will delete these models anyway next sprint)