### PR TITLE
feat: expansion of the python client

### DIFF
--- a/tools/pyclient/README.md
+++ b/tools/pyclient/README.md
@@ -27,11 +27,17 @@ with Client('https://example.molgeniscloud.org') as client:
         catalogue
         ExampleSchema
         ...
-    Version: v8.214.1
+    Version: v10.10.1
     """
     
     # Retrieve data from a table on a schema
-    data = client.get(schema='ExampleSchame', table='Cohorts')
+    data = client.get(schema='ExampleSchema', table='Cohorts')
+    
+    # Create a new schema on the server
+    client.create_schema(name='New Schema')
+    
+    # Delete a schema from the server
+    client.delete_schema(name='New Schema')
 
 ```
 
@@ -86,8 +92,10 @@ pip install -r requirements.txt
 ```
 
 ## Build
-
+Before building the source, the package `build` needs to be installed.
 ```console
+(venv) $ pip install build
+
 (venv) $ python -m build
 
 (venv) $ pip install dist/molgenis_emx2_pyclient*.whl

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -19,7 +19,8 @@ import pandas as pd
 from dotenv import load_dotenv
 
 from tools.pyclient.src.molgenis_emx2_pyclient import Client
-from tools.pyclient.src.molgenis_emx2_pyclient.exceptions import NoSuchSchemaException, NoSuchTableException, GraphQLException
+from tools.pyclient.src.molgenis_emx2_pyclient.exceptions import (NoSuchSchemaException, NoSuchTableException,
+                                                                  GraphQLException)
 
 
 async def main():
@@ -129,35 +130,35 @@ async def main():
         client.delete(schema='pet store', table='Pet', file='demodata/Pet.csv')
         client.delete(schema='pet store', table='Tag', file='demodata/Tag.csv')
 
-    # Connect to server and create, update, and drop schemas,
+    # Connect to server and create, update, and drop schemas
     with Client('https://emx2.dev.molgenis.org/') as client:
         client.signin(username, password)
         
-        # create a schema
+        # Create a schema
         try:
-          client.createSchema(schema='myNewSchema')
-          client.schemas
+            client.create_schema(schema='myNewSchema')
+            print(client.schema_names)
         except GraphQLException as e:
             print(e)
             
-        # update the description
+        # Update the description
         try:
-          client.updateSchema(schema='myNewSchema', description='I forgot the description')
-          client.schemas
+            client.update_schema(schema='myNewSchema', description='I forgot the description')
+            print(client.schema_names)
         except GraphQLException as e:
             print(e)
         
-        # recreate the schema: delete and create
+        # Recreate the schema: delete and create
         try:
-          client.recreateSchema(schema='myNewSchema')
-          client.schemas
+            client.recreate_schema(schema='myNewSchema')
+            print(client.schema_names)
         except GraphQLException as e:
             print(e)
         
-        # delete the schema
+        # Delete the schema
         try:
-          client.deleteSchema(schema='myNewSchema')
-          client.schemas
+            client.delete_schema(schema='myNewSchema')
+            print(client.schema_names)
         except GraphQLException as e:
             print(e)
 

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -111,8 +111,8 @@ async def main():
 
         # Drop records
         tags_to_remove = [{'name': row['name']} for row in new_tags if row['name'] == 'canis']
-        client.delete(schema='pet store', table='Pet', data=new_pets)
-        client.delete(schema='pet store', table='Tag', data=tags_to_remove)
+        client.delete_records(schema='pet store', table='Pet', data=new_pets)
+        client.delete_records(schema='pet store', table='Tag', data=tags_to_remove)
 
         # ///////////////////////////////////////
 
@@ -127,8 +127,8 @@ async def main():
         client.save_schema(name='pet store', table='Tag', file='demodata/Tag.csv')
         client.save_schema(name='pet store', table='Pet', file='demodata/Pet.csv')
 
-        client.delete(schema='pet store', table='Pet', file='demodata/Pet.csv')
-        client.delete(schema='pet store', table='Tag', file='demodata/Tag.csv')
+        client.delete_records(schema='pet store', table='Pet', file='demodata/Pet.csv')
+        client.delete_records(schema='pet store', table='Tag', file='demodata/Tag.csv')
 
     # Connect to server and create, update, and drop schemas
     with Client('https://emx2.dev.molgenis.org/') as client:

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -145,6 +145,7 @@ async def main():
         try:
             client.update_schema(schema='myNewSchema', description='I forgot the description')
             print(client.schema_names)
+            print(client.schemas)
         except GraphQLException as e:
             print(e)
         

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -100,8 +100,8 @@ async def main():
         }]
 
         # Import new data
-        client.save(schema='pet store', table='Tag', data=new_tags)
-        client.save(schema='pet store', table='Pet', data=new_pets)
+        client.save_schema(name='pet store', table='Tag', data=new_tags)
+        client.save_schema(name='pet store', table='Pet', data=new_pets)
 
         # Retrieve records
         tags_data = client.get(schema='pet store', table='Tag', as_df=True)
@@ -124,8 +124,8 @@ async def main():
         pd.DataFrame(new_pets).to_csv('demodata/Pet.csv', index=False)
 
         # Import files
-        client.save(schema='pet store', table='Tag', file='demodata/Tag.csv')
-        client.save(schema='pet store', table='Pet', file='demodata/Pet.csv')
+        client.save_schema(name='pet store', table='Tag', file='demodata/Tag.csv')
+        client.save_schema(name='pet store', table='Pet', file='demodata/Pet.csv')
 
         client.delete(schema='pet store', table='Pet', file='demodata/Pet.csv')
         client.delete(schema='pet store', table='Tag', file='demodata/Tag.csv')
@@ -136,14 +136,14 @@ async def main():
         
         # Create a schema
         try:
-            client.create_schema(schema='myNewSchema')
+            client.create_schema(name='myNewSchema')
             print(client.schema_names)
         except GraphQLException as e:
             print(e)
             
         # Update the description
         try:
-            client.update_schema(schema='myNewSchema', description='I forgot the description')
+            client.update_schema(name='myNewSchema', description='I forgot the description')
             print(client.schema_names)
             print(client.schemas)
         except GraphQLException as e:
@@ -151,14 +151,14 @@ async def main():
         
         # Recreate the schema: delete and create
         try:
-            client.recreate_schema(schema='myNewSchema')
+            client.recreate_schema(name='myNewSchema')
             print(client.schema_names)
         except GraphQLException as e:
             print(e)
         
         # Delete the schema
         try:
-            client.delete_schema(schema='myNewSchema')
+            client.delete_schema(name='myNewSchema')
             print(client.schema_names)
         except GraphQLException as e:
             print(e)

--- a/tools/pyclient/requirements.txt
+++ b/tools/pyclient/requirements.txt
@@ -1,2 +1,3 @@
 requests~=2.31.0
 pandas~=2.1.1
+python-dotenv~=1.0.0

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -367,3 +367,104 @@ class Client:
                 with open(filename, "wb") as f:
                     f.write(response.content)
                 log.info(f"Exported data from table {table} in schema {current_schema} to '{filename}'.")
+
+    def createSchema(self, schema: str = None, description: str = None, template: str = None, includeDemoData: bool = None):
+        """Create a new schema
+        
+        :param schema: the name of the new schema
+        :type schema: str
+        :param description: additional text that provides context for a schema
+        :type description: str
+        :param template: (optional) the name of a template to set as the schema
+        :type template: str
+        :param includeDemoData: If true and a template schema is selected, any example data will be loaded into the schema
+        :type includeDemoData: bool
+        """
+        query = queries.create_schema()
+        variables = {'name': schema, 'description': description, 'template': template, 'includeDemoData': includeDemoData}
+        response = self.session.post(
+           url=f"{self.url}/{schema}/graphql",
+           json={'query': query, 'variables': variables}
+        )
+        
+        response_json = response.get('data').get('createSchema')
+        if response_json.get('status') == 'SUCCESS':
+            message = response_json.get('message')
+            log.info(message)
+            print(message)
+        else:
+            if 'error' in response:
+                message = response.get('error').get('errors')[0].get('message')
+                log.error(message)
+            else:
+                message = f"Failed to create schema '{schema}'"
+                log.error(message)
+                
+    def deleteSchema(self, schema: str = None):
+        """Delete a schema
+        
+        :param schema: the name of the new schema
+        :type schema: str
+        """
+        query = queries.delete_schema()
+        variables = {'name': schema}
+        response = self.session.post(
+            url=f"{self.url}/{schema}/graphql",
+            json={'query': query, 'variables': variables}
+        )
+        
+        response_json = response.get('data').get('deleteSchema')
+        if response_json.get('status') == 'SUCCESS':
+            message = response_json.get('message')
+            log.info(message)
+            print(message)
+        else:
+            if 'error' in response:
+                message = response.get('error').get('errors')[0].get('message')
+                log.error(message)
+            else:
+                message = f"Failed to create schema '{schema}'"
+                log.error(message)
+    
+    def updateSchema(self, schema: str = None, description: str = None):
+        """Update a schema's description
+        
+        :param schema: the name of the new schema
+        :type schema: str
+        :param description: additional text that provides context for a schema
+        :type description: str
+        """
+        query = queries.update_schema()
+        variables = {'name': schema, 'descrition': description}
+        response = self.session.post(
+            url=f"{self.url}/{schema}/graphql",
+            json={'query': query, 'variables': variables}
+        )
+        
+        response_json = response.get('data').get('updateSchema')
+        if response_json.get('status') == 'SUCCESS':
+            message = response_json.get('message')
+            log.info(message)
+            print(message)
+        else:
+            if 'error' in response:
+                message = response.get('error').get('errors')[0].get('message')
+                log.error(message)
+            else:
+                message = f"Failed to update schema '{schema}'"
+                log.error(message)
+                
+    def recreateSchema(self, schema: str = None, description: str = None, template: str = None, includeDemoData: bool = None):
+        """Delete a schema and recreate it""" 
+    
+        currentDescription = "..."
+        self.deleteSchema(schema=schema)
+        self.createSchema(
+            schema = schema,
+            description = currentDescription,
+            template = template,
+            includeDemoData = includeDemoData
+        )
+        
+        
+        

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -109,22 +109,6 @@ class Client:
                       f"\n{response_json.get('message')}"
             log.error(message)
             raise SigninError(message)
-
-    def signout(self):
-        """Signs the client out of the EMX2 server."""
-        response = self.session.post(
-            url=self.api_graphql,
-            json={'query': queries.signout()}
-        )        
-        
-        status = response.json().get('data', {}).get('signout', {}).get('status')
-        if status == 'SUCCESS':
-            print(f"User '{self.username}' is signed out of '{self.url}'.")
-            self.signin_status = 'signed out'
-        else:
-            print(f"Unable to sign out of {self.url}.")
-            message = response.json().get('errors')[0].get('message')
-            print(message)
             
     @property
     def status(self):

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -110,6 +110,7 @@ class Client:
                       f"\n{response_json.get('message')}"
             log.error(message)
             raise SigninError(message)
+        self.schemas = self.get_schemas()
         
     def signout(self):
         """Signs the client out of the EMX2 server."""
@@ -248,6 +249,8 @@ class Client:
         args = {key: params[key] for key in keys if (key != 'self') and (key is not None)}
         if 'schema' in args.keys():
             args['name'] = args.pop('schema')
+        if 'include_demo_data' in args.keys():
+            args['includeDemoData'] = args.pop('include_demo_data')
         return args
 
     def _table_in_schema(self, table: str, schema: str) -> bool:
@@ -476,6 +479,7 @@ class Client:
             mutation='createSchema',
             fallback_error_message=f"Failed to create schema '{schema}'"
         )
+        self.schemas = self.get_schemas()
               
     def delete_schema(self, schema: str = None):
         """Delete a schema
