### PR TITLE
fix: reload collectionReport on routeing change

### DIFF
--- a/apps/directory/src/router/index.js
+++ b/apps/directory/src/router/index.js
@@ -60,6 +60,9 @@ const router = createRouter({
       },
     },
   ],
+  scrollBehavior(to, from, savedPosition) {
+    return { top: 0 };
+  },
 });
 
 export default router;

--- a/apps/directory/src/views/CollectionReport.vue
+++ b/apps/directory/src/views/CollectionReport.vue
@@ -68,7 +68,7 @@
 </template>
 
 <script setup>
-import { computed, ref } from "vue";
+import { computed, ref, watch } from "vue";
 import { useRoute } from "vue-router";
 import { Breadcrumb, Spinner } from "../../../molgenis-components";
 import CheckOut from "../components/checkout-components/CheckOut.vue";
@@ -92,18 +92,10 @@ const route = useRoute();
 
 let loaded = ref(false);
 
-const collectionsPromise = collectionStore
-  .getCollectionReport(route.params.id)
-  .then((result) => {
-    collection.value = result.Collections.length ? result.Collections[0] : {};
-    facts.value =
-      result.CollectionFacts && result.CollectionFacts.length
-        ? result.CollectionFacts
-        : {};
-  });
-const qualitiesPromise = qualitiesStore.getQualityStandardInformation();
-Promise.all([qualitiesPromise, collectionsPromise]).then(() => {
-  loaded.value = true;
+loadCollectionReport(route.params.id);
+
+watch(route, async (route) => {
+  loadCollectionReport(route.params.id);
 });
 
 const uiText = computed(() => {
@@ -124,6 +116,23 @@ const bioschemasJsonld = computed(() => {
     return undefined;
   }
 });
+
+function loadCollectionReport(id) {
+  loaded.value = false;
+  const collectionsPromise = collectionStore
+    .getCollectionReport(id)
+    .then((result) => {
+      collection.value = result.Collections.length ? result.Collections[0] : {};
+      facts.value =
+        result.CollectionFacts && result.CollectionFacts.length
+          ? result.CollectionFacts
+          : {};
+    });
+  const qualitiesPromise = qualitiesStore.getQualityStandardInformation();
+  Promise.all([qualitiesPromise, collectionsPromise]).then(() => {
+    loaded.value = true;
+  });
+}
 
 function wrapBioschema(schemaData) {
   /** ignore because it is not useless ;) */


### PR DESCRIPTION
fixes: #3163

fixed by reloading the data after change in router state

Note: i also added a scroll to top after following a router link. I think this is a better user experience than having users be at the bottom of a page at random moments.