### PR TITLE
chore: update build image to 1.2.2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ orbs:
 definitions:
   build_config: &build_config
     docker:
-    - image: molgenis/ci-build:1.2.0
+    - image: molgenis/ci-build:1.2.2
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -29,7 +29,7 @@ definitions:
       TERM: dumb
   test_config: &test_config
     docker:
-    - image: molgenis/ci-build:1.2.0
+    - image: molgenis/ci-build:1.2.2
     - image: postgres:15-alpine
       environment:
         POSTGRES_USER: postgres
@@ -147,9 +147,7 @@ jobs:
 
     - run:
         name: prepare sql test database
-        command: |
-          apt-get update && apt-get install postgresql-client -y
-          psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql
+        command: psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql
 
     - run:
         name: run tests and push to sonar
@@ -169,9 +167,7 @@ jobs:
     
     - run:
         name: prepare sql test database
-        command: |
-          apt-get update && apt-get install postgresql-client -y
-          psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql
+        command: psql -h 127.0.0.1 -p 5432 -U postgres < .docker/initdb.sql
 
     # we might be optimistic and skip tests here
     - run:

--- a/ci-build-images/Dockerfile
+++ b/ci-build-images/Dockerfile
@@ -24,12 +24,10 @@ RUN install -m 0755 -d /etc/apt/keyrings
 ##docker
 RUN curl -sSL https://get.docker.com/ | sh
 
-# kubectl repo
-RUN curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add
-RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update
-RUN apt-get install kubectl -y
-
+# kubectl
+RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
+RUN chmod +x ./kubectl
+RUN mv ./kubectl /usr/local/bin/kubectl
 #
 ##helm repo
 RUN curl https://baltocdn.com/helm/signing.asc | gpg --dearmor | tee /usr/share/keyrings/helm.gpg > /dev/null
@@ -45,3 +43,6 @@ RUN chmod go+r /etc/apt/keyrings/microsoft.gpg
 RUN  AZ_DIST=$(lsb_release -cs) && echo "deb [arch=`dpkg --print-architecture` signed-by=/etc/apt/keyrings/microsoft.gpg] https://packages.microsoft.com/repos/azure-cli/ $AZ_DIST main" | tee /etc/apt/sources.list.d/azure-cli.list
 RUN apt-get update
 RUN apt-get install azure-cli
+
+RUN apt-get update
+RUN apt-get install postgresql-client -y


### PR DESCRIPTION
updated image includes:
- install psql-client
- download kubectl tools

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
