### PR TITLE
fix: ontologies with label set cannot be saved. closes #3031

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -780,16 +780,16 @@ public class GraphqlTableFieldFactory {
     String rowInputType = getTableTypeIdentifier(table);
     if (rowInputTypes.get(rowInputType) == null) {
       // in case of self reference
-      rowInputTypes.put(rowInputType, GraphQLTypeReference.typeRef(rowInputType));
+      rowInputTypes.put(rowInputType, GraphQLTypeReference.typeRef(rowInputType + INPUT));
       GraphQLInputObjectType.Builder inputBuilder =
           GraphQLInputObjectType.newInputObject().name(rowInputType + INPUT);
       for (Column col : table.getColumnsWithoutHeadings()) {
         GraphQLInputType type;
         if (col.isReference()) {
           if (col.isRef()) {
-            type = getPrimaryKeyInput(col.getRefTable());
+            type = rowInputType(col.getRefTable());
           } else {
-            type = GraphQLList.list(getPrimaryKeyInput(col.getRefTable()));
+            type = GraphQLList.list(rowInputType(col.getRefTable()));
           }
         } else {
           ColumnType columnType = col.getPrimitiveColumnType();


### PR DESCRIPTION
to test:
* go to pet store
* edit a Tag to have label, e.g. 'color' = 'kleuren'
* edit Pet pooky and chose the 'kleuren'
* save
* reload
* then open pooky again and save without changes

before bug:
* error 

With this fix:
* save

N.B. we have loosened type constraints to ignore non-primary key values on reference fields. However, this might lead to expectation that any changes on those will also be changes which is not the case. Meanwhile this will make it easier to make clients for this API so we think this is a good compromise.

Alternative considered:

Alternative solution would be to filter non pkey fields in InputOntology.vue value on loading and emit that as model-value