### PR TITLE
feat!: added check that refTable can only be set for refs

### DIFF
--- a/docs/molgenis/use_schema.md
+++ b/docs/molgenis/use_schema.md
@@ -126,7 +126,7 @@ these translate to foreign keys, and array of foreign key with triggers protecti
 ### refTable
 
 This metadata is used to define relationships between tables. When columnType is 'ref' or 'ref_array' then you must provide refTable. In simple cases, this is
-all you need. The value of refTable should a defined tableName. Default value: empty
+all you need. The value of refTable should a defined tableName. N.B. if your columnType is not of a 'ref' than having refTable will produce an error. Default value: empty
 
 A simple reference:
 


### PR DESCRIPTION
Breaking change: you cannot set refTable when your data type is not a ref(_array) or ontology(_array). 

This will break existing databases. Please download your data first and empty refTable in error cases and reload again. 

BREAKING CHANGE