@@ -499,6 +503,7 @@ class Client:
             mutation='deleteSchema',
             fallback_error_message=f"Failed to delete schema '{schema}'"
         )
+        self.schemas = self.get_schemas()
 
     def update_schema(self, schema: str = None, description: str = None):
         """Update a schema's description
@@ -524,6 +529,7 @@ class Client:
             mutation='updateSchema',
             fallback_error_message=f"Failed to update schema '{schema}'"
         )
+        self.schemas = self.get_schemas()
                 
     def recreate_schema(self, schema: str = None, description: str = None, template: str = None,
                         include_demo_data: bool = None):
@@ -560,6 +566,7 @@ class Client:
             message = f"Failed to recreate '{schema}'"
             log.error(message)
             print(message)
-        
+
+        self.schemas = self.get_schemas()
         
         

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -18,12 +18,12 @@ OutputFormat: TypeAlias = Literal['csv', 'xlsx']
 
 class Client:
     """
-    Use the Client object to log in to a Molgenis server and perform operations on the server.
-    Specify a default schema
+    Use the Client object to log in to a Molgenis EMX2 server
+    and perform operations on the server.
     """
     def __init__(self, url: str, schema: str = None) -> None:
         """
-        A Client class instances is created with a server url.
+        Initializes a Client object with a server url.
         """
         self._as_context_manager = False
         self.url: str = utils.parse_url(url)
@@ -61,7 +61,7 @@ class Client:
         self.session.close()
 
     def signin(self, username: str, password: str):
-        """Signs in to Molgenis and retrieves session cookie.
+        """Signs in to the EMX2 server and retrieves session cookie.
 
         :param username: the username or email address for an account on this server
         :type username: str
@@ -130,7 +130,9 @@ class Client:
             
     @property
     def status(self):
-        """View client information"""
+        """Shows the sign-in status of the user, the server version
+        and the schemas that the user can interact with.
+        """
         schemas = '\n\t'.join(self.schema_names)
         message = (
           f"Host: {self.url}\n"
@@ -166,7 +168,7 @@ class Client:
 
     @property
     def version(self):
-        """List the current EMX2 version on the server"""
+        """Lists the current EMX2 version on the server"""
         query = queries.version_number()
         response = self.session.post(
             url=self.api_graphql,
@@ -213,7 +215,7 @@ class Client:
     
     @staticmethod
     def _graphql_validate_response(response_json: dict, mutation: str, fallback_error_message: str):
-        """Validates a GraphQL response and print the appropriate message
+        """Validates a GraphQL response and prints the appropriate message.
         
         :param response_json: a graphql response from the server
         :type response_json: dict
@@ -248,6 +250,7 @@ class Client:
             
     @staticmethod
     def _format_optional_params(**kwargs):
+        """Parses optional keyword arguments to a format suitable for GraphQL queries."""
         keys = kwargs.keys()
         args = {key: kwargs[key] for key in keys if (key != 'self') and (key is not None)}
         if 'name' in args.keys():
@@ -313,8 +316,8 @@ class Client:
             errors = '\n'.join([err['message'] for err in response.json().get('errors')])
             log.error(f"Failed to import data into {current_schema}::{table}\n{errors}.")
 
-    def delete(self, schema: str = None, table: str = None, file: str = None, data: list = None):
-        """Deletes records from table.
+    def delete_records(self, schema: str = None, table: str = None, file: str = None, data: list = None):
+        """Deletes records from a table.
         
         :param schema: name of a schema
         :type schema: str
@@ -392,7 +395,7 @@ class Client:
         return response_data
 
     def export(self, schema: str = None, table: str = None, fmt: OutputFormat = 'csv'):
-        """Export data from a schema to a file in the desired format.
+        """Exports data from a schema to a file in the desired format.
         
         :param schema: the name of the schema
         :type schema: str
@@ -455,7 +458,7 @@ class Client:
                       description: str = None,
                       template: str = None,
                       include_demo_data: bool = None):
-        """Create a new schema
+        """Creates a new schema on the EMX2 server.
         
         :param name: the name of the new schema
         :type name: str
@@ -488,7 +491,7 @@ class Client:
         self.schemas = self.get_schemas()
               
     def delete_schema(self, name: str = None):
-        """Delete a schema
+        """Deletes a schema from the EMX2 server.
         
         :param name: the name of the new schema
         :type name: str
@@ -513,7 +516,7 @@ class Client:
         self.schemas = self.get_schemas()
 
     def update_schema(self, name: str = None, description: str = None):
-        """Update a schema's description
+        """Updates a schema's description.
         
         :param name: the name of the new schema
         :type name: str
@@ -543,7 +546,8 @@ class Client:
                         description: str = None,
                         template: str = None,
                         include_demo_data: bool = None):
-        """Recreates a schema
+        """Recreates a schema on the EMX2 server by deleting and subsequently
+        creating it without data on the EMX2 server.
         
         :param name: the name of the new schema
         :type name: str
@@ -583,7 +587,7 @@ class Client:
         self.schemas = self.get_schemas()
         
     def get_schema_metadata(self, name: str = None):
-        """Retrieve a schema's metadata
+        """Retrieves a schema's metadata.
         
         :param name: the name of the new schema
         :type name: str

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -152,6 +152,9 @@ class Client:
             json={'query': query}
         )
 
+        if response.status_code == 404:
+            raise ServerNotFoundError(f"Server with url '{self.url}'")
+
         response_json: dict = response.json()
         schemas = response_json['data']['_schemas']
         return schemas
@@ -448,7 +451,9 @@ class Client:
                     f.write(response.content)
                 log.info(f"Exported data from table {table} in schema {current_schema} to '{filename}'.")
 
-    def create_schema(self, name: str = None, description: str = None, template: str = None,
+    def create_schema(self, name: str = None,
+                      description: str = None,
+                      template: str = None,
                       include_demo_data: bool = None):
         """Create a new schema
         
