### PR TITLE
fix: required computeds

### DIFF
--- a/apps/dev-proxy.config.js
+++ b/apps/dev-proxy.config.js
@@ -1,4 +1,4 @@
-const HOST = process.env.MOLGENIS_APPS_HOST || "http://localhost:8080";
+const HOST = process.env.MOLGENIS_APPS_HOST || "https://emx2.dev.molgenis.org";
 const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "pet store";
 
 const opts = { changeOrigin: true, secure: false, logLevel: "debug" };

--- a/apps/dev-proxy.config.js
+++ b/apps/dev-proxy.config.js
@@ -1,4 +1,4 @@
-const HOST = process.env.MOLGENIS_APPS_HOST || "https://emx2.dev.molgenis.org";
+const HOST = process.env.MOLGENIS_APPS_HOST || "http://localhost:8080";
 const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "pet store";
 
 const opts = { changeOrigin: true, secure: false, logLevel: "debug" };

--- a/apps/dev-proxy.config.js
+++ b/apps/dev-proxy.config.js
@@ -1,5 +1,5 @@
 const HOST = process.env.MOLGENIS_APPS_HOST || "https://emx2.dev.molgenis.org";
-const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "FAIR%20data%20hub";
+const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "pet store";
 
 const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
 

--- a/apps/schema/package.json
+++ b/apps/schema/package.json
@@ -13,6 +13,7 @@
     "core-js": "3.34.0",
     "graphql-request": "5.2.0",
     "graphql-tag": "2.12.6",
+    "meta-data-utils": "*",
     "molgenis-components": "*",
     "vue": "3.4.15",
     "vue-router": "4.2.5",

--- a/apps/schema/src/components/ColumnEditModal.vue
+++ b/apps/schema/src/components/ColumnEditModal.vue
@@ -551,7 +551,7 @@ export default {
     },
     handleComputedUpdate() {
       if (this.column.computed) {
-        this.column.requiredSelect = false;
+        this.requiredSelect = false;
         delete this.column.required;
       }
     },

--- a/apps/schema/src/components/ColumnEditModal.vue
+++ b/apps/schema/src/components/ColumnEditModal.vue
@@ -48,6 +48,7 @@
                   v-model="column.columnType"
                   :options="columnTypes"
                   label="columnType"
+                  @update:modelValue="handleColumnTypeChanged"
                 />
               </div>
               <div
@@ -191,7 +192,7 @@
                       ? 'Use pattern like \'pre${mg_autoid}post\' to customize prefix/postfix of your auto id'
                       : 'When set only the input will be readonly and value computed using this formula'
                   "
-                  @update:modelValue="handleComputedUpdate()"
+                  @update:modelValue="handleComputedChanged()"
                 />
               </div>
             </div>
