### PR TITLE
fix(molgenis-components): have working click handlers in inputOntology

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -91,7 +91,7 @@
           @deselect="deselect"
           @toggleExpand="toggleExpand"
           style="max-height: 100vh"
-          class="pt-2 pl-0 dropdown-item"
+          class="pt-2 pl-0"
         />
         <Spinner v-else-if="loading" />
         <div v-else>No results found</div>

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -21,7 +21,7 @@
           class="btn btn-sm btn-primary text-white mr-1"
           v-for="selectedTerm in selectionWithoutChildren"
           :key="selectedTerm"
-          @click.stop="deselect(selectedTerm)"
+          @click.stop="deselect(selectedTerm.name)"
         >
           {{ selectedTerm.label ? selectedTerm.label : selectedTerm.name }}
           <span class="fa fa-times"></span>
@@ -265,7 +265,7 @@ export default {
       if (!this.isMultiSelect) {
         //deselect other items
         Object.keys(this.terms).forEach(
-          (key) => (this.terms[key].selected = false)
+          (key) => (this.terms[key].selected = "unselected")
         );
       }
       let term = this.terms[item];
@@ -277,7 +277,11 @@ export default {
         );
         //select parent(s) if all siblings are selected
         this.getParents(term).forEach((parent) => {
-          if (parent.children.every((childTerm) => childTerm.selected)) {
+          if (
+            parent.children.every(
+              (childTerm) => childTerm.selected === "complete"
+            )
+          ) {
             parent.selected = "complete";
           } else {
             parent.selected = "partial";
@@ -290,25 +294,24 @@ export default {
     },
     deselect(item) {
       if (this.isMultiSelect) {
-        let term = this.terms[item.name];
-
-        term.selected = false;
+        let term = this.terms[item];
+        term.selected = "unselected";
         //also deselect all its children
-        this.getAllChildren(this.terms[item.name]).forEach(
-          (childTerm) => (childTerm.selected = false)
+        this.getAllChildren(this.terms[item]).forEach(
+          (childTerm) => (childTerm.selected = "unselected")
         );
         //also its deselect its parents, might be partial
         this.getParents(term).forEach((parent) => {
-          if (parent.children.some((child) => child.selected)) {
+          if (parent.children.some((child) => child.selected === "complete")) {
             parent.selected = "partial";
           } else {
-            parent.selected = false;
+            parent.selected = "unselected";
           }
         });
       } else {
         //non-list, deselect all
         Object.keys(this.terms).forEach(
-          (key) => (this.terms[key].selected = false)
+          (key) => (this.terms[key].selected = "unselected")
         );
       }
       this.emitValue();
@@ -317,7 +320,9 @@ export default {
     },
     clearSelection() {
       if (this.terms) {
-        Object.values(this.terms).forEach((term) => (term.selected = false));
+        Object.values(this.terms).forEach(
+          (term) => (term.selected = "unselected")
+        );
       }
       this.emitValue();
       this.$refs.search.focus();
@@ -338,7 +343,7 @@ export default {
     applySelection(value) {
       //deselect all
       Object.keys(this.terms).forEach(
-        (key) => (this.terms[key].selected = false)
+        (key) => (this.terms[key].selected = "unselected")
       );
       //apply selection to the tree
       if (value && this.isMultiSelect) {
@@ -357,7 +362,11 @@ export default {
               );
               //select parent(s) if all siblings are selected
               this.getParents(term).forEach((parent) => {
-                if (parent.children.every((childTerm) => childTerm.selected)) {
+                if (
+                  parent.children.every(
+                    (childTerm) => childTerm.selected === "complete"
+                  )
+                ) {
                   parent.selected = "complete";
                 } else {
                   parent.selected = "partial";
@@ -464,7 +473,7 @@ export default {
             terms[e.name] = {
               name: e.name,
               visible: true,
-              selected: false,
+              selected: "unselected",
               definition: e.definition,
               code: e.code,
               codesystem: e.codesystem,
@@ -479,7 +488,7 @@ export default {
               terms[e.parent.name] = {
                 name: e.parent.name,
                 visible: true,
-                selected: false,
+                selected: "unselected",
               };
             }
             // if first child then add children array
@@ -592,7 +601,7 @@ function getSelectedChildNodes(term) {
           :showExpanded="true"
           description="please choose your options in tree below"
           :options="options"
-          :isMultiSelect="false"
+          :isMultiSelect="unselected"
       />
       <div>You selected: {{ value5 }}</div>
     </demo-item>

--- a/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
@@ -5,18 +5,20 @@
       :key="term.name + term.selected + term.expanded"
     >
       <!--show if selected or search-->
-      <i
-        class="fa-fw pl-2 pt-1 ml-3"
-        role="button"
-        :class="getExpandState(term)"
-        @click.stop="toggleExpand(term)"
-      />
-      <i
-        class="fa-fw text-primary pl-2 pt-1"
-        :class="getSelectState(term)"
-        @click.stop="toggleSelect(term)"
-        role="button"
-      />
+      <span @click.stop="toggleExpand(term)">
+        <i
+          class="fa-fw pl-2 pt-1 ml-3"
+          role="button"
+          :class="getExpandState(term)"
+        />
+      </span>
+      <span @click.stop="toggleSelect(term)">
+        <i
+          class="fa-fw text-primary pl-2 pt-1"
+          :class="getSelectState(term)"
+          role="button"
+        />
+      </span>
       <span
         @click.stop="toggleExpandOrSelect(term)"
         class="flex-grow-1 pl-2"

--- a/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntologySubtree.vue
@@ -88,11 +88,11 @@ export default {
       return childNames;
     },
     getSelectState(term) {
-      if (term.selected == "complete") {
+      if (term.selected === "complete") {
         return this.isMultiSelect
           ? "fas fa-check-square"
           : "fas fa-check-circle";
-      } else if (term.selected == "partial") {
+      } else if (term.selected === "partial") {
         return this.isMultiSelect ? "far fa-check-square" : "far fa-circle";
       } else {
         return this.isMultiSelect ? "far fa-square" : "far fa-circle";
@@ -111,7 +111,7 @@ export default {
     toggleSelect(term) {
       //if selecting then also expand
       //if deselection we keep it open
-      if (term.selected == "complete") {
+      if (term.selected === "complete") {
         this.$emit("deselect", term.name);
       } else {
         this.$emit("select", term.name);


### PR DESCRIPTION
the click handlers of the inputOntology where on the SVG tags, that works terribly. Wrapt a span around it that made the click way more consistent.

You can now also click on other parts than only the name to open en select Ontologies.

- [x] working expand/collaps buttons
- [x] working select by clicking on the circle/square
- [x] working deselect select by clicking on the circle/square
- [x] working select/expand by clicking on the name
- [x] working deselect select by clicking on the name
- [x] Selecting an items should not select al its brothers

Also made the 'selected' not change type between boolean and string.

Note: deselecting in component-library still triggers an internal error. I was not able to fix that.
