### PR TITLE
fix: ensure properly signing out of Pyclient session

### DIFF
--- a/tools/pyclient/README.md
+++ b/tools/pyclient/README.md
@@ -6,13 +6,33 @@ pip install molgenis_emx2_pyclient
 
 ## How to use
 
-Within your Python project import the class Client and use it to sign in
+Within your Python project import the class Client and use it as a context manager
 
 ```py
 from molgenis_emx2_pyclient import Client
 
-client = Client('https://example.molgeniscloud.org')
-client.signin('username', 'password')
+username = 'username'
+password = '...'
+
+with Client('https://example.molgeniscloud.org') as client:
+    client.signin(username, password)
+
+    # Retrieve signin information
+    print(client.status)
+    """ Output:
+    Host: https://example.molgeniscloud.org
+    Status: Signed in
+    Schemas:
+        CatalogueOntologies
+        catalogue
+        ExampleSchema
+        ...
+    Version: v8.214.1
+    """
+    
+    # Retrieve data from a table on a schema
+    data = client.get(schema='ExampleSchame', table='Cohorts')
+
 ```
 
 ## Development

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -2,7 +2,7 @@
 # FILE: dev.py
 # AUTHOR: David Ruvolo, Ype Zijlstra
 # CREATED: 2023-05-22
-# MODIFIED: 2023-09-08
+# MODIFIED: 2023-09-11
 # PURPOSE: development script for initial testing of the py-client
 # STATUS: ongoing
 # PACKAGES: pandas, python-dotenv
@@ -128,9 +128,6 @@ async def main():
 
         client.delete(schema='pet store', table='Pet', file='demodata/Pet.csv')
         client.delete(schema='pet store', table='Tag', file='demodata/Tag.csv')
-
-        # Sign out
-        client.signout()
 
 
 if __name__ == '__main__':

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -11,6 +11,7 @@
 #           MG_USERNAME = blabla
 #           MG_PASSWORD = blabla123
 # ///////////////////////////////////////////////////////////////////////////////
+import asyncio
 import logging
 import os
 
@@ -21,7 +22,7 @@ from tools.pyclient.src.molgenis_emx2_pyclient import Client
 from tools.pyclient.src.molgenis_emx2_pyclient.exceptions import NoSuchSchemaException, NoSuchTableException
 
 
-def main():
+async def main():
     # Set up the logger
     logging.basicConfig(level='INFO')
     logging.getLogger("requests").setLevel(logging.WARNING)
@@ -33,49 +34,47 @@ def main():
     password = os.environ.get('MG_PASSWORD')
 
     # Connect to the server and sign in
-    client = Client('https://emx2.dev.molgenis.org/')
-    client.signin(username, password)
+    async with Client('https://emx2.dev.molgenis.org/') as client:
+        client.signin(username, password)
 
-    # Check sign in status
-    print(client.status)
+        # Check sign in status
+        print(client.status)
 
-    # Retrieve data from a table in a schema on the server using the 'get' method
-    # Passing non-existing schema name yields a NoSuchSchemaException
-    try:
-        data = client.get(schema='', table='')  # run without specifying target
-        print(data)
-    except NoSuchSchemaException as e:
-        print(e)
+        # Retrieve data from a table in a schema on the server using the 'get' method
+        # Passing non-existing schema name yields a NoSuchSchemaException
+        try:
+            data = client.get(schema='', table='')  # run without specifying target
+            print(data)
+        except NoSuchSchemaException as e:
+            print(e)
 
-    # Passing table name not on the schema yields a NoSuchTableException
-    try:
-        data = client.get(schema='pet store', table='')  # run without specifying table
-        print(data)
-    except NoSuchTableException as e:
-        print(e)
+        # Passing table name not on the schema yields a NoSuchTableException
+        try:
+            data = client.get(schema='pet store', table='')  # run without specifying table
+            print(data)
+        except NoSuchTableException as e:
+            print(e)
 
-    # Export the entire 'pet store' schema to a .xlsx file
-    # and export the 'Cohorts' table from schema 'catalogue' to a .csv file
-    client.export(schema='pet store', fmt='xlsx')
-    client.export(schema='catalogue-demo', table='Cohorts', fmt='csv')
+        # Export the entire 'pet store' schema to a .xlsx file
+        # and export the 'Cohorts' table from schema 'catalogue' to a .csv file
+        client.export(schema='pet store', fmt='xlsx')
+        client.export(schema='catalogue-demo', table='Cohorts', fmt='csv')
 
