### PR TITLE
build: move NODE_OPTIONS environment into gradle into gradle

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,6 @@ jobs:
     environment:
       # Customize the JVM maximum heap limit
       JVM_OPTS: -Xmx3200m
-      NODE_OPTIONS: "--max-old-space-size=4096"
       GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
       TERM: dumb
 

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -72,6 +72,8 @@ subprojects {
 
 
     task build(type: YarnTask, dependsOn: format) {
+        environment "NODE_OPTIONS" "--max-old-space-size=4096"
+
          // force build order: molgenis-components > ...apps
         if (project.name != 'molgenis-components') {
             dependsOn ":apps:molgenis-components:build"

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -72,7 +72,7 @@ subprojects {
 
 
     task build(type: YarnTask, dependsOn: format) {
-        environment "NODE_OPTIONS" "--max-old-space-size=4096"
+        environment = ["NODE_OPTIONS":"--max-old-space-size=4096"]
 
          // force build order: molgenis-components > ...apps
         if (project.name != 'molgenis-components') {


### PR DESCRIPTION
motivation: 
* local builds now sometimes fails with yarn 'finished with non-zero exit value 139'
* we now set these options only on circleci and azure
* I don't know why but 'directory' build takes much memory

solution:
* move the options into gradle so runs everywhere

potential issues:
* might result in build issues on smaller systems.