### PR TITLE
fix: use id and not pid in cohort filter in variable explorer

### DIFF
--- a/apps/catalogue/src/views/VariableExplorer.vue
+++ b/apps/catalogue/src/views/VariableExplorer.vue
@@ -32,9 +32,7 @@
             refLabel="${id}"
             :maxNum="100"
             :orderBy="{ pid: 'ASC' }"
-            :filter="
-              network ? { networks: { pid: { equals: network } } } : null
-            "
+            :filter="network ? { networks: { id: { equals: network } } } : null"
           ></InputRefList>
         </div>
       </div>
@@ -207,6 +205,7 @@ export default {
     },
   },
   async created() {
+    this.$store.commit("setSearchInput", "");
     await this.fetchSchema();
     if (!this.variables.length) {
       // Only on initial creation


### PR DESCRIPTION
fixes: #2414

the filters use 'pid' but that data field is empty in the data, switched it to filter on 'id'
