### PR TITLE
feat: add bbmri styling via css override

### DIFF
--- a/apps/directory/src/App.vue
+++ b/apps/directory/src/App.vue
@@ -93,4 +93,30 @@ ol.breadcrumb {
   margin-top: 0.25rem !important;
   margin-bottom: 0.25rem !important;
 }
+
+/* emx2 style override */
+#app > div {
+  background-color: white !important;
+}
+nav.navbar {
+  background-color: #e9ecef !important;
+}
+nav.navbar a.nav-link,
+nav.navbar button.btn {
+  color: #495057 !important;
+  background-color: transparent;
+}
+nav.navbar a.nav-link:hover,
+nav.navbar button.btn:hover {
+  color: #ec6707 !important;
+}
+
+nav.navbar button.btn.btn-outline-light:not(.border-0) {
+  border-color: #495057 !important;
+}
+nav.navbar button.btn.btn-outline-light:not(.border-0):hover {
+  border-color: #ec6707 !important;
+  background-color: #ec6707 !important;
+  color: #dbedff !important;
+}
 </style>

--- a/apps/directory/vite.config.js
+++ b/apps/directory/vite.config.js
@@ -8,7 +8,7 @@ import monacoEditorPlugin from "vite-plugin-monaco-editor";
 const HOST =
   process.env.MOLGENIS_APPS_HOST || "https://bbmri-emx2-test.molgeniscloud.org";
 // eslint-disable-next-line no-undef
-const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "BBMRI-ERIC%20Directory";
+const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "Directory";
 
 const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
 
@@ -45,11 +45,15 @@ export default defineConfig(({ command }) => ({
       "/api": { target: `${HOST}`, ...opts },
       "/apps": { target: `${HOST}`, ...opts },
       "/theme.css": { target: `${HOST}/${SCHEMA}`, ...opts },
-      '/public_html/apps/directory/img/': {
+      "/public_html/apps/directory/img/": {
         secure: false,
-        rewrite: (path) => path.replace(/^\/public_html\/apps\/directory/, ''), /** removes the part of the url, so this will go straight to /img in public folder */
-        target: 'http://localhost:5173'
-      }
+        rewrite: (path) =>
+          path.replace(
+            /^\/public_html\/apps\/directory/,
+            ""
+          ) /** removes the part of the url, so this will go straight to /img in public folder */,
+        target: "http://localhost:5173",
+      },
     },
   },
 }));


### PR DESCRIPTION
fixes: https://github.com/molgenis/molgenis-emx2/issues/3110
made to replace: https://github.com/molgenis/molgenis-emx2/pull/3146

#3146 was getting ugly by trying to drill down the styling via the molgenis component, i kept finding more and more deeper issues. Just overriding the css is way cleaner. 

Note: The emx2 custom menubar color from the settings menu will not work within the directory app.
