### PR TITLE
feat: add e2e tests for basic functionality

### DIFF
--- a/e2e/package.json
+++ b/e2e/package.json
@@ -8,6 +8,7 @@
     "@playwright/test": "1.39.0"
   },
   "scripts": {
-    "e2e": "playwright test"
+    "e2e": "playwright test",
+    "codegen": "playwright codegen localhost:8080"
   }
 }

--- a/e2e/tests/databases.spec.ts
+++ b/e2e/tests/databases.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "@playwright/test";
 
-test("Create and Remove a new Database", async ({ page }) => {
+test("Create and remove a new database with template", async ({ page }) => {
   await page.goto("http://localhost:8080/apps/central/");
   await page.goto("http://localhost:8080/apps/central/#/");
   await page.getByRole("button", { name: "Sign in" }).click();

--- a/e2e/tests/databases.spec.ts
+++ b/e2e/tests/databases.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from "@playwright/test";
+
+test("Create and Remove a new Database", async ({ page }) => {
+  await page.goto("http://localhost:8080/apps/central/");
+  await page.goto("http://localhost:8080/apps/central/#/");
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.getByPlaceholder("Enter username").click();
+  await page.getByPlaceholder("Enter username").fill("admin");
+  await page.getByPlaceholder("Enter username").press("Tab");
+  await page.getByPlaceholder("Password").fill("admin");
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Sign in" })
+    .click();
+  await page.getByRole("button", { name: "" }).click();
+  await page.getByLabel("name").click();
+  await page.getByLabel("name").fill("DatabaseTest");
+  await page.getByLabel("template").selectOption("PET_STORE");
+  await page
+    .locator("div")
+    .filter({ hasText: /^true$/ })
+    .click();
+  await page.getByRole("button", { name: "Create database" }).click();
+  await page.getByText("Schema DatabaseTest created").click();
+  await page.getByText("Close").click();
+  await page
+    .getByRole("row", { name: "DatabaseTest" })
+    .getByRole("button")
+    .nth(1)
+    .click();
+  await page.getByRole("button", { name: "Delete database" }).click();
+  await page.getByText("Close").click();
+});

--- a/e2e/tests/schema.spec.ts
+++ b/e2e/tests/schema.spec.ts
@@ -1,0 +1,105 @@
+import { test, expect } from "@playwright/test";
+
+test("Create a simple table with the schema editor", async ({ page }) => {
+  await page.goto("http://localhost:8080/apps/central/");
+  await page.goto("http://localhost:8080/apps/central/#/");
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.getByPlaceholder("Enter username").click();
+  await page.getByPlaceholder("Enter username").fill("admin");
+  await page.getByPlaceholder("Enter username").press("Tab");
+  await page.getByPlaceholder("Password").fill("admin");
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Sign in" })
+    .click();
+  await page.getByRole("button", { name: "" }).click();
+  await page.getByLabel("name").click();
+  await page.getByLabel("name").fill("schematest");
+  await page.getByRole("button", { name: "Create database" }).click();
+  await page.getByText("Close").click();
+  await page.getByRole("link", { name: "schematest" }).click();
+  await page.getByRole("link", { name: "Schema", exact: true }).click();
+  await page.getByRole("button", { name: "" }).click();
+  await page.getByLabel("Name").click();
+  await page.getByLabel("Name").fill("TestTable");
+  await page
+    .locator("div")
+    .filter({ hasText: /^label$/ })
+    .getByRole("textbox")
+    .click();
+  await page
+    .locator("div")
+    .filter({ hasText: /^label$/ })
+    .getByRole("textbox")
+    .fill("TestTable");
+  await page.getByRole("button", { name: "Apply" }).click();
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await page.getByRole("button", { name: "Save" }).click();
+  await page.getByLabel("columnName").click();
+  await page.getByLabel("columnName").fill("test");
+  await page.getByLabel("columnName").dblclick();
+  await page.getByLabel("columnName").dblclick();
+  await page.locator("#column_required0").check();
+  await page.getByLabel("key").selectOption("1");
+  await page.locator("textarea").first().click();
+  await page.locator("textarea").first().fill("test");
+  await page.getByRole("button", { name: "Apply" }).click();
+  await page.getByLabel("columnName").click();
+  await page.getByLabel("columnName").fill("boolean");
+  await page.getByLabel("columnType").selectOption("BOOL");
+  await page.getByRole("button", { name: "Apply" }).click();
+  await page.getByLabel("columnName").click();
+  await page.getByLabel("columnName").fill("defaultvalue");
+  await page.getByLabel("defaultValue").click();
+  await page.getByLabel("defaultValue").fill("defaultvalue");
+  await page.getByRole("button", { name: "Apply" }).click();
+  await page.getByRole("button", { name: "Save" }).click();
+  await page.getByRole("link", { name: "Tables" }).click();
+  await page.getByRole("link", { name: "TestTable" }).click();
+  await page.getByRole("link", { name: "Schema", exact: true }).click();
+  await page.getByRole("link", { name: "brand-logo" }).click();
+  await page
+    .getByRole("row", { name: "schematest" })
+    .getByRole("button")
+    .nth(1)
+    .click();
+  await page.getByRole("button", { name: "Delete database" }).click();
+  await page.getByText("Close").click();
+});
+
+test("Create a ontology with the schema editor", async ({ page }) => {
+  await page.goto("http://localhost:8080/apps/central/");
+  await page.goto("http://localhost:8080/apps/central/#/");
+  await page.getByRole("button", { name: "Sign in" }).click();
+  await page.getByPlaceholder("Enter username").click();
+  await page.getByPlaceholder("Enter username").fill("admin");
+  await page.getByPlaceholder("Enter username").press("Tab");
+  await page.getByPlaceholder("Password").fill("admin");
+  await page
+    .getByRole("dialog")
+    .getByRole("button", { name: "Sign in" })
+    .click();
+  await page.getByRole("button", { name: "" }).click();
+  await page.getByLabel("name").click();
+  await page.getByLabel("name").fill("schemaontology");
+  await page.getByLabel("name").click();
+  await page.getByRole("button", { name: "Create database" }).click();
+  await page.getByText("Close").click();
+  await page.getByRole("link", { name: "schemaontology" }).click();
+  await page.getByRole("link", { name: "Schema", exact: true }).click();
+  await page.getByLabel("Name").click();
+  await page.getByLabel("Name").fill("testontology");
+  await page.getByRole("button", { name: "Apply" }).click();
+  await page.getByRole("button", { name: "Save" }).click();
+  await page.getByRole("link", { name: "testontology" }).click();
+  await page.getByRole("link", { name: "Tables" }).click();
+  await page.getByRole("link", { name: "testontology" }).click();
+  await page.getByRole("link", { name: "< schemaontology" }).click();
+  await page.getByRole("link", { name: "brand-logo" }).click();
+  await page
+    .getByRole("row", { name: "schemaontology" })
+    .getByRole("button")
+    .nth(1)
+    .click();
+  await page.getByRole("button", { name: "Delete database" }).click();
+});


### PR DESCRIPTION
@MaxPostema and @Fernananas Would like to have a set of minimal expected emx2 functionality smoke tested

Our expected minimal set of basic functionality:
https://docs.google.com/spreadsheets/d/19DEH8fcV7tYCkYW0LDeG2kvgpz2bzdVGhpjDGrUehTE/edit#gid=0

Note: in tests we want to keep or database the same, so i think every change done must be done in a newly created database and removed and the end of the test
Note: for simple test creation use `yarn codegen` note that you can verify a generated value by clicking on text. The click may look like a bogus test but the selection to click checks if the text exists.

Problem to solve: the schema editor button to create a new table, ontology and other `+` buttons all have the same selector name

- [ ] Create md manual tests
- [ ] documentation and list of issues