### PR TITLE
fix: force menu links with anchor reload

### DIFF
--- a/apps/molgenis-components/src/components/layout/MolgenisMenu.vue
+++ b/apps/molgenis-components/src/components/layout/MolgenisMenu.vue
@@ -38,6 +38,7 @@
               :href="addBaseUrl(sub.href)"
               :key="sub.label"
               :target="sub.newWindow ? '_blank' : '_self'"
+              @click="navigate(addBaseUrl(sub.href))"
               >{{ sub.label }}</a
             >
           </ButtonDropdown>
@@ -46,6 +47,7 @@
             class="nav-link"
             :href="addBaseUrl(item.href)"
             :target="item.newWindow ? '_blank' : '_self'"
+            @click="navigate(addBaseUrl(item.href))"
             >{{ item.label }}
           </a>
         </li>
@@ -125,6 +127,14 @@ export default {
         //relative paths use the baseURL
         return this.baseURL + (href ? href : "");
       }
+    },
+    navigate(href) {
+      window.location.href = href;
+      if (href.includes("#")) {
+        // Force reload to have our links with anchors work.
+        window.location.reload(true);
+      }
+      return false; // This makes the a tag not use its navigation
     },
     permitted(item) {
       if (!item.role) {


### PR DESCRIPTION
fixes: #2341

Our main menu knows nothing about the routing done in our app. Still we want to be able to link to the inside of our apps like `tables/#/Subject`.

This fix makes it possible by forcing a reload if there is a '#' in the url. 