### PR TITLE
fix: exclude folders on build

### DIFF
--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -16,6 +16,7 @@ def nodeSpec = {
 
 def excludeDef = {
     // Exclude 'build', 'dist', and 'showCase' directories from inputs
+    exclude ".gradle"
     exclude "dist"
     exclude "node_modules"
     exclude "showCase"
@@ -23,6 +24,7 @@ def excludeDef = {
     exclude ".fingerprint.js"
     exclude ".nuxt"
     exclude "public/_nuxt-styles"
+    exclude "build"
 }
 
 node {
@@ -71,7 +73,7 @@ subprojects { subproject ->
             }
         }
         outputs.dir "dist"
-        //for caching
+//        for caching
         inputs.files fileTree(projectDir).matching {
             with excludeDef
         }


### PR DESCRIPTION
excludes more output folders during js build in order to be able to build on windows.

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