-    client.signout()
-    
     # Connect to server with a default schema specified
-    client = Client('https://emx2.dev.molgenis.org/', schema='pet store')
-    client.signin(username, password)
+    with Client('https://emx2.dev.molgenis.org/', schema='pet store') as client:
+        client.signin(username, password)
 
-    client.export(fmt='csv')
-    client.export(table='Pet', fmt='csv')
-    client.export(table='Pet', fmt='xlsx')
+        client.export(fmt='csv')
+        client.export(table='Pet', fmt='csv')
+        client.export(table='Pet', fmt='xlsx')
 
-    # Retrieving data from table Pet as a list
-    data = client.get(table='Pet')  # get Pets
-    print(data)
+        # Retrieving data from table Pet as a list
+        data = client.get(table='Pet')  # get Pets
+        print(data)
 
-    # Retrieving data from table Pet as a pandas DataFrame
-    data = client.get(table='Pet', as_df=True)  # get Pets
-    print(data)
+        # Retrieving data from table Pet as a pandas DataFrame
+        data = client.get(table='Pet', as_df=True)  # get Pets
+        print(data)
 
     # ///////////////////////////////////////////////////////////////////////////////
 
@@ -86,53 +85,53 @@ def main():
     # Check import via the `data` parameters
     # Add new record to the pet store with new tags
 
-    new_tags = [
-        {'name': 'brown', 'parent': 'colors'},
-        {'name': 'canis', 'parent': 'species'},
-    ]
+        new_tags = [
+            {'name': 'brown', 'parent': 'colors'},
+            {'name': 'canis', 'parent': 'species'},
+        ]
 
-    new_pets = [{
-        'name': 'Woofie',
-        'category': 'dog',
-        'status': 'available',
-        'weight': 6.8,
-        'tags': 'brown,canis'
-    }]
+        new_pets = [{
+            'name': 'Woofie',
+            'category': 'dog',
+            'status': 'available',
+            'weight': 6.8,
+            'tags': 'brown,canis'
+        }]
 
-    # Import new data
-    client.save(schema='pet store', table='Tag', data=new_tags)
-    client.save(schema='pet store', table='Pet', data=new_pets)
+        # Import new data
+        client.save(schema='pet store', table='Tag', data=new_tags)
+        client.save(schema='pet store', table='Pet', data=new_pets)
 
-    # Retrieve records
-    tags_data = client.get(schema='pet store', table='Tag', as_df=True)
-    print(tags_data)
-    pets_data = client.get(schema='pet store', table='Pet', as_df=True)
-    print(pets_data)
+        # Retrieve records
+        tags_data = client.get(schema='pet store', table='Tag', as_df=True)
+        print(tags_data)
+        pets_data = client.get(schema='pet store', table='Pet', as_df=True)
+        print(pets_data)
 
-    # Drop records
-    tags_to_remove = [{'name': row['name']} for row in new_tags if row['name'] == 'canis']
-    client.delete(schema='pet store', table='Pet', data=new_pets)
-    client.delete(schema='pet store', table='Tag', data=tags_to_remove)
+        # Drop records
+        tags_to_remove = [{'name': row['name']} for row in new_tags if row['name'] == 'canis']
+        client.delete(schema='pet store', table='Pet', data=new_pets)
+        client.delete(schema='pet store', table='Tag', data=tags_to_remove)
 
-    # ///////////////////////////////////////
+        # ///////////////////////////////////////
 
-    # ~ 1b ~
-    # Check import via the `file` parameter
+        # ~ 1b ~
+        # Check import via the `file` parameter
 
-    # Save datasets
-    pd.DataFrame(new_tags).to_csv('demodata/Tag.csv', index=False)
-    pd.DataFrame(new_pets).to_csv('demodata/Pet.csv', index=False)
+        # Save datasets
+        pd.DataFrame(new_tags).to_csv('demodata/Tag.csv', index=False)
+        pd.DataFrame(new_pets).to_csv('demodata/Pet.csv', index=False)
 
