### PR TITLE
fix: 2562 browser back button does not go back to previous page

### DIFF
--- a/apps/nuxt3-ssr/components/Pagination.vue
+++ b/apps/nuxt3-ssr/components/Pagination.vue
@@ -23,6 +23,13 @@ const props = defineProps({
 });
 const emit = defineEmits(["update"]);
 
+onMounted(() => {
+  window.addEventListener("popstate", () => {
+    // react to external navigation ( e.g. back button in browser)
+    window.location.reload();
+  });
+});
+
 const TEXT_STYLE_MAPPING = {
   gray: "text-pagination-label-gray",
   white: "text-pagination-label-white",
@@ -75,7 +82,7 @@ function changeCurrentPage(event) {
     class="pt-12.5 flex items-center justify-center font-display text-heading-xl -mx-2.5"
   >
     <a
-      :href="currentPage > 1 ? '#' : undefined"
+      :href="currentPage > 1 ? '' : undefined"
       role="button"
       @click="onPrevClick"
       class="flex justify-center transition-colors border border-pagination rounded-pagination bg-pagination text-pagination h-15 w-15"
@@ -100,7 +107,7 @@ function changeCurrentPage(event) {
       OF {{ totalPages }}
     </div>
     <a
-      :href="currentPage < totalPages ? '#' : undefined"
+      :href="currentPage < totalPages ? '' : undefined"
       role="button"
       @click="onNextClick"
       class="flex justify-center transition-colors border border-pagination rounded-pagination bg-pagination text-pagination h-15 w-15"


### PR DESCRIPTION
Closes #2562

Note: the down side of this solution / work around is that when the user used the browser-back-button ( on a page containing a Pagination component) the page gets reloaded from the server ( instead of having a spa data refresh). 

This workaround is need as the router does not react to query param updates ( triggered via the backbutton ), it does react to changes in the route itself ( going to a different location instead of only change the page number)