@@ -493,6 +498,7 @@ class Client:
         """
         query = queries.delete_schema()
         variables = {'id': name}
+
         response = self.session.post(
             url=f"{self.url}/api/graphql",
             json={'query': query, 'variables': variables}
@@ -519,6 +525,7 @@ class Client:
         """
         query = queries.update_schema()
         variables = {'name': name, 'description': description}
+
         response = self.session.post(
             url=f"{self.url}/api/graphql",
             json={'query': query, 'variables': variables}
@@ -532,9 +539,11 @@ class Client:
         )
         self.schemas = self.get_schemas()
                 
-    def recreate_schema(self, name: str = None, description: str = None, template: str = None,
+    def recreate_schema(self, name: str = None,
+                        description: str = None,
+                        template: str = None,
                         include_demo_data: bool = None):
-        """Recreate a schema
+        """Recreates a schema
         
         :param name: the name of the new schema
         :type name: str

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -109,6 +109,22 @@ class Client:
                       f"\n{response_json.get('message')}"
             log.error(message)
             raise SigninError(message)
+        
+    def signout(self):
+      """Signs the client out of the EMX2 server."""
+      response = self.session.post(
+          url=self.api_graphql,
+          json={'query': queries.signout()}
+      )        
+
+      status = response.json().get('data', {}).get('signout', {}).get('status')
+      if status == 'SUCCESS':
+          print(f"User '{self.username}' is signed out of '{self.url}'.")
+          self.signin_status = 'signed out'
+      else:
+          print(f"Unable to sign out of {self.url}.")
+          message = response.json().get('errors')[0].get('message')
+          print(message)
             
     @property
     def status(self):

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -215,7 +215,7 @@ class Client:
         :type response_json: dict
         :param mutation: the name of the graphql mutation executed
         :type mutation: str
-        :param fallback_error_message: a failback error message
+        :param fallback_error_message: a fallback error message
         :type fallback_error_message: str
       
         :returns: a success or error message
@@ -243,9 +243,9 @@ class Client:
                 print(message)
             
     @staticmethod
-    def _format_optional_params(params: dict = None) :
+    def _format_optional_params(params: dict = None):
         keys = params.keys()
-        args = { key: params[key] for key in keys if (key != 'self') and (key is not None) }
+        args = {key: params[key] for key in keys if (key != 'self') and (key is not None)}
         if 'schema' in args.keys():
             args['name'] = args.pop('schema')
         return args
@@ -371,7 +371,7 @@ class Client:
         if not self._table_in_schema(table, current_schema):
             raise NoSuchTableException(f"Table '{table}' not found in schema '{current_schema}'.")
 
-        response = self.session.get(url=f"{self.url}/{schema}/api/csv/{table}")
+        response = self.session.get(url=f"{self.url}/{current_schema}/api/csv/{table}")
 
         if response.status_code != 200:
             message = f"Failed to retrieve data from '{current_schema}::{table}'." \
@@ -445,7 +445,8 @@ class Client:
                     f.write(response.content)
                 log.info(f"Exported data from table {table} in schema {current_schema} to '{filename}'.")
 
-    def createSchema(self, schema: str = None, description: str = None, template: str = None, includeDemoData: bool = None):
+    def create_schema(self, schema: str = None, description: str = None, template: str = None,
+                      include_demo_data: bool = None):
         """Create a new schema
         
         :param schema: the name of the new schema
@@ -454,8 +455,9 @@ class Client:
         :type description: str
         :param template: (optional) the name of a template to set as the schema
         :type template: str
-        :param includeDemoData: If true and a template schema is selected, any example data will be loaded into the schema
-        :type includeDemoData: bool
+        :param include_demo_data: If true and a template schema is selected, 
+                                any example data will be loaded into the schema
+        :type include_demo_data: bool
         
         :returns: a success or error message
         :rtype: string
@@ -472,10 +474,10 @@ class Client:
         self._graphql_validate_response(
             response_json=response_json,
             mutation='createSchema',
-            fallback_error_message= f"Failed to create schema '{schema}'"
+            fallback_error_message=f"Failed to create schema '{schema}'"
         )
               
-    def deleteSchema(self, schema: str = None):
+    def delete_schema(self, schema: str = None):
         """Delete a schema
         
         :param schema: the name of the new schema
@@ -498,7 +500,7 @@ class Client:
             fallback_error_message=f"Failed to delete schema '{schema}'"
         )
 
