### PR TITLE
feat(gportal): add dataset view

### DIFF
--- a/apps/gportal/src/components/Datasets.vue
+++ b/apps/gportal/src/components/Datasets.vue
@@ -1,0 +1,23 @@
+<template>
+  <div>
+    <RoutedTableExplorer
+      tableName="Dataset"
+      :showColumns="['id', 'title', 'description', 'publisher']"
+      :canEdit="false"
+      :canManage="false"
+    >
+      <template v-slot:rowheader="slotProps">
+        <ButtonAction href="todo">Request</ButtonAction>
+      </template>
+    </RoutedTableExplorer>
+  </div>
+</template>
+<script>
+import { RoutedTableExplorer, ButtonAction } from "molgenis-components";
+export default {
+  components: {
+    RoutedTableExplorer,
+    ButtonAction,
+  },
+};
+</script>

--- a/apps/gportal/src/components/Welcome.vue
+++ b/apps/gportal/src/components/Welcome.vue
@@ -1,0 +1,22 @@
+<template>
+  <div>
+    <h1>Welcome to genome data portal</h1>
+    <div>
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod
+      tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim
+      veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea
+      commodo consequat. Duis aute irure dolor in reprehenderit in voluptate
+      velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat
+      cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id
+      est laborum.
+    </div>
+    <RouterLink to="/datasets" class="btn btn-primary mr-2">
+      Navigate datasets
+    </RouterLink>
+    <RouterLink to="/beacon" class="btn btn-primary">Go to beacon</RouterLink>
+  </div>
+</template>
+
+<script setup>
+import { RouterLink } from "vue-router";
+</script>

--- a/apps/gportal/src/main.js
+++ b/apps/gportal/src/main.js
@@ -1,0 +1,33 @@
+import { createApp } from "vue";
+import { createRouter, createWebHashHistory } from "vue-router";
+import App from "./App.vue";
+import Datasets from "./components/Datasets.vue";
+import Beacon from "./components/Beacon.vue";
+import Welcome from "./components/Welcome.vue";
+
+import "molgenis-components/dist/style.css";
+
+const router = createRouter({
+  history: createWebHashHistory(),
+  routes: [
+    {
+      path: "/beacon",
+      component: Beacon,
+      props: true,
+    },
+    {
+      path: "/datasets",
+      component: Datasets,
+      props: true,
+    },
+    {
+      path: "/",
+      component: Welcome,
+      props: true,
+    },
+  ],
+});
+
+const app = createApp(App);
+app.use(router);
+app.mount("#app");


### PR DESCRIPTION
Add dataset view. This made me conclude that I believe we are better of by creating a more dedicated data model and then map to dcat than using the generic dcat. In other words, I believe we should start building GDI catalogue as soon as we can on top of data-catalogue. Because I really need specific details that match  my domain, not the generic dcat stuffs. But for now, here you go.