### PR TITLE
Don't put the port in the URL if it is a well-known port

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
@@ -178,10 +178,25 @@ public class RDFApi {
 
   private static String extractBaseURL(Request request) {
     // NOTE: The request.host() already includes the server port!
-    return request.scheme()
+    String scheme = request.scheme();
+    String port = null;
+    var parts = request.host().split(":", 2);
+    String host = parts[0];
+    if (parts.length == 2) {
+      if (!isWellKnownPort(scheme, parts[1])) {
+        port = parts[1];
+      }
+    }
+    return scheme
         + "://"
-        + request.host()
+        + host
+        + (port != null ? ":" + port : "")
         + (StringUtils.isNotEmpty(request.servletPath()) ? "/" + request.servletPath() + "/" : "/");
+  }
+
+  private static boolean isWellKnownPort(String scheme, String port) {
+    return (scheme.equals("http") && port.equals("80"))
+        || (scheme.equals("https") && port.equals("443"));
   }
 
   public static RDFFormat selectFormat(Request request) {


### PR DESCRIPTION
If the port is the well known port for the schema, i.e. 80 for http or 443 for https it should not be put in the url. 
fixes #3164