-    def updateSchema(self, schema: str = None, description: str = None):
+    def update_schema(self, schema: str = None, description: str = None):
         """Update a schema's description
         
         :param schema: the name of the new schema
@@ -523,7 +525,8 @@ class Client:
             fallback_error_message=f"Failed to update schema '{schema}'"
         )
                 
-    def recreateSchema(self, schema: str = None, description: str = None, template: str = None, includeDemoData: bool = None):
+    def recreate_schema(self, schema: str = None, description: str = None, template: str = None,
+                        include_demo_data: bool = None):
         """Recreate a schema
         
         :param schema: the name of the new schema
@@ -532,10 +535,9 @@ class Client:
         :type description: str
         :param template: (optional) the name of a template to set as the schema
         :type template: str
-        :param includeDemoData: If true and a template schema is selected, any example data will be loaded into the schema
-        :type includeDemoData: bool
-        
-        :return
+        :param include_demo_data: If true and a template schema is selected,
+                                any example data will be loaded into the schema
+        :type include_demo_data: bool
         """
         if schema not in self.schema_names:
             message = f"Schema '{schema}' does not exist"
@@ -546,13 +548,13 @@ class Client:
         schema_description = description if description else schema_meta.get('description', None)
 
         try:
-          self.deleteSchema(schema=schema)
-          self.createSchema(
-              schema = schema,
-              description = schema_description,
-              template = template,
-              includeDemoData = includeDemoData
-          )
+            self.delete_schema(schema=schema)
+            self.create_schema(
+                schema=schema,
+                description=schema_description,
+                template=template,
+                include_demo_data=include_demo_data
+            )
 
         except GraphQLException:
             message = f"Failed to recreate '{schema}'"

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -544,6 +544,9 @@ class Client:
         :param include_demo_data: If true and a template schema is selected,
                                 any example data will be loaded into the schema
         :type include_demo_data: bool
+        
+        :returns: a success or error message
+        :rtype: string
         """
         if schema not in self.schema_names:
             message = f"Schema '{schema}' does not exist"
