### PR TITLE
feat: Add datasets/subcohorts info card to landing

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/index.vue
@@ -168,7 +168,7 @@ function getSettingValue(settingKey: string, settings: ISetting[]) {
           getSettingValue(
             "CATALOGUE_LANDING_PARTICIPANTS_TEXT",
             data.data._settings
-          ) || "The cumulative number of participants of all datasets combined."
+          ) || "The cumulative number of participants of all cohorts and subcohorts combined."
         }}
       </LandingCardSecondary>
 

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/index.vue
@@ -47,8 +47,8 @@ const { data, pending, error, refresh } = await useFetch(
           "CATALOGUE_LANDING_SAMPLES_TEXT"
           "CATALOGUE_LANDING_DESIGN_LABEL"
           "CATALOGUE_LANDING_DESIGN_TEXT"
-          "CATALOGUE_LANDING_DATASETS_LABEL"
-          "CATALOGUE_LANDING_DATASETS_TEXT"
+          "CATALOGUE_LANDING_SUBCOHORTS_LABEL"
+          "CATALOGUE_LANDING_SUBCOHORTS_TEXT"
         ]){ 
           key
           value 
@@ -223,17 +223,17 @@ function getSettingValue(settingKey: string, settings: ISetting[]) {
           {{ data.data.Subcohorts_agg.count }}
           {{
             getSettingValue(
-              "CATALOGUE_LANDING_DATASETS_LABEL",
+              "CATALOGUE_LANDING_SUBCOHORTS_LABEL",
               data.data._settings
-            ) || "Datasets"
+            ) || "Subcohorts"
           }}
         </b>
         <br />
         {{
           getSettingValue(
-            "CATALOGUE_LANDING_DATASETS_TEXT",
+            "CATALOGUE_LANDING_SUBCOHORTS_TEXT",
             data.data._settings
-          ) || "The total number of datasets / subcohorts included "
+          ) || "The total number of subcohorts included"
         }}
       </LandingCardSecondary>
     </div>

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/index.vue
@@ -19,6 +19,9 @@ const { data, pending, error, refresh } = await useFetch(
             numberOfParticipantsWithSamples 
           }
         }
+        Subcohorts_agg {
+          count
+        }
         Networks_agg { 
           count
         }
@@ -44,6 +47,8 @@ const { data, pending, error, refresh } = await useFetch(
           "CATALOGUE_LANDING_SAMPLES_TEXT"
           "CATALOGUE_LANDING_DESIGN_LABEL"
           "CATALOGUE_LANDING_DESIGN_TEXT"
+          "CATALOGUE_LANDING_DATASETS_LABEL"
+          "CATALOGUE_LANDING_DATASETS_TEXT"
         ]){ 
           key
           value 
@@ -186,7 +191,7 @@ function getSettingValue(settingKey: string, settings: ISetting[]) {
             "CATALOGUE_LANDING_SAMPLES_TEXT",
             data.data._settings
           ) ||
-          "The cumulative number of participants with samples collected of all datasets combined."
+          "The cumulative number of participants with samples collected of all datasets combined"
         }}
       </LandingCardSecondary>
 
@@ -211,6 +216,25 @@ function getSettingValue(settingKey: string, settings: ISetting[]) {
           ) || "Percentage of longitudinal datasets. The remaining datasets are"
         }}
         cross-sectional.
+      </LandingCardSecondary>
+
+      <LandingCardSecondary icon="viewTable">
+        <b>
+          {{ data.data.Subcohorts_agg.count }}
+          {{
+            getSettingValue(
+              "CATALOGUE_LANDING_DATASETS_LABEL",
+              data.data._settings
+            ) || "Datasets"
+          }}
+        </b>
+        <br />
+        {{
+          getSettingValue(
+            "CATALOGUE_LANDING_DATASETS_TEXT",
+            data.data._settings
+          ) || "The total number of datasets / subcohorts included "
+        }}
       </LandingCardSecondary>
     </div>
   </LayoutsLandingPage>

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/index.vue
@@ -168,7 +168,7 @@ function getSettingValue(settingKey: string, settings: ISetting[]) {
           getSettingValue(
             "CATALOGUE_LANDING_PARTICIPANTS_TEXT",
             data.data._settings
-          ) || "The cumulative number of participants of all cohorts and subcohorts combined."
+          ) || "The cumulative number of participants of all (sub)cohorts combined."
         }}
       </LandingCardSecondary>
 
@@ -191,7 +191,7 @@ function getSettingValue(settingKey: string, settings: ISetting[]) {
             "CATALOGUE_LANDING_SAMPLES_TEXT",
             data.data._settings
           ) ||
-          "The cumulative number of participants with samples collected of all datasets combined"
+          "The cumulative number of participants with samples collected of all (sub)cohorts combined"
         }}
       </LandingCardSecondary>
 

--- a/docs/catalogue/cat_server_side-rendered.md
+++ b/docs/catalogue/cat_server_side-rendered.md
@@ -85,9 +85,9 @@ The label shown on landing CTA element for each of the main sections
 
 ```CATALOGUE_LANDING_DESIGN_TEXT```
 
-```CATALOGUE_LANDING_DATASETS_LABEL```
+```CATALOGUE_LANDING_SUBCOHORTS_LABEL```
 
-```CATALOGUE_LANDING_DATASETS_TEXT```
+```CATALOGUE_LANDING_SUBCOHORTS_TEXT```
 
 
 #### default

--- a/docs/catalogue/cat_server_side-rendered.md
+++ b/docs/catalogue/cat_server_side-rendered.md
@@ -85,6 +85,10 @@ The label shown on landing CTA element for each of the main sections
 
 ```CATALOGUE_LANDING_DESIGN_TEXT```
 
+```CATALOGUE_LANDING_DATASETS_LABEL```
+
+```CATALOGUE_LANDING_DATASETS_TEXT```
+
 
 #### default
 - CATALOGUE_LANDING_PARTICIPANTS_LABEL: *Participants*
@@ -94,7 +98,9 @@ The label shown on landing CTA element for each of the main sections
         all datasets combined.*
 - CATALOGUE_LANDING_DESIGN_LABEL: *Longitudinal*
 - CATALOGUE_LANDING_DESIGN_TEXT: *Percentage of longitudinal datasets. The remaining datasets are
-        cross-sectional.*
+        cross-sectional*
+- CATALOGUE_LANDING_DATASETS_LABEL: *Datasets*
+- CATALOGUE_LANDING_DATASETS_TEXT: *The total number of datasets / subcohorts included*
 
 
 

--- a/docs/catalogue/cat_server_side-rendered.md
+++ b/docs/catalogue/cat_server_side-rendered.md
@@ -99,8 +99,8 @@ The label shown on landing CTA element for each of the main sections
 - CATALOGUE_LANDING_DESIGN_LABEL: *Longitudinal*
 - CATALOGUE_LANDING_DESIGN_TEXT: *Percentage of longitudinal datasets. The remaining datasets are
         cross-sectional*
-- CATALOGUE_LANDING_DATASETS_LABEL: *Datasets*
-- CATALOGUE_LANDING_DATASETS_TEXT: *The total number of datasets / subcohorts included*
+- CATALOGUE_LANDING_SUBCOHORTS_LABEL: *Subcohorts*
+- CATALOGUE_LANDING_SUBCOHORTS_TEXT: *The total number of subcohorts included*
 
 
 


### PR DESCRIPTION
note: default label and text can be overridden via setting ( see docs )