### PR TITLE
fix: local builds on windows now show correct encoding with firefox

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -3,4 +3,5 @@ org.gradle.jvmargs=-Xmx2048M --add-exports jdk.compiler/com.sun.tools.javac.api=
   --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED \
   --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED \
-  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
+  --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED \
+  -Dfile.encoding=UTF-8


### PR DESCRIPTION
Fixes the issue that local builds on windows show incorrect characters when using firefox 