### PR TITLE
feat: add automatic id to each row

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
@@ -230,7 +230,7 @@ class SqlSchemaMetadataExecutor {
       db.getJooq().dropSequence(name(schemaName, MG_ID));
 
       // drop schema
-      db.getJooq().dropSchema(name(schemaName)).cascade().execute();
+      db.getJooq().dropSchema(name(schemaName)).execute();
 
       for (String role : executeGetRoles(db.getJooq(), schemaName)) {
         db.getJooq().execute("DROP ROLE IF EXISTS {0}", name(getRolePrefix(schemaName) + role));

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
@@ -219,7 +219,7 @@ class SqlSchemaMetadataExecutor {
       tables.forEach(table -> executeDropTable(db.getJooq(), table.getMetadata()));
 
       // drop schema
-      db.getJooq().dropSchema(name(schemaName)).execute();
+      db.getJooq().dropSchema(name(schemaName)).cascade().execute();
 
       for (String role : executeGetRoles(db.getJooq(), schemaName)) {
         db.getJooq().execute("DROP ROLE IF EXISTS {0}", name(getRolePrefix(schemaName) + role));

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -432,7 +432,6 @@ class SqlTable implements Table {
         step2.set(field(name(MG_UPDATEDON)), now);
       }
     }
-
     return step.execute();
   }
 

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -432,6 +432,7 @@ class SqlTable implements Table {
         step2.set(field(name(MG_UPDATEDON)), now);
       }
     }
+
     return step.execute();
   }
 

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
@@ -29,7 +29,11 @@ class SqlTableMetadataExecutor {
 
     // create the table
     Table jooqTable = table.getJooqTable();
-    jooq.execute("CREATE TABLE {0}()", jooqTable);
+    Name mg_id = name(table.getSchemaName(), "mg_id");
+    jooq.execute(
+        "create sequence if not exists {0} as bigint increment by 9 minvalue 59049 cache 1000 no cycle",
+        mg_id);
+    jooq.execute("CREATE TABLE {0}(mg_id bigint default nextval({1) unique)", jooqTable, mg_id);
     MetadataUtils.saveTableMetadata(jooq, table);
 
     // grant rights to schema manager, editor and viewer role

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
@@ -29,11 +29,11 @@ class SqlTableMetadataExecutor {
 
     // create the table
     Table jooqTable = table.getJooqTable();
-    Name mg_id = name(table.getSchemaName(), "mg_id");
     jooq.execute(
-        "create sequence if not exists {0} as bigint increment by 9 minvalue 59049 cache 1000 no cycle",
-        mg_id);
-    jooq.execute("CREATE TABLE {0}(mg_id bigint default nextval({1) unique)", jooqTable, mg_id);
+        "CREATE TABLE {0}(mg_id BIGINT DEFAULT nextval('\""
+            + table.getSchemaName()
+            + "\".mg_id') PRIMARY KEY)",
+        jooqTable);
     MetadataUtils.saveTableMetadata(jooq, table);
 
     // grant rights to schema manager, editor and viewer role

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Constants.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Constants.java
@@ -103,6 +103,7 @@ public class Constants {
 
   public static final String CONTACT_RECIPIENTS_QUERY_SETTING_KEY = "contactRecipientsQuery";
   public static final String CONTACT_BCC_ADDRESS = "contactBccAddress";
+  public static final String MG_ID = "mg_id";
 
   private Constants() {
     // hide constructor


### PR DESCRIPTION
motivation:
- for RDF we need single id per row
- for Catalogue ui routing we need a row id to avoid the need to rebuild a complex row identifier for use in route 

result:
- [x] each row gets automatic id
- [ ] this id is used in the backend to have faster joins and easier backend code
- [ ] updates can still be done using key=1 columns
- [ ] id can be queried via Query.retrieveRows and Query.retrieveJson so it can be used in RDF
- [ ] decide if we make this visible in UI or not