### PR TITLE
chore: Add CI = true env var to azure build

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -49,3 +49,4 @@ steps:
     JVM_OPTS: -Xmx3200m
     NODE_OPTIONS: "--max-old-space-size=4096"
     GRADLE_OPTS: "-Dorg.gradle.daemon=false -Dorg.gradle.workers.max=2"
+    CI: true


### PR DESCRIPTION
CI env is read by gradle during build, when set to true it uses the image node instead of downloading node on each build this should improve stability and reduce build times