### PR TITLE
fix: columns headers of columns without labels were empty

### DIFF
--- a/apps/molgenis-components/src/components/tables/TableMolgenis.vue
+++ b/apps/molgenis-components/src/components/tables/TableMolgenis.vue
@@ -19,7 +19,7 @@
             class="mb-0 align-text-bottom text-nowrap"
             @click="onColumnClick(col)"
           >
-            {{ col.label }}
+            {{ col.label || col.name || col.id }}
             <slot name="colheader" :col="col" />
           </h6>
         </th>

--- a/apps/molgenis-components/src/components/tables/TableMolgenis.vue
+++ b/apps/molgenis-components/src/components/tables/TableMolgenis.vue
@@ -19,7 +19,7 @@
             class="mb-0 align-text-bottom text-nowrap"
             @click="onColumnClick(col)"
           >
-            {{ col.label || col.name || col.id }}
+            {{ col.label }}
             <slot name="colheader" :col="col" />
           </h6>
         </th>

--- a/apps/schema/src/utils.ts
+++ b/apps/schema/src/utils.ts
@@ -206,7 +206,7 @@ export function addTableIdsLabelsDescription(originalTable: ITableMetaData) {
   table.inheritId = convertToPascalCase(table.inheritName);
   table.columns = table.columns.map((column) => {
     column.id = convertToCamelCase(column.name);
-    column.label = getLocalizedLabel(column, "en");
+    column.label = getLocalizedLabel(column, "en") || column.name;
     column.description = getLocalizedDescription(column, "en");
     column.refTableId = convertToPascalCase(column.refTableName);
     column.refLinkId = convertToCamelCase(column.refLinkName);


### PR DESCRIPTION
stepz2rep: 
go to the schema editor 
add a column to a table, without entering a label
save
look at the table, the column header is empty