@@ -568,5 +571,36 @@ class Client:
             print(message)
 
         self.schemas = self.get_schemas()
+        
+    def get_schema_metadata(self, schema: str = None):
+        """Retrieve a schema's metadata
+        
+        :param schema: the name of the new schema
+        :type schema: str
+        
+        :returns: schema metadata
+        :rtype: dict
+        """
+        current_schema = schema if schema is not None else self.default_schema
+        if current_schema not in self.schema_names:
+            raise NoSuchSchemaException(f"Schema '{current_schema}' not found on server.")
+        
+        query = queries.list_schema_meta()
+        response = self.session.post(
+           url=f"{self.url}/{current_schema}/api/graphql",
+           json={'query': query}
+        )
+        
+        response_json = response.json()
+
+        if 'id' not in response_json.get('data').get('_schema'):
+          message = f"Unable to retrieve metadata for schema '{current_schema}'"
+          log.error(message)
+          raise GraphQLException(message)
+        
+        metadata = response_json.get('data').get('_schema')
+        return metadata
+        
+        
         
         

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -36,8 +36,7 @@ class Client:
         
         self.default_schema = schema
         
-        self.schemas = None
-        self.schema_names = None
+        self.schemas = self.get_schemas()
 
     def __str__(self):
         return self.url
@@ -142,9 +141,10 @@ class Client:
         )
         return message
 
