### PR TITLE
fix(forms): can save draft when errors exist

### DIFF
--- a/apps/molgenis-components/src/components/forms/EditModal.vue
+++ b/apps/molgenis-components/src/components/forms/EditModal.vue
@@ -208,10 +208,10 @@ export default {
     saveDraftDisabledMessage() {
       if (
         this.tableMetaData?.columns.some(
-          (c) =>
-            c.key == 1 &&
-            c.columnType != "AUTO_ID" &&
-            this.rowData[c.id] == null
+          (column) =>
+            column.key === 1 &&
+            column.columnType !== "AUTO_ID" &&
+            this.rowData[column.id] === ""
         )
       ) {
         return "Cannot save draft: primary key is required";

--- a/apps/molgenis-components/src/components/forms/EditModal.vue
+++ b/apps/molgenis-components/src/components/forms/EditModal.vue
@@ -211,12 +211,12 @@ export default {
           (column) =>
             column.key === 1 &&
             column.columnType !== "AUTO_ID" &&
-            this.rowData[column.id] === ""
+            this.rowData[column.id] === null
         )
       ) {
         return "Cannot save draft: primary key is required";
       } else {
-        return null;
+        return "";
       }
     },
   },

--- a/apps/molgenis-components/src/components/forms/EditModal.vue
+++ b/apps/molgenis-components/src/components/forms/EditModal.vue
@@ -64,6 +64,7 @@
         :tableName="tableName"
         :errorMessage="errorMessage"
         :saveDisabledMessage="saveDisabledMessage"
+        :saveDraftDisabledMessage="saveDraftDisabledMessage"
         @cancel="handleClose"
         @saveDraft="handleSaveDraftRequest"
         @save="handleSaveRequest"
@@ -203,6 +204,20 @@ export default {
           errorFields,
         };
       });
+    },
+    saveDraftDisabledMessage() {
+      if (
+        this.tableMetaData?.columns.some(
+          (c) =>
+            c.key == 1 &&
+            c.columnType != "AUTO_ID" &&
+            this.rowData[c.id] == null
+        )
+      ) {
+        return "Cannot save draft: primary key is required";
+      } else {
+        return null;
+      }
     },
   },
   methods: {

--- a/apps/molgenis-components/src/components/forms/RowEditFooter.vue
+++ b/apps/molgenis-components/src/components/forms/RowEditFooter.vue
@@ -12,16 +12,21 @@
       <slot></slot>
       <ButtonAlt @click="$emit('cancel')"> Close</ButtonAlt>
       <Tooltip
-        name="disabled-save-tooltip"
-        :value="saveDisabledMessage ? saveDisabledMessage : ''"
+        name="disabled-draft-tooltip"
+        :value="saveDraftDisabledMessage ? saveDraftDisabledMessage : ''"
       >
         <ButtonOutline
           @click="$emit('saveDraft')"
-          :disabled="Boolean(saveDisabledMessage)"
+          :disabled="Boolean(saveDraftDisabledMessage)"
           class="mr-2 pr-3"
         >
           Save draft
         </ButtonOutline>
+      </Tooltip>
+      <Tooltip
+        name="disabled-save-tooltip"
+        :value="saveDisabledMessage ? saveDisabledMessage : ''"
+      >
         <ButtonAction
           @click="$emit('save')"
           :disabled="Boolean(saveDisabledMessage)"
@@ -47,13 +52,19 @@ const props = withDefaults(
     tableName: string;
     successMessage?: string;
     errorMessage?: string;
+    saveDraftDisabledMessage?: string;
     saveDisabledMessage?: string;
   }>(),
   { tableName: "" }
 );
 
-const { tableName, successMessage, errorMessage, saveDisabledMessage } =
-  toRefs(props);
+const {
+  tableName,
+  successMessage,
+  errorMessage,
+  saveDraftDisabledMessage,
+  saveDisabledMessage,
+} = toRefs(props);
 </script>
 
 <docs>
@@ -80,8 +91,12 @@ const { tableName, successMessage, errorMessage, saveDisabledMessage } =
       <RowEditFooter id="sample-error-msg" errorMessage="We have a problem" />
     </DemoItem>
      <DemoItem>
-      <label for="sample-error-msg">With disabled tooltip</label>
+      <label for="sample-error-msg">With disabled save tooltip</label>
       <RowEditFooter id="sample-error-msg" :saveDisabledMessage="'Disabled because it\'s an example'" />
+    </DemoItem>
+    <DemoItem>
+      <label for="sample-error-msg">With disabled draft tooltip</label>
+      <RowEditFooter id="sample-error-msg2" :saveDraftDisabledMessage="'Draft disabled because it\'s an example'" />
     </DemoItem>
   </div>
 </template>


### PR DESCRIPTION
point of draft is that it can be saved with errors, however, primary key is required

closes #2366 