### PR TITLE
Fix #2928 columns of type HYPERLINK or HYPERLINK_ARRAY should be an owl:ObjectProperty

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -326,8 +326,13 @@ public class RDFService {
       Table refTable = column.getRefTable().getTable();
       builder.add(subject, RDFS.RANGE, getTableIRI(refTable));
     } else {
-      builder.add(subject, RDF.TYPE, OWL.DATATYPEPROPERTY);
-      builder.add(subject, RDFS.RANGE, columnTypeToXSD(column.getColumnType()));
+      var type = column.getColumnType();
+      if (type == ColumnType.HYPERLINK || type == ColumnType.HYPERLINK_ARRAY) {
+        builder.add(subject, RDF.TYPE, OWL.OBJECTPROPERTY);
+      } else {
+        builder.add(subject, RDF.TYPE, OWL.DATATYPEPROPERTY);
+        builder.add(subject, RDFS.RANGE, columnTypeToXSD(column.getColumnType()));
+      }
     }
     builder.add(subject, RDFS.LABEL, column.getName());
     builder.add(subject, RDFS.DOMAIN, getTableIRI(column.getTable().getTable()));

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -439,6 +439,11 @@ public class RDFService {
           IRI columnIRI = getColumnIRI(column);
           for (final Value value : formatValue(row, column)) {
             builder.add(subject, columnIRI, value);
+            if (column.getColumnType().equals(ColumnType.HYPERLINK)
+                || column.getColumnType().equals(ColumnType.HYPERLINK_ARRAY)) {
+              var resource = Values.iri(value.stringValue());
+              builder.add(resource, RDFS.LABEL, Values.literal(value.stringValue()));
+            }
           }
         }
       }

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java
@@ -384,6 +384,7 @@ public class RDFTest {
     var handler = new InMemoryRDFHandler() {};
     getAndParseRDF(Selection.of(schema, table.getName()), handler);
     boolean isObjectProperty = false;
+    boolean linkHasLabel = false;
     for (var subject : handler.resources.keySet()) {
       if (subject.stringValue().contains("/column/website")) {
         var types = handler.resources.get(subject).get(RDF.TYPE);
@@ -394,7 +395,16 @@ public class RDFTest {
           }
         }
       }
+      if (subject.stringValue().equals("https://www.molgenis.org/")) {
+        var labels = handler.resources.get(subject).get(RDFS.LABEL);
+        for (var label : labels) {
+          if (label.stringValue().equals("https://www.molgenis.org/")) {
+            linkHasLabel = true;
+          }
+        }
+      }
     }
+    assertTrue(linkHasLabel, "The link should have a label to make it easer to read.");
     assertTrue(isObjectProperty, "The column website should be defined as a Object Property.");
     database.dropSchema("Website");
   }


### PR DESCRIPTION
fix #2928 
- Check if a column is a HYPERLINK or HYPERLINK_ARRAY and set it to be a owl:ObjectProperty
- Added unittest
