### PR TITLE
fix: mappings not shown for repeated variables. closes #2439

### DIFF
--- a/apps/catalogue/src/components/VariableListItem.vue
+++ b/apps/catalogue/src/components/VariableListItem.vue
@@ -150,7 +150,7 @@ export default {
           }
         });
       }
-      return [...new Set(mappings)].join(",");
+      return [...new Set(mappings)].join(", ");
     },
   },
   methods: {

--- a/apps/catalogue/src/components/VariableListItem.vue
+++ b/apps/catalogue/src/components/VariableListItem.vue
@@ -71,7 +71,7 @@
 
         <dt class="col-2">mapped by</dt>
         <dd class="col-10">
-          <span v-if="variable.mappings">
+          <span v-if="mappedByString">
             {{ mappedByString }}
             <router-link
               v-if="network"
@@ -134,9 +134,23 @@ export default {
         .sort((a, b) => a.order <= b.order);
     },
     mappedByString() {
-      return Object.values(this.variable.mappings)
-        .map((mapping) => mapping.sourceDataset.resource.id)
-        .join(", ");
+      const mappings = this.variable.mappings
+        ? Object.values(this.variable.mappings).map(
+            (mapping) => mapping.sourceDataset.resource.id
+          )
+        : [];
+      if (this.variable.repeats) {
+        Object.values(this.variable.repeats).forEach((repeat) => {
+          if (repeat.mappings) {
+            mappings.push(
+              ...Object.values(repeat.mappings).map(
+                (mapping) => mapping.sourceDataset.resource.id
+              )
+            );
+          }
+        });
+      }
+      return [...new Set(mappings)].join(",");
     },
   },
   methods: {

--- a/apps/catalogue/src/store/actions.js
+++ b/apps/catalogue/src/store/actions.js
@@ -68,6 +68,35 @@ export default {
                   label
                   repeats {
                     name
+                    mappings {
+                      source {
+                        id
+                      }
+                      targetVariable {
+                        name
+                      }
+                      targetDataset {
+                        resource {
+                          id
+                        }
+                      }
+                      sourceDataset {
+                        resource {
+                          id
+                        }
+                      }
+                      match {
+                        name
+                      }
+                      syntax
+                      description
+                      sourceVariablesOtherDatasets {
+                        dataset {
+                          name
+                        }
+                        name
+                      }
+                    }
                   }
                   mappings {
                     source {
@@ -280,7 +309,7 @@ export default {
         },
         {}
       );
-      variableDetails.mappings = mappingsById;
+      variableDetails.mappings = [...variableDetails, ...mappingsById];
     }
 
     return variableDetails;

--- a/apps/catalogue/src/store/actions.js
+++ b/apps/catalogue/src/store/actions.js
@@ -309,7 +309,7 @@ export default {
         },
         {}
       );
-      variableDetails.mappings = [...variableDetails, ...mappingsById];
+      variableDetails.mappings = mappingsById;
     }
 
     return variableDetails;


### PR DESCRIPTION
how to test:

In catalogue-demo:
Brenda_ variable is een voorbeeld waarbij het niet werkt (maar in deze PR wel)
headcircage_0 is een voorbeeld waarbij wel het eerste time point is gemapped door een cohort en je wel door kan klikken naar de details

Please test:
- [ ] when no mappings are available it should say 'none'
- [ ] if there are mappings in 'root' or 'repeat' it should list the cohorts that have mappings

closes #1894
close #2439
