### PR TITLE
fix:emx2_testing_on_windows

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -99,7 +99,7 @@ subprojects {
     }
 
     test {
-        jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED")
+        jvmArgs("--add-opens=java.base/java.util=ALL-UNNAMED", "--add-opens=java.base/java.lang=ALL-UNNAMED")
         useJUnitPlatform ()
         failFast true
         testLogging {


### PR DESCRIPTION
When running the WebApiSmokeTests on Windows, the following error would pop up:
"java.lang.reflect.InaccessibleObjectException: Unable to make field private static final java.util.Map java.lang.ProcessEnvironment.theCaseInsensitiveEnvironment accessible: module java.base does not "opens java.lang" to unnamed module". 
The issue is fixed by adding "--add-opens java.base/java.lang=ALL-UNNAMED" as a test JVM parameter in the build.gradle file on the backend.