### PR TITLE
fix: improve ssr style cache busting dev setup

### DIFF
--- a/apps/nuxt3-ssr/.gitignore
+++ b/apps/nuxt3-ssr/.gitignore
@@ -7,4 +7,4 @@ node_modules
 .env
 dist
 public/_nuxt-styles/css/styles*
-utils/fingerprint.js
+.fingerprint.js

--- a/apps/nuxt3-ssr/app.vue
+++ b/apps/nuxt3-ssr/app.vue
@@ -60,7 +60,7 @@
 
 <script setup>
 import BackgroundGradient from "./components/BackgroundGradient.vue";
-import { hash } from "./utils/fingerprint.js";
+import { hash } from ".fingerprint.js";
 const config = useRuntimeConfig();
 
 let themeFilename = "styles";

--- a/apps/nuxt3-ssr/custom-build.js
+++ b/apps/nuxt3-ssr/custom-build.js
@@ -19,7 +19,7 @@ fs.readdir(location, (err, files) => {
 
 var fingerPrint = Date.now().toString(36);
 fs.writeFileSync(
-  "./utils/fingerprint.js",
+  ".fingerprint.js",
   "export const hash = '" + fingerPrint + "';"
 );
 

--- a/apps/nuxt3-ssr/custom-dev.js
+++ b/apps/nuxt3-ssr/custom-dev.js
@@ -31,3 +31,5 @@ shell.exec(
   `tailwindcss -c ./tailwind.config.umcg.cjs -i ${location}main.css -o ${location}styles.umcg.css --watch`,
   { async: true }
 );
+
+shell.exec("nuxt dev");

--- a/apps/nuxt3-ssr/error.vue
+++ b/apps/nuxt3-ssr/error.vue
@@ -1,6 +1,6 @@
 <script setup>
 import BackgroundGradient from "./components/BackgroundGradient.vue";
-import { hash } from "./utils/fingerprint.js";
+import { hash } from ".fingerprint.js";
 
 defineProps(["error"]);
 

--- a/apps/nuxt3-ssr/package.json
+++ b/apps/nuxt3-ssr/package.json
@@ -6,7 +6,7 @@
     "prepare": "nuxt prepare",
     "build": "node custom-build.js",
     "test": "vitest",
-    "dev": "nuxt dev",
+    "dev": "node custom-dev.js",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
     "postinstall": "nuxt prepare",

--- a/apps/nuxt3-ssr/utils/fingerprint.js
+++ b/apps/nuxt3-ssr/utils/fingerprint.js
@@ -1,1 +1,0 @@
-export const hash = "";


### PR DESCRIPTION
Generate empty fingerprint file for each dev run.
This way we can be sure there is a fingerprint file without having file in the repo