### PR TITLE
fix: added word break to variable names

### DIFF
--- a/apps/nuxt3-ssr/components/VariableCard.vue
+++ b/apps/nuxt3-ssr/components/VariableCard.vue
@@ -18,35 +18,29 @@ const resourcePathId = resourceIdPath(variableKey.value);
 
 <template>
   <article class="py-5 lg:px-12.5 p-5">
-    <header class="flex">
-      <div class="grow flex items-center">
-        <h2 class="min-w-[160px] mr-4 md:inline-block block">
+    <header class="flex md:flex-row gap-3 items-start md:items-center">
+      <div class="md:basis-1/5 p-2">
+        <h2 class="break-all">
           <NuxtLink
             :to="`/${schema}/ssr-catalogue/${catalogue}/variables/${resourcePathId}`"
-            class="text-body-base font-extrabold text-blue-500 hover:underline hover:bg-blue-50 break-words"
+            class="text-body-base font-extrabold text-blue-500 hover:underline hover:bg-blue-50"
           >
             {{ variable?.name }}
           </NuxtLink>
         </h2>
-
-        <span class="mr-4 text-body-base hidden md:block">
-          {{ variable?.label }}
-        </span>
       </div>
-      <div class="flex">
-        <!--
-        <IconButton
-          icon="star"
-          :class="iconStarClasses"
-          class="text-blue-500 xl:justify-end"
-        />
-        -->
+      <div class="hidden md:flex md:basis-3/5">
+        <p class="text-body-base">
+          {{ variable?.label }}
+        </p>
+      </div>
+      <div class="hidden basis-1/5 xl:flex xl:justify-end">
         <NuxtLink
           :to="`/${schema}/ssr-catalogue/${catalogue}/variables/${resourcePathId}`"
         >
-          <IconButton
+          <BaseIcon
             icon="arrow-right"
-            class="text-blue-500 hidden xl:flex xl:justify-end"
+            class="text-blue-500"
           />
         </NuxtLink>
       </div>

--- a/apps/nuxt3-ssr/components/VariableCard.vue
+++ b/apps/nuxt3-ssr/components/VariableCard.vue
@@ -23,7 +23,7 @@ const resourcePathId = resourceIdPath(variableKey.value);
         <h2 class="min-w-[160px] mr-4 md:inline-block block">
           <NuxtLink
             :to="`/${schema}/ssr-catalogue/${catalogue}/variables/${resourcePathId}`"
-            class="text-body-base font-extrabold text-blue-500 hover:underline hover:bg-blue-50"
+            class="text-body-base font-extrabold text-blue-500 hover:underline hover:bg-blue-50 break-words"
           >
             {{ variable?.name }}
           </NuxtLink>

--- a/apps/nuxt3-ssr/components/VariableCard.vue
+++ b/apps/nuxt3-ssr/components/VariableCard.vue
@@ -38,10 +38,7 @@ const resourcePathId = resourceIdPath(variableKey.value);
         <NuxtLink
           :to="`/${schema}/ssr-catalogue/${catalogue}/variables/${resourcePathId}`"
         >
-          <BaseIcon
-            icon="arrow-right"
-            class="text-blue-500"
-          />
+          <BaseIcon icon="arrow-right" class="text-blue-500" />
         </NuxtLink>
       </div>
     </header>

--- a/apps/nuxt3-ssr/components/VariableCard.vue
+++ b/apps/nuxt3-ssr/components/VariableCard.vue
@@ -38,7 +38,8 @@ const resourcePathId = resourceIdPath(variableKey.value);
         <NuxtLink
           :to="`/${schema}/ssr-catalogue/${catalogue}/variables/${resourcePathId}`"
         >
-          <BaseIcon icon="arrow-right" class="text-blue-500" />
+          <icons-arrow-right width="24" class="text-blue-500" />
+          <span class="sr-only">go to page on {{ variable.name }}</span>
         </NuxtLink>
       </div>
     </header>

--- a/apps/nuxt3-ssr/components/VariableCard.vue
+++ b/apps/nuxt3-ssr/components/VariableCard.vue
@@ -34,6 +34,9 @@ const resourcePathId = resourceIdPath(variableKey.value);
           {{ variable?.label }}
         </p>
       </div>
+      <!-- <div class="hidden basis-1/5 xl:flex xl:justify-end">
+        <IconButton icon="star" class="text-blue-500" />
+      </div> -->
       <div class="hidden basis-1/5 xl:flex xl:justify-end">
         <NuxtLink
           :to="`/${schema}/ssr-catalogue/${catalogue}/variables/${resourcePathId}`"


### PR DESCRIPTION
This request address issue #3418. To prevent variable names from going out of bounds, names are now broken when they reach the width of the parent element. Names and labels are kept in the same column arrangement.

how to test:
- Navigate variables view in the preview
- Note the word breaks

todo:
- ~~updated docs in case of new feature~~
- ~~added tests~~