-    @property
-    def schemas(self):
-        """List the databases present on the server."""
+    def get_schemas(self) -> list:
+        """Returns the schemas as a list of dictionary containing
+        for each schema the id, name, label and description.
+        """
         query = queries.list_schemas()
 
         response = self.session.post(
@@ -155,9 +155,13 @@ class Client:
         response_json: dict = response.json()
 
         schemas = response_json['data']['_schemas']
-        self.schema_names = [schema['name'] for schema in schemas]
 
         return schemas
+
+    @property
+    def schema_names(self) -> list:
+        """Returns the names of the schemas on the database for this user."""
+        return [schema['name'] for schema in self.schemas]
 
     @property
     def version(self):

--- a/tools/pyclient/src/molgenis_emx2_pyclient/exceptions.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/exceptions.py
@@ -35,3 +35,6 @@ class ServiceUnavailableError(PyclientException):
 
 class NoContextManagerException(PyclientException):
     """Thrown when sign in is attempted outside a context manager."""
+
+class GraphQLException(PyclientException):
+    """Thrown when a query fails to execute"""

--- a/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
@@ -31,6 +31,93 @@ def signin():
         }
     """
 
+def create_schema():
+    """GraphQL query to create a new schema. Function must contain name in the
+    posted data.
+    
+    @example
+    ```py
+    import requests
+    requests.post(...,
+        json={
+            'query': graphql.create_schema(),
+            'variables': {'name': ...}
+        }
+    )
+    ```
+    """
+    return """
+        mutation(
+            $name: String,
+            $description: String,
+            $template: String,
+            $includeDemoData: Boolean
+        ) {
+            createSchema(
+                name: $name,
+                description: $description,
+                template: $template,
+                includeDemoData: $includeDemoData
+              ) {
+                  status
+                  message
+                  taskId
+            }
+        }
+    """
+
+def delete_schema():
+    """GraphQL query for deleting a schema. Function must include the name of
+    the schema
+    
+    @example
+    ```py
+    import requests
+    requests.post(...,
+        json={
+            'query': graphql.delete_schema(),
+            'variables': {'name': ...}
+        }
+    )
+    ```
+    """
+    return """
+        mutation($name:String) {
+            deleteSchema(name: $name) {
+                status
+                message
+                taskId
+            }
+        }
+    """
+
+
+def update_schema():
+    """GraphQL query to update a schema description. Function must include
+    the name of the schema and description in the posted data.
+    
+    @example
+    ```py
+    import requests
+    requests.post(...,
+        json={
+            'query': graphql.update_schema(),
+            'variables': {'name': ..., 'description', ...}
+        }
+    )
+    ```
+    """
+    return """
+        mutation($name: String, $description: String) {
+            updateSchema(name: $name, description: $description) {
+                status
+                message
+                taskId
+            }
+        }
+    """
+
+
 def list_schemas():
     """GraphQL query to view all available schemas."""
     return """

