### PR TITLE
fix: set url of "submit patient" button

### DIFF
--- a/apps/cranio-provider/src/components/ProviderSidebar.vue
+++ b/apps/cranio-provider/src/components/ProviderSidebar.vue
@@ -73,7 +73,7 @@
 
 <script setup>
 import { Accordion } from "molgenis-viz";
-import { ArrowUpTrayIcon } from "@heroicons/vue/24/outline"
+import { ArrowUpTrayIcon } from "@heroicons/vue/24/outline";
 </script>
 
 <style lang="scss">
@@ -157,16 +157,16 @@ import { ArrowUpTrayIcon } from "@heroicons/vue/24/outline"
 #btnSubmitPatient {
   @include buttonLink;
   @include textTransform;
-  
+
   color: $cranio-orange-050;
   background-color: $cranio-orange;
-  
+
   span {
     letter-spacing: 0.15em;
     border-bottom: 2px solid transparent;
-    
   }
-  &:hover, &:focus {
+  &:hover,
+  &:focus {
     text-decoration: none;
     filter: brightness(110%);
   }

--- a/apps/cranio-provider/src/components/ProviderSidebar.vue
+++ b/apps/cranio-provider/src/components/ProviderSidebar.vue
@@ -64,14 +64,16 @@
         </li>
       </ul>
     </nav>
-    <p id="btnSubmitPatient">
+    <a id="btnSubmitPatient" href="../tables/#/Subject">
       <span>Submit patient</span>
-    </p>
+      <ArrowUpTrayIcon />
+    </a>
   </aside>
 </template>
 
 <script setup>
 import { Accordion } from "molgenis-viz";
+import { ArrowUpTrayIcon } from "@heroicons/vue/24/outline"
 </script>
 
 <style lang="scss">
@@ -85,7 +87,7 @@ import { Accordion } from "molgenis-viz";
   nav {
     padding: 0;
     margin-top: 1em;
-    margin-bottom: 2.5em;
+    margin-bottom: 1.5em;
 
     $link-font-size: 12pt;
 
@@ -155,10 +157,23 @@ import { Accordion } from "molgenis-viz";
 #btnSubmitPatient {
   @include buttonLink;
   @include textTransform;
+  
+  color: $cranio-orange-050;
+  background-color: $cranio-orange;
+  
+  span {
+    letter-spacing: 0.15em;
+    border-bottom: 2px solid transparent;
+    
+  }
+  &:hover, &:focus {
+    text-decoration: none;
+    filter: brightness(110%);
+  }
 
   svg {
     position: relative;
-    width: 21px;
+    width: 18px;
     margin-left: 4px;
     margin-top: -4px;
     path {

--- a/apps/cranio-provider/src/styles/variables.scss
+++ b/apps/cranio-provider/src/styles/variables.scss
@@ -1,6 +1,13 @@
 $cranio-primary: #f3833e;
 $cranio-primary-alt: hsl(23, 88%, 83%);
 
+$cranio-orange-500: hsl(23, 88%, 45%);
+$cranio-orange-400: hsl(23, 88%, 55%);
+$cranio-orange: hsl(23, 88%, 60%);
+$cranio-orange-200: hsl(23, 88%, 75%);
+$cranio-orange-100: hsl(23, 88%, 85%);
+$cranio-orange-050: hsl(23, 88%, 98%);
+
 @mixin buttonLink($width: 100%) {
   display: block;
   width: $width;


### PR DESCRIPTION
In the `cranio-provider` vue app, there is a "Submit Patient" button in the sidebar component. It is currently disabled as the data model wasn't finished, but the button can be enabled. This request enables the button by redirecting users to the `Subjects` table.

To Do:
- [x] Change the "Submit Patient" button to an anchor element (it's currently a `<p>` tag). 
- [x] Set the url to the `Subjects` table. We will need to use relative paths here as the vue application is hosted at the same level as the `Tables` vue app. The url should "exit" the `cranio-provider` app and into the table view.
- [x] Add an icon to emphasise the action
- [x] Adjust styling for focus and hover events
- [x] Adjust css variables for brand colours (especially the primary color)