### PR TITLE
fix: row edit

### DIFF
--- a/apps/molgenis-components/src/components/forms/RowEdit.vue
+++ b/apps/molgenis-components/src/components/forms/RowEdit.vue
@@ -102,7 +102,7 @@ export default {
     },
     errorPerColumn: {
       type: Object,
-      default: () => {},
+      default: () => ({}),
     },
   },
   emits: ["update:modelValue", "errorsInForm"],


### PR DESCRIPTION
errorPerColumn should return empty object by default ( instead of undefined)