### PR TITLE
chore: extend ssr nginx config with single catalogue workaround

### DIFF
--- a/apps/nuxt3-ssr/sample-nginx.conf
+++ b/apps/nuxt3-ssr/sample-nginx.conf
@@ -7,6 +7,11 @@ location  / {
     proxy_http_version 1.1;
 }
 
+# workaround for pre catalogue routes to post catalogue routes
+# enable these lines if the /catalogue routes are not used
+# location ~* /(.*)/ssr-catalogue/(?!all)(.*)$ {
+#     return 301 $scheme://$host/$1/ssr-catalogue/all/$2;
+# }
 
 location ~* /.+/ssr-catalogue/ {
     proxy_pass http://localhost:3000;


### PR DESCRIPTION
Add config to ssr-catalogue sample config 

If a catalogue needs to skilp the catalogue part ( i.e. should always use the /all route) then redirect the non-all routes to the all route version of the same route.

for example 

https://catalogue-acc.molgeniscloud.org/UMCG/ssr-catalogue/cohorts 
becomes 
https://catalogue-acc.molgeniscloud.org/UMCG/ssr-catalogue/all/cohorts