### PR TITLE
stack overflow issue

### DIFF
--- a/apps/molgenis-components/src/components/forms/RowEdit.vue
+++ b/apps/molgenis-components/src/components/forms/RowEdit.vue
@@ -188,7 +188,6 @@ export default {
       this.$emit("errorsInForm", this.errorPerColumn);
     },
     applyComputed() {
-      //apply computed
       this.tableMetaData.columns.forEach((c) => {
         if (c.computed && c.columnType !== AUTO_ID) {
           try {
@@ -197,7 +196,6 @@ export default {
               this.internalValues,
               this.tableMetaData
             );
-            this.onValuesUpdate();
           } catch (error) {
             this.errorPerColumn[c.id] = "Computation failed: " + error;
           }


### PR DESCRIPTION
fixes: #2340

removed "onValuesUpdate" call from the "applyComputed" function. 
( Notice that "applyComputed" is only called from  "onValuesUpdate" creating a recursive function )

Removing it makes sure the update is called once and not near infinite times on big data sets.