### PR TITLE
fix: required fields in DataCatalogue model

### DIFF
--- a/data/_models/shared/DataCatalogue-TODO.csv
+++ b/data/_models/shared/DataCatalogue-TODO.csv
@@ -1,8 +1,8 @@
 tableName,tableExtends,columnName,columnType,key,required,refSchema,refTable,refLink,refBack,validation,semantics,description,profiles
 Version,,,,,,,,,,,,3.11,"DataCatalogue,EMA,SharedStaging,CohortStaging"
 Catalogues,,,,,,,,,,,,A collection of resources within a network or consortium or about a common topic,DataCatalogue
-Catalogues,,network,ref,1,TRUE,,Networks,,,,,Network or consortium that leads this catalogue,DataCatalogue
-Catalogues,,type,ontology,,TRUE,CatalogueOntologies,CatalogueTypes,,,,,Type of catalogue,DataCatalogue
+Catalogues,,network,ref,1,true,,Networks,,,,,Network or consortium that leads this catalogue,DataCatalogue
+Catalogues,,type,ontology,,true,CatalogueOntologies,CatalogueTypes,,,,,Type of catalogue,DataCatalogue
 Resources,,,,,,,,,,,,"Generic listing of all resources. Should not be used directly, instead use specific types such as Databanks and Studies","DataCatalogue,EMA,SharedStaging,CohortStaging"
 Organisations,Resources,,,,,,,,,,,Research departments and research groups,"DataCatalogue,EMA,SharedStaging"
 Extended resources,Resources,,,,,,,,,,,"Generic listing of all extended resources. Should not be used directly, instead use specific types such as Databanks and Cohorts","DataCatalogue,EMA,CohortStaging"
@@ -15,10 +15,10 @@ Data sources,RWE resources,,,,,,,,,,,Collections of multiple data banks covering
 Networks,Extended resources,,,,,,,,,,,Collaborations of multiple institutions,"DataCatalogue,EMA"
 Studies,Extended resources,,,,,,,,,,,"Collaborations of multiple institutions, addressing research questions using data sources and/or data banks","DataCatalogue,EMA"
 Resources,,overview,heading,,,,,,,,,General information,"DataCatalogue,CohortStaging"
-Resources,,id,,1,TRUE,,,,,,,Internal identifier,"DataCatalogue,EMA,SharedStaging,CohortStaging"
+Resources,,id,,1,true,,,,,,,Internal identifier,"DataCatalogue,EMA,SharedStaging,CohortStaging"
 Resources,,pid,,2,,,,,,,,Persistent identifier,"DataCatalogue,EMA,SharedStaging,CohortStaging"
 Resources,,acronym,,,,,,,,,,Acronym if applicable,"DataCatalogue,EMA,SharedStaging,CohortStaging"
-Resources,,name,text,3,TRUE,,,,,,,Name used in European projects,"DataCatalogue,EMA,SharedStaging,CohortStaging"
+Resources,,name,text,3,true,,,,,,,Name used in European projects,"DataCatalogue,EMA,SharedStaging,CohortStaging"
 Data resources,,local name,,,,,,,,,,"If different from above, name in the national language","DataCatalogue,CohortStaging"
 Organisations,,type,ontology_array,,,CatalogueOntologies,Organisation types,,,,,Type of organisation; in which sector is the organisation active?,"DataCatalogue,EMA,SharedStaging"
 Organisations,,type other,text,,,,,,,,,"If type is 'other', a description of type of organisation","DataCatalogue,SharedStaging"
@@ -194,7 +194,7 @@ Studies,,networks other,text,,,,,,,,,List the names of any other networks that a
 RWE resources,,networks,refback,,,,Networks,,data sources,,,List of networks that this datasource is associated with,"DataCatalogue,EMA"
 RWE resources,,studies,refback,,,,Studies,,data sources,,,List of studies that this datasource is associated with,"DataCatalogue,EMA"
 Publications,,,,,,,,,,,,Publications following bibtex format,"DataCatalogue,CohortStaging"
