### PR TITLE
fix: safari details render issue workaround

### DIFF
--- a/apps/directory/src/components/report-components/CollapseComponent.vue
+++ b/apps/directory/src/components/report-components/CollapseComponent.vue
@@ -1,6 +1,8 @@
 <template>
   <details>
-    <summary @click="open = !open">{{ openText }}</summary>
+    <summary @click="open = !open">
+      <span>{{ openText }}</span>
+    </summary>
     <slot />
   </details>
 </template>


### PR DESCRIPTION
fixes: #3083
This is a safari only render issue, updating the text in the summary tag removes the click state. 
Workaround is to add a span en change its content.