### PR TITLE
chore: use custom image for ci build

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ jobs:
   build:
     docker:
     # specify the version you desire here
-    - image: gradle:jdk17-jammy
+    - image: molgenis/ci-build:latest
     - image: postgres:14-alpine
       environment:
         POSTGRES_USER: postgres
@@ -48,10 +48,6 @@ jobs:
         command: |
           ./gradlew dependencies
           apt-get update && apt-get install postgresql-client -y 
-          curl -sL https://deb.nodesource.com/setup_18.x | bash -
-          apt install nodejs
-          npx playwright install --with-deps
-          npm install -D @playwright/test
 
     - save_cache:
         paths:
@@ -60,13 +56,6 @@ jobs:
 
     # Initialize the database
     - run: psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql
-
-    - run:
-        name: install python
-        command: |
-          apt-get -y install python3 python3-venv python3-pip 
-          python3 -m pip install --upgrade build twine
-
 
     # install additional software
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,7 +81,7 @@ jobs:
     - run:
         name: build and test java
         command: |
-          ./gradlew test --no-daemon
+          ./gradlew build -x test --no-daemon
 
     - run:
         name: test e2e

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -82,10 +82,13 @@ jobs:
         name: build and test java
         command: |
           ./gradlew build -x test --no-daemon
+#         ./gradlew test --no-daemon
+
 
     - run:
         name: test e2e
         command: |
+          npm install -D -g @playwright/test
           set CI=true && npx playwright test --config e2e --project=chromium
 
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,8 @@ jobs:
     - run:
         name: test e2e
         command: |
-          npm install -D -g @playwright/test
+          npx playwright install --with-deps
+          npm install -D @playwright/test
           set CI=true && npx playwright test --config e2e --project=chromium
 
 

--- a/ci-build-images/Dockerfile
+++ b/ci-build-images/Dockerfile
@@ -15,8 +15,3 @@ RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
 ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
 RUN node --version
 RUN npm --version
-
-RUN npx playwright install --with-deps
-RUN npm install -D -g @playwright/test
-
-RUN npx playwright --version

--- a/ci-build-images/Dockerfile
+++ b/ci-build-images/Dockerfile
@@ -1,6 +1,8 @@
 FROM gradle:jdk17-jammy
 
 RUN apt-get update && apt-get install python3 python3-venv -y
+RUN apt-get install python3 python3-venv python3-pip -y
+RUN python3 -m pip install --upgrade build twine
 RUN python3 --version
 
 ENV NODE_VERSION=18.17.1
@@ -15,4 +17,6 @@ RUN node --version
 RUN npm --version
 
 RUN npx playwright install --with-deps
-RUN npm install -D @playwright/test
+RUN npm install -D -g @playwright/test
+
+RUN npx playwright --version

--- a/ci-build-images/Dockerfile
+++ b/ci-build-images/Dockerfile
@@ -1,0 +1,18 @@
+FROM gradle:jdk17-jammy
+
+RUN apt-get update && apt-get install python3 python3-venv -y
+RUN python3 --version
+
+ENV NODE_VERSION=18.17.1
+RUN apt install -y curl
+RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
+ENV NVM_DIR=/root/.nvm
+RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm use v${NODE_VERSION}
+RUN . "$NVM_DIR/nvm.sh" && nvm alias default v${NODE_VERSION}
+ENV PATH="/root/.nvm/versions/node/v${NODE_VERSION}/bin/:${PATH}"
+RUN node --version
+RUN npm --version
+
+RUN npx playwright install --with-deps
+RUN npm install -D @playwright/test


### PR DESCRIPTION
use emx2 build images that has node and python installed

This means the node / python binarie  repositories only need to be reachable when a new image is build instead of each pr/master build. 