### PR TITLE
feat: table explorer should show names instead of labels

### DIFF
--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -173,6 +173,7 @@ const metaDataQuery = `{
       semantics,
       columns {
         id,
+        name,
         label,
         description,
         columnType,

--- a/apps/molgenis-components/src/components/tables/TableMolgenis.vue
+++ b/apps/molgenis-components/src/components/tables/TableMolgenis.vue
@@ -19,7 +19,7 @@
             class="mb-0 align-text-bottom text-nowrap"
             @click="onColumnClick(col)"
           >
-            {{ col.label }}
+            {{ col.name }}
             <slot name="colheader" :col="col" />
           </h6>
         </th>


### PR DESCRIPTION
So the rules should be:
- labels are only used in forms
- the names are used in table explorer and csv upload/download
- the identifiers are use in API

Out of scope:
- a potential future feature request is to show identifiers in table view AND ability to set identifiers manually.