### PR TITLE
fix: mg_tableclass should not have default value. closes #2926

### DIFF
--- a/apps/molgenis-components/src/components/forms/RowEdit.vue
+++ b/apps/molgenis-components/src/components/forms/RowEdit.vue
@@ -256,12 +256,7 @@ export default {
   },
   created() {
     this.tableMetaData.columns.forEach((column: IColumn) => {
-      //mg_tableclass filter to correct for a backend bug before v9.3.3
-      if (
-        column.defaultValue &&
-        !column.id == "mg_tableclass" &&
-        !this.internalValues[column.id]
-      ) {
+      if (column.defaultValue && !this.internalValues[column.id]) {
         this.internalValues[column.id] = column.defaultValue;
       }
     });

--- a/apps/molgenis-components/src/components/forms/RowEdit.vue
+++ b/apps/molgenis-components/src/components/forms/RowEdit.vue
@@ -256,7 +256,12 @@ export default {
   },
   created() {
     this.tableMetaData.columns.forEach((column: IColumn) => {
-      if (column.defaultValue && !this.internalValues[column.id]) {
+      //mg_tableclass filter to correct for a backend bug before v9.3.3
+      if (
+        column.defaultValue &&
+        !column.id == "mg_tableclass" &&
+        !this.internalValues[column.id]
+      ) {
         this.internalValues[column.id] = column.defaultValue;
       }
     });

--- a/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestInherits.java
+++ b/backend/molgenis-emx2-sql-it/src/test/java/org/molgenis/emx2/sql/TestInherits.java
@@ -57,6 +57,9 @@ public class TestInherits {
     Table employee =
         s.create(table("Employee").setInherit(person.getName()).add(column("salary").setType(INT)));
 
+    // check that mg_tableclass column doesn't have a default (regression #2936)
+    assertNull(employee.getMetadata().getColumn(MG_TABLECLASS).getDefaultValue());
+
     Table manager =
         s.create(
             table("Manager")

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 public class Migrations {
   // version the current software needs to work
-  private static final int SOFTWARE_DATABASE_VERSION = 12;
+  private static final int SOFTWARE_DATABASE_VERSION = 13;
   private static Logger logger = LoggerFactory.getLogger(Migrations.class);
 
   public static synchronized void initOrMigrate(SqlDatabase db) {
@@ -87,6 +87,10 @@ public class Migrations {
 
           if (version < 12)
             executeMigrationFile(tdb, "migration12.sql", "add defaultValue in metadata schema");
+
+          if (version < 13)
+            executeMigrationFile(
+                tdb, "migration13.sql", "remove default value for mg_tableclass columns");
 
           // if success, update version to SOFTWARE_DATABASE_VERSION
           updateDatabaseVersion((SqlDatabase) tdb, SOFTWARE_DATABASE_VERSION);

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadataExecutor.java
@@ -148,11 +148,7 @@ class SqlTableMetadataExecutor {
     }
     // add column to superclass table
     if (other.getLocalColumn(MG_TABLECLASS) == null) {
-      other.add(
-          column(MG_TABLECLASS)
-              .setReadonly(true)
-              .setPosition(10005)
-              .setDefaultValue(other.getSchemaName() + "." + other.getTableName()));
+      other.add(column(MG_TABLECLASS).setReadonly(true).setPosition(10005));
 
       // should not be user editable, we add trigger
       createMgTableClassCannotUpdateCheck((SqlTableMetadata) other, jooq);

--- a/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/migration13.sql
+++ b/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/migration13.sql
@@ -1,0 +1,1 @@
+UPDATE "MOLGENIS"."column_metadata" SET "defaultValue"=NULL WHERE "column_name"='mg_tableclass'


### PR DESCRIPTION
the bug was that a default for mg_tableclass was set. And then records added could use that default value, defaulting to the first subclass of a table. 

Until PR #2884 this bug didn't have effect because in row_edit form column default values are only applied to visible columns. However, in #2884 now default are applied to all columns, which include the mg_tableclass.

This PR removes that default for new mg_tableclass column instances, and has a migration to delete the defaultValue in existing mg_tableclass instances

closes #2926