--- a/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
@@ -31,6 +31,17 @@ def signin():
         }
     """
 
+def signout():
+    """GraphQL mutation to sign out and close the session."""
+    return """
+        mutation {
+            signout {
+                status
+                message
+            }
+        }
+    """
+
 def create_schema():
     """GraphQL query to create a new schema. Function must contain name in the
     posted data.

--- a/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
@@ -134,12 +134,93 @@ def list_schemas():
     return """
         {
             _schemas {
+                id
                 name
+                label
                 description
             }
         }
     """
 
+
+def list_schema_meta():
+    """GraphQL query to view metadata about a schema including the definition of tables and columns, as well as schema settings and members."""
+    return """
+      { 
+        _schema {
+            id
+            name
+            label
+            tables {
+                name
+                label
+                description
+                labels {
+                    locale
+                    value
+                }
+                id
+                schemaName
+                schemaId
+                inheritName
+                inheritId
+                descriptions {
+                    locale
+                    value
+                }
+                columns {
+                    table
+                    name
+                    description
+                    labels {
+                        locale
+                        value
+                    }
+                    id
+                    descriptions {
+                        locale
+                        value
+                    }
+                    position
+                    columnType
+                    inherited
+                    key
+                    required
+                    defaultValue
+                    refSchemaId
+                    refSchemaName
+                    refTableName
+                    refTableId
+                    refLinkName
+                    refBackId
+                    refLabel
+                    validation
+                    visible
+                    readonly
+                    computed
+                    semantics
+                }
+                settings {
+                    key
+                    value
+                }
+                semantics
+                tableType
+            }
+            members {
+                email
+                role
+            }
+            settings {
+                key
+                value
+            }
+            roles {
+                name
+            }
+        }
+      }
+    """
 
 def list_tables():
     """GraphQL query to list the tables in a schema."""

