### PR TITLE
fix: Pyclient status after signing out

### DIFF
--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -122,6 +122,8 @@ class Client:
         status = response.json().get('data', {}).get('signout', {}).get('status')
         if status == 'SUCCESS':
             print(f"Signed out of {self.url}")
+            self.username = 'anonymous'
+            self.signin_status = 'signed out'
         else:
             print(f"Unable to sign out of {self.url}.")
             message = response.json().get('errors')[0].get('message')
@@ -134,7 +136,7 @@ class Client:
         message = (
           f"Host: {self.url}\n"
           f"User: {self.username}\n"
-          f"Status: {'Signed in' if self.signin_status == 'success' else 'Logged out'}\n"
+          f"Status: {'Signed in' if self.signin_status == 'success' else 'Signed out'}\n"
           f"Schemas: \n\t{schemas}\n"
           f"Version: {self.version}\n"
         )

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -67,13 +67,13 @@ class Client:
         :param password: the password corresponding to this username.
         :type username: str
         """
+        self.username = username
+
         if not self._as_context_manager:
             raise NoContextManagerException("Ensure the Client is called as a context manager,\n"
                                             "e.g. `with Client(url) as client:`")
         query = queries.signin()
-        variables = {'email': username, 'password': password}
-
-        self.username = username
+        variables = {'email': self.username, 'password': password}
 
         response = self.session.post(
             url=self.api_graphql,
@@ -94,23 +94,21 @@ class Client:
         
         if response_json.get('status') == 'SUCCESS':
             self.signin_status = 'success'
-            message = f"Success: Signed in to {self.url} as {username}."
+            message = f"User '{self.username}' is signed in to '{self.url}'."
             log.info(message)
             print(message)
         elif response_json.get('status') == 'FAILED':
             self.signin_status = 'failed'
-            message = f"Error: Unable to sign in to {self.url} as {username}." \
+            message = f"Error: Unable to sign in to {self.url} as {self.username}." \
                       f"\n{response_json.get('message')}"
             log.error(message)
             raise SigninError(message)
         else:
             self.signin_status = 'failed'
-            message = f"Error: Unable to sign in to {self.url} as {username}." \
+            message = f"Error: Unable to sign in to {self.url} as {self.username}." \
                       f"\n{response_json.get('message')}"
             log.error(message)
             raise SigninError(message)
-
-        self.username = username
 
     def signout(self):
         """Signs the client out of the EMX2 server."""
@@ -121,7 +119,7 @@ class Client:
         
         status = response.json().get('data', {}).get('signout', {}).get('status')
         if status == 'SUCCESS':
-            print(f"Signed out of {self.url}")
+            print(f"User '{self.username}' is signed out of '{self.url}'.")
             self.signin_status = 'signed out'
         else:
             print(f"Unable to sign out of {self.url}.")

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -122,7 +122,6 @@ class Client:
         status = response.json().get('data', {}).get('signout', {}).get('status')
         if status == 'SUCCESS':
             print(f"Signed out of {self.url}")
-            self.username = 'anonymous'
             self.signin_status = 'signed out'
         else:
             print(f"Unable to sign out of {self.url}.")


### PR DESCRIPTION
Addresses issue #2875.

Do you agree it should say `anonymous` when not signed in? I used this term as it shows the same schemas as the `anonymous` viewer in the UI would see, but I'm not entirely happy with the word