### PR TITLE
fix: graphql key filter doesn't work when having names with spaces breaking refback.

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -542,8 +542,8 @@ public class GraphqlTableFieldFactory {
   }
 
   private static Filter createKeyFilter(TableMetadata table, Map<String, Object> map) {
-    Objects.nonNull(table);
-    Objects.nonNull(map);
+    Objects.requireNonNull(table);
+    Objects.requireNonNull(map);
     List<Filter> result = new ArrayList<>();
     for (Map.Entry<String, Object> entry : map.entrySet()) {
       Optional<Column> column = findColumnById(table, entry.getKey());

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -542,6 +542,8 @@ public class GraphqlTableFieldFactory {
   }
 
   private static Filter createKeyFilter(TableMetadata table, Map<String, Object> map) {
+    Objects.nonNull(table);
+    Objects.nonNull(map);
     List<Filter> result = new ArrayList<>();
     for (Map.Entry<String, Object> entry : map.entrySet()) {
       Optional<Column> column = findColumnById(table, entry.getKey());

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -506,7 +506,7 @@ public class GraphqlTableFieldFactory {
           subFilters.add(
               or(
                   ((List<Map<String, Object>>) entry.getValue())
-                      .stream().map(v -> createKeyFilter(v)).collect(Collectors.toList())));
+                      .stream().map(v -> createKeyFilter(table, v)).collect(Collectors.toList())));
         }
       } else {
         // find column by escaped name
@@ -541,13 +541,22 @@ public class GraphqlTableFieldFactory {
     return subFilters.toArray(new FilterBean[subFilters.size()]);
   }
 
-  private static Filter createKeyFilter(Map<String, Object> map) {
+  private static Filter createKeyFilter(TableMetadata table, Map<String, Object> map) {
     List<Filter> result = new ArrayList<>();
     for (Map.Entry<String, Object> entry : map.entrySet()) {
+      Optional<Column> column = findColumnById(table, entry.getKey());
+      if (column.isEmpty()) {
+        throw new MolgenisException(
+            "Filter " + entry.getKey() + " unknown in table " + table.getIdentifier());
+      }
       if (entry.getValue() instanceof Map) {
-        result.add(f(entry.getKey(), createKeyFilter((Map<String, Object>) entry.getValue())));
+        result.add(
+            f(
+                column.get().getName(),
+                createKeyFilter(
+                    column.get().getRefTable(), (Map<String, Object>) entry.getValue())));
       } else {
-        result.add(f(entry.getKey(), Operator.EQUALS, entry.getValue()));
+        result.add(f(column.get().getName(), Operator.EQUALS, entry.getValue()));
       }
     }
     return and(result);
@@ -624,7 +633,7 @@ public class GraphqlTableFieldFactory {
     return result.toArray(new SelectColumn[result.size()]);
   }
 
-  private Optional<Column> findColumnById(TableMetadata aTable, String id) {
+  private static Optional<Column> findColumnById(TableMetadata aTable, String id) {
     if (aTable != null) {
       return aTable.getColumns().stream()
           .filter(

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlSchemaFields.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlSchemaFields.java
@@ -626,13 +626,19 @@ public class TestGraphqlSchemaFields {
               "Some",
               column("id").setPkey(),
               column("Person details").setType(REF).setRefTable("Person details"),
-              column("Persons details").setType(REF_ARRAY).setRefTable("Person details")));
+              column("Persons details").setType(REF_ARRAY).setRefTable("Person details")),
+          table(
+              "Child details",
+              column("Parent details").setPkey().setType(REF).setRefTable("Person details"),
+              column("name").setPkey()),
+          table(
+              "Other",
+              column("id").setPkey(),
+              column("Child details").setType(REF).setRefTable("Child details")));
 
       grapql = new GraphqlApiFactory().createGraphqlForSchema(myschema, taskService);
       execute(
           "mutation{insert(PersonDetails:{firstName:\"blaata\",last_name:\"blaata2\",someNumber: 6}){message}}");
-      execute(
-          "mutation{insert(Some:{id:\"one\",personDetails:{firstName:\"blaata\",last_name:\"blaata2\"},personsDetails:[{firstName:\"blaata\",last_name:\"blaata2\"}]}){message}}");
 
       int count = execute("{PersonDetails_agg{count}}").at("/PersonDetails_agg/count").intValue();
 
@@ -679,15 +685,33 @@ public class TestGraphqlSchemaFields {
       assertEquals(6, agg.at("/PersonDetails_agg/max/someNumber").asInt());
 
       // equals key filters
+      execute(
+          "mutation{insert(Some:{id:\"one\",personDetails:{firstName:\"blaata\",last_name:\"blaata2\"},personsDetails:[{firstName:\"blaata\",last_name:\"blaata2\"}]}){message}}");
       JsonNode sub =
           execute(
               "{Some(filter:{personDetails:{equals:{firstName:\"blaata\",last_name:\"blaata2\"}}}){id}}");
       assertEquals("one", sub.at("/Some/0/id").asText());
 
+      // equals nested key filters
+      execute(
+          "mutation{insert(ChildDetails:{name:\"b\",parentDetails:{firstName:\"blaata\",last_name:\"blaata2\"}}){message}}");
+      execute(
+          "mutation{insert(Other:{id:\"one\",childDetails:{name:\"b\",parentDetails:{firstName:\"blaata\",last_name:\"blaata2\"}}}){message}}");
+
+      JsonNode subsub =
+          execute(
+              "{Other(filter:{childDetails:{equals:{name:\"b\",parentDetails:{firstName:\"blaata\",last_name:\"blaata2\"}}}}){id}}");
+      assertEquals("one", subsub.at("/Other/0/id").asText());
+
       // delete
+      execute("mutation{delete(Other:{id:\"one\"}){message}}");
+      execute(
+          "mutation{delete(ChildDetails:{name:\"b\",parentDetails:{firstName:\"blaata\",last_name:\"blaata2\"}}){message}}");
       execute("mutation{delete(Some:{id:\"one\"}){message}}");
       execute(
           "mutation{delete(PersonDetails:{firstName:\"blaata\",last_name:\"blaata2\"}){message}}");
+      execute(
+          "mutation{delete(PersonDetails:{firstName:\"blaatb\",last_name:\"blaata2\"}){message}}");
       assertEquals(
           count, execute("{PersonDetails_agg{count}}").at("/PersonDetails_agg/count").intValue());
 


### PR DESCRIPTION
To reproduce, on master:
- use the junit test but without the fix, and then with the fix

OR
- load attached schema
- create a row in ProjectUnits
- notice error in console for refback 'planning' when opening ProjectUnits

Then do same in preview
- see the refback does load properly and you can add/edit some planning records

The example schema:
[molgenis.csv](https://github.com/molgenis/molgenis-emx2/files/13646140/molgenis.csv)


