### PR TITLE
fix: created emit for deleting menu items

### DIFF
--- a/apps/settings/src/components/MenuDesign.vue
+++ b/apps/settings/src/components/MenuDesign.vue
@@ -52,7 +52,6 @@
               :options="['Viewer', 'Editor', 'Manager']"
             />
           </div>
-          <!-- <IconDanger icon="trash" @click="items.splice(key, 1)" /> -->
           <IconDanger icon="trash" @click="$emit('delete', element.key)" />
         </form>
         <MenuManager

--- a/apps/settings/src/components/MenuDesign.vue
+++ b/apps/settings/src/components/MenuDesign.vue
@@ -5,42 +5,55 @@
     ghost-class="border-primary"
     :group="{ name: 'g1' }"
     :move="$emit('change')"
-    item-key="idx"
+    item-key="key"
     class="flex-nowrap"
   >
     <template #item="{ element }">
       <div>
         <form class="form-inline flex-nowrap">
           <div class="text-nowrap">
-            <label v-if="idx == 0">&nbsp;</label>
-            <IconAction class="menu-drag-icon" icon="ellipsis-v" />
+            <label :for="'menu-drag-' + element.key" class="sr-only">
+              drag item
+            </label>
+            <IconAction
+              :id="'menu-drag-' + element.key"
+              class="menu-drag-icon"
+              icon="ellipsis-v"
+            />
           </div>
           <div>
-            <label v-if="idx == 0">label</label>
+            <label :for="'menu-label-' + element.key" class="sr-only">
+              label
+            </label>
             <InputString
-              :id="'menu-label' + idx"
+              :id="'menu-label-' + element.key"
               v-model="element.label"
               :defaultValue="element.label"
             />
           </div>
           <div>
-            <label v-if="idx == 0">href</label>
+            <label :for="'menu-href-' + element.key" class="sr-only">
+              href
+            </label>
             <InputString
-              :id="'menu-href' + idx"
+              :id="'menu-href-' + element.key"
               v-model="element.href"
               :defaultValue="element.href"
             />
           </div>
           <div>
-            <label v-if="idx == 0">role</label>
+            <label :for="'menu-role-' + element.key" class="sr-only">
+              role
+            </label>
             <InputSelect
-              :id="'menu-role' + idx"
+              :id="'menu-role-' + element.key"
               v-model="element.role"
               :defaultValue="element.role"
               :options="['Viewer', 'Editor', 'Manager']"
             />
           </div>
-          <IconDanger icon="trash" @click="items.splice(idx, 1)" />
+          <!-- <IconDanger icon="trash" @click="items.splice(key, 1)" /> -->
+          <IconDanger icon="trash" @click="$emit('delete', element.key)" />
         </form>
         <MenuManager
           v-if="element.submenu"
@@ -73,6 +86,6 @@ export default {
     items: Array,
   },
   name: "MenuManager",
-  emits: ["change"],
+  emits: ["change", "delete"],
 };
 </script>

--- a/apps/settings/src/components/MenuManager.vue
+++ b/apps/settings/src/components/MenuManager.vue
@@ -110,7 +110,7 @@ export default {
       this.updateKey();
     },
     deleteItem(value) {
-      this.draft = this.draft.filter(item => item.key !== value);
+      this.draft = this.draft.filter((item) => item.key !== value);
     },
     updateKey() {
       this.key = Math.random().toString(36).substring(7);

--- a/apps/settings/src/components/MenuManager.vue
+++ b/apps/settings/src/components/MenuManager.vue
@@ -6,17 +6,17 @@
     <MessageSuccess v-if="success">{{ success }}</MessageSuccess>
     <Spinner v-if="loading" />
     <div v-else class="container">
-      <div>
+      <div class="mb-2">
         <IconAction @click="addItem" icon="plus" />
         <ButtonAlt @click="reset">Reset</ButtonAlt>
         <ButtonAction @click="saveSettings">Save</ButtonAction>
       </div>
-      <br />
       <MenuDesign
         :items="draft"
         :key="key"
         @change="sanitizeDraft"
         @add="addItem"
+        @delete="deleteItem"
       />
     </div>
     <div>
@@ -108,6 +108,9 @@ export default {
     addItem() {
       this.draft.unshift({ label: "new", href: "" });
       this.updateKey();
+    },
+    deleteItem(value) {
+      this.draft = this.draft.filter(item => item.key !== value);
     },
     updateKey() {
       this.key = Math.random().toString(36).substring(7);


### PR DESCRIPTION
This request introduces a fix for issue #2739. Currently, when a the delete button is clicked, the first item in the list `items` is removed. This is not desirable as it does not take into account if the menu items were reordered or changed.

## About the fix

After testing various options (e.g., click event on the delete button, filtering the array `items` in the draggable component etc.), it was decided to emit the key of the target element (in `MenuDesign`) into the parent element (in `MenuManager`).

- New emit event `@delete`:  `items.splice(...)` is replaced by `$emits('delete', ...)`. 
- New method for removing items: In `MenuManager`, there is a new method for deleting menu links from `this.drafts`
- Fix undefined in html attributes: Before, the key was `idx`. However, this was always undefined. The new key is `key` and all instances of `idx` were replaced by `element.key`.
- Added `for` attribute to labels: labels and inputs are now linked using the following format - `menu-*-<key>`
- All labels are properly hidden: previously, the labels were displayed if the key was 0. Labels should always be displayed for proper semantics, but labels can be hidden visually and still be web accessible. All labels have the class `sr-only`.
- Removed `<br/>` element in `MenuManager` and added `mb-2` to the button container

## Testing process

Navigate to the preview server and log in as admin. Open any schema (such as the `pet store`), and go to Settings >> Menu. Create a new menu item.

1. If you click the delete button associated with the new item, is the item deleted?
2. If you reordered the list and deleted the new menu item, is it deleted?
3. If you created multiple menu items, can you delete each item independently?
4. Is the menu saved when you log in/out? (link and ordering)
