### PR TITLE
fix: table explorer showed schemas from other schemas. closes #3022"

### DIFF
--- a/apps/schema/src/utils.ts
+++ b/apps/schema/src/utils.ts
@@ -63,7 +63,7 @@ export function addOldNamesAndRemoveMeta(rawSchema: any) {
     //normal tables
     let tables = !schema.tables
       ? []
-      : schema.tables.filter((table) => table.tableType !== "ONTOLOGIES");
+      : schema.tables.filter((table) => table.tableType !== "ONTOLOGIES" && table.schemaName === schema.name);
     tables.forEach((t) => {
       t.oldName = t.name;
       if (t.columns) {

--- a/apps/tables/src/components/ListTables.vue
+++ b/apps/tables/src/components/ListTables.vue
@@ -74,7 +74,7 @@ export default {
             )
           );
       } else {
-        return this.schema.tables;
+        return this.schema.tables          .filter((table) => table.schemaId === this.schema.id);
       }
     },
     tables() {

--- a/apps/tables/src/components/ListTables.vue
+++ b/apps/tables/src/components/ListTables.vue
@@ -74,7 +74,9 @@ export default {
             )
           );
       } else {
-        return this.schema.tables          .filter((table) => table.schemaId === this.schema.id);
+        return this.schema.tables.filter(
+          (table) => table.schemaId === this.schema.id
+        );
       }
     },
     tables() {

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Schema.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Schema.java
@@ -25,7 +25,7 @@ public class Schema {
             .map(entry -> new Setting(entry.getKey(), entry.getValue()))
             .toList();
     List<TableMetadata> list = new ArrayList<>();
-    list.addAll(schema.getTables());
+    list.addAll(schema.getTablesIncludingExternal());
     // deterministic order is important for all kinds of comparisons
     Collections.sort(list);
     // add these tables

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlCrossSchemaRefs.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlCrossSchemaRefs.java
@@ -54,6 +54,14 @@ public class TestGraphqlCrossSchemaRefs {
             .contains("upserted"));
   }
 
+  @Test
+  void testCrossSchemaTablesAreInSchemaEndpoint() throws IOException {
+    String result =
+        execute("{_schema{tables{name,id,schemaName,schemaId}}}").at("/_schema").toString();
+    assertTrue(result.contains(schemaName1));
+    assertTrue(result.contains(schemaName2));
+  }
+
   private JsonNode execute(String query) throws IOException {
     String result = convertExecutionResultToJson(graphql.execute(query));
     JsonNode node = new ObjectMapper().readTree(result);


### PR DESCRIPTION
closes #3071

todo:
- [x] check that tables from other schemas are filtered in cases that is needed
- [x] check that #3071 works now

Sorry to have wasted your time with 'fundamental decisions' as you can see original bugfix was only 1 line.