-Publications,,doi,hyperlink,1,TRUE,,,,,,,Digital object identifier,"DataCatalogue,EMA,CohortStaging"
+Publications,,doi,hyperlink,1,true,,,,,,,Digital object identifier,"DataCatalogue,EMA,CohortStaging"
 Publications,,title,text,,,,,,,,,Publication title,"DataCatalogue,EMA,CohortStaging"
 Publications,,authors,string_array,,,,,,,,,"List of authors, one entry per author",DataCatalogue
 Publications,,year,int,,,,,,,,,"Year of publication (or, if unpublished, year of creation)",DataCatalogue
@@ -207,11 +207,11 @@ Publications,,school,,,,,,,,,,School where the thesis was written (in case of th
 Publications,,abstract,text,,,,,,,,,Publication abstract,DataCatalogue
 Publications,,resources,refback,,,,Extended resources,,publications,,,List of resources that refer to this publication,DataCatalogue
 Contacts,,,,,,,,,,,,Listing of contact persons per resource,"DataCatalogue,EMA,CohortStaging"
-Contacts,,resource,ref,1,TRUE,,Resources,,,,,Resource the contact is affiliated with,"DataCatalogue,EMA,CohortStaging"
+Contacts,,resource,ref,1,true,,Resources,,,,,Resource the contact is affiliated with,"DataCatalogue,EMA,CohortStaging"
 Contacts,,role,ontology_array,,,CatalogueOntologies,Contribution types,,,,,Type(s) of contribution or role in the resource,"DataCatalogue,EMA,CohortStaging"
 Contacts,,role description,text,,,,,,,,,Description of the role,"DataCatalogue,CohortStaging"
-Contacts,,first name,,1,TRUE,,,,,,,First name of the contact person,"DataCatalogue,EMA,CohortStaging"
-Contacts,,last name,,1,TRUE,,,,,,,Last name of the contact person,"DataCatalogue,EMA,CohortStaging"
+Contacts,,first name,,1,true,,,,,,,First name of the contact person,"DataCatalogue,EMA,CohortStaging"
+Contacts,,last name,,1,true,,,,,,,Last name of the contact person,"DataCatalogue,EMA,CohortStaging"
 Contacts,,prefix,,,,,,,,,,"Surname prefix, if applicable","DataCatalogue,CohortStaging"
 Contacts,,initials,,,,,,,,,,Initials of the contact person,"DataCatalogue,CohortStaging"
 Contacts,,title,ontology,,,CatalogueOntologies,Titles,,,,,Title of the contact person,"DataCatalogue,EMA,CohortStaging"
@@ -223,15 +223,15 @@ Contacts,,homepage,,,,,,,,,,Link to contact's homepage,"DataCatalogue,CohortStag
 Contacts,,photo,file,,,,,,,,,Contact's photograph,"DataCatalogue,CohortStaging"
 Contacts,,expertise,,,,,,,,,,Description of contact's expertise,"DataCatalogue,CohortStaging"
 Documentation,,,,,,,,,,,,Documentation attached to a resource,"DataCatalogue,CohortStaging"
-Documentation,,resource,ref,1,TRUE,,Extended resources,,,,,The resource this documentation is for,"DataCatalogue,EMA,CohortStaging"
-Documentation,,name,,1,TRUE,,,,,,,Document name,"DataCatalogue,EMA,CohortStaging"
+Documentation,,resource,ref,1,true,,Extended resources,,,,,The resource this documentation is for,"DataCatalogue,EMA,CohortStaging"
+Documentation,,name,,1,true,,,,,,,Document name,"DataCatalogue,EMA,CohortStaging"
 Documentation,,type,ontology,,,CatalogueOntologies,Document types,,,,,Type of documentation,"DataCatalogue,EMA,CohortStaging"
 Documentation,,description,text,,,,,,,,,Description of the document,"DataCatalogue,CohortStaging"
 Documentation,,url,hyperlink,,,,,,,,,Hyperlink to the source of the documentation,"DataCatalogue,EMA,CohortStaging"
 Documentation,,file,file,,,,,,,,,Optional file attachment containing the documentation,"DataCatalogue,EMA,CohortStaging"
 Linked resources,,,,,,,,,,,,Links between datasource and databank,"DataCatalogue,EMA"
-Linked resources,,main resource,ref,1,TRUE,,RWE resources,,,,,,"DataCatalogue,EMA"
-Linked resources,,linked resource,ref,1,TRUE,,RWE resources,,,,,,"DataCatalogue,EMA"
+Linked resources,,main resource,ref,1,true,,RWE resources,,,,,,"DataCatalogue,EMA"
+Linked resources,,linked resource,ref,1,true,,RWE resources,,,,,,"DataCatalogue,EMA"
 Linked resources,,other linked resource,,,,,,,,,,"If other linked data source, enter the name of the data source (default = not applicable)","DataCatalogue,EMA"
 Linked resources,,linkage strategy,ontology,,,CatalogueOntologies,Linkage strategies,,,,,The linkage method that was used to link data banks. One entry per data bank,"DataCatalogue,EMA"
 Linked resources,,linkage variable,text,,,,,,,,,"If a single variable (or linkage key) is used to link a data bank to others, a name and description of the variable is provided. One entry per data bank","DataCatalogue,EMA"
@@ -249,8 +249,8 @@ Quantitative information,,mean years active,int,,,,,,,,,Median time for which un
 Quantitative information,,median age,int,,,,,,,,,Median age of individuals within data source,DataCatalogue
 Quantitative information,,proportion female,int,,,,,,,,,Proportion of females in the data source,DataCatalogue
 Collection events,,,,,,,,,,,,Definition of a data collection event for a resource,"DataCatalogue,CohortStaging"
-Collection events,,resource,ref,1,TRUE,,Extended resources,,,,,Resource this collection event is part of,"DataCatalogue,CohortStaging"
-Collection events,,name,,1,TRUE,,,,,,,Name of the collection event,"DataCatalogue,CohortStaging"
+Collection events,,resource,ref,1,true,,Extended resources,,,,,Resource this collection event is part of,"DataCatalogue,CohortStaging"
+Collection events,,name,,1,true,,,,,,,Name of the collection event,"DataCatalogue,CohortStaging"
 Collection events,,description,text,,,,,,,,,Description of the collection event,"DataCatalogue,CohortStaging"
 Collection events,,subcohorts,ref_array,,,,Subcohorts,resource,,,,Subcohorts that are targetted by this collection event,"DataCatalogue,CohortStaging"
 Collection events,,start year,ontology,,,CatalogueOntologies,Years,,,,,Start year of data collection,"DataCatalogue,CohortStaging"
@@ -267,8 +267,8 @@ Collection events,,standardized tools other,,,,,,,,,,"If 'other', please specify
 Collection events,,core variables,string_array,,,,,,,,,Name 10-20 relevant variables that were collected in this collection event,"DataCatalogue,CohortStaging"
 Collection events,,supplementary information,text,,,,,,,,,Any other information that needs to be disclosed for this collection event,"DataCatalogue,CohortStaging"
 Subcohorts,,,,,,,,,,,,Subcohorts defined for this resource,"DataCatalogue,CohortStaging"
-Subcohorts,,resource,ref,1,TRUE,,Extended resources,,,,,Resource this subcohort is part of,"DataCatalogue,CohortStaging"
-Subcohorts,,name,,1,TRUE,,,,,,,"Subcohort name, e.g. 'mothers in first trimester','newborns'","DataCatalogue,CohortStaging"
+Subcohorts,,resource,ref,1,true,,Extended resources,,,,,Resource this subcohort is part of,"DataCatalogue,CohortStaging"
+Subcohorts,,name,,1,true,,,,,,,"Subcohort name, e.g. 'mothers in first trimester','newborns'","DataCatalogue,CohortStaging"
 Subcohorts,,description,text,,,,,,,,,Subcohort description,"DataCatalogue,CohortStaging"
 Subcohorts,,number of participants,int,,,,,,,,,Number of participants in this subcohort,"DataCatalogue,CohortStaging"
 Subcohorts,,counts,refback,,,,Subcohort counts,,subcohort,,,"Total number of unique individuals per age(group), gender and year","DataCatalogue,CohortStaging"
@@ -341,8 +341,8 @@ Studies,,study scope other,text,,,,,,,,,If scope 'other',"DataCatalogue,EMA"
 Studies,,population of interest,ontology_array,,,CatalogueOntologies,Population of interest,,,,,"If population of interest is 'Other', please specify which other population has been studied","DataCatalogue,EMA"
 Studies,,population of interest other,text,,,,,,,,,"If population of interest is 'Other', please specify which other population has been studied","DataCatalogue,EMA"
 Datasets,,,,,,,,,,,,Definition of a dataset within a (common) data model,"DataCatalogue,CohortStaging"
-Datasets,,resource,ref,1,TRUE,,Extended resources,,,,,resources that these variables are part of,"DataCatalogue,CohortStaging"
-Datasets,,name,,1,TRUE,,,,,,,unique dataset name in the model,"DataCatalogue,CohortStaging"
+Datasets,,resource,ref,1,true,,Extended resources,,,,,resources that these variables are part of,"DataCatalogue,CohortStaging"
+Datasets,,name,,1,true,,,,,,,unique dataset name in the model,"DataCatalogue,CohortStaging"
 Datasets,,label,,,,,,,,,,short human readable description,"DataCatalogue,CohortStaging"
 Datasets,,unit of observation,ontology,,,CatalogueOntologies,Observation targets,,,,,defines what each record in this table describes,"DataCatalogue,CohortStaging"
 Datasets,,keywords,ontology_array,,,CatalogueOntologies,Keywords,,,,,enables grouping of table list into topic and to display tables in a tree,"DataCatalogue,CohortStaging"
@@ -353,9 +353,9 @@ Datasets,,mapped from,refback,,,,Dataset mappings,,target dataset,,,source datas
 Datasets,,since version,,,,,,,,,,When this dataset was introduced,"DataCatalogue,CohortStaging"
 Datasets,,until version,,,,,,,,,,When this dataset was removed if applicable,"DataCatalogue,CohortStaging"
 All variables,,,,,,,,,,,,"Generic listing of all source variables. Should not be used directly, please use SourceVariables or RepeatedSourceVariables instead","DataCatalogue,CohortStaging"
-All variables,,resource,ref,1,TRUE,,Extended resources,,,,,Data source that this variable was collected in,"DataCatalogue,CohortStaging"
-All variables,,dataset,ref,1,TRUE,,Datasets,resource,,,,Dataset this variable is part of,"DataCatalogue,CohortStaging"
-All variables,,name,,1,TRUE,,,,,,,"name of the variable, unique within a table","DataCatalogue,CohortStaging"
+All variables,,resource,ref,1,true,,Extended resources,,,,,Data source that this variable was collected in,"DataCatalogue,CohortStaging"
+All variables,,dataset,ref,1,true,,Datasets,resource,,,,Dataset this variable is part of,"DataCatalogue,CohortStaging"
+All variables,,name,,1,true,,,,,,,"name of the variable, unique within a table","DataCatalogue,CohortStaging"
 All variables,,label,,,,,,,,,,"Human friendly longer name, if applicable","DataCatalogue,CohortStaging"
 All variables,,collection event,ref,,,,Collection events,,,,,in case of protocolised data collection this defines the moment(s) in time this variable is collected on,"DataCatalogue,CohortStaging"
 All variables,,since version,,,,,,,,,,When this variable was introduced,"DataCatalogue,CohortStaging"
@@ -375,21 +375,21 @@ Variables,,vocabularies,ontology_array,,,CatalogueOntologies,Vocabularies,,,,,,"
 Variables,,notes,text,,,,,,,,,Any other information on this variable,"DataCatalogue,CohortStaging"
 All variables,,mappings,refback,,,,Variable mappings,,target variable,,,in case of protocolised data collection this defines the moment in time this variable is collected on,DataCatalogue
 Variable values,,,,,,,,,,,,Listing of categorical value+label definition in case of a categorical variable,"DataCatalogue,CohortStaging"
-Variable values,,resource,ref,1,TRUE,,Extended resources,,,,,,"DataCatalogue,CohortStaging"
-Variable values,,variable,ref,1,TRUE,,Variables,resource,,,,e.g. PATO,"DataCatalogue,CohortStaging"
-Variable values,,value,,1,TRUE,,,,,,,e.g. '1',"DataCatalogue,CohortStaging"
-Variable values,,label,,,TRUE,,,,,,,,"DataCatalogue,CohortStaging"
+Variable values,,resource,ref,1,true,,Extended resources,,,,,,"DataCatalogue,CohortStaging"
+Variable values,,variable,ref,1,true,,Variables,resource,,,,e.g. PATO,"DataCatalogue,CohortStaging"
+Variable values,,value,,1,true,,,,,,,e.g. '1',"DataCatalogue,CohortStaging"
+Variable values,,label,,,true,,,,,,,,"DataCatalogue,CohortStaging"
 Variable values,,order,int,,,,,,,,,,"DataCatalogue,CohortStaging"
 Variable values,,is missing,bool,,,,,,,,,,"DataCatalogue,CohortStaging"
 Variable values,,ontology term URI,,,,,,,,,,reference to ontology term that defines this categorical value,"DataCatalogue,CohortStaging"
 Variable values,,since version,,,,,,,,,,When this variable value was introduced if applicable,"DataCatalogue,CohortStaging"
 Variable values,,until version,,,,,,,,,,When this variable value was removed if applicable,"DataCatalogue,CohortStaging"
 Repeated variables,All variables,,,,,,,,,,,Definition of a repeated sourceVariable. Refers to another variable for its definition,"DataCatalogue,CohortStaging"
-Repeated variables,,is repeat of,ref,,TRUE,,Variables,resource,,,,reference to the definition of the sourceVariable that is being repeated,"DataCatalogue,CohortStaging"
+Repeated variables,,is repeat of,ref,,true,,Variables,resource,,,,reference to the definition of the sourceVariable that is being repeated,"DataCatalogue,CohortStaging"
 Mappings,,,,,,,,,,,,"Mapping from collected datasets to standard/harmonised datasets, optionally including ETL syntaxes","DataCatalogue,EMA"
-Mappings,,source,ref,1,TRUE,,Extended resources,,,,,Data source that is being mapped to a (common) data model,"DataCatalogue,EMA"
+Mappings,,source,ref,1,true,,Extended resources,,,,,Data source that is being mapped to a (common) data model,"DataCatalogue,EMA"
 Mappings,,source version,string,,,,,,,,,version of the datasource that is being mapped,"DataCatalogue,EMA"
-Mappings,,target,ref,1,TRUE,,Models,,,,,model being mapped to,"DataCatalogue,EMA"
+Mappings,,target,ref,1,true,,Models,,,,,model being mapped to,"DataCatalogue,EMA"
 Mappings,,target version,string,,,,,,,,,version of the model being mapped to,"DataCatalogue,EMA"
 Mappings,,cdms other,,,,,,,,,,"if cdm is not under targets, which cdm was mapped to? (default = not applicable)","DataCatalogue,EMA"
 Mappings,,mapping status,ontology,,,CatalogueOntologies,Mapping status,,,,,"Mapping from collected datasets to standard/harmonised datasets, optionally including ETL syntaxes","DataCatalogue,EMA"
@@ -397,45 +397,45 @@ Mappings,,ETL frequency,int,,,,,,,,,"The frequency of the ETL process, in months
 Mappings,,ETL specification url,hyperlink,,,,,,,,,Link to ETL specification documentation,"DataCatalogue,EMA"
 Mappings,,ETL specification document,file,,,,,,,,,Documentation concerning ETL details,"DataCatalogue,EMA"
 Dataset mappings,,,,,,,,,,,,Mappings from collected or source datasets to harmonised or target datasets,"DataCatalogue,CohortStaging"
-Dataset mappings,,source,ref,1,TRUE,,Extended resources,,,,,datasource being mapped from,"DataCatalogue,CohortStaging"
-Dataset mappings,,source dataset,ref,1,TRUE,,Datasets,source,,,,name of the table being mapped from,"DataCatalogue,CohortStaging"
-Dataset mappings,,target,ref,1,TRUE,,Extended resources,,,,,"model being mapped to, i.e. toModel.resource + toModel.version",DataCatalogue
-Dataset mappings,,target dataset,ref,1,TRUE,,Datasets,target,,,,name of the table being mapped to,DataCatalogue
-Dataset mappings,,target,ref,1,TRUE,catalogue,Extended resources,,,,,"model being mapped to, i.e. toModel.resource + toModel.version",CohortStaging
-Dataset mappings,,target dataset,ref,1,TRUE,catalogue,Datasets,target,,,,name of the table being mapped to,CohortStaging
+Dataset mappings,,source,ref,1,true,,Extended resources,,,,,datasource being mapped from,"DataCatalogue,CohortStaging"
+Dataset mappings,,source dataset,ref,1,true,,Datasets,source,,,,name of the table being mapped from,"DataCatalogue,CohortStaging"
+Dataset mappings,,target,ref,1,true,,Extended resources,,,,,"model being mapped to, i.e. toModel.resource + toModel.version",DataCatalogue
+Dataset mappings,,target dataset,ref,1,true,,Datasets,target,,,,name of the table being mapped to,DataCatalogue
+Dataset mappings,,target,ref,1,true,catalogue,Extended resources,,,,,"model being mapped to, i.e. toModel.resource + toModel.version",CohortStaging
+Dataset mappings,,target dataset,ref,1,true,catalogue,Datasets,target,,,,name of the table being mapped to,CohortStaging
 Dataset mappings,,order,int,,,,,,,,,Order in which table ETLs should be executed for this source-target combination,"DataCatalogue,CohortStaging"
 Dataset mappings,,description,text,,,,,,,,,human readible description of the mapping,"DataCatalogue,CohortStaging"
 Dataset mappings,,syntax,text,,,,,,,,,"formal definition of the mapping, ideally executable code","DataCatalogue,CohortStaging"
 Variable mappings,,,,,,,,,,,,"Mappings from collected variables to standard/harmonised variables, optionally including ETL syntax","DataCatalogue,CohortStaging"
-Variable mappings,,source,ref,1,TRUE,,Extended resources,,,,,,"DataCatalogue,CohortStaging"
-Variable mappings,,source dataset,ref,1,TRUE,,Datasets,source,,,,,"DataCatalogue,CohortStaging"
+Variable mappings,,source,ref,1,true,,Extended resources,,,,,,"DataCatalogue,CohortStaging"
+Variable mappings,,source dataset,ref,1,true,,Datasets,source,,,,,"DataCatalogue,CohortStaging"
 Variable mappings,,source variables,ref_array,,,,All variables,source dataset,,,,"Optional, source variable that was mapped from. You may also indicate that a mapping to a target variable was not done and leave this field empty (match = na)","DataCatalogue,CohortStaging"
 Variable mappings,,source variables other datasets,ref_array,,,,All variables,source,,,,"optional, variable from other source datasets. Initially one may only define mapping between releases","DataCatalogue,CohortStaging"
-Variable mappings,,target,ref,1,TRUE,,Extended resources,,,,,,DataCatalogue
-Variable mappings,,target dataset,ref,1,TRUE,,Datasets,target,,,,,DataCatalogue
-Variable mappings,,target variable,ref,1,TRUE,,All variables,target dataset,,,,"in UI this is then one lookup field. In Excel it will be two columns. Value of 'targetVariable' is filtered based on selected 'targetCollection' and together be used for fkey(collection,dataset,name) in Variable",DataCatalogue
-Variable mappings,,target,ref,1,TRUE,catalogue,Extended resources,,,,,,CohortStaging
-Variable mappings,,target dataset,ref,1,TRUE,catalogue,Datasets,target,,,,,CohortStaging
-Variable mappings,,target variable,ref,1,TRUE,catalogue,All variables,target dataset,,,,"in UI this is then one lookup field. In Excel it will be two columns. Value of 'targetVariable' is filtered based on selected 'targetCollection' and together be used for fkey(collection,dataset,name) in Variable",CohortStaging
-Variable mappings,,match,ontology,,TRUE,CatalogueOntologies,Status details,,,,,"e.g. 'complete, partial, planned, no-match'","DataCatalogue,CohortStaging"
+Variable mappings,,target,ref,1,true,,Extended resources,,,,,,DataCatalogue
+Variable mappings,,target dataset,ref,1,true,,Datasets,target,,,,,DataCatalogue
+Variable mappings,,target variable,ref,1,true,,All variables,target dataset,,,,"in UI this is then one lookup field. In Excel it will be two columns. Value of 'targetVariable' is filtered based on selected 'targetCollection' and together be used for fkey(collection,dataset,name) in Variable",DataCatalogue
+Variable mappings,,target,ref,1,true,catalogue,Extended resources,,,,,,CohortStaging
+Variable mappings,,target dataset,ref,1,true,catalogue,Datasets,target,,,,,CohortStaging
+Variable mappings,,target variable,ref,1,true,catalogue,All variables,target dataset,,,,"in UI this is then one lookup field. In Excel it will be two columns. Value of 'targetVariable' is filtered based on selected 'targetCollection' and together be used for fkey(collection,dataset,name) in Variable",CohortStaging
+Variable mappings,,match,ontology,,true,CatalogueOntologies,Status details,,,,,"e.g. 'complete, partial, planned, no-match'","DataCatalogue,CohortStaging"
 Variable mappings,,status,ontology,,,CatalogueOntologies,Status,,,,,whether harmonisation is still draft or final,"DataCatalogue,CohortStaging"
 Variable mappings,,description,text,,,,,,,,,human readible description of the mapping,"DataCatalogue,CohortStaging"
 Variable mappings,,syntax,text,,,,,,,,,"formal definition of the mapping, ideally executable code","DataCatalogue,CohortStaging"
 Variable mappings,,comments,text,,,,,,,,,additional notes and comments,"DataCatalogue,CohortStaging"
 Network variables,,,,,,,,,,,,Listing of the variables used in a network,DataCatalogue
-Network variables,,network,ref,1,TRUE,,Networks,,,,,,DataCatalogue
-Network variables,,variable,ref,1,TRUE,,All variables,,,,,,DataCatalogue
+Network variables,,network,ref,1,true,,Networks,,,,,,DataCatalogue
+Network variables,,variable,ref,1,true,,All variables,,,,,,DataCatalogue
 Subcohort counts,,,,,,,,,,,,"Number of participants per subcohort age group, optionally divided per sex","DataCatalogue,CohortStaging"
-Subcohort counts,,subcohort,ref,1,TRUE,,Subcohorts,,,,,,"DataCatalogue,CohortStaging"
-Subcohort counts,,age group,ontology,1,TRUE,CatalogueOntologies,Age groups,,,,,,"DataCatalogue,CohortStaging"
+Subcohort counts,,subcohort,ref,1,true,,Subcohorts,,,,,,"DataCatalogue,CohortStaging"
+Subcohort counts,,age group,ontology,1,true,CatalogueOntologies,Age groups,,,,,,"DataCatalogue,CohortStaging"
 Subcohort counts,,N total,int,,,,,,,,,,"DataCatalogue,CohortStaging"
 Subcohort counts,,N female,int,,,,,,,,,,"DataCatalogue,CohortStaging"
 Subcohort counts,,N male,int,,,,,,,,,,"DataCatalogue,CohortStaging"
 Submissions,,,,,,,,,,,,Documentation of data submissions related to a resource,"DataCatalogue,EMA"
-Submissions,,submission date,datetime,1,TRUE,,,,,,,Date of submission,"DataCatalogue,EMA"
-Submissions,,submitter name,string,1,TRUE,,,,,,,Name of person who submitted,DataCatalogue
-Submissions,,resources,ref_array,,TRUE,,Extended resources,,,,,Resource(s) that this submission is related to,"DataCatalogue,EMA"
-Submissions,,submitter email,string,,TRUE,,,,,,,Email of person who submitted,DataCatalogue
+Submissions,,submission date,datetime,1,true,,,,,,,Date of submission,"DataCatalogue,EMA"
+Submissions,,submitter name,string,1,true,,,,,,,Name of person who submitted,DataCatalogue
+Submissions,,resources,ref_array,,true,,Extended resources,,,,,Resource(s) that this submission is related to,"DataCatalogue,EMA"
+Submissions,,submitter email,string,,true,,,,,,,Email of person who submitted,DataCatalogue
 Submissions,,submitter organisation,ref,,,,Organisations,,,,,Organisation of submitter,DataCatalogue
 Submissions,,submitter role,ontology,,,CatalogueOntologies,Submitter roles,,,,,Role of submitter in organisation,DataCatalogue
 Submissions,,submitter role other,text,,,,,,,,,"Role of submitter in organisation, if other than above",DataCatalogue
@@ -444,13 +444,13 @@ Submissions,,submission description,text,,,,,,,,,"Description of the submission,
 Submissions,,responsible persons,text,,,,,,,,,List of responsible persons related to this submission,DataCatalogue
 Submissions,,acceptance date,datetime,,,,,,,,,Date submission was accepted,"DataCatalogue,EMA"
 External identifiers,,,,,,,,,,,,External identifier(s) for this resource,"DataCatalogue,EMA,CohortStaging"
-External identifiers,,resource,ref,1,TRUE,,Extended resources,,,,,Resource that this external identifier belongs to,"DataCatalogue,EMA,CohortStaging"
-External identifiers,,identifier,text,1,TRUE,,,,,,,External identifier,"DataCatalogue,EMA,CohortStaging"
+External identifiers,,resource,ref,1,true,,Extended resources,,,,,Resource that this external identifier belongs to,"DataCatalogue,EMA,CohortStaging"
+External identifiers,,identifier,text,1,true,,,,,,,External identifier,"DataCatalogue,EMA,CohortStaging"
 External identifiers,,external identifier type,ontology,,,CatalogueOntologies,External identifier types,,,,,External identifier type,"DataCatalogue,EMA,CohortStaging"
 External identifiers,,external identifier type other,text,,,,,,,,,"If other, enter external identifier type","DataCatalogue,CohortStaging"
 DAPs,,,,,,,,,,,,Data access provider relationship where an institution can provide access to (parts of) a resource,DataCatalogue
-DAPs,,organisation,ref,1,TRUE,,Organisations,,,,,Institution that provides access,DataCatalogue
-DAPs,,resource,ref,1,TRUE,,Resources,,,,,Resource that is access or has experience with provided to,DataCatalogue
+DAPs,,organisation,ref,1,true,,Organisations,,,,,Institution that provides access,DataCatalogue
+DAPs,,resource,ref,1,true,,Resources,,,,,Resource that is access or has experience with provided to,DataCatalogue
 DAPs,,is data access provider,ontology_array,,,CatalogueOntologies,DAP information,,,,,"Description of population subset, data access levels, completeness, reason for access",DataCatalogue
 DAPs,,reason access other,text,,,,,,,,,"If reason access is 'other', reason for being able to access (an extract of) the data source",DataCatalogue
 DAPs,,population subset other,text,,,,,,,,,"If 'other' is selected above, describe the subset that can be accessed",DataCatalogue


### PR DESCRIPTION
Update: this issue is caused by a change on the backend. required values `TRUE` used to work in data models but somehow do not anymore.


The `required` columns in the DataCatalogue model have values set to `TRUE`, causing issues in the editor, which shows 
>Invalid expression 'TRUE', reason: ReferenceError: TRUE is not defined

underneath those fields. Replacing those values by `true` in the data model fixes the issue.

how to test:
- create a new schema on a server, selecting one of the `DATA_CATALOGUE*` templates.
- see that the messages for required fields is now presented correctly. 

todo:
- [ ] check in preview if it indeed works