### PR TITLE
fix: order by ref column sort order

### DIFF
--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQuery.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQuery.java
@@ -149,32 +149,56 @@ public class TestQuery {
     assertEquals((Integer) 2, rows.get(0).getInteger("Mother-ID"));
   }
 
-  private Query selectPerson() {
-    return schema.getTable(PERSON).select(s("ID"), s("First_Name"), s("Last_Name"));
-  }
   @Test
   void  orderByRefColumnAsc() {
-    final String unorderd = selectPerson()
+    final String unorderd = schema
+            .getTable(PERSON)
+            .select(
+
+                    s("ID"),
+                    s("First_Name"),
+                    s("Last_Name"))
+
             .retrieveRows()
             .stream()
             .map(r -> r.getString("First_Name"))
             .collect(Collectors.joining(","));
 
 
-    final String orderdbyRefDefaultOrder = selectPerson().retrieveRows()
+    final String orderdbyRefDefaultOrder = schema
+            .getTable(PERSON)
+            .select(
+                s("ID"),
+                s("First_Name"),
+                s("Last_Name"))
+            .orderBy("Mother")
+            .retrieveRows()
                 .stream()
                 .map(r -> r.getString("First_Name"))
                 .collect(Collectors.joining(","));
 
 
-    final String orderdbyRefAsc = selectPerson()
+    final String orderdbyRefAsc = schema
+            .getTable(PERSON)
+            .select(
+                    s("ID"),
+                    s("First_Name"),
+                    s("Last_Name"))
+            .orderBy("Mother", Order.ASC)
             .retrieveRows()
             .stream()
             .map(r -> r.getString("First_Name"))
             .collect(Collectors.joining(","));
 
 
-    final String orderdbyRefDesc = selectPerson().retrieveRows()
+    final String orderdbyRefDesc = schema
+            .getTable(PERSON)
+            .select(
+                    s("ID"),
+                    s("First_Name"),
+                    s("Last_Name"))
+            .orderBy("Mother", Order.DESC)
+            .retrieveRows()
             .stream()
             .map(r -> r.getString("First_Name"))
             .collect(Collectors.joining(","));

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQuery.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQuery.java
@@ -10,6 +10,8 @@ import static org.molgenis.emx2.SelectColumn.s;
 import static org.molgenis.emx2.TableMetadata.table;
 
 import java.util.List;
+import java.util.stream.Collectors;
+
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.*;
@@ -146,4 +148,44 @@ public class TestQuery {
     assertEquals(1, rows.size());
     assertEquals((Integer) 2, rows.get(0).getInteger("Mother-ID"));
   }
+
+  private Query selectPerson() {
+    return schema.getTable(PERSON).select(s("ID"), s("First_Name"), s("Last_Name"));
+  }
+  @Test
+  void  orderByRefColumnAsc() {
+    final String unorderd = selectPerson()
+            .retrieveRows()
+            .stream()
+            .map(r -> r.getString("First_Name"))
+            .collect(Collectors.joining(","));
+
+
+    final String orderdbyRefDefaultOrder = selectPerson().retrieveRows()
+                .stream()
+                .map(r -> r.getString("First_Name"))
+                .collect(Collectors.joining(","));
+
+
+    final String orderdbyRefAsc = selectPerson()
+            .retrieveRows()
+            .stream()
+            .map(r -> r.getString("First_Name"))
+            .collect(Collectors.joining(","));
+
+
+    final String orderdbyRefDesc = selectPerson().retrieveRows()
+            .stream()
+            .map(r -> r.getString("First_Name"))
+            .collect(Collectors.joining(","));
+
+    assertEquals("Donald,Katrien,Kwik,Kwek,Kwak", unorderd);
+    assertEquals("Kwik,Kwek,Kwak,Donald,Katrien", orderdbyRefDefaultOrder);
+    assertEquals("Kwik,Kwek,Kwak,Donald,Katrien", orderdbyRefAsc);
+    assertEquals("Donald,Katrien,Kwik,Kwek,Kwak", orderdbyRefDesc);
+  }
+
+
+
+
 }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -1263,6 +1263,8 @@ public class SqlQuery extends QueryBean {
       } else {
         if (column.isReference()) {
           for (Reference ref : column.getReferences()) {
+//            query =
+//                    (SelectJoinStep<org.jooq.Record>) query.orderBy(field(name(ref.getName())).desc());
             query =
                 (SelectJoinStep<org.jooq.Record>) query.orderBy(field(name(ref.getName())).asc());
           }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -1263,10 +1263,8 @@ public class SqlQuery extends QueryBean {
       } else {
         if (column.isReference()) {
           for (Reference ref : column.getReferences()) {
-//            query =
-//                    (SelectJoinStep<org.jooq.Record>) query.orderBy(field(name(ref.getName())).desc());
             query =
-                (SelectJoinStep<org.jooq.Record>) query.orderBy(field(name(ref.getName())).asc());
+                (SelectJoinStep<org.jooq.Record>) query.orderBy(field(name(ref.getName())).desc());
           }
         } else {
           query = (SelectJoinStep<org.jooq.Record>) query.orderBy(field(name(col.getKey())).desc());


### PR DESCRIPTION
Note: PR adds failing test to show issue
Note2: Inversion of control with simple unit test for branches (default, asc, desc, ref , no ref) could have prevented typo from reaching release