### PR TITLE
feat: redesigned header image and title

### DIFF
--- a/apps/ern-skin/src/components/CustomPageHeader.vue
+++ b/apps/ern-skin/src/components/CustomPageHeader.vue
@@ -2,7 +2,7 @@
   <div :class="headerClassNames">
     <div
       v-if="imageSrc"
-      :class="`height-${height} header-image`"
+      :class="`header-image height-${height}`"
       :style="`background-image: url(${imageSrc})`"
     />
     <div class="header-content">
@@ -67,7 +67,6 @@ const headerClassNames = computed(() => {
   const css = [
     "custom-page-header",
     `text-position-x-${props.titlePositionX} text-position-y-${props.titlePositionY}`,
-    `padding-h-${props.horizontalPadding} padding-v-${props.verticalPadding}`,
   ];
 
   if (props.imageSrc) {

--- a/apps/ern-skin/src/components/CustomPageHeader.vue
+++ b/apps/ern-skin/src/components/CustomPageHeader.vue
@@ -1,7 +1,7 @@
 <template>
-  <div :class="containerClassNames">
+  <div :class="headerClassNames">
     <div
-    v-if="imageSrc"
+      v-if="imageSrc"
       :class="`height-${height} header-image`"
       :style="`background-image: url(${imageSrc})`"
     />
@@ -16,21 +16,20 @@
 import { computed } from "vue";
 
 const props = defineProps({
-  
   // A short title that describes the page
   title: {
     type: String,
-    required: true
+    required: true,
   },
-  
+
   // A brief description about the page
   subtitle: {
     type: String,
   },
-  
+
   // Location of an image to display
   imageSrc: String,
-  
+
   // specify the height of the image
   height: {
     // `'small' / 'medium' / 'large' / `xlarge / 'full'`
@@ -38,10 +37,10 @@ const props = defineProps({
     // `small`
     default: "large",
     validator: (value) => {
-      return ["small", "medium", "large", 'xlarge', "full"].includes(value);
+      return ["small", "medium", "large", "xlarge", "full"].includes(value);
     },
   },
-    
+
   // the horizontal position of the title and subtitle
   titlePositionX: {
     // `'left' / 'center' / 'right'`
@@ -62,46 +61,44 @@ const props = defineProps({
       return ["top", "center", "bottom"].includes(value);
     },
   },
-  
 });
 
-
-const containerClassNames = computed(() => {
+const headerClassNames = computed(() => {
   const css = [
-    'custom-page-header',
+    "custom-page-header",
     `text-position-x-${props.titlePositionX} text-position-y-${props.titlePositionY}`,
-    `padding-h-${props.horizontalPadding} padding-v-${props.verticalPadding}`
-  ]
-  
-  if (props.imageSrc) {
-    css.push('header-image-background');
-  }
-  
-  return css.join(' ');
-});
+    `padding-h-${props.horizontalPadding} padding-v-${props.verticalPadding}`,
+  ];
 
+  if (props.imageSrc) {
+    css.push("header-image-background");
+  }
+
+  return css.join(" ");
+});
 </script>
 
 <style lang="scss">
 .custom-page-header {
   position: relative;
-  
+
   .header-image {
     background-size: cover;
     background-position: 0 0;
   }
-  
+
   .header-content {
     width: 90%;
     margin: 0 auto;
     padding: 1em 0;
-    
-    h1, h2 {
+
+    h1,
+    h2 {
       margin: 0;
       line-height: 1.3;
       color: currentColor;
     }
-    
+
     .header-title {
       font-size: 13pt;
       text-transform: uppercase;

--- a/apps/ern-skin/src/components/CustomPageHeader.vue
+++ b/apps/ern-skin/src/components/CustomPageHeader.vue
@@ -1,0 +1,118 @@
+<template>
+  <div :class="containerClassNames">
+    <div
+    v-if="imageSrc"
+      :class="`height-${height} header-image`"
+      :style="`background-image: url(${imageSrc})`"
+    />
+    <div class="header-content">
+      <h1 class="header-title">{{ title }}</h1>
+      <h2 class="header-subtitle" v-if="subtitle">{{ subtitle }}</h2>
+    </div>
+  </div>
+</template>
+
+<script setup>
+import { computed } from "vue";
+
+const props = defineProps({
+  
+  // A short title that describes the page
+  title: {
+    type: String,
+    required: true
+  },
+  
+  // A brief description about the page
+  subtitle: {
+    type: String,
+  },
+  
+  // Location of an image to display
+  imageSrc: String,
+  
+  // specify the height of the image
+  height: {
+    // `'small' / 'medium' / 'large' / `xlarge / 'full'`
+    type: String,
+    // `small`
+    default: "large",
+    validator: (value) => {
+      return ["small", "medium", "large", 'xlarge', "full"].includes(value);
+    },
+  },
+    
+  // the horizontal position of the title and subtitle
+  titlePositionX: {
+    // `'left' / 'center' / 'right'`
+    type: String,
+    // `left`
+    default: "left",
+    validator: (value) => {
+      return ["left", "center", "right"].includes(value);
+    },
+  },
+  // the vertical position of the title and subtitle
+  titlePositionY: {
+    // `'top' / 'center' / 'bottom'`
+    type: String,
+    // `center`
+    default: "center",
+    validator: (value) => {
+      return ["top", "center", "bottom"].includes(value);
+    },
+  },
+  
+});
+
+
+const containerClassNames = computed(() => {
+  const css = [
+    'custom-page-header',
+    `text-position-x-${props.titlePositionX} text-position-y-${props.titlePositionY}`,
+    `padding-h-${props.horizontalPadding} padding-v-${props.verticalPadding}`
+  ]
+  
+  if (props.imageSrc) {
+    css.push('header-image-background');
+  }
+  
+  return css.join(' ');
+});
+
+</script>
+
+<style lang="scss">
+.custom-page-header {
+  position: relative;
+  
+  .header-image {
+    background-size: cover;
+    background-position: 0 0;
+  }
+  
+  .header-content {
+    width: 90%;
+    margin: 0 auto;
+    padding: 1em 0;
+    
+    h1, h2 {
+      margin: 0;
+      line-height: 1.3;
+      color: currentColor;
+    }
+    
+    .header-title {
+      font-size: 13pt;
+      text-transform: uppercase;
+      letter-spacing: 4px;
+      font-weight: bold;
+    }
+
+    .header-subtitle {
+      font-size: 32pt;
+      font-weight: 200;
+    }
+  }
+}
+</style>

--- a/apps/ern-skin/src/styles/index.scss
+++ b/apps/ern-skin/src/styles/index.scss
@@ -31,8 +31,8 @@
 
 .erras-header {
   .height-xlarge {
-    @media screen and (min-width: 1200px) {
-      height: 36em;
+    @media screen and (min-width: 1500px) {
+      height: 34em;
     }
   }
 

--- a/apps/ern-skin/src/styles/index.scss
+++ b/apps/ern-skin/src/styles/index.scss
@@ -30,13 +30,12 @@
 }
 
 .erras-header {
-  
-  .height-xlarge {    
+  .height-xlarge {
     @media screen and (min-width: 1200px) {
       height: 36em;
     }
   }
-  
+
   .header-content {
     color: $erras-blue;
   }

--- a/apps/ern-skin/src/styles/index.scss
+++ b/apps/ern-skin/src/styles/index.scss
@@ -5,12 +5,16 @@
 
 .app-page {
   .page-header {
-    height: auto;
-    filter: saturate(60%);
-    background-position: 0 0;
+    height: auto; 
+    background-position: 0 15%;
+    padding: 9em 0;
 
     .header-content {
-      padding: 6em 0;
+      padding: 1em 0;
+    }
+    
+    .background-image-filter {
+      opacity: 0.5;
     }
   }
 
@@ -22,6 +26,12 @@
         margin-bottom: 0.15em;
       }
     }
+  }
+}
+
+.erras-header {
+  .header-content {
+    color: $erras-blue;
   }
 }
 

--- a/apps/ern-skin/src/styles/index.scss
+++ b/apps/ern-skin/src/styles/index.scss
@@ -30,6 +30,13 @@
 }
 
 .erras-header {
+  
+  .height-xlarge {    
+    @media screen and (min-width: 1200px) {
+      height: 36em;
+    }
+  }
+  
   .header-content {
     color: $erras-blue;
   }

--- a/apps/ern-skin/src/styles/index.scss
+++ b/apps/ern-skin/src/styles/index.scss
@@ -5,14 +5,14 @@
 
 .app-page {
   .page-header {
-    height: auto; 
+    height: auto;
     background-position: 0 15%;
     padding: 9em 0;
 
     .header-content {
       padding: 1em 0;
     }
-    
+
     .background-image-filter {
       opacity: 0.5;
     }

--- a/apps/ern-skin/src/views/view-about.vue
+++ b/apps/ern-skin/src/views/view-about.vue
@@ -4,7 +4,7 @@
       class="project-header main-header"
       title="ERN-Skin Registry"
       subtitle="About Us"
-      imageSrc="app-header-background.png"
+      imageSrc="erras-header.jpg"
     />
     <PageSection aria-labelledby="the-european-reference-networks-title">
       <h2 id="the-european-reference-networks-title">

--- a/apps/ern-skin/src/views/view-documents.vue
+++ b/apps/ern-skin/src/views/view-documents.vue
@@ -1,10 +1,13 @@
 <template>
   <Page id="page-documents">
-    <PageHeader
-      class="project-header main-header"
-      title="ERN-Skin"
+    <CustomPageHeader
+      class="erras-header"
+      title="ERN-Skin Registry"
       subtitle="Download Documents"
-      imageSrc="app-header-background.png"
+      imageSrc="erras-header.jpg"
+      height="xlarge"
+      title-position-x="center"
+      title-position-y="center"
     />
     <PageSection
       id="section-documents"
@@ -21,5 +24,6 @@
 </template>
 
 <script setup>
-import { Page, PageHeader, PageSection, MessageBox } from "molgenis-viz";
+import { Page, PageSection, MessageBox } from "molgenis-viz";
+import CustomPageHeader from "../components/CustomPageHeader.vue";
 </script>

--- a/apps/ern-skin/src/views/view-home.vue
+++ b/apps/ern-skin/src/views/view-home.vue
@@ -1,10 +1,13 @@
 <template>
   <Page id="page-home">
-    <PageHeader
-      class="project-header main-header"
+    <CustomPageHeader
+      class="erras-header"
       title="ERN-Skin Registry"
       subtitle="Registry for Rare and Undiagnosed Skin Diseases"
-      imageSrc="app-header-background.png"
+      imageSrc="erras-header.jpg"
+      height="xlarge"
+      title-position-x="center"
+      title-position-y="center"
     />
     <PageSection
       id="section-welcome"
@@ -115,12 +118,15 @@
 </template>
 
 <script setup>
-import { Page, PageHeader, PageSection, LinkCard } from "molgenis-viz";
+import { Page, PageSection, LinkCard } from "molgenis-viz";
 import {
   InformationCircleIcon,
   PresentationChartLineIcon,
   DocumentTextIcon,
 } from "@heroicons/vue/24/outline";
+
+import CustomPageHeader from "../components/CustomPageHeader.vue";
+
 </script>
 
 <style lang="scss">

--- a/apps/ern-skin/src/views/view-home.vue
+++ b/apps/ern-skin/src/views/view-home.vue
@@ -126,7 +126,6 @@ import {
 } from "@heroicons/vue/24/outline";
 
 import CustomPageHeader from "../components/CustomPageHeader.vue";
-
 </script>
 
 <style lang="scss">

--- a/apps/molgenis-viz/src/styles/heightwidth.scss
+++ b/apps/molgenis-viz/src/styles/heightwidth.scss
@@ -17,6 +17,14 @@
   height: 18em;
 }
 
+.height-xlarge {
+  height: 26em;
+}
+
+.height-xxlarge {
+  height: 38em;
+}
+
 .height-full {
   min-height: 100vh;
 }


### PR DESCRIPTION
Changes to the layout of the header component were made in the EMX1 version and approved. Now, these changes must be made to the EMX2 version. However, the implementation differs. In the EMX2 version, I created a new header component (`<CustomPageHeader`>) that stacks the header image and content (title and subtitle). For the time being, this will work as I do not wish to rewrite the existing page header component (although this might be useful in the future). 

This pull request contains the following changes to the `ern-skin` vue app.

- [x] Add new image and compress
- [x] Create new header component
- [x] Add new header component to the home and documents page
- [x] Change the color of the text to `erras-blue`