### PR TITLE
fix(catalogue): make descriptions of cta on overview page about equal

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/[datasource].vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/[datasource].vue
@@ -67,6 +67,7 @@ function datasetMapper(item: { name: string; description: string }) {
       <PageHeader
         :title="dataSource?.acronym || dataSource?.name"
         :description="dataSource?.acronym ? dataSource?.name : ''"
+        icon="image-data-warehouse"
       >
         <template #prefix>
           <BreadCrumbs :crumbs="crumbs" :current="dataSource?.id" />

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
@@ -145,10 +145,10 @@ crumbs[
           <PageHeader
             title="Data sources"
             description="Group of individuals sharing a defining demographic characteristic."
-            icon="data-warehouse"
+            icon="image-data-warehouse"
           >
             <template #prefix>
-              <BreadCrumbs :crumbs="crumbs" current="cohorts" />
+              <BreadCrumbs :crumbs="crumbs" current="data sources" />
             </template>
             <template #suffix>
               <div

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
@@ -286,7 +286,7 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
 
       <LandingCardPrimary
         v-if="numberOfNetworks > 0 && !cohortOnly"
-        image="image-diagram-2"
+        image="image-diagram"
         title="Networks"
         :description="
           getSettingValue(

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
@@ -292,7 +292,7 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
           getSettingValue(
             'CATALOGUE_LANDING_NETWORKS_TEXT',
             data.data._settings
-          ) || 'Networks &amp; consortia'
+          ) || 'Networks &amp; Consortia'
         "
         :count="numberOfNetworks"
         :callToAction="

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
@@ -237,10 +237,7 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
           getSettingValue(
             'CATALOGUE_LANDING_COHORTS_TEXT',
             data.data._settings
-          ) ||
-          ' A complete overview of ' +
-            catalogueRouteParam +
-            ' cohorts and biobanks.'
+          ) || 'Cohorts &amp; Biobanks'
         "
         :callToAction="
           getSettingValue('CATALOGUE_LANDING_COHORTS_CTA', data.data._settings)
@@ -256,7 +253,7 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
           getSettingValue(
             'CATALOGUE_LANDING_DATASOURCES_TEXT',
             data.data._settings
-          ) || catalogueRouteParam + ' databanks and registries'
+          ) || 'Databanks &amp; Registries'
         "
         :callToAction="
           getSettingValue(
@@ -275,7 +272,7 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
           getSettingValue(
             'CATALOGUE_LANDING_VARIABLES_TEXT',
             data.data._settings
-          ) || catalogueRouteParam + ' harmonized variables.'
+          ) || 'Harmonized variables'
         "
         :count="data.data.Variables_agg.count"
         :callToAction="
@@ -295,7 +292,7 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
           getSettingValue(
             'CATALOGUE_LANDING_NETWORKS_TEXT',
             data.data._settings
-          ) || 'Networks'
+          ) || 'Networks &amp; consortia'
         "
         :count="numberOfNetworks"
         :callToAction="

--- a/apps/nuxt3-ssr/utils/ontologyUtils.ts
+++ b/apps/nuxt3-ssr/utils/ontologyUtils.ts
@@ -11,6 +11,8 @@ export const buildTree = (
 ): IOntologyItem[] => {
   if (!selectedOntologyItems) {
     return [];
+  } else if (!Array.isArray(selectedOntologyItems)) {
+    selectedOntologyItems = [selectedOntologyItems];
   }
 
   // list-of-tree to list


### PR DESCRIPTION
how to test:
- this fixes that layout of CTA on overview pages was unequal. E.g. look at eosc4cancer. Proper fix should be to fix the layout itself.
- also fixes the logo of the 'network' cta

todo:
- [na] updated docs in case of new feature
- [na] added tests
