### PR TITLE
fix(molgenis-components): inputref

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputRef.vue
+++ b/apps/molgenis-components/src/components/forms/InputRef.vue
@@ -36,7 +36,7 @@
             :selection="modelValue"
             :errorMessage="errorMessage"
             @update:modelValue="select"
-          ></InputRefItem>
+          />
         </div>
         <ButtonAlt
           class="pl-0"

--- a/apps/molgenis-components/src/components/forms/InputRefItem.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefItem.vue
@@ -14,9 +14,10 @@
   </label>
 </template>
 
-<script>
+<script lang="ts">
 import BaseInput from "./baseInputs/BaseInput.vue";
 import { flattenObject } from "../utils";
+import { IRow } from "../../Interfaces/IRow";
 
 export default {
   name: "InputRefItem",
@@ -41,18 +42,10 @@ export default {
       return this.rowKey?.name === this.selection?.name;
     },
   },
-  watch: {
-    selection: {
-      handler(newValue) {
-        this.isSelected = this.rowKey?.name === newValue?.name;
-      },
-      deep: true,
-    },
-  },
   mounted() {
     this.client
       .convertRowToPrimaryKey(this.row, this.tableName)
-      .then((rowKey) => {
+      .then((rowKey: IRow) => {
         this.rowKey = rowKey;
       });
   },

--- a/apps/molgenis-components/src/components/tables/TableRow.vue
+++ b/apps/molgenis-components/src/components/tables/TableRow.vue
@@ -67,7 +67,11 @@ export default {
     isSelected() {
       return Boolean(
         this.selection?.find((selectionItem) => {
-          return selectionItem && deepEqual(selectionItem, this.rowKey);
+          return (
+            selectionItem &&
+            this.rowKey &&
+            deepEqual(selectionItem, this.rowKey)
+          );
         })
       );
     },


### PR DESCRIPTION
Fixes warning from trying to overwrite computed (test: components library -> inputRef -> select some ref -> see console) and fixes an initialization bug where the rowkey would still be null when opening the modal view (test: in the component library -> goto inputRef -> click view as table at the last example)