--- a/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
@@ -31,6 +31,7 @@ def signin():
         }
     """
 
+
 def signout():
     """GraphQL mutation to sign out and close the session."""
     return """
@@ -41,6 +42,7 @@ def signout():
             }
         }
     """
+
 
 def create_schema():
     """GraphQL query to create a new schema. Function must contain name in the
@@ -76,6 +78,7 @@ def create_schema():
             }
         }
     """
+
 
 def delete_schema():
     """GraphQL query for deleting a schema. Function must include the name of
@@ -144,7 +147,9 @@ def list_schemas():
 
 
 def list_schema_meta():
-    """GraphQL query to view metadata about a schema including the definition of tables and columns, as well as schema settings and members."""
+    """GraphQL query to view metadata about a schema including
+    the definition of tables and columns, as well as schema settings and members.
+    """
     return """
       { 
         _schema {
@@ -221,6 +226,7 @@ def list_schema_meta():
         }
       }
     """
+
 
 def list_tables():
     """GraphQL query to list the tables in a schema."""

--- a/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
@@ -31,19 +31,6 @@ def signin():
         }
     """
 
-
-def signout():
-    """GraphQL mutation to sign out and close the session."""
-    return """
-        mutation {
-            signout {
-                status
-                message
-            }
-        }
-    """
-
-
 def list_schemas():
     """GraphQL query to view all available schemas."""
     return """

--- a/tools/pyclient/src/molgenis_emx2_pyclient/utils.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/utils.py
@@ -4,7 +4,8 @@ Utility functions for the Molgenis EMX2 Pyclient package
 
 
 def parse_url(url: str) -> str:
-    """Standardises the host by removing trailing slash and ensuring url starts with 'https://'.
+    """Standardises the host by removing trailing slash
+    and ensuring url starts with 'https://'.
     
     :param url: string containing a URL
     :type url: str


### PR DESCRIPTION
This request addresses issue #2934 by adding new methods to the python client for managing schemas. Specifically, this includes the following methods:

- `create_schema`: create a new schema. Users can create an empty schema that will be populated by an external `molgenis.csv` file or using a schema template.
- `delete_schema`: delete a schema from an emx2 instance
- `update_schema`: update a schema's description
- `recreate_schema`: delete a schema and recreate it.
- `get_schema_metadata`: retrieve information about a schema

~~In addition, `sigout` was removed from the client as it is no an available graphql option.~~

## To Do

- [x] Create graphql queries for `createSchema`, `deleteSchema`, and `updateSchema`
- [x] Create python wrappers for new graphql queries
- [x] Create a function that recreates a schema
- [x] Add support for retrieving schema metadata

Additional tasks?
- [x] How should description be saved? Perhaps the list of schemas can be generated upon sign in? It might be good to store both the schema names and the descriptions. The `recreateSchema` method could retrieve the description from there.
- [x] Create new exception for graphql errors? How do you want to handle errors?
- [ ] Add status_code checks? I see that other methods have this. Do we want in these methods?
- [x] Write generic graphql error handling functions for recurring checks?