### PR TITLE
build: add scaled object to scale to previews from 1 to 0 when not used

### DIFF
--- a/helm-chart/scaledObject.yml
+++ b/helm-chart/scaledObject.yml
@@ -1,0 +1,18 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ template "emx2.name" . }}
+spec:
+  scaleTargetRef:
+    name: {{ template "emx2.name" . }}
+  pollingInterval: 15
+  cooldownPeriod: 60
+  minReplicaCount: 0
+  maxReplicaCount: 1
+  triggers:
+  - type: external
+    metadata:
+      metricName: http-metric
+      url: {{- range .Values.ingress.hosts }}"/apps/central/graphql"
+      threshold: "1"
+      queryType: Object


### PR DESCRIPTION
not exactly what we want. After it is downscaled it is totally destroyed and we cannot get it back again.

todo:
- [ ] verify that downscale works (didn't work on first try)