### PR TITLE
fix: groupBy with composite pkey containing refs are linked via refLink

### DIFF
--- a/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/TestLoaders.java
+++ b/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/TestLoaders.java
@@ -1,6 +1,7 @@
 package org.molgenis.emx2.datamodels;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.molgenis.emx2.SelectColumn.s;
 import static org.molgenis.emx2.datamodels.DataCatalogueCohortStagingLoader.DATA_CATALOGUE;
 import static org.molgenis.emx2.datamodels.DataCatalogueCohortStagingLoader.SHARED_STAGING;
 import static org.molgenis.emx2.datamodels.DataCatalogueLoader.CATALOGUE_ONTOLOGIES;
@@ -49,6 +50,13 @@ public class TestLoaders {
     Schema dataCatalogue = database.createSchema(DATA_CATALOGUE);
     AvailableDataModels.DATA_CATALOGUE.install(dataCatalogue, true);
     assertEquals(33, dataCatalogue.getTableNames().size());
+
+    // test composite pkey having refs that are linked via refLink
+    dataCatalogue
+        .getTable("Variables")
+        .groupBy()
+        .select(s("count"), s("resource", s("name")), s("dataset", s("name")))
+        .retrieveJSON();
   }
 
   @Test

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -8,10 +8,7 @@ import static org.molgenis.emx2.SelectColumn.s;
 import static org.molgenis.emx2.sql.SqlTableMetadataExecutor.searchColumnName;
 import static org.molgenis.emx2.utils.TypeUtils.*;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import org.jooq.*;
 import org.jooq.Table;
@@ -671,7 +668,9 @@ public class SqlQuery extends QueryBean {
         selectFields.add(field("COUNT(*)"));
       } else {
         Column col = getColumnByName(table, field.getColumn());
-        List<Field> subselectFields = new ArrayList<>();
+        // composite keys might have overlapping underlying columns via 'refLink'
+        // therefore we use a Set here.
+        Set<Field> subselectFields = new HashSet<>();
 
         // need pkey to allow for joining of the subqueries
         table
@@ -684,7 +683,9 @@ public class SqlQuery extends QueryBean {
                         .forEach(
                             pkeyRef -> {
                               subselectFields.add(
-                                  field(name("pkey_" + convertToCamelCase(pkeyRef.getName()))));
+                                  pkeyRef
+                                      .getJooqField()
+                                      .as(name("pkey_" + convertToCamelCase(pkeyRef.getName()))));
                             });
                   } else {
                     subselectFields.add(


### PR DESCRIPTION
closes #2092 

This is using the most complex data model feature we have which we should add to our pet store somehow, that is having composite pkey (so multiple columns together make up the key) AND that at least two of these columns are a reference (type=REF) that also have composite keys AND these references have some overlap (i.e. their composite key has same reference) which is collapsed in the user interface using the ‘refLink’ feature. As a consequence when trying to find unique rows the bug was that same column was included more than once (in the example: ‘resource’) 

N.B. to test I have used the fact that TestLoaders actually loads the catalogue schema so we can directly test the example reported in #2092