### PR TITLE
build: don't share database instance between tests because setActiveUser may results in build errors

### DIFF
--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/PetStoreLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/PetStoreLoader.java
@@ -92,15 +92,20 @@ public class PetStoreLoader extends AbstractDataLoader {
     final String shopmanager = "shopmanager";
     final String shopowner = "shopowner";
 
-    // initual user
+    // initialize users
+    if (!schema.getDatabase().hasUser(shopmanager)) {
+      schema.getDatabase().setUserPassword(shopmanager, shopmanager);
+    }
+    if (!schema.getDatabase().hasUser(shopviewer)) {
+      schema.getDatabase().setUserPassword(shopviewer, shopviewer);
+    }
+    if (!schema.getDatabase().hasUser(shopowner)) {
+      schema.getDatabase().setUserPassword(shopowner, shopowner);
+    }
+
     schema.addMember(shopmanager, "Manager");
-    schema.getDatabase().setUserPassword(shopmanager, shopmanager);
-
     schema.addMember(shopviewer, "Viewer");
-    schema.getDatabase().setUserPassword(shopviewer, shopviewer);
-
     schema.addMember(shopowner, "Owner");
-    schema.getDatabase().setUserPassword(shopowner, shopowner);
 
     schema
         .getTable(CATEGORY)

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/TestDatabaseFactory.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/TestDatabaseFactory.java
@@ -3,12 +3,11 @@ package org.molgenis.emx2.sql;
 import org.molgenis.emx2.Database;
 
 public class TestDatabaseFactory {
-  private static Database db;
 
   public static Database getTestDatabase() {
-    db = new SqlDatabase(false);
+    Database db = new SqlDatabase(false);
     db.setActiveUser(db.getAdminUserName());
     return db;
-    // don't share the database between tests because different users different permissions.
+    // don't share the database between tests because when setting active user that leadds to errors
   }
 }


### PR DESCRIPTION
motivation: parallel tests get interactions sharing the same database because setActiveUser may lead to permission changes that break another test

drawback: this results in overhead in database instantiation (i.e. loading the metadata).

advantage: much more similar to our production environment where users don't share their database instance by having database instance per session.