### PR TITLE
fix: catalogue shows aggregate instead of table view

### DIFF
--- a/apps/catalogue/src/views/ResourceListView.vue
+++ b/apps/catalogue/src/views/ResourceListView.vue
@@ -8,6 +8,7 @@
       :initialSearchTerms="searchTerm"
       :canEdit="canEdit"
       :canManage="canManage"
+      :canView="true"
       @rowClick="openDetailView"
       @searchTerms="onSearchTermUpdate"
     />


### PR DESCRIPTION
this fixes that ResourceDetails view gives aggregate instead of table view

 Compare
- https://emx2.dev.molgenis.org/catalogue/catalogue/#/cohorts
- https://emx2.dev.molgenis.org/catalogue/catalogue/#/datasources

Agains the PR
- https://preview-emx2-pr-2749.dev.molgenis.org/catalogue-demo/catalogue/#/cohorts
- https://preview-emx2-pr-2749.dev.molgenis.org/catalogue-demo/catalogue/#/datasources

Hopefully closes #2743