### PR TITLE
fix: Add cleanup migration

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
@@ -20,7 +20,7 @@ import org.slf4j.LoggerFactory;
 
 public class Migrations {
   // version the current software needs to work
-  private static final int SOFTWARE_DATABASE_VERSION = 13;
+  private static final int SOFTWARE_DATABASE_VERSION = 14;
   private static Logger logger = LoggerFactory.getLogger(Migrations.class);
 
   public static synchronized void initOrMigrate(SqlDatabase db) {
@@ -91,6 +91,10 @@ public class Migrations {
           if (version < 13)
             executeMigrationFile(
                 tdb, "migration13.sql", "remove default value for mg_tableclass columns");
+
+          if (version < 14) {
+            executeMigrationFile(tdb, "migration14.sql", "cleanup column_metadata ref column");
+          }
 
           // if success, update version to SOFTWARE_DATABASE_VERSION
           updateDatabaseVersion((SqlDatabase) tdb, SOFTWARE_DATABASE_VERSION);

--- a/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/migration14.sql
+++ b/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/migration14.sql
@@ -1,0 +1,8 @@
+UPDATE
+    "MOLGENIS"."column_metadata"
+SET "ref_table"=NULL
+WHERE "columnType" != 'REF'
+  AND "columnType" != 'REF_ARRAY'
+  AND "columnType" != 'ONTOLOGY'
+  AND "columnType" != 'ONTOLOGY_ARRAY'
+  AND "columnType" != 'REFBACK'


### PR DESCRIPTION
Some metadata columns might be corrupt due to data that was valid add the time of entry but later became invalid due added checks. Specifically; only ref type columns can have a non null value in the column_metadata.refTable column This migration remove all column_metadata.refTable entries for all non ref type rows