### PR TITLE
Chore: e2e add catalogue test 1

### DIFF
--- a/e2e/tests/catalogue/catalogue-test_1.spec.ts
+++ b/e2e/tests/catalogue/catalogue-test_1.spec.ts
@@ -1,0 +1,14 @@
+import { test, expect } from '@playwright/test';
+
+test('Catalogue test number 1: Athlete network manager', async ({ page }) => {
+  await page.goto('catalogue-demo/ssr-catalogue/');
+  await page.getByRole('button', { name: 'Accept' }).click();
+  await expect(page.locator('h1')).toContainText('European Health Research Data and Sample Catalogue');
+  await expect(page.getByRole('main')).toContainText('Project catalogues');
+  await expect(page.getByRole('main')).toContainText('ATHLETE');
+  await expect(page.getByRole('main')).toContainText('Advancing Tools for Human Early Lifecourse Exposome Research and Translation');
+  await page.getByRole('row', { name: 'ATHLETE Advancing Tools for' }).getByRole('button').click();
+  await expect(page.getByRole('main')).toContainText('ATHLETE');
+  await expect(page.getByRole('main')).toContainText('Cohorts');
+  await expect(page.getByRole('main')).toContainText('Variables');
+});


### PR DESCRIPTION
- added Playwright tests based on [catalogue test setup](https://github.com/molgenis/molgenis-emx2/pull/3399)

how to test:
- In vscode navigate to `/e2e/`
- Open the README.md and run `yarn install` and `npx playwright test` (run once)
- Make sure you have installed the vscode plugin 'Playwright Test for VSCode'
- Navigate to `/e2e/tests/catalogue/catalogue-test_1.spec.ts` to review the test code
- Use the playwright plugin to run the test (Flask icon) and run this specific test
