### PR TITLE
fix(directory): change ID to Id in the negotiator request

### DIFF
--- a/apps/directory/src/stores/checkoutStore.js
+++ b/apps/directory/src/stores/checkoutStore.js
@@ -193,8 +193,8 @@ export const useCheckoutStore = defineStore("checkoutStore", () => {
       for (const collection of collectionSelection) {
         collections.push(
           toRaw({
-            collectionID: collection.value,
-            biobankID: biobankIdDictionary.value[biobank],
+            collectionId: collection.value,
+            biobankId: biobankIdDictionary.value[biobank],
           })
         );
       }


### PR DESCRIPTION
how to test:
- Directory App: Select collections, create the request and send to the negotiator. When pushing the send button, a create_request query is created. In this query there should be collectionId and biobankId instead of collectionID and biobankID.

todo:
- [na] updated docs in case of new feature
- [na] added tests
