### PR TITLE
chore: add test hook

### DIFF
--- a/apps/meta-data-utils/package.json
+++ b/apps/meta-data-utils/package.json
@@ -18,6 +18,7 @@
   "scripts": {
     "dev": "vite",
     "test": "vitest",
+    "test-ci": "vitest run",
     "build": "vite build",
     "preview": "vite preview",
     "format": "prettier src test --write --config ../.prettierrc.js"


### PR DESCRIPTION
Add the test-ci key to the script, this is the key the gradle task scans for