### PR TITLE
fix: javascript client should also cache current (nameless) schema

### DIFF
--- a/apps/catalogue/src/components/CohortCards.vue
+++ b/apps/catalogue/src/components/CohortCards.vue
@@ -166,6 +166,7 @@ export default {
     const resp = await this.client.fetchTableData(this.table, {
       filter: this.graphqlFilter,
       orderby: this.orderBy,
+      limit: this.limit,
     });
     this.cohorts = resp[this.table] ? resp[this.table] : [];
     this.count = resp[this.table + "_agg"].count;

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -272,7 +272,9 @@ const fetchSchemaMetaData = async (
     .post(graphqlURL(schemaName), { query: metaDataQuery })
     .then((result: AxiosResponse<{ data: { _schema: ISchemaMetaData } }>) => {
       const schema = result.data.data._schema;
-      schemaCache.set(currentSchemaName, schema);
+      if(schemaName == null) {
+        schemaCache.set(currentSchemaName, schema);
+      }
       schemaCache.set(schema.name, schema);
       return deepClone(schema);
     })

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -264,13 +264,15 @@ const fetchSchemaMetaData = async (
   axios: Axios,
   schemaName?: string
 ): Promise<ISchemaMetaData> => {
-  if (schemaName && schemaCache.has(schemaName)) {
-    return schemaCache.get(schemaName) as ISchemaMetaData;
+  const currentSchemaName = schemaName ? schemaName : "CACHE_OF_CURRENT_SCHEMA";
+  if (schemaCache.has(currentSchemaName)) {
+    return schemaCache.get(currentSchemaName) as ISchemaMetaData;
   }
   return await axios
     .post(graphqlURL(schemaName), { query: metaDataQuery })
     .then((result: AxiosResponse<{ data: { _schema: ISchemaMetaData } }>) => {
       const schema = result.data.data._schema;
+      schemaCache.set(currentSchemaName, schema);
       schemaCache.set(schema.name, schema);
       return deepClone(schema);
     })


### PR DESCRIPTION
previously, when using newClient(), so without specifying the schemaName, the schema would not be cached.
This potentially can still result in many calls.

with this fix, we give a special name when schemaName === undefined to also cache the current schema.