### PR TITLE
fix: missing collaboration information on collection report

### DIFF
--- a/apps/directory/src/property-config/initialCollectionColumns.js
+++ b/apps/directory/src/property-config/initialCollectionColumns.js
@@ -111,6 +111,8 @@ const initialCollectionColumns = [
       "sub_collections.order_of_magnitude.label",
       "sub_collections.materials.label",
       "sub_collections.data_categories.label",
+      "collaboration_commercial",
+      "collaboration_non_for_profit",
     ],
   },
 ];


### PR DESCRIPTION
fixes #3086

The collaboration information (commercial and non-for-profit) are now displayed in the collection report.