### PR TITLE
fix: #3046 tables that extend another table should not be directly a subclass of owl:Thing and #2930 incorrect use of SIO

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -265,15 +265,13 @@ public class RDFService {
     final IRI subject = getTableIRI(table);
     builder.add(subject, RDF.TYPE, OWL.CLASS);
     builder.add(subject, RDFS.SUBCLASSOF, IRI_DATASET_CLASS);
-    builder.add(subject, RDFS.SUBCLASSOF, IRI_DATABASE_TABLE);
-    builder.add(subject, RDFS.SUBCLASSOF, OWL.THING);
-    // Specify the tables that this table inherits from.
     Table parent = table.getInheritedTable();
-    while (parent != null) {
+    // A table is a subclass of owl:Thing or of it's direct parent
+    if (parent == null) {
+      builder.add(subject, RDFS.SUBCLASSOF, OWL.THING);
+    } else {
       builder.add(subject, RDFS.SUBCLASSOF, getTableIRI(parent));
-      parent = parent.getInheritedTable();
     }
-
     if (table.getMetadata().getSemantics() != null) {
       for (final String tableSemantics : table.getMetadata().getSemantics()) {
         builder.add(subject, RDFS.ISDEFINEDBY, iri(tableSemantics));

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/OntologyTableSemantics.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/OntologyTableSemantics.java
@@ -42,9 +42,8 @@ public class OntologyTableSemantics {
      * Situation before: the 'Tag' ontology table has the default annotation of NCIT:C48697
      * (Controlled Vocabulary)
      */
-    System.out.println(result);
     assertTrue(
-        result.contains("rdfs:subClassOf qb:DataSet, sio:SIO_000754, owl:Thing;"),
+        result.contains("rdfs:subClassOf qb:DataSet, owl:Thing;"),
         "Tag should be a subclass of the given classes");
     assertTrue(
         result.contains("PetStore:Tag a owl:Class;"), "Tag should be an instance of owl:Class");
@@ -74,7 +73,7 @@ public class OntologyTableSemantics {
      * ontology
      */
     assertTrue(
-        result.contains("rdfs:subClassOf qb:DataSet, sio:SIO_000754, owl:Thing;"),
+        result.contains("rdfs:subClassOf qb:DataSet, owl:Thing;"),
         "Tag should be a subclass of the given classes");
     assertTrue(
         result.contains("PetStore:Tag a owl:Class;"), "Tag should be an instance of owl:Class");


### PR DESCRIPTION
fix #3046 tables that extend another table should not be directly a subclass of owl:Thing
- make subclass of owl:thing only if parent is null
- make subclass of only the direct parent if parent is not null

fix #2930 tables should not be SIO_00754
- remove subclass of SIO_000754