### PR TITLE
feat: list view counts

### DIFF
--- a/apps/nuxt3-ssr/components/SearchResultsCount.vue
+++ b/apps/nuxt3-ssr/components/SearchResultsCount.vue
@@ -23,6 +23,6 @@ const pluralizedLabel = computed(() => {
 
 <template>
   <div class="mt-1 mb-0 lg:mb-3 text-body-lg flex flex-col text-title">
-    <p>{{ valuePrefix }} {{ value }} {{ pluralizedLabel }}</p>
+    <p class="search-results-count">{{ valuePrefix }} {{ value }} {{ pluralizedLabel }}</p>
   </div>
 </template>

--- a/apps/nuxt3-ssr/components/SearchResultsCount.vue
+++ b/apps/nuxt3-ssr/components/SearchResultsCount.vue
@@ -4,7 +4,7 @@ const props = withDefaults(
     value: number;
     label?: string;
     suffix?: string;
-    valuePrefix?: string,
+    valuePrefix?: string;
   }>(),
   {
     value: 0,
@@ -23,6 +23,8 @@ const pluralizedLabel = computed(() => {
 
 <template>
   <div class="mt-1 mb-0 lg:mb-3 text-body-lg flex flex-col text-title">
-    <p class="search-results-count">{{ valuePrefix }} {{ value }} {{ pluralizedLabel }}</p>
+    <p class="search-results-count">
+      {{ valuePrefix }} {{ value }} {{ pluralizedLabel }}
+    </p>
   </div>
 </template>

--- a/apps/nuxt3-ssr/components/SearchResultsCount.vue
+++ b/apps/nuxt3-ssr/components/SearchResultsCount.vue
@@ -4,11 +4,13 @@ const props = withDefaults(
     value: number;
     label?: string;
     suffix?: string;
+    valuePrefix?: string,
   }>(),
   {
     value: 0,
     label: "result",
     suffix: "s",
+    valuePrefix: null,
   }
 );
 
@@ -21,6 +23,6 @@ const pluralizedLabel = computed(() => {
 
 <template>
   <div class="mt-1 mb-0 lg:mb-3 text-body-lg flex flex-col text-title">
-    <p>{{ value }} {{ pluralizedLabel }}</p>
+    <p>{{ valuePrefix }} {{ value }} {{ pluralizedLabel }}</p>
   </div>
 </template>

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
@@ -187,7 +187,7 @@ crumbs[
         </template>
 
         <template #search-results>
-          <SearchResultsCount :value="numberOfDataSources" label="Data source"/>
+          <SearchResultsCount :value="numberOfDataSources" label="data source"/>
           <FilterWell :filters="filters"></FilterWell>
           <SearchResultsList>
             <CardList v-if="data?.data?.DataSources?.length > 0">

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
@@ -101,7 +101,9 @@ if (error.value) {
   throw new Error("Error on datasources data fetch");
 }
 
-const numberOfDataSources = computed(() => (data?.value.data.DataSources_agg?.count || 0));
+const numberOfDataSources = computed(
+  () => data?.value.data.DataSources_agg?.count || 0
+);
 
 function setCurrentPage(pageNumber: number) {
   router.push({ path: route.path, query: { page: pageNumber } });
@@ -187,7 +189,10 @@ crumbs[
         </template>
 
         <template #search-results>
-          <SearchResultsCount :value="numberOfDataSources" label="data source"/>
+          <SearchResultsCount
+            :value="numberOfDataSources"
+            label="data source"
+          />
           <FilterWell :filters="filters"></FilterWell>
           <SearchResultsList>
             <CardList v-if="data?.data?.DataSources?.length > 0">

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
@@ -101,6 +101,8 @@ if (error.value) {
   throw new Error("Error on datasources data fetch");
 }
 
+const numberOfDataSources = computed(() => (data?.value.data.DataSources_agg?.count || 0));
+
 function setCurrentPage(pageNumber: number) {
   router.push({ path: route.path, query: { page: pageNumber } });
   currentPage.value = pageNumber;
@@ -185,6 +187,7 @@ crumbs[
         </template>
 
         <template #search-results>
+          <SearchResultsCount :value="numberOfDataSources" label="Data source"/>
           <FilterWell :filters="filters"></FilterWell>
           <SearchResultsList>
             <CardList v-if="data?.data?.DataSources?.length > 0">

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/networks/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/networks/index.vue
@@ -178,7 +178,7 @@ crumbs[
         </template>
 
         <template #search-results>
-          <SearchResultsCount :value="numberOfNetworks" label="network"/>
+          <SearchResultsCount :value="numberOfNetworks" label="network" />
           <FilterWell :filters="filters"></FilterWell>
           <SearchResultsList>
             <CardList v-if="networks?.length > 0">

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/networks/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/networks/index.vue
@@ -178,6 +178,7 @@ crumbs[
         </template>
 
         <template #search-results>
+          <SearchResultsCount :value="numberOfNetworks" label="network"/>
           <FilterWell :filters="filters"></FilterWell>
           <SearchResultsList>
             <CardList v-if="networks?.length > 0">

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
@@ -105,13 +105,15 @@ const query = computed(() => {
   `;
 });
 
-const numberOfVariables = computed(() => data?.value.data?.Variables_agg.count || 0);
+const numberOfVariables = computed(
+  () => data?.value.data?.Variables_agg.count || 0
+);
 const numberOfCohorts = computed(() => {
   if (data?.value.data?.Cohorts) {
     return data?.value.data?.Cohorts.length;
   }
   return false;
-})
+});
 
 let search = computed(() => {
   // @ts-ignore

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
@@ -105,6 +105,14 @@ const query = computed(() => {
   `;
 });
 
+const numberOfVariables = computed(() => data?.value.data?.Variables_agg.count || 0);
+const numberOfCohorts = computed(() => {
+  if (data?.value.data?.Cohorts) {
+    return data?.value.data?.Cohorts.length;
+  }
+  return false;
+})
+
 let search = computed(() => {
   // @ts-ignore
   return filters.find((f) => f.columnType === "_SEARCH").search;
@@ -248,14 +256,15 @@ const data = await loadPageData();
         </template>
 
         <template #search-results>
-          <p class="mt-1 mb-0 lg:mb-3 text-body-lg flex flex-col text-title">
-            <span
-              >{{ data?.data?.Variables_agg.count }} variables
-              <span v-if="data?.data?.Cohorts"
-                >in {{ data?.data?.Cohorts.length }} cohorts
-              </span>
-            </span>
-          </p>
+          <div class="flex align-start gap-1">
+            <SearchResultsCount :value="numberOfVariables" label="variable" />
+            <SearchResultsCount
+              v-if="numberOfCohorts"
+              :value="numberOfCohorts"
+              value-prefix="in"
+              label="cohort"
+            />
+          </div>
           <FilterWell :filters="filters"></FilterWell>
 
           <SearchResultsList>

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
@@ -108,11 +108,9 @@ const query = computed(() => {
 const numberOfVariables = computed(
   () => data?.value.data?.Variables_agg.count || 0
 );
+
 const numberOfCohorts = computed(() => {
-  if (data?.value.data?.Cohorts) {
-    return data?.value.data?.Cohorts.length;
-  }
-  return false;
+  return data?.value.data?.Cohorts ? data?.value.data?.Cohorts.length : 0;
 });
 
 let search = computed(() => {
@@ -261,7 +259,7 @@ const data = await loadPageData();
           <div class="flex align-start gap-1">
             <SearchResultsCount :value="numberOfVariables" label="variable" />
             <SearchResultsCount
-              v-if="numberOfCohorts"
+              v-if="numberOfCohorts > 0"
               :value="numberOfCohorts"
               value-prefix="in"
               label="cohort"

--- a/e2e/tests/catalogue/search-results-count.spec.ts
+++ b/e2e/tests/catalogue/search-results-count.spec.ts
@@ -1,7 +1,31 @@
 import { test, expect } from '@playwright/test';
 
-test('test', async ({ page }) => {
-  await page.goto('/catalogue-demo/ssr-catalogue/all/cohorts');
-  await page.getByRole('button', { name: 'Reject' }).click();
-  await expect(page.getByRole('main')).toContainText('53 cohorts');
-});
+const pattern = new RegExp(/^(([a-zA-Z]{1,})?(\s)?(([0-9]{1,})\s(cohort([s])?|variable([s])?|data\ssource([s])?|result([s])?)))$/);
+
+test('validate cohort search result counts @cohort-view @search-result-counts',
+  async ({ page }) => {
+    await page.goto('/catalogue-demo/ssr-catalogue/all/cohorts');
+    await page.getByRole('button', { name: 'Reject' }).click(); 
+    const text = await page.locator(".search-results-count").textContent();
+    await expect(text).toMatch(pattern);
+  }
+);
+
+test('validate data sources search result counts @data-sources-view @search-result-counts',
+  async ({ page }) => {
+    await page.goto('/catalogue-demo/ssr-catalogue/all/datasources');
+    await page.getByRole('button', { name: 'Reject' }).click();
+    const text = await page.locator(".search-results-count").textContent();
+    await expect(text).toMatch(pattern);
+  }
+);
+
+test('validate variables sources search result counts @variables-view @search-result-counts',
+  async ({ page }) => {
+    await page.goto('/catalogue-demo/ssr-catalogue/all/variables');
+    await page.getByRole('button', { name: 'Reject' }).click();
+    const text = await page.locator(".search-results-count").textContent();
+    await expect(text).toMatch(pattern);
+  }
+);
+

--- a/e2e/tests/catalogue/search-results-count.spec.ts
+++ b/e2e/tests/catalogue/search-results-count.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 
-const numberOfResultsPattern = new RegExp(/^(([a-zA-Z]{1,})?(\s)?(([0-9]{1,})\s(cohort([s])?|variable([s])?|data\ssource([s])?|result([s])?)))$/);
+const numberOfResultsPattern = new RegExp(/^(([a-zA-Z]{1,})?(\s)?(([0-9]{1,})\s(cohort([s])?|variable([s])?|data\ssource([s])?|result([s])?|networks([s])? )))$/);
 
 test('validate cohort search result counts @cohort-view @search-result-counts',
   async ({ page }) => {

--- a/e2e/tests/catalogue/search-results-count.spec.ts
+++ b/e2e/tests/catalogue/search-results-count.spec.ts
@@ -1,11 +1,25 @@
+/**
+ * Test all instances where the component <SearchResultsCounts> is used.
+ * All values must follow this format: <value-prefix> <value> <label>. 
+ * Value prefixes are optional and used if you would like to add a label
+ * before the value (e.g., `Found 12 results`). If testing locally, disable
+ * the `enableRejectCookiesClick` as this does not exist when running the
+ * preview locally and the action will timeout.
+ */
+
 import { test, expect } from '@playwright/test';
 
-const numberOfResultsPattern = new RegExp(/^(([a-zA-Z]{1,})?(\s)?(([0-9]{1,})\s(cohort([s])?|variable([s])?|data\ssource([s])?|result([s])?|networks([s])? )))$/);
+const enableRejectCookiesClick = true;
+const numberOfResultsPattern = new RegExp(/^(([a-zA-Z]{1,})?(\s)?(([0-9]{1,})\s(cohort([s])?|variable([s])?|data\ssource([s])?|result([s])?|networks([s])?)))$/);
 
 test('validate cohort search result counts @cohort-view @search-result-counts',
   async ({ page }) => {
     await page.goto('/catalogue-demo/ssr-catalogue/all/cohorts');
-    await page.getByRole('button', { name: 'Reject' }).click(); 
+    
+    if (enableRejectCookiesClick) {
+      await page.getByRole('button', { name: 'Reject' }).click();
+    }
+    
     const text = await page.locator(".search-results-count").textContent();
     await expect(text).toMatch(numberOfResultsPattern);
   }
@@ -14,7 +28,11 @@ test('validate cohort search result counts @cohort-view @search-result-counts',
 test('validate data sources search result counts @data-sources-view @search-result-counts',
   async ({ page }) => {
     await page.goto('/catalogue-demo/ssr-catalogue/all/datasources');
-    await page.getByRole('button', { name: 'Reject' }).click();
+    
+    if (enableRejectCookiesClick) {
+      await page.getByRole('button', { name: 'Reject' }).click();
+    }
+    
     const text = await page.locator(".search-results-count").textContent();
     await expect(text).toMatch(numberOfResultsPattern);
   }
@@ -23,7 +41,11 @@ test('validate data sources search result counts @data-sources-view @search-resu
 test('validate variables sources search result counts @variables-view @search-result-counts',
   async ({ page }) => {
     await page.goto('/catalogue-demo/ssr-catalogue/all/variables');
-    await page.getByRole('button', { name: 'Reject' }).click();
+    
+    if (enableRejectCookiesClick) {
+      await page.getByRole('button', { name: 'Reject' }).click();
+    }
+    
     const text = await page.locator(".search-results-count").textContent();
     await expect(text).toMatch(numberOfResultsPattern);
   }
@@ -32,7 +54,11 @@ test('validate variables sources search result counts @variables-view @search-re
 test('validate networks sources search result counts @networks-view @search-result-counts',
   async ({ page }) => {
     await page.goto('/catalogue-demo/ssr-catalogue/all/networks');
-    await page.getByRole('button', { name: 'Reject' }).click();
+    
+    if (enableRejectCookiesClick) {
+      await page.getByRole('button', { name: 'Reject' }).click();
+    }
+    
     const text = await page.locator(".search-results-count").textContent();
     await expect(text).toMatch(numberOfResultsPattern);
   }

--- a/e2e/tests/catalogue/search-results-count.spec.ts
+++ b/e2e/tests/catalogue/search-results-count.spec.ts
@@ -1,13 +1,13 @@
 import { test, expect } from '@playwright/test';
 
-const pattern = new RegExp(/^(([a-zA-Z]{1,})?(\s)?(([0-9]{1,})\s(cohort([s])?|variable([s])?|data\ssource([s])?|result([s])?)))$/);
+const numberOfResultsPattern = new RegExp(/^(([a-zA-Z]{1,})?(\s)?(([0-9]{1,})\s(cohort([s])?|variable([s])?|data\ssource([s])?|result([s])?)))$/);
 
 test('validate cohort search result counts @cohort-view @search-result-counts',
   async ({ page }) => {
     await page.goto('/catalogue-demo/ssr-catalogue/all/cohorts');
     await page.getByRole('button', { name: 'Reject' }).click(); 
     const text = await page.locator(".search-results-count").textContent();
-    await expect(text).toMatch(pattern);
+    await expect(text).toMatch(numberOfResultsPattern);
   }
 );
 
@@ -16,7 +16,7 @@ test('validate data sources search result counts @data-sources-view @search-resu
     await page.goto('/catalogue-demo/ssr-catalogue/all/datasources');
     await page.getByRole('button', { name: 'Reject' }).click();
     const text = await page.locator(".search-results-count").textContent();
-    await expect(text).toMatch(pattern);
+    await expect(text).toMatch(numberOfResultsPattern);
   }
 );
 
@@ -25,7 +25,16 @@ test('validate variables sources search result counts @variables-view @search-re
     await page.goto('/catalogue-demo/ssr-catalogue/all/variables');
     await page.getByRole('button', { name: 'Reject' }).click();
     const text = await page.locator(".search-results-count").textContent();
-    await expect(text).toMatch(pattern);
+    await expect(text).toMatch(numberOfResultsPattern);
+  }
+);
+
+test('validate networks sources search result counts @networks-view @search-result-counts',
+  async ({ page }) => {
+    await page.goto('/catalogue-demo/ssr-catalogue/all/networks');
+    await page.getByRole('button', { name: 'Reject' }).click();
+    const text = await page.locator(".search-results-count").textContent();
+    await expect(text).toMatch(numberOfResultsPattern);
   }
 );
 


### PR DESCRIPTION
This PR is a continuation of #3469 which added a component to display the number of search results in each view. Search results are now displayed in each view (cohorts, data sources, and variables) and e2e testing is available for all pages.

how to test:
- Navigate to the preview:
- Navigate to the Cohorts, Data Sources, and Variables pages
- Note the counts above the results
- Apply filters and note the change

todo:
- [x] added tests
