### PR TITLE
fix: improved ontology loading in options menu

### DIFF
--- a/apps/molgenis-components/src/client/IClient.ts
+++ b/apps/molgenis-components/src/client/IClient.ts
@@ -51,4 +51,5 @@ export interface INewClient {
     row: IRow,
     tableName: string
   ) => Promise<Record<string, any>>;
+  fetchOntologyOptions: (tableName: string) => Promise<any>;
 }

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -154,6 +154,9 @@ const client: IClient = {
       convertRowToPrimaryKey: async (row: IRow, tableName: string) => {
         return convertRowToPrimaryKey(row, tableName, schemaName);
       },
+      fetchOntologyOptions: async (tableName: string) => {
+        return fetchOntologyOptions(tableName, schemaName);
+      },
     };
   },
 };
@@ -318,6 +321,34 @@ const fetchTableData = async (
       throw error;
     });
   return resp?.data.data;
+};
+
+const fetchOntologyOptions = async (
+  tableName: string,
+  schemaName: string | undefined
+) => {
+  const tableId = convertToPascalCase(tableName);
+  const tableDataQuery = `query ${tableId} {
+        ${tableId}(
+          limit:100000
+          )
+          {
+          	order 
+            name 
+            label 
+            parent { order name label } 
+            children { order name label parent { name } } 
+          }
+        }`;
+  const resp = await axios
+    .post(graphqlURL(schemaName), {
+      query: tableDataQuery,
+    })
+    .catch((error: AxiosError) => {
+      console.log(error);
+      throw error;
+    });
+  return resp?.data.data[tableId];
 };
 
 const fetchSettings = async (schemaName?: string) => {

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -502,9 +502,7 @@ export default {
   async mounted() {
     if (this.tableName) {
       const client = Client.newClient(this.schemaName);
-      this.data = (
-        await client.fetchTableData(this.tableName, { limit: this.limit || 20 })
-      )[this.tableId];
+      this.data = await client.fetchOntologyOptions(this.tableName);
     }
   },
   created() {


### PR DESCRIPTION
Fixes #2898 by reducing the amount of data queried from the server.

Created function `fetchOntologyOptions` specifically for fetching ontology table for an ontology options list.
* fetchOntologyOptions generates a lean query to fetch an ontology without definition, ontologytermURI, nested parent/child data, mg metadata, etc.
* function is implemented in client.ts, IClient.ts, InputOntology.vue