### PR TITLE
feat: add is(not)null to gql filter option

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlConstants.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlConstants.java
@@ -30,6 +30,8 @@ public class GraphqlConstants {
   public static final String TYPE = "type";
   public static final String VALUE = "value";
   public static final String FILTER_EQUALS = "equals";
+  public static final String FILTER_IS_NULL = "is_null";
+  public static final String FILTER_IS_NOTT_NULL = "is_not_null";
   public static final String FILTER_SEARCH = "_search";
   public static final String FILTER_OR = "_or";
   public static final String FILTER_AND = "_and";

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQuery.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestQuery.java
@@ -6,6 +6,8 @@ import static org.molgenis.emx2.ColumnType.INT;
 import static org.molgenis.emx2.ColumnType.REF;
 import static org.molgenis.emx2.FilterBean.f;
 import static org.molgenis.emx2.Operator.EQUALS;
+import static org.molgenis.emx2.Operator.IS_NOT_NULL;
+import static org.molgenis.emx2.Operator.IS_NULL;
 import static org.molgenis.emx2.SelectColumn.s;
 import static org.molgenis.emx2.TableMetadata.table;
 
@@ -193,5 +195,35 @@ public class TestQuery {
     assertEquals("Kwik,Kwek,Kwak,Donald,Katrien", orderdbyRefDefaultOrder);
     assertEquals("Kwik,Kwek,Kwak,Donald,Katrien", orderdbyRefAsc);
     assertEquals("Donald,Katrien,Kwik,Kwek,Kwak", orderdbyRefDesc);
+  }
+
+  @Test
+  void isNullQuery() {
+    final String isNull =
+        schema
+            .getTable(PERSON)
+            .select(s("First_Name"))
+            .where(f("Mother", IS_NULL))
+            .retrieveRows()
+            .stream()
+            .map(r -> r.getString("First_Name"))
+            .collect(Collectors.joining(","));
+
+    assertEquals("Donald,Katrien", isNull);
+  }
+
+  @Test
+  void isNotNullQuery() {
+    final String isNull =
+        schema
+            .getTable(PERSON)
+            .select(s("First_Name"))
+            .where(f("Mother", IS_NOT_NULL))
+            .retrieveRows()
+            .stream()
+            .map(r -> r.getString("First_Name"))
+            .collect(Collectors.joining(","));
+
+    assertEquals("Kwik,Kwek,Kwak", isNull);
   }
 }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Operator.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Operator.java
@@ -7,6 +7,9 @@ public enum Operator {
   // equality
   EQUALS("equals", "Uses '=' operator. In case of arrays '= ANY'"),
   NOT_EQUALS("not_equals", "Uses != operator. In case of array 'NOT (= ANY)'"),
+  // null
+  IS_NULL("is_null", "Uses IS NULL operator"),
+  IS_NOT_NULL("is_not_null", "Uses IS NOT NULL operator"),
   // ordinal
   BETWEEN("between", "Uses BETWEEN operator"),
   NOT_BETWEEN("not_between", "Uses NOT BETWEEN operator"),


### PR DESCRIPTION
todo: 

- [x] add is(not)null via SqlQuery 
- [ ] expose _is_null_ ,  _is_not_null_ via graphql filter, for example  `{
  AgeGroups(filter: {is_null: parent}) {
    name
  }
}

{
  AgeGroups(filter: {parent: is_null}) {
    name
  }
}
` to get top level tree structure items

