### PR TITLE
fix: fix cohorts paging reactivity

### DIFF
--- a/e2e/tests/catalogue/navigate-to-next-page-on-cohorts-list-page.spec.ts
+++ b/e2e/tests/catalogue/navigate-to-next-page-on-cohorts-list-page.spec.ts
@@ -1,0 +1,9 @@
+import { test, expect } from '@playwright/test';
+
+test('navigate-to-next-page-on-cohorts-list-page', async ({ page }) => {
+  await page.goto('/catalogue-demo/ssr-catalogue/ATHLETE');
+  await page.getByRole('button', { name: 'Accept' }).click();
+  await page.getByRole('button', { name: 'Cohorts' }).click();
+  await page.locator('nav').filter({ hasText: 'Page OF' }).getByRole('button').nth(1).click();
+  await expect(page.getByRole('list')).toContainText('SEPAGES');
+});


### PR DESCRIPTION
- keep query reactive, do no read value during fetch

Closes #3415

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
