### PR TITLE
chore: remove dep, no longer needed with current nuxt setup

### DIFF
--- a/apps/nuxt3-ssr/package.json
+++ b/apps/nuxt3-ssr/package.json
@@ -22,7 +22,6 @@
     "@nuxt/vite-builder": "3.10.2",
     "@tailwindcss/forms": "^0.5.3",
     "@tailwindcss/typography": "^0.5.8",
-    "@types/node": "16.18.82",
     "@vitejs/plugin-vue": "4.6.2",
     "@vue/test-utils": "2.4.4",
     "autoprefixer": "10.4.17",

--- a/apps/yarn.lock
+++ b/apps/yarn.lock
@@ -2607,11 +2607,6 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@16.18.82":
-  version "16.18.82"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.18.82.tgz#58d734b4acaa5be339864bbec9cd8024dd0b43d5"
-  integrity sha512-pcDZtkx9z8XYV+ius2P3Ot2VVrcYOfXffBQUBuiszrlUzKSmoDYqo+mV+IoL8iIiIjjtOMvNSmH1hwJ+Q+f96Q==
-
 "@types/prop-types@*":
   version "15.7.11"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.11.tgz#2596fb352ee96a1379c657734d4b913a613ad563"


### PR DESCRIPTION
@types/node 16.x is no longer used 
