### PR TITLE
fix: an instance of Pet should refer back to the collection of pets with qb:dataSet and not qb:DataSet

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -74,7 +74,10 @@ public class RDFService {
   public static final String NAMESPACE_DCTERMS = "http://purl.org/dc/terms/";
   public static final IRI IRI_DATABASE_TABLE =
       Values.iri("http://semanticscience.org/resource/SIO_000754");
-  public static final IRI IRI_DATASET = Values.iri("http://purl.org/linked-data/cube#DataSet");
+  public static final IRI IRI_DATASET_CLASS =
+      Values.iri("http://purl.org/linked-data/cube#DataSet");
+  public static final IRI IRI_DATASET_PREDICATE =
+      Values.iri("http://purl.org/linked-data/cube#dataSet");
   public static final IRI IRI_CONTROLLED_VOCABULARY =
       Values.iri("http://purl.obolibrary.org/obo/NCIT_C48697");
   /**
@@ -299,7 +302,7 @@ public class RDFService {
   private void describeTable(final ModelBuilder builder, final Table table) {
     final IRI subject = getTableIRI(table);
     builder.add(subject, RDF.TYPE, OWL.CLASS);
-    builder.add(subject, RDFS.SUBCLASSOF, IRI_DATASET);
+    builder.add(subject, RDFS.SUBCLASSOF, IRI_DATASET_CLASS);
     builder.add(subject, RDFS.SUBCLASSOF, IRI_DATABASE_TABLE);
     builder.add(subject, RDFS.SUBCLASSOF, OWL.THING);
     // Specify the tables that this table inherits from.
@@ -433,7 +436,7 @@ public class RDFService {
       } else {
         builder.add(subject, RDF.TYPE, IRI_OBSERVATION);
       }
-      builder.add(subject, IRI_DATASET, tableIRI);
+      builder.add(subject, IRI_DATASET_PREDICATE, tableIRI);
 
       for (final Column column : table.getMetadata().getColumns()) {
         // Exclude the system columns like mg_insertedBy

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java
@@ -223,6 +223,24 @@ public class RDFTest {
         iris.contains(subjectWithCompositeKey),
         "A Sample resource should have a key based on patient.firstName, patient.lastName and id");
   }
+
+  @Test
+  void testThatInstancesUseReferToDatasetWithTheRightPredicate() throws IOException {
+    var handler = new InMemoryRDFHandler() {};
+    getAndParseRDF(Selection.ofRow(petStore_nr1, "Pets", "pooky"), handler);
+    for (var iri : handler.resources.keySet()) {
+      // Select the triples for pooky
+      if (iri.stringValue().endsWith("pooky")) {
+
+        var pooky = handler.resources.get(iri);
+        assertTrue(
+            pooky.containsKey(RDFService.IRI_DATASET_PREDICATE),
+            "An instance of a Pet should refer back to the Collection using qb:dataSet");
+        assertFalse(
+            pooky.containsKey(RDFService.IRI_DATASET_CLASS), "qb:DataSet is not a predicate");
+      }
+    }
+  }
   /**
    * Helper method to reduce boilerplate code in the tests.<br>
    * <b>Note</b> this method delegates to the handler for the results of parsing.


### PR DESCRIPTION
- test case for verify that the qb:dataSet predicate is used
- use IRI_DATASET_CLASS and IRI_DATASET_PREDICATE to distinguish between the class and the predicate
- fix the rowsToRdf method to use the IRI_DATASET_PREDICATE

Closes #2931 