### PR TITLE
feat: log ssr data fetch resp errors

### DIFF
--- a/apps/nuxt3-ssr/interfaces/types.ts
+++ b/apps/nuxt3-ssr/interfaces/types.ts
@@ -265,3 +265,8 @@ export interface IMapping {
 export type HarmonizationStatus = "unmapped" | "partial" | "complete";
 
 export type HarmonizationIconSize = "small" | "large";
+export interface IMgError {
+  message: string;
+  statusCode: number;
+  data: { errors: { message: string }[] };
+}

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { ISetting } from "meta-data-utils";
+import type { IMgError } from "~~/interfaces/types";
 
 const route = useRoute();
 const config = useRuntimeConfig();
@@ -106,7 +107,7 @@ const dataSourcesFilter = scoped
   ? { networks: { id: { equals: catalogueRouteParam } } }
   : undefined;
 
-const { data, error } = await useAsyncData(
+const { data, error } = await useAsyncData<any, IMgError>(
   `lading-page-${catalogueRouteParam}`,
   async () => {
     const models = await $fetch(`/${route.params.schema}/catalogue/graphql`, {
@@ -153,7 +154,9 @@ const { data, error } = await useAsyncData(
 );
 
 if (error.value) {
-  console.log("Error on landing-page data fetch: ", error.value);
+  const contextMsg = "Error on landing-page data fetch";
+  logError(error.value, contextMsg);
+  throw new Error(contextMsg);
 }
 
 function percentageLongitudinal(

--- a/apps/nuxt3-ssr/utils/errorLogger.test.ts
+++ b/apps/nuxt3-ssr/utils/errorLogger.test.ts
@@ -1,0 +1,31 @@
+import { afterAll, describe, it, expect, vi } from "vitest";
+import { logError } from "./errorLogger";
+
+describe("logError", () => {
+  const consoleMock = vi
+    .spyOn(console, "log")
+    .mockImplementation(() => undefined);
+
+  afterAll(() => {
+    consoleMock.mockReset();
+  });
+
+  const error = {
+    message: "a message to you ",
+    statusCode: 418,
+    data: { errors: [{ message: "test" }] },
+  };
+
+  it("should log the error", () => {
+    logError(error);
+    expect(consoleMock).toBeCalledWith("[ERROR] MESSAGES FROM API: ");
+    expect(consoleMock).toBeCalledWith("[ERROR] StatusCode: 418");
+    expect(consoleMock).toBeCalledWith("[ERROR] Message: a message to you ");
+    expect(consoleMock).toBeCalledWith("    0: test");
+  });
+
+  it("should log the error context", () => {
+    logError(error, "test context");
+    expect(consoleMock).nthCalledWith(5, "[ERROR] test context");
+  });
+});

--- a/apps/nuxt3-ssr/utils/errorLogger.ts
+++ b/apps/nuxt3-ssr/utils/errorLogger.ts
@@ -1,0 +1,14 @@
+import type { IMgError } from "~~/interfaces/types";
+
+export const logError = (error: IMgError, contextMsg?: string) => {
+  if (contextMsg) {
+    console.log(`[ERROR] ${contextMsg}`);
+  }
+
+  console.log(`[ERROR] StatusCode: ${error.statusCode}`);
+  console.log(`[ERROR] Message: ${error.message}`);
+  console.log("[ERROR] MESSAGES FROM API: ");
+  error.data.errors.forEach((e: { message: string }, lineNr) =>
+    console.log(`    ${lineNr}: ${e.message}`)
+  );
+};


### PR DESCRIPTION
feat: log ssr data fetch resp errors 

Add util function the log data fetch errors and show api error response message 

- note still need to use everywhere (where needed )
- maybe wrap all gql data fetching in composable that includes error logging/handling 