@@ -354,8 +355,6 @@ export default {
       // working value of the column (copy of the value)
       column: null,
       requiredSelect: false,
-      //the type options
-      columnTypes,
       //in case a refSchema has to be used for the table lookup
       refSchema: undefined,
       error: null,
@@ -364,6 +363,8 @@ export default {
       previewShow: false,
       previewData: {},
       rowErrors: {},
+      columnTypes,
+      AUTO_ID,
     };
   },
   computed: {
@@ -516,7 +517,9 @@ export default {
     setupRequiredSelect() {
       if (this.column.required === "true") {
         this.requiredSelect = true;
-      } else if (this.column.required === "condition") {
+      } else if (this.column.required === "false") {
+        this.requiredSelect = false;
+      } else if (this.column.required) {
         this.requiredSelect = "condition";
       } else {
         this.requiredSelect = false;
@@ -549,15 +552,25 @@ export default {
     checkForErrors() {
       this.rowErrors = getRowErrors(this.table, this.previewData);
     },
-    handleComputedUpdate() {
+    handleComputedChanged() {
       if (this.column.computed) {
         this.requiredSelect = false;
         delete this.column.required;
       }
     },
     handleRequiredSelectChanged() {
+      this.column.required = this.requiredSelect;
       if (this.requiredSelect) {
         delete this.column.computed;
+      }
+    },
+    handleColumnTypeChanged(newType) {
+      console.log(newType);
+      if (newType === AUTO_ID) {
+        this.requiredSelect = false;
+        delete this.column.required;
+        delete this.column.visible;
+        this.column.readonly = true;
       }
     },
   },

--- a/apps/schema/src/components/ColumnEditModal.vue
+++ b/apps/schema/src/components/ColumnEditModal.vue
@@ -120,7 +120,6 @@
                   :options="[true, false, 'condition']"
                   v-model="requiredSelect"
                   description="Will give error unless field is filled in. Is not checked if not visible"
-                  @update:modelValue="setRequired"
                 />
                 <InputString
                   id="column_required"
@@ -181,7 +180,7 @@
                   description="When set only show when javascript expression is !null or !false. Example: other > 5"
                 />
               </div>
-              <div class="col-4">
+              <div class="col-4" v-if="column.required === `false`">
                 <InputText
                   id="column_computed"
                   v-model="column.computed"
@@ -191,6 +190,7 @@
                       ? 'Use pattern like \'pre${mg_autoid}post\' to customize prefix/postfix of your auto id'
                       : 'When set only the input will be readonly and value computed using this formula'
                   "
+                  @update:modelValue="handleComputedUpdate()"
                 />
               </div>
             </div>
@@ -272,11 +272,11 @@ import {
   Client,
   IconAction,
   InputBoolean,
+  InputRadio,
   InputSelect,
   InputString,
   InputText,
   InputTextLocalized,
-  InputRadio,
   LayoutForm,
   LayoutModal,
   MessageError,
@@ -287,13 +287,7 @@ import {
   getRowErrors,
 } from "molgenis-components";
 import columnTypes from "../columnTypes.js";
-import {
-  getLocalizedDescription,
-  getLocalizedLabel,
-  convertToPascalCase,
-  convertToCamelCase,
-  addTableIdsLabelsDescription,
-} from "../utils";
+import { addTableIdsLabelsDescription } from "../utils";
 
 const AUTO_ID = "AUTO_ID";
 
@@ -482,9 +476,7 @@ export default {
       this.reset();
       this.modalVisible = false;
     },
-    setRequired() {
-      this.column.required = this.requiredSelect;
-    },
+
     refLinkCandidates() {
       return this.table.columns
         .filter(
@@ -521,7 +513,6 @@ export default {
       this.loading = false;
     },
     setupRequiredSelect() {
-      console.log(this.column.required);
       if (this.column.required === "true") {
         this.requiredSelect = true;
       } else if (this.column.required === "false") {
@@ -553,6 +544,11 @@ export default {
     },
     checkForErrors() {
       this.rowErrors = getRowErrors(this.table, this.previewData);
+    },
+    handleComputedUpdate() {
+      if (this.column.computed) {
+        this.column.required = false;
+      }
     },
   },
   created() {

--- a/apps/schema/src/components/ColumnEditModal.vue
+++ b/apps/schema/src/components/ColumnEditModal.vue
@@ -565,6 +565,7 @@ export default {
       if (this.column.computed) {
         this.requiredSelect = false;
         delete this.column.required;
+        delete this.column.validation;
       }
     },
     handleRequiredSelectChanged() {

--- a/apps/schema/src/components/ColumnEditModal.vue
+++ b/apps/schema/src/components/ColumnEditModal.vue
@@ -113,8 +113,8 @@
                 />
               </div>
             </div>
-            <div class="row">
-              <div class="col-4" v-if="isEditable(column)">
+            <div class="row" v-if="isEditable(column)">
+              <div class="col-4">
                 <InputRadio
                   id="column_required_radio"
                   label="required"
@@ -129,14 +129,14 @@
                   v-if="requiredSelect === 'condition'"
                 />
               </div>
-              <div class="col-4" v-if="isEditable(column)">
+              <div class="col-4">
                 <InputBoolean
                   id="column_readonly"
                   v-model="column.readonly"
                   label="isReadonly"
                 />
               </div>
-              <div class="col-4" v-if="isEditable(column)">
+              <div class="col-4">
                 <InputString
                   id="column_default"
                   v-model="column.defaultValue"
@@ -145,7 +145,7 @@
               </div>
             </div>
             <div class="row">
-              <div class="col-4" v-if="column.columnType !== 'CONSTANT'">
+              <div class="col-4">
                 <InputSelect
                   id="column_key"
                   v-model="column.key"
@@ -552,11 +552,7 @@ export default {
       this.modalVisible = false;
     },
     isEditable(column: Record<string, any>) {
-      return (
-        column.columnType !== "CONSTANT" &&
-        !column.computed &&
-        column.columnType !== AUTO_ID
-      );
+      return !column.computed && column.columnType !== AUTO_ID;
     },
     checkForErrors() {
       this.rowErrors = getRowErrors(this.table, this.previewData);
@@ -566,6 +562,7 @@ export default {
         this.requiredSelect = false;
         delete this.column.required;
         delete this.column.validation;
+        delete this.column.defaultValue;
       }
     },
     handleRequiredSelectChanged() {
@@ -579,7 +576,8 @@ export default {
         this.requiredSelect = false;
         delete this.column.required;
         delete this.column.visible;
-        this.column.readonly = true;
+        delete this.column.validation;
+        delete this.column.defaultValue;
       }
     },
   },

--- a/apps/schema/src/components/SchemaToc.vue
+++ b/apps/schema/src/components/SchemaToc.vue
@@ -115,6 +115,9 @@ export default {
       if (!Array.isArray(this.schema.tables)) {
         this.schema.tables = [];
       }
+      if (!Array.isArray(table.columns)) {
+        table.columns = [];
+      }
       this.schema.tables.push(table);
       this.$emit("update:modelValue", this.schema);
     },

--- a/apps/schema/tsconfig.json
+++ b/apps/schema/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "strict": true,
+    "isolatedModules": true,
+    "allowJs": true,
+    "types": ["vite/client"],
+    "lib": ["es2015"]
+  }
+}


### PR DESCRIPTION
Currently it is possible to have a computed that is required by first setting required to true and then adding a computed expression.  Having a computed expressions should set required to false to prevent saving problems in forms.

Additionally: 
- This pr sets default for required to false instead of expression, since that is a more sensible default.
- Fixes a bug where creating/editing an AUTO_ID column let the visibility field visible and some other side effect related to auto id in the schema editor.
- Fixes a bug where you can't add columns to a new table that is not saved yet.

how to test:
- Go to the schema editor 
- Add a column
- Set required to true / condition
- Note that the computed field is hidden
- Set required to false
- Add a computed expression
- See that the required toggle is hidden.

Other test:
- Create a new table
- Add a column (on master the + will just disappear without opening a modal)

Other other test:
- Set column to autoId
- See that the text by the computed field changes

todo:
- [NA] updated docs in case of new feature
- [ ] added tests
