### PR TITLE
fix: 3459 missing settings text

### DIFF
--- a/apps/nuxt3-ssr/components/CohortCard.vue
+++ b/apps/nuxt3-ssr/components/CohortCard.vue
@@ -75,7 +75,11 @@ const iconStarClasses = computed(() => {
     </header>
 
     <div v-if="!compact">
-      <ContentReadMore :text="cohort.description" :cutoff="cutoff" />
+      <ContentReadMore
+        class="text-body-base"
+        :text="cohort.description"
+        :cutoff="cutoff"
+      />
 
       <dl class="hidden xl:flex gap-5 xl:gap-14 text-body-base">
         <div>

--- a/apps/nuxt3-ssr/components/DataSourceCard.vue
+++ b/apps/nuxt3-ssr/components/DataSourceCard.vue
@@ -76,7 +76,11 @@ const iconStarClasses = computed(() => {
     </header>
 
     <div v-if="!compact">
-      <ContentReadMore :text="datasource.description" :cutoff="cutoff" />
+      <ContentReadMore
+        class="text-body-base"
+        :text="datasource.description"
+        :cutoff="cutoff"
+      />
 
       <dl class="hidden xl:flex gap-5 xl:gap-14 text-body-base">
         <div v-if="datasource?.type?.length > 0">

--- a/apps/nuxt3-ssr/components/NetworkCard.vue
+++ b/apps/nuxt3-ssr/components/NetworkCard.vue
@@ -115,7 +115,10 @@ const links = [];
         </header>
 
         <div v-if="!compact">
-          <ContentReadMore :text="network.description"></ContentReadMore>
+          <ContentReadMore
+            class="text-body-base"
+            :text="network.description"
+          ></ContentReadMore>
         </div>
 
         <a

--- a/apps/nuxt3-ssr/components/ReferenceCard.vue
+++ b/apps/nuxt3-ssr/components/ReferenceCard.vue
@@ -50,7 +50,7 @@ defineProps({
         </header>
 
         <p class="text-body-base my-5 hidden sm:block">
-          <ContentReadMore :value="description" />
+          <ContentReadMore class="text-body-base" :value="description" />
         </p>
 
         <a

--- a/apps/nuxt3-ssr/components/ResourceCard.vue
+++ b/apps/nuxt3-ssr/components/ResourceCard.vue
@@ -87,7 +87,7 @@ const iconStarClasses = computed(() => {
 
     <div v-if="!compact">
       <template v-if="resource.description">
-        <ContentReadMore :text="resource.description" />
+        <ContentReadMore class="text-body-base" :text="resource.description" />
       </template>
 
       <!-- TODO think about generic way to add additional context -->

--- a/apps/nuxt3-ssr/components/content/ContentBlock.vue
+++ b/apps/nuxt3-ssr/components/content/ContentBlock.vue
@@ -13,7 +13,7 @@ defineProps<{
       {{ title }}
     </h2>
     <div class="mb-5 prose max-w-none" v-if="description">
-      <ContentReadMore :text="description" />
+      <ContentReadMore class="text-body-base" :text="description" />
     </div>
     <slot></slot>
   </section>

--- a/apps/nuxt3-ssr/components/content/ReadMore.vue
+++ b/apps/nuxt3-ssr/components/content/ReadMore.vue
@@ -12,7 +12,7 @@ const { text, cutoff } = withDefaults(
 let truncate = ref(true);
 </script>
 <template>
-  <p v-if="text" class="text-body-base mb-5 xl:block hidden">
+  <p v-if="text" class="mb-5 xl:block hidden">
     {{ truncate ? `${text?.substring(0, cutoff)}` : text }}
     <button
       v-if="truncate && text && text.length > cutoff"
@@ -30,7 +30,7 @@ let truncate = ref(true);
     </button>
   </p>
 
-  <p v-if="text" class="text-body-base mt-5 block xl:hidden">
+  <p v-if="text" class="mt-5 block xl:hidden">
     {{ truncate ? `${text?.substring(0, cutoff)}...` : text }}
     <button
       v-if="truncate && text && text.length > cutoff"

--- a/apps/nuxt3-ssr/components/content/type/ContentTypeText.vue
+++ b/apps/nuxt3-ssr/components/content/type/ContentTypeText.vue
@@ -6,5 +6,5 @@ defineProps<{
 </script>
 
 <template>
-  <ContentReadMore :text="field.value" :cutoff="500" />
+  <ContentReadMore class="text-body-base" :text="field.value" :cutoff="500" />
 </template>

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
@@ -194,7 +194,7 @@ const title = computed(() => {
   }
 });
 
-let description = computed(() => {
+const description = computed(() => {
   if (getSettingValue("CATALOGUE_LANDING_DESCRIPTION", settings.value)) {
     return getSettingValue("CATALOGUE_LANDING_DESCRIPTION", settings.value);
   } else {
@@ -221,9 +221,9 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
         >{{ network.id && network.name ? ": " : "" }}{{ network.name }}. Select
         one of the content categories listed below.</template
       >
-      <template v-else v-slot:description
-        ><ContentReadMore>{{ description }}</ContentReadMore></template
-      >
+      <template v-else v-slot:description>
+        <ContentReadMore :text="description" />
+      </template>
     </PageHeader>
 
     <LandingPrimary>
@@ -232,13 +232,11 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
         image="image-link"
         title="Cohorts"
         :description="
-          getSettingValue(
-            'CATALOGUE_LANDING_COHORTS_TEXT',
-            data.data._settings
-          ) || 'Cohorts &amp; Biobanks'
+          getSettingValue('CATALOGUE_LANDING_COHORTS_TEXT', settings) ||
+          'Cohorts &amp; Biobanks'
         "
         :callToAction="
-          getSettingValue('CATALOGUE_LANDING_COHORTS_CTA', data.data._settings)
+          getSettingValue('CATALOGUE_LANDING_COHORTS_CTA', settings)
         "
         :count="data.data.Cohorts_agg.count"
         :link="`/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/cohorts`"
@@ -248,16 +246,11 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
         image="image-data-warehouse"
         title="Data sources"
         :description="
-          getSettingValue(
-            'CATALOGUE_LANDING_DATASOURCES_TEXT',
-            data.data._settings
-          ) || 'Databanks &amp; Registries'
+          getSettingValue('CATALOGUE_LANDING_DATASOURCES_TEXT', settings) ||
+          'Databanks &amp; Registries'
         "
         :callToAction="
-          getSettingValue(
-            'CATALOGUE_LANDING_DATASOURCES_CTA',
-            data.data._settings
-          )
+          getSettingValue('CATALOGUE_LANDING_DATASOURCES_CTA', settings)
         "
         :count="data.data.DataSources_agg.count"
         :link="`/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/datasources`"
@@ -267,17 +260,12 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
         image="image-diagram-2"
         title="Variables"
         :description="
-          getSettingValue(
-            'CATALOGUE_LANDING_VARIABLES_TEXT',
-            data.data._settings
-          ) || 'Harmonized variables'
+          getSettingValue('CATALOGUE_LANDING_VARIABLES_TEXT', settings) ||
+          'Harmonized variables'
         "
         :count="data.data.Variables_agg.count"
         :callToAction="
-          getSettingValue(
-            'CATALOGUE_LANDING_VARIABLES_CTA',
-            data.data._settings
-          )
+          getSettingValue('CATALOGUE_LANDING_VARIABLES_CTA', settings)
         "
         :link="`/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/variables`"
       />
@@ -287,14 +275,12 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
         image="image-diagram"
         title="Networks"
         :description="
-          getSettingValue(
-            'CATALOGUE_LANDING_NETWORKS_TEXT',
-            data.data._settings
-          ) || 'Networks &amp; Consortia'
+          getSettingValue('CATALOGUE_LANDING_NETWORKS_TEXT', settings) ||
+          'Networks &amp; Consortia'
         "
         :count="numberOfNetworks"
         :callToAction="
-          getSettingValue('CATALOGUE_LANDING_NETWORKS_CTA', data.data._settings)
+          getSettingValue('CATALOGUE_LANDING_NETWORKS_CTA', settings)
         "
         :link="`/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/networks`"
       />
@@ -312,17 +298,12 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
             )
           }}
           {{
-            getSettingValue(
-              "CATALOGUE_LANDING_PARTICIPANTS_LABEL",
-              data.data._settings
-            ) || "Participants"
+            getSettingValue("CATALOGUE_LANDING_PARTICIPANTS_LABEL", settings) ||
+            "Participants"
           }}
         </b>
         <br />{{
-          getSettingValue(
-            "CATALOGUE_LANDING_PARTICIPANTS_TEXT",
-            data.data._settings
-          ) ||
+          getSettingValue("CATALOGUE_LANDING_PARTICIPANTS_TEXT", settings) ||
           "The cumulative number of participants of all (sub)cohorts combined."
         }}
       </LandingCardSecondary>
@@ -338,17 +319,12 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
             )
           }}
           {{
-            getSettingValue(
-              "CATALOGUE_LANDING_SAMPLES_LABEL",
-              data.data._settings
-            ) || "Samples"
+            getSettingValue("CATALOGUE_LANDING_SAMPLES_LABEL", settings) ||
+            "Samples"
           }}</b
         >
         <br />{{
-          getSettingValue(
-            "CATALOGUE_LANDING_SAMPLES_TEXT",
-            data.data._settings
-          ) ||
+          getSettingValue("CATALOGUE_LANDING_SAMPLES_TEXT", settings) ||
           "The cumulative number of participants with samples collected of all (sub)cohorts combined"
         }}
       </LandingCardSecondary>
@@ -359,10 +335,8 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
       >
         <b
           >{{
-            getSettingValue(
-              "CATALOGUE_LANDING_DESIGN_LABEL",
-              data.data._settings
-            ) || "Longitudinal"
+            getSettingValue("CATALOGUE_LANDING_DESIGN_LABEL", settings) ||
+            "Longitudinal"
           }}
           {{
             percentageLongitudinal(
@@ -371,10 +345,8 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
             )
           }}%</b
         ><br />{{
-          getSettingValue(
-            "CATALOGUE_LANDING_DESIGN_TEXT",
-            data.data._settings
-          ) || "Percentage of longitudinal datasets. The remaining datasets are"
+          getSettingValue("CATALOGUE_LANDING_DESIGN_TEXT", settings) ||
+          "Percentage of longitudinal datasets. The remaining datasets are"
         }}
         cross-sectional.
       </LandingCardSecondary>
@@ -386,18 +358,14 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
         <b>
           {{ data.data.Subcohorts_agg.count }}
           {{
-            getSettingValue(
-              "CATALOGUE_LANDING_SUBCOHORTS_LABEL",
-              data.data._settings
-            ) || "Subcohorts"
+            getSettingValue("CATALOGUE_LANDING_SUBCOHORTS_LABEL", settings) ||
+            "Subcohorts"
           }}
         </b>
         <br />
         {{
-          getSettingValue(
-            "CATALOGUE_LANDING_SUBCOHORTS_TEXT",
-            data.data._settings
-          ) || "The total number of subcohorts included"
+          getSettingValue("CATALOGUE_LANDING_SUBCOHORTS_TEXT", settings) ||
+          "The total number of subcohorts included"
         }}
       </LandingCardSecondary>
     </LandingSecondary>

--- a/e2e/tests/catalogue/catalogue-description.spec.ts
+++ b/e2e/tests/catalogue/catalogue-description.spec.ts
@@ -1,0 +1,7 @@
+import { test, expect } from '@playwright/test';
+
+test('catalogue description should be shown', async ({ page }) => {
+  await page.goto('/catalogue-demo/ssr-catalogue/all');
+  await page.getByRole('button', { name: 'Accept' }).click();
+  await expect(page.getByRole('main')).toContainText('Select one of the content categories listed below.');
+});


### PR DESCRIPTION
- Pass readmore as prop instead of slot, it only takes props
- Fix readmore style on landingpage in header, extract style to enable reuse

Closes #3459

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
