### PR TITLE
fix: facts table on directory app

### DIFF
--- a/apps/directory/src/stores/collectionStore.js
+++ b/apps/directory/src/stores/collectionStore.js
@@ -112,7 +112,7 @@ export const useCollectionStore = defineStore("collectionStore", () => {
         "disease.label",
         "disease.name",
       ])
-      .where("id")
+      .where("collection.id")
       .like(id);
 
     const factResults = await factQuery.execute();


### PR DESCRIPTION
Added the correct ID in the where clause of the factQuery in the collectionStore and the facts tables are now rendered properly in the collection reports. 
fixes: #2981