### PR TITLE
Feat: new schema template for dashboards

### DIFF
--- a/apps/central/src/components/SchemaCreateModal.vue
+++ b/apps/central/src/components/SchemaCreateModal.vue
@@ -124,6 +124,7 @@ export default {
         "DATA_CATALOGUE_COHORT_STAGING",
         "DATA_CATALOGUE_NETWORK_STAGING",
         "RD3",
+        "DASHBOARD"
       ],
       includeDemoData: false,
     };

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/AvailableDataModels.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/AvailableDataModels.java
@@ -8,7 +8,8 @@ public enum AvailableDataModels {
   DATA_CATALOGUE(new DataCatalogueLoader()),
   PET_STORE(new PetStoreLoader()),
   FAIR_DATA_HUB(new FAIRDataHubLoader()),
-  RD3(new Rd3Loader());
+  RD3(new Rd3Loader()),
+  Dashboard(new DashboardLoader());
 
   private AbstractDataLoader installer;
 

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DashboardLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DashboardLoader.java
@@ -1,0 +1,12 @@
+package org.molgenis.emx2.datamodels;
+
+import org.molgenis.emx2.Schema;
+import org.molgenis.emx2.io.MolgenisIO;
+
+public class DashboardLoader extends AbstractDataLoader {
+
+  @Override
+  void loadInternalImplementation(Schema schema, boolean includeDemoData) {
+    createSchema(schema, "dasboard/molgenis.csv");
+  }
+}

--- a/data/dashboard/molgenis.csv
+++ b/data/dashboard/molgenis.csv
@@ -1,0 +1,27 @@
+tableName,tableType,tableExtends,columnName,columnType,key,required,refTable,refBack,semantics,description
+inclusionCriteria,,,,,,,,,,Define or modify inclusion criteria for each subgroup
+inclusionCriteria,,,id,string,1,TRUE,,,http://purl.obolibrary.org/obo/NCIT_C25364,A unique ID used to identify a group
+inclusionCriteria,,,name,string,,,,,https://schema.org/name,A unique ID used to identify a group
+inclusionCriteria,,,criteria,heading,,,,,,An inclusion criteria
+inclusionCriteria,,,type,string,,,,,,"A variable to identify criteria for a specific group (e.g., ""genes"", ""disease"", etc.)"
+inclusionCriteria,,,value,string,,,,,http://www.w3.org/ns/prov#value,"values used to select rows (IDs, codes, etc.)"
+inclusionCriteria,,,label,string,,,,,http://www.w3.org/2000/01/rdf-schema#label,additional context that describes the criteria
+dataproviders,,,,,,,,,,Information about organisations within the context of the project
+dataproviders,,,providerIdentifier,string,1,TRUE,,,http://purl.obolibrary.org/obo/NCIT_C25364,
+dataproviders,,,organisation,ref,,,organisations,,http://purl.obolibrary.org/obo/NCIT_C25412,
+dataproviders,,,hasSubmittedData,bool,,,,,http://purl.obolibrary.org/obo/NCIT_C172872,"An indication that a file, record, or dataset has been sbmitted to a data repository"
+statistics,,,,,,,,,http://purl.obolibrary.org/obo/STATO_0000039,A set label-value pairs containing calculations to be used in the dashboard
+statistics,,,id,string,1,TRUE,,,http://purl.obolibrary.org/obo/NCIT_C25364,A unique identifier for each label-value pair
+statistics,,,label,string,,,,,http://www.w3.org/2000/01/rdf-schema#label,A human readable name that describes the value. This is also the text that will be displayed in the dashboard.
+statistics,,,value,decimal,,,,,http://www.w3.org/ns/prov#value,The calculated value
+statistics,,,valueOrder,int,,,,,http://www.w3.org/ns/prov#order,A numerical value indicating the sorting method for a group of similar label-value pairs.
+statistics,,,component,ref,,,components,,http://www.w3.org/ns/prov#component,The name of the visualisation component that indicates where the label-value pair should be used.
+statistics,,,description,text,,,,,http://www.w3.org/ns/prov#definition,"A description of the label-value pair; e.g., calculation notes, etc."
+components,ONTOLOGIES,,,,,,,,http://www.w3.org/ns/prov#component,List of visualisation components used in the dashboard
+components,ONTOLOGIES,,statistics,refback,,,statistics,component,http://purl.obolibrary.org/obo/STATO_0000039,
+organisations,ONTOLOGIES,,,,,,,,http://purl.obolibrary.org/obo/NCIT_C25412,Information about organisations and where they are located
+organisations,ONTOLOGIES,,city,string,,,,,NCIT_C25160 http://purl.obolibrary.org/obo/NCIT_C25160,A large and densely populated urban area; a city specified in an address.
+organisations,ONTOLOGIES,,country,string,,,,,NCIT_C25464 http://purl.obolibrary.org/obo/NCIT_C25464,"A collective generic term that refers here to a wide variety of dependencies, areas of special sovereignty, uninhabited islands, and other entities in addition to the traditional countries or independent states."
+organisations,ONTOLOGIES,,latitude,decimal,,,,,NCIT_C68642 http://purl.obolibrary.org/obo/NCIT_C68642,The angular distance north or south between an imaginary line around a heavenly body parallel to its equator and the equator itself.
+organisations,ONTOLOGIES,,longitude,decimal,,,,,NCIT_C68643 http://purl.obolibrary.org/obo/NCIT_C68643,An imaginary great circle on the surface of a heavenly body passing through the poles at right angles to the equator.
+organisations,ONTOLOGIES,,providerInformation,refback,,,dataproviders,organisation,,


### PR DESCRIPTION
This request introduces a new template for creating schemas that are used in the dashboards. This includes the following tables.

## Model

### Tables
- Data providers: information on how organisations are progressing within the project and any other information (ref to organisations) 
- Inclusion Criteria: a table used for defining criteria for grouping similar records.
- Statistics: values and labels that will be displayed in the dashboard per visualisation component

### Ontologies
- Components: a list of visualisation components that are used in the dashboard (includes refbacks to `statistics`)
- Organisations (ontology): information about organisations and where they are located (includes refbacks to `dataproviders`)

By using refbacks, developers can request data from the the components and organisations tables.
 