-    # Import files
-    client.save(schema='pet store', table='Tag', file='demodata/Tag.csv')
-    client.save(schema='pet store', table='Pet', file='demodata/Pet.csv')
+        # Import files
+        client.save(schema='pet store', table='Tag', file='demodata/Tag.csv')
+        client.save(schema='pet store', table='Pet', file='demodata/Pet.csv')
 
-    client.delete(schema='pet store', table='Pet', file='demodata/Pet.csv')
-    client.delete(schema='pet store', table='Tag', file='demodata/Tag.csv')
+        client.delete(schema='pet store', table='Pet', file='demodata/Pet.csv')
+        client.delete(schema='pet store', table='Tag', file='demodata/Tag.csv')
 
-    # Sign out
-    client.signout()
+        # Sign out
+        client.signout()
 
 
 if __name__ == '__main__':
-    main()
+    asyncio.run(main())

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -2,7 +2,7 @@
 # FILE: dev.py
 # AUTHOR: David Ruvolo, Ype Zijlstra
 # CREATED: 2023-05-22
-# MODIFIED: 2023-08-14
+# MODIFIED: 2023-09-08
 # PURPOSE: development script for initial testing of the py-client
 # STATUS: ongoing
 # PACKAGES: pandas, python-dotenv

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -2,7 +2,7 @@
 # FILE: dev.py
 # AUTHOR: David Ruvolo, Ype Zijlstra
 # CREATED: 2023-05-22
-# MODIFIED: 2023-09-11
+# MODIFIED: 2023-09-13
 # PURPOSE: development script for initial testing of the py-client
 # STATUS: ongoing
 # PACKAGES: pandas, python-dotenv
@@ -76,14 +76,14 @@ async def main():
         data = client.get(table='Pet', as_df=True)  # get Pets
         print(data)
 
-    # ///////////////////////////////////////////////////////////////////////////////
+        # ///////////////////////////////////////////////////////////////////////////////
 
-    # ~ 1 ~
-    # Check Import Methods
+        # ~ 1 ~
+        # Check Import Methods
 
-    # ~ 1a ~
-    # Check import via the `data` parameters
-    # Add new record to the pet store with new tags
+        # ~ 1a ~
+        # Check import via the `data` parameters
+        # Add new record to the pet store with new tags
 
         new_tags = [
             {'name': 'brown', 'parent': 'colors'},

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -43,12 +43,14 @@ class Client:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         self.signout()
+        self.session.close()
 
     async def __aenter__(self):
         return self
 
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         self.signout()
+        self.session.close()
 
     def signin(self, username: str, password: str):
         """Signs in to Molgenis and retrieves session cookie.

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -38,6 +38,18 @@ class Client:
     def __str__(self):
         return self.url
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.signout()
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb):
+        self.signout()
+
     def signin(self, username: str, password: str):
         """Signs in to Molgenis and retrieves session cookie.
 
@@ -96,11 +108,11 @@ class Client:
         )        
         
         status = response.json().get('data', {}).get('signout', {}).get('status')
-        message = response.json().get('data', {}).get('signout', {}).get('message')
         if status == 'SUCCESS':
             print(f"Signed out of {self.url}")
         else:
             print(f"Unable to sign out of {self.url}.")
+            message = response.json().get('errors')[0].get('message')
             print(message)
             
     @property

--- a/tools/pyclient/src/molgenis_emx2_pyclient/exceptions.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/exceptions.py
@@ -31,3 +31,7 @@ class ServerNotFoundError(PyclientException):
 
 class ServiceUnavailableError(PyclientException):
     """Thrown when a server is not available for handling a request."""
+
+
+class NoContextManagerException(PyclientException):
+    """Thrown when sign in is attempted outside a context manager."""


### PR DESCRIPTION
This PR aims to prevent resource leaks. Usage of the Pyclient can cause sessions on a Molgenis server to be created without being properly closed, either due to an error occuring during execution, termination of the program or simply due to forgetting to call the signout() method.
The creation of too many sessions that are not closed causes memory problems on the server.

This PR fixes that by forcing the client to be used as a context manager. The context manager ensures that the signout and closing of the session are performed under normal use and also in the scenario's listed above.