### PR TITLE
feat: 10417 Add BCC option to email

### DIFF
--- a/backend/molgenis-emx2-email/src/main/java/org/molgenis/emx2/email/EmailMessage.java
+++ b/backend/molgenis-emx2-email/src/main/java/org/molgenis/emx2/email/EmailMessage.java
@@ -1,0 +1,7 @@
+package org.molgenis.emx2.email;
+
+import java.util.List;
+import java.util.Optional;
+
+public record EmailMessage(
+    List<String> recipients, String subject, String messageText, Optional<String> bccRecipient) {}

--- a/backend/molgenis-emx2-email/src/test/java/org/molgenis/emx2/email/EmailServiceTest.java
+++ b/backend/molgenis-emx2-email/src/test/java/org/molgenis/emx2/email/EmailServiceTest.java
@@ -2,7 +2,8 @@ package org.molgenis.emx2.email;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import java.util.Arrays;
+import java.util.Collections;
+import java.util.Optional;
 import javax.mail.internet.AddressException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
@@ -20,6 +21,7 @@ class EmailServiceTest {
   @Test
   @EnabledIfEnvironmentVariable(named = "EMX2_TEST_EMAIL_SENDER", matches = ".*")
   @EnabledIfEnvironmentVariable(named = "EMX2_TEST_EMAIL_PASSWORD", matches = ".*")
+  @EnabledIfEnvironmentVariable(named = "EMX2_TEST_EMAIL_BCC_ADDRESS", matches = ".*")
   @EnabledIfEnvironmentVariable(named = "EMX2_TEST_SMTP_SERVER", matches = ".*")
   @EnabledIfEnvironmentVariable(named = "EMX2_TEST_SMTP_RECEIVER", matches = ".*")
   // note set env vars to test sending a mail via smtp server
@@ -33,11 +35,14 @@ class EmailServiceTest {
     builder.debug("true");
     EmailSettings settings = builder.build();
     EmailService emailService = new EmailService(settings);
-    boolean isSuccess =
-        emailService.send(
-            Arrays.asList(System.getenv("EMX2_TEST_SMTP_RECEIVER")),
+    String bccAddress = System.getenv("EMX2_TEST_EMAIL_BCC_ADDRESS");
+    EmailMessage message =
+        new EmailMessage(
+            Collections.singletonList(System.getenv("EMX2_TEST_SMTP_RECEIVER")),
             "This is just a test",
-            "This is a test mail from EMX2");
+            "This is a test mail from EMX2",
+            Optional.of(bccAddress));
+    boolean isSuccess = emailService.send(message);
     assertTrue(isSuccess);
   }
 }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Constants.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Constants.java
@@ -101,6 +101,7 @@ public class Constants {
   public static final String SYSTEM_SCHEMA = "_SYSTEM_";
 
   public static final String CONTACT_RECIPIENTS_QUERY_SETTING_KEY = "contactRecipientsQuery";
+  public static final String CONTACT_BCC_ADDRESS = "contactBccAddress";
 
   private Constants() {
     // hide constructor


### PR DESCRIPTION
Allow schema owner to configure public email fiels to act as bcc field ('blind' carbon copy)