### PR TITLE
fix: when label is empty string it should return name. closes #3036

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Column.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Column.java
@@ -671,7 +671,7 @@ public class Column extends HasLabelsDescriptionsAndSettings<Column> implements 
   }
 
   public String getLabel() {
-    if (getLabels().get("en") != null) {
+    if (getLabels().get("en") != null && !getLabels().get("en").trim().equals("")) {
       return getLabels().get("en");
     } else {
       return getName();

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/HasLabelsDescriptionsAndSettings.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/HasLabelsDescriptionsAndSettings.java
@@ -29,6 +29,9 @@ public class HasLabelsDescriptionsAndSettings<T> extends HasSettings<T> {
 
   public T setLabel(String label, String locale) {
     Objects.requireNonNull(locale);
+    if (label == null || label.trim().equals("")) {
+      this.labels.remove(locale);
+    }
     this.labels.put(locale, label);
     return (T) this;
   }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -568,7 +568,7 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
   }
 
   public String getLabel() {
-    if (this.getLabels().get("en") != null) {
+    if (this.getLabels().get("en") != null && !this.getLabels().get("en").trim().equals("")) {
       return this.getLabels().get("en");
     } else {
       return this.getTableName();

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTableColumnLabels.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTableColumnLabels.java
@@ -1,0 +1,27 @@
+package org.molgenis.emx2;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.Test;
+
+public class TestTableColumnLabels {
+  @Test
+  void testTableLabel() {
+    TableMetadata tm = new TableMetadata("Foo");
+    assertEquals(tm.getLabel(), "Foo");
+    tm.setLabel("Bar", "en");
+    assertEquals(tm.getLabel(), "Bar");
+    tm.setLabel("", "en");
+    assertEquals(tm.getLabel(), "Foo");
+  }
+
+  @Test
+  void testTableColumn() {
+    Column cm = new Column("Foo");
+    assertEquals(cm.getLabel(), "Foo");
+    cm.setLabel("Bar", "en");
+    assertEquals(cm.getLabel(), "Bar");
+    cm.setLabel("", "en");
+    assertEquals(cm.getLabel(), "Foo");
+  }
+}


### PR DESCRIPTION
closes #3036

To test, add a label using schema editor interface and then delete it again. 
(n.b. of course better solution would be to set to null but given that we have existing data this will also work for those cases)