### PR TITLE
fix: bump slf4j2 logger impl to allow 2.x logger

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -37,7 +37,7 @@ subprojects {
     /* default dependencies for all projects*/
     dependencies {
         implementation 'org.apache.logging.log4j:log4j-core:2.20.0'
-        implementation 'org.apache.logging.log4j:log4j-slf4j-impl:2.20.0'
+        implementation 'org.apache.logging.log4j:log4j-slf4j2-impl:2.20.0'
         implementation 'org.jooq:jooq:3.17.8'
         implementation 'com.zaxxer:HikariCP:5.0.1'
         implementation 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.15.2'


### PR DESCRIPTION
This fixes the "SLF4J: No SLF4J providers were found." warning

Closes #2581