### PR TITLE
Add an rdfs:label to all instances

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -430,7 +430,7 @@ public class RDFService {
         builder.add(subject, RDF.TYPE, tableIRI);
         builder.add(subject, RDF.TYPE, IRI_OBSERVATION);
         builder.add(subject, IRI_DATASET_PREDICATE, tableIRI);
-        builder.add(subject, RDFS.LABEL, getLabelForRow(row, table.getMetadata()));
+        builder.add(subject, RDFS.LABEL, Values.literal(getLabelForRow(row, table.getMetadata())));
 
         for (final Column column : table.getMetadata().getColumns()) {
           // Exclude the system columns like mg_insertedBy
@@ -454,7 +454,14 @@ public class RDFService {
   private String getLabelForRow(final Row row, final TableMetadata metadata) {
     List<String> primaryKeyValues = new ArrayList<>();
     for (Column column : metadata.getPrimaryKeyColumns()) {
-      primaryKeyValues.add(row.getString(column.getName()));
+      if (column.isReference()) {
+        for (final Reference reference : column.getReferences()) {
+          final String value = row.getString(reference.getName());
+          primaryKeyValues.add(value);
+        }
+      } else {
+        primaryKeyValues.add(row.getString(column.getName()));
+      }
     }
     return String.join(" ", primaryKeyValues);
   }

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -430,6 +430,7 @@ public class RDFService {
         builder.add(subject, RDF.TYPE, tableIRI);
         builder.add(subject, RDF.TYPE, IRI_OBSERVATION);
         builder.add(subject, IRI_DATASET_PREDICATE, tableIRI);
+        builder.add(subject, RDFS.LABEL, getLabelForRow(row, table.getMetadata()));
 
         for (final Column column : table.getMetadata().getColumns()) {
           // Exclude the system columns like mg_insertedBy
@@ -448,6 +449,14 @@ public class RDFService {
         }
       }
     }
+  }
+
+  private String getLabelForRow(final Row row, final TableMetadata metadata) {
+    List<String> primaryKeyValues = new ArrayList<>();
+    for (Column column : metadata.getPrimaryKeyColumns()) {
+      primaryKeyValues.add(row.getString(column.getName()));
+    }
+    return String.join(" ", primaryKeyValues);
   }
 
   private List<Row> getRows(final Table table, final String rowId) {

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java
@@ -437,6 +437,22 @@ public class RDFTest {
     database.dropSchema("Website");
   }
 
+  @Test
+  void testThatAllInstancesHaveALabel() throws IOException {
+    var handler = new InMemoryRDFHandler() {};
+    getAndParseRDF(Selection.of(petStore_nr1), handler);
+    int instancesWithOutALabel = 0;
+    for (var resource : handler.resources.keySet()) {
+      var labels = handler.resources.get(resource).get(RDFS.LABEL);
+      if (labels.isEmpty()) {
+        System.err.println(
+            "Each resource should have a label. " + resource.stringValue() + " has none.");
+        instancesWithOutALabel += 1;
+      }
+    }
+    assertEquals(0, instancesWithOutALabel, "All instances should have a label.");
+  }
+
   /**
    * Helper method to reduce boilerplate code in the tests.<br>
    * <b>Note</b> this method delegates to the handler for the results of parsing.


### PR DESCRIPTION
fixed #3048 Add an rdfs:label to all instances
- created a getLabelForRow that creates a label by concatenating all the primary key values for now
- add an rdfs:label predicate to a row in rowsToRDF for the data tables
- added a test