### PR TITLE
chore: Update config ref

### DIFF
--- a/apps/nuxt3-ssr/app.vue
+++ b/apps/nuxt3-ssr/app.vue
@@ -82,8 +82,8 @@ useHead({
   ],
   titleTemplate: (titleChunk) => {
     return titleChunk
-      ? `${titleChunk} | ${config.siteTitle}`
-      : `${config.siteTitle}`;
+      ? `${titleChunk} | ${config.public.siteTitle}`
+      : `${config.public.siteTitle}`;
   },
 });
 </script>

--- a/apps/nuxt3-ssr/error.vue
+++ b/apps/nuxt3-ssr/error.vue
@@ -19,8 +19,8 @@ useHead({
   link: [{ rel: "stylesheet", type: "text/css", href: styleHref }],
   titleTemplate: (titleChunk) => {
     return titleChunk
-      ? `${titleChunk} | ${config.siteTitle}`
-      : `${config.siteTitle}`;
+      ? `${titleChunk} | ${config.public.siteTitle}`
+      : `${config.public.siteTitle}`;
   },
 });
 </script>


### PR DESCRIPTION
In future release the public config will no longer be the default, therefore explicitly use the public path in reference to public config setting. Removes deprication warning during dev.