### PR TITLE
chore: add anonymous access to the directory demo

### DIFF
--- a/data/biobank-directory/demo/molgenis_members.csv
+++ b/data/biobank-directory/demo/molgenis_members.csv
@@ -1,0 +1,2 @@
+user,role
+anonymous,Viewer


### PR DESCRIPTION
Add molgenis_members.csv to set anonymous viewer access to the Directory app by default.

**how to test**
_Preview:_
-  Preview should load the directory-demo schema and anonymous should have Viewer access.

_Local system:_
```
export MOLGENIS_INCLUDE_DIRECTORY_DEMO=true
./gradlew clean cleandb
./gradlew run
```