### PR TITLE
fix: Rename DefinitionList to CatalogueItemsList

### DIFF
--- a/apps/nuxt3-ssr/components/CollectionEventDisplay.vue
+++ b/apps/nuxt3-ssr/components/CollectionEventDisplay.vue
@@ -132,6 +132,6 @@ if (collectionEvent?.coreVariables?.length) {
     :title="collectionEvent?.name"
     :description="collectionEvent?.description"
   >
-    <DefinitionList :items="items" :small="true" />
+    <CatalogueItemList :items="items" :small="true" />
   </ContentBlockModal>
 </template>


### PR DESCRIPTION
A previous change renamed DefinitionList to CatalogueItemList The use of this component in the CollectionEventDisplay was not renamed

Closes #2892