### PR TITLE
fix: make large horziontal tables not scroll out of the application

### DIFF
--- a/apps/molgenis-components/src/components/tables/TableMolgenis.vue
+++ b/apps/molgenis-components/src/components/tables/TableMolgenis.vue
@@ -1,10 +1,6 @@
-/* eslint-disable vue/no-unused-components */
 <template>
-  <div style="max-width: 100%" class="flex-grow-1">
-    <table
-      class="table table-sm bg-white table-bordered table-hover"
-      :class="{ 'table-hover': showSelect }"
-    >
+  <div style="overflow: scroll">
+    <table class="table table-sm bg-white table-bordered table-hover">
       <thead>
         <th slot="header" scope="col" style="width: 1px" v-if="hasColheader">
           <h6 class="mb-0 mt-2 d-inline">#</h6>

--- a/apps/molgenis-components/src/components/tables/TableMolgenis.vue
+++ b/apps/molgenis-components/src/components/tables/TableMolgenis.vue
@@ -1,5 +1,5 @@
 <template>
-  <div style="overflow: scroll">
+  <div style="overflow-x: scroll">
     <table class="table table-sm bg-white table-bordered table-hover">
       <thead>
         <th slot="header" scope="col" style="width: 1px" v-if="hasColheader">


### PR DESCRIPTION
Make sure large tables e.g. catalogue -> databanks don't scroll away the molgenis application i.e. elements like the top bar menu.