### PR TITLE
feat: Include ontology details in search field

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
@@ -308,6 +308,25 @@ class SqlTableMetadataExecutor {
       if (!c.isSystemColumn()) {
         if (c.isFile()) {
           // do nothing for now
+        } else if (c.isOntology()) {
+          for (Reference r : c.getReferences()) {
+            String schemaName =
+                r.toPrimitiveColumn().getRefSchema().isEmpty()
+                    ? table.getSchema().getName()
+                    : r.toPrimitiveColumn().getRefSchema();
+
+            if (c.isArray()) {
+              mgSearchVector.append(
+                  String.format(
+                      " || coalesce((SELECT string_agg(\"%1$s_TEXT_SEARCH_COLUMN\", ' ') FROM \"%3$s\".\"%1$s\" WHERE \"%1$s\".\"name\" = ANY( NEW.\"%2$s\") ),'') || ' '",
+                      r.getTargetTable(), r.getName(), schemaName));
+            } else {
+              mgSearchVector.append(
+                  String.format(
+                      " || coalesce((SELECT \"%1$s_TEXT_SEARCH_COLUMN\" FROM \"%3$s\".\"%1$s\" WHERE \"%1$s\".\"name\" = NEW.\"%2$s\"),'') || ' '",
+                      r.getTargetTable(), r.getName(), schemaName));
+            }
+          }
         } else if (c.isReference()) {
           for (Reference r : c.getReferences()) {
             mgSearchVector.append(

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
@@ -310,21 +310,16 @@ class SqlTableMetadataExecutor {
           // do nothing for now
         } else if (c.isOntology()) {
           for (Reference r : c.getReferences()) {
-            String schemaName =
-                r.toPrimitiveColumn().getRefSchema().isEmpty()
-                    ? table.getSchema().getName()
-                    : r.toPrimitiveColumn().getRefSchema();
-
             if (c.isArray()) {
               mgSearchVector.append(
                   String.format(
                       " || coalesce((SELECT string_agg(\"%1$s_TEXT_SEARCH_COLUMN\", ' ') FROM \"%3$s\".\"%1$s\" WHERE \"%1$s\".\"name\" = ANY( NEW.\"%2$s\") ),'') || ' '",
-                      r.getTargetTable(), r.getName(), schemaName));
+                      r.getTargetTable(), r.getName(), c.getRefSchema()));
             } else {
               mgSearchVector.append(
                   String.format(
                       " || coalesce((SELECT \"%1$s_TEXT_SEARCH_COLUMN\" FROM \"%3$s\".\"%1$s\" WHERE \"%1$s\".\"name\" = NEW.\"%2$s\"),'') || ' '",
-                      r.getTargetTable(), r.getName(), schemaName));
+                      r.getTargetTable(), r.getName(), c.getRefSchema()));
             }
           }
         } else if (c.isReference()) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/TriggerBuilderHelpers.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/TriggerBuilderHelpers.java
@@ -1,0 +1,31 @@
+package org.molgenis.emx2.sql;
+
+public class TriggerBuilderHelpers {
+
+  private TriggerBuilderHelpers() {
+    throw new IllegalStateException("Utility class");
+  }
+
+  public static String buildOntologySearchSection(
+      String schemaName, String tableName, String columnName, boolean isArray) {
+    String template =
+        isArray
+            ? """
+                SELECT
+                    string_agg("%2$s_TEXT_SEARCH_COLUMN", ' ')
+                FROM
+                    "%1$s"."%2$s"
+                WHERE
+                    "%2$s"."name" = ANY( NEW."%3$s")
+                """
+            : """
+                SELECT
+                    "%2$s_TEXT_SEARCH_COLUMN"
+                FROM
+                    "%1$s"."%2$s"
+                WHERE
+                    "%2$s"."name" = NEW."%3$s"
+                """;
+    return template.formatted(schemaName, tableName, columnName);
+  }
+}

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/TriggerBuilderHelpers.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/TriggerBuilderHelpers.java
@@ -28,4 +28,11 @@ public class TriggerBuilderHelpers {
                 """;
     return template.formatted(schemaName, tableName, columnName);
   }
+
+  public static String buildCallSearchTriggerFunction(String schemaName, String tableName) {
+    return """
+        UPDATE "%1$s"."%2$s" set "%2$s_TEXT_SEARCH_COLUMN" = "%2$s_TEXT_SEARCH_COLUMN";
+        """
+        .formatted(schemaName, tableName);
+  }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TriggerBuilderHelpersTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TriggerBuilderHelpersTest.java
@@ -33,4 +33,13 @@ WHERE
 """,
         TriggerBuilderHelpers.buildOntologySearchSection("mySchema", "myTable", "myColumn", true));
   }
+
+  @Test
+  void buildCallSearchTriggerFunction() {
+    assertEquals(
+        """
+UPDATE "mySchema"."myTable" set "myTable_TEXT_SEARCH_COLUMN" = "myTable_TEXT_SEARCH_COLUMN";
+""",
+        TriggerBuilderHelpers.buildCallSearchTriggerFunction("mySchema", "myTable"));
+  }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TriggerBuilderHelpersTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TriggerBuilderHelpersTest.java
@@ -1,0 +1,36 @@
+package org.molgenis.emx2.sql;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+class TriggerBuilderHelpersTest {
+
+  @Test
+  void buildOntologySearchSectionForSingleValueType() {
+    assertEquals(
+        """
+    SELECT
+        "myTable_TEXT_SEARCH_COLUMN"
+    FROM
+        "mySchema"."myTable"
+    WHERE
+        "myTable"."name" = NEW."myColumn"
+    """,
+        TriggerBuilderHelpers.buildOntologySearchSection("mySchema", "myTable", "myColumn", false));
+  }
+
+  @Test
+  void buildOntologySearchSectionForArrayType() {
+    assertEquals(
+        """
+SELECT
+    string_agg("myTable_TEXT_SEARCH_COLUMN", ' ')
+FROM
+    "mySchema"."myTable"
+WHERE
+    "myTable"."name" = ANY( NEW."myColumn")
+""",
+        TriggerBuilderHelpers.buildOntologySearchSection("mySchema", "myTable", "myColumn", true));
+  }
+}


### PR DESCRIPTION
Add the ontology ( ontology search values) to row search field

todo:

- [x] test and cleanup code, extract string hacking to separate function and add tests
- [x] migration to update existing triggers and indexes ( requires updating the search col value for each row in each table in each schema :( )

🚨 Need to evaluate performance ( specifically on migration ), consider removing migration and adding to change only for new schemas  