### PR TITLE
build: fix python release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,21 +45,24 @@ definitions:
 
 commands:
   pre_steps:
-    parameters:
-      release2pypi:
-        description: A boolean parameter indicating if a new version of the emx2-pyclient needs to be released
-        type: boolean
-        default: false
-      commit-message:
-        description: commit message to check if a new version of the emx2-pyclient needs to be released
-        type: env_var_name
-        default: COMMIT_MESSAGE
+#    parameters:
+#      release2pypi:
+#        description: A boolean parameter indicating if a new version of the emx2-pyclient needs to be released
+#        type: boolean
+#        default: false
+#      commit-message:
+#        description: commit message to check if a new version of the emx2-pyclient needs to be released
+#        type: env_var_name
+#        default: COMMIT_MESSAGE
     steps:
     - checkout
     - run: git fetch --all --tags
     - run:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
+          echo "COMMIT MESSAGE: $COMMIT_MESSAGE"
+          export COMMIT_MESSAGE_ENV=$(git log -1 --pretty=format:%s) "$BASH_ENV"
+          echo "COMMIT MESSAGE ENV: $COMMIT_MESSAGE_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user
         command: |
@@ -129,16 +132,21 @@ commands:
 jobs:
   preview:
     <<: *build_config
-
+#    parameters:
+#      commit-message:
+#        description: commit message to check if a new version of the emx2-pyclient needs to be released
+#        type: env_var_name
+#        default: COMMIT_MESSAGE
     steps:
+#    - run: echo << parameters.commit-message >>
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
-    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
-    - pre_steps:
-        commit-message: COMMIT_MESSAGE
+#    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
+    - pre_steps
     - run:
         command: |
-          echo "COMMIT MESSAGE: $(git log -1 --pretty=format:%s)"
+          echo "COMMIT MESSAGE in preview: $COMMIT_MESSAGE"
+          echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"
 #          if [[ $(git log -1 --pretty=format:%s) == *"(emx2-pyclient)"* ]]; then
 #            release2pypi: true
 #          else
@@ -179,12 +187,12 @@ jobs:
 #        condition: <<parameters.release2pypi>>
 #        steps:
 #          - pypi-release
-    - when:
-        condition:
-          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
-        steps:
-          - run: echo "START RELEASE"
-          - pypi-release
+#    - when:
+#        condition:
+#          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
+#        steps:
+#          - run: echo "START RELEASE"
+#          - pypi-release
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
     - run: echo "RELEASE2PYPI? ${<< parameters.commit-message >>}
     - when:
         condition:
-          matches: { pattern: "build(emx2-pyclient): test commit message", value: ${<< parameters.commit-message >>} }
+          matches: { pattern: "build(emx2-pyclient): test commit message", value: $<< parameters.commit-message >> }
         steps:
         - run: echo "START RELEASE"
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -197,7 +197,7 @@ jobs:
 
     - post_steps
     - release2pypi:
-        commit-message: "$COMMIT_MESSAGE"
+        commit-message: "$COMMIT_MESSAGE_ENV"
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ commands:
           name: Release to PyPI if needed
           command: |
             echo "commit message $COMMIT_MESSAGE_ENV"
-            export REGEX="^.*\(emx2-pyclient\).*$"
+            export REGEX="^.*(emx2-pyclient).*$"
             if [[ $COMMIT_MESSAGE_ENV =~ $REGEX ]]; then  
               echo "RELEASE TO PYPI"
               export $( cat build/ci.properties | xargs )

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,6 +249,7 @@ jobs:
     <<: *build_config
 
     steps:
+      - pre-steps
       - run:
           name: Reset TWINE_PASSWORD in case of release to PyPI (default is testPyPI token)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ commands:
 #        default: false
       commit-message:
         description: commit message to check if a new version of the emx2-pyclient needs to be released
-        type: env_var_name
-        default: COMMIT_MESSAGE_ENV
+        type: string
+        default: ""
     steps:
     - checkout
     - run: git fetch --all --tags
@@ -142,7 +142,8 @@ jobs:
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
 #    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
-    - pre_steps
+    - pre_steps:
+        - commit-message:"echo ${COMMIT_MESSAGE_ENV}"
     - run:
         command: |
           echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,6 +134,7 @@ commands:
             command: |
               if [ -z "$CIRCLE_PULL_REQUEST" ]; then
                  export TWINE_PASSWORD=$PYPI_TOKEN
+                 echo "Reset PyPI Password"
               fi
               echo $TWINE_PASSWORD
         - run:
@@ -196,7 +197,7 @@ jobs:
 
     - post_steps
     - release2pypi:
-        commit-message: "test"
+        commit-message: "$COMMIT_MESSAGE"
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -151,7 +151,7 @@ jobs:
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
 #    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
-    - pre_steps:
+    - pre_steps
     - run:
         command: |
           echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -271,6 +271,7 @@ jobs:
       - run:
           name: Message slack about a new molgenis-emx2-pyclient version
           command: |
+            export REGEX="^.*(emx2-pyclient).*$"
             if [[ $(git log -1 --pretty=format:%s) =~ $REGEX ]]; then
               curl -d "token=${SLACK_TOKEN}" \
               -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,8 +137,8 @@ commands:
       - run:
           name: Release to PyPI if needed
           command: |
-            echo "commit message $COMMIT_ENV_VAR"
-            if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then  
+            echo "commit message $COMMIT_MESSAGE_ENV"
+            if [[ $COMMIT_MESSAGE_ENV =~ "^.*(emx2-pyclient).*$" ]]; then  
               echo "RELEASE TO PYPI"
               export $( cat build/ci.properties | xargs )
               ./gradlew -s --no-daemon publishPython

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
         type: env_var_name
         default: COMMIT_MESSAGE_ENV
     steps:
-    - run: echo "RELEASE2PYPI? ${<< parameters.commit-message >>}
+    - run: echo "RELEASE2PYPI? ${<< parameters.commit-message >>}"
     - when:
         condition:
           matches: { pattern: "build(emx2-pyclient): test commit message", value: $<< parameters.commit-message >> }

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,16 +118,17 @@ commands:
     #              - pypi-release
 
   release2pypi:
-    parameters:
-      commit-message:
-        description: commit message to check if a new version of the emx2-pyclient needs to be released
-        type: env_var_name
-        default: COMMIT_MESSAGE_ENV
     steps:
-    - run: echo "RELEASE2PYPI? ${<< parameters.commit-message >>}"
+    - run: echo << pipeline.git.tag >>
+#    - run:
+#        command: |
+#          if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then
+#            << parameters.commit-message >>
     - when:
         condition:
-          matches: { pattern: "test", value: $<< parameters.commit-message >> }
+          matches:
+            pattern: ^.*(emx2-pyclient).*$
+            value: << pipeline.git.tag >>
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -147,9 +148,9 @@ commands:
     # ^.*(emx2-pyclient).*$
     - unless:
         condition:
-          matches: { pattern: "test", value: << parameters.commit-message >>  }
+          matches: { pattern: test, value: << pipeline.git.tag >>  }
         steps:
-        - run: echo "RELEASE2PYPI NO RELEASE << parameters.commit-message >>"
+        - run: echo "RELEASE2PYPI NO RELEASE << pipeline.git.tag >>"
 
 # jobs for pull request and master
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,10 @@ commands:
     steps:
     - checkout
     - run: git fetch --all --tags
-    - run:
-        command: |
-          export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
-          echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
+#    - run:
+#        command: |
+#          export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
+#          echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user
         command: |
@@ -114,15 +114,15 @@ commands:
           name: Release to PyPI if needed
           command: |
             export REGEX="^.*(emx2-pyclient).*$"
-            if [[ $COMMIT_MESSAGE_ENV =~ $REGEX ]]; then  
+            if [[ $(git log -1 --pretty=format:%s) =~ $REGEX ]]; then  
               echo "RELEASE TO PYPI"
               export $( cat build/ci.properties | xargs )
               ./gradlew -s --no-daemon publishPython > pypi_output
-              curl -d "token=${SLACK_TOKEN}" \
-              -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
-              A new molgenis-emx2-pyclient version is released: $( grep 'View at:' pypi_output -A 1 | grep -v 'View at:' )" \
-              -d "channel=C02AZDG6QQ7" \
-              -X POST https://slack.com/api/chat.postMessage            
+#              curl -d "token=${SLACK_TOKEN}" \
+#              -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
+#              A new molgenis-emx2-pyclient version is released: $( grep 'View at:' pypi_output -A 1 | grep -v 'View at:' )" \
+#              -d "channel=C02AZDG6QQ7" \
+#              -X POST https://slack.com/api/chat.postMessage
             else
               echo "NO RELEASE NECESSARY"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
     - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
     - when:
         condition:
-          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
+          matches: { pattern: "test", value: << parameters.commit-message >>  }
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -196,7 +196,7 @@ jobs:
 
     - post_steps
     - release2pypi:
-        commit-message: $COMMIT_MESSAGE_ENV
+        commit-message: "test"
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,7 +105,7 @@ commands:
   release2pypi:
     steps:
       - run:
-          name: reset PyPI credentials
+          name: Reset PyPI credentials
           command: |
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then
                echo "Reset PyPI Password"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,35 +123,30 @@ commands:
         type: string
         default: "IETS"
     steps:
-      - run: echo << parameters.commit-message >>
-      - when:
-          condition:
-            matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
-          steps:
-            - run: echo "START RELEASE"
-            - run:
-                name: reset PyPI credentials
-                command: |
-                  if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-                     export TWINE_PASSWORD=$PYPI_TOKEN
-                  fi
-                  echo $TWINE_PASSWORD
-            - run:
-               name: Publish to testPyPI or PyPI
-               command: |
-                 echo "RELEASE TO PYPI"
-      #         export $( cat build/ci.properties | xargs )
-      #         ./gradlew -s --no-daemon publishPython
+    - run: echo << parameters.commit-message >>
+    - when:
+        condition:
+          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
+        steps:
+        - run: echo "START RELEASE"
+        - run:
+            name: reset PyPI credentials
+            command: |
+              if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+                 export TWINE_PASSWORD=$PYPI_TOKEN
+              fi
+              echo $TWINE_PASSWORD
+        - run:
+           name: Publish to testPyPI or PyPI
+           command: |
+             echo "RELEASE TO PYPI"
+    #         export $( cat build/ci.properties | xargs )
+    #         ./gradlew -s --no-daemon publishPython
 
 # jobs for pull request and master
 jobs:
   preview:
     <<: *build_config
-#    parameters:
-#      commit-message:
-#        description: commit message to check if a new version of the emx2-pyclient needs to be released
-#        type: env_var_name
-#        default: COMMIT_MESSAGE
     steps:
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
           echo "COMMIT MESSAGE: $COMMIT_MESSAGE"
-          export COMMIT_MESSAGE_ENV=$(git log -1 --pretty=format:%s) >> "$BASH_ENV"
+          echo "export COMMIT_MESSAGE_ENV=$(git log -1 --pretty=format:%s)" >> "$BASH_ENV"
           echo "COMMIT MESSAGE ENV: $COMMIT_MESSAGE_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,8 +52,8 @@ commands:
         default: false
       commit-message:
         description: commit message to check if a new version of the emx2-pyclient needs to be released
-        type: string
-        default: ""
+        type: env_var_name
+        default: COMMIT_MESSAGE
     steps:
     - checkout
     - run: git fetch --all --tags
@@ -181,7 +181,7 @@ jobs:
 #          - pypi-release
     - when:
         condition:
-          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>> }
+          matches: { pattern: "^.*(emx2-pyclient).*$", value: ${ <<parameters.commit-message>> } }
         steps:
           - run: echo "START RELEASE"
           - pypi-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,11 +57,12 @@ commands:
     steps:
     - checkout
     - run: git fetch --all --tags
+      # echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
     - run:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
           echo "COMMIT MESSAGE: $COMMIT_MESSAGE"
-          echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
+          echo "export COMMIT_MESSAGE_ENV=test
           echo "COMMIT MESSAGE ENV: $COMMIT_MESSAGE_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user
@@ -126,7 +127,7 @@ commands:
     - run: echo "RELEASE2PYPI? ${<< parameters.commit-message >>}"
     - when:
         condition:
-          matches: { pattern: "build(emx2-pyclient): test commit message", value: $<< parameters.commit-message >> }
+          matches: { pattern: "test", value: $<< parameters.commit-message >> }
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -146,7 +147,7 @@ commands:
     # ^.*(emx2-pyclient).*$
     - unless:
         condition:
-          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
+          matches: { pattern: "test", value: << parameters.commit-message >>  }
         steps:
         - run: echo "RELEASE2PYPI NO RELEASE << parameters.commit-message >>"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -156,7 +156,7 @@ commands:
     # ^.*(emx2-pyclient).*$
     - unless:
         condition:
-          matches: { pattern: ^.*python-release.*$, value: << pipeline.git.branch >>  }
+          matches: { pattern: ^.*\(emx2-pyclient\).*$, value: << parameters.commit-message >>  }
         steps:
         - run: echo "RELEASE2PYPI NO RELEASE << pipeline.git.branch >>"
 
@@ -207,8 +207,8 @@ jobs:
 
     - post_steps
     - release2pypi:
-        commit-message: $COMMIT_MESSAGE_ENV
-
+        commit-message: "build(emx2-pyclient): test commit message"
+  # $COMMIT_MESSAGE_ENV
   test:
     <<: *test_config
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -130,8 +130,8 @@ commands:
       - run:
           name: reset PyPI credentials
           command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-               export TWINE_PASSWORD=$PYPI_TOKEN
+            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+               export TWINE_PASSWORD=$PYPI_PASSWORD
                echo "Reset PyPI Password"
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,8 +118,14 @@ commands:
     #              - pypi-release
 
   release2pypi:
+    parameters:
+      commit-message:
+        description: commit message to check if a new version of the emx2-pyclient needs to be released
+        type: string
+        default: ""
     steps:
     - run: echo "PIPELINE BRANCH << pipeline.git.branch >>"
+    - run: echo "commit parameter << parameter.commit-message >>"
 #    - run:
 #        command: |
 #          if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then
@@ -127,9 +133,10 @@ commands:
     - when:
         condition:
           matches:
-      #      pattern: ^.*(emx2-pyclient).*$
-            pattern: ^.*python-release.*$
-            value: << pipeline.git.branch >>
+            pattern: ^.*(emx2-pyclient).*$
+            value: << parameters.commit-message >>
+      #      pattern: ^.*python-release.*$
+      #      value: << pipeline.git.branch >>
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -199,8 +206,8 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
-    - release2pypi
-      #  commit-message: COMMIT_MESSAGE_ENV
+    - release2pypi:
+        commit-message: $COMMIT_MESSAGE_ENV
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,15 +134,15 @@ commands:
                export TWINE_PASSWORD=$PYPI_TOKEN
                echo "Reset PyPI Password"
             fi
-            test=$TWINE_PASSWORD
-            echo $test
       - run:
           name: Release to PyPI if needed
           command: |
+            echo $COMMIT_ENV_VAR
             if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then  
               echo "RELEASE TO PYPI"
-#         export $( cat build/ci.properties | xargs )
-#         ./gradlew -s --no-daemon publishPython
+              export $( cat build/ci.properties | xargs )
+              ./gradlew -s --no-daemon publishPython
+            fi
 
 # jobs for pull request and master
 jobs:
@@ -151,7 +151,6 @@ jobs:
     steps:
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
-#    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
     - pre_steps
     - run:
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,15 +45,15 @@ definitions:
 
 commands:
   pre_steps:
-    parameters:
+#    parameters:
 #      release2pypi:
 #        description: A boolean parameter indicating if a new version of the emx2-pyclient needs to be released
 #        type: boolean
 #        default: false
-      commit-message:
-        description: commit message to check if a new version of the emx2-pyclient needs to be released
-        type: string
-        default: ""
+#      commit-message:
+#        description: commit message to check if a new version of the emx2-pyclient needs to be released
+#        type: string
+#        default: ""
     steps:
     - checkout
     - run: git fetch --all --tags
@@ -111,22 +111,37 @@ commands:
         path: ~/test-results
 #    - store_artifacts:
 #        path: ./build/libs
+    #        - when:
+    #            condition: <<parameters.release2pypi>>
+    #            steps:
+    #              - pypi-release
 
   pypi-release:
+    parameters:
+      commit-message:
+        description: commit message to check if a new version of the emx2-pyclient needs to be released
+        type: string
+        default: "IETS"
     steps:
-    - run:
-        name: reset PyPI credentials
-        command: |
-          if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-             export TWINE_PASSWORD=$PYPI_TOKEN
-          fi
-          echo $TWINE_PASSWORD
-    - run:
-       name: Publish to testPyPI or PyPI
-       command: |
-         echo "RELEASE TO PYPI"
-#         export $( cat build/ci.properties | xargs )
-#         ./gradlew -s --no-daemon publishPython
+      - run: echo << parameters.commit-message >>
+      - when:
+          condition:
+            matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
+          steps:
+            - run: echo "START RELEASE"
+            - run:
+                name: reset PyPI credentials
+                command: |
+                  if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+                     export TWINE_PASSWORD=$PYPI_TOKEN
+                  fi
+                  echo $TWINE_PASSWORD
+            - run:
+               name: Publish to testPyPI or PyPI
+               command: |
+                 echo "RELEASE TO PYPI"
+      #         export $( cat build/ci.properties | xargs )
+      #         ./gradlew -s --no-daemon publishPython
 
 # jobs for pull request and master
 jobs:
@@ -138,16 +153,13 @@ jobs:
 #        type: env_var_name
 #        default: COMMIT_MESSAGE
     steps:
-#    - run: echo << parameters.commit-message >>
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
 #    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
     - pre_steps:
-        commit-message: "IETS"
     - run:
         command: |
           echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"
-          echo << parameters.commit-message >>
 #          if [[ $(git log -1 --pretty=format:%s) == *"(emx2-pyclient)"* ]]; then
 #            release2pypi: true
 #          else
@@ -184,16 +196,8 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
-#    - when:
-#        condition: <<parameters.release2pypi>>
-#        steps:
-#          - pypi-release
-#    - when:
-#        condition:
-#          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
-#        steps:
-#          - run: echo "START RELEASE"
-#          - pypi-release
+    - pypi-release:
+        commit-message: $COMMIT_MESSAGE_ENV
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,15 +45,6 @@ definitions:
 
 commands:
   pre_steps:
-#    parameters:
-#      release2pypi:
-#        description: A boolean parameter indicating if a new version of the emx2-pyclient needs to be released
-#        type: boolean
-#        default: false
-#      commit-message:
-#        description: commit message to check if a new version of the emx2-pyclient needs to be released
-#        type: string
-#        default: ""
     steps:
     - checkout
     - run: git fetch --all --tags
@@ -114,23 +105,11 @@ commands:
 #        path: ./build/libs
 
   release2pypi:
-#    parameters:
-#      commit-message:
-#        description: commit message to check if a new version of the emx2-pyclient needs to be released
-#        type: string
-#        default: ""
-    #    - when:
-    #        condition:
-    #          matches:
-    #            pattern: ^.*\(emx2-pyclient\).*$
-    #            value: << parameters.commit-message >>
-    #      pattern: ^.*python-release.*$
-    #      value: << pipeline.git.branch >>
     steps:
       - run:
           name: reset PyPI credentials
           command: |
-            if [ -n "$CIRCLE_PULL_REQUEST" ]; then
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
                echo "export TWINE_PASSWORD=$PYPI_PASSWORD" >> "$BASH_ENV"
                echo "Reset PyPI Password"
             fi
@@ -142,7 +121,13 @@ commands:
             if [[ $COMMIT_MESSAGE_ENV =~ $REGEX ]]; then  
               echo "RELEASE TO PYPI"
               export $( cat build/ci.properties | xargs )
-              ./gradlew -s --no-daemon publishPython
+              ./gradlew -s --no-daemon publishPython > pypi_output
+              curl -d "token=${SLACK_TOKEN}" \
+              -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
+              A new molgenis-emx2-pyclient version is released: $( grep 'View at:' pypi_output -A 1 | grep -v 'View at:' )" \
+              -d "channel=C02AZDG6QQ7" \
+              -X POST https://slack.com/api/chat.postMessage
+            
             else
               echo "NO RELEASE NECESSARY"
             fi
@@ -158,11 +143,6 @@ jobs:
     - run:
         command: |
           echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"
-#          if [[ $(git log -1 --pretty=format:%s) == *"(emx2-pyclient)"* ]]; then
-#            release2pypi: true
-#          else
-#            echo "NO PYPI RELEASE"
-#          fi
     - run:
         name: build and push emx2 java docker images for the preview
         command: ./gradlew -s --no-daemon shadowJar dockerPush ci -x test
@@ -263,6 +243,7 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage  
 
     - post_steps
+    - release2pypi
   e2e-preview:
     docker:
       - image: mcr.microsoft.com/playwright:v1.42.1-jammy

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -196,8 +196,8 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
-    - release2pypi:
-        commit-message: $COMMIT_MESSAGE_ENV
+    - release2pypi
+      #  commit-message: COMMIT_MESSAGE_ENV
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -101,31 +101,6 @@ commands:
 #    - store_artifacts:
 #        path: ./build/libs
 
-  release2pypi:
-    steps:
-      - run:
-          name: Reset PyPI credentials
-          command: |
-            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-               echo "Reset PyPI Password"
-               echo "export TWINE_PASSWORD=$PYPI_PASSWORD" >> "$BASH_ENV"
-            fi
-      - run:
-          name: Release to PyPI if needed
-          command: |
-            export REGEX="^.*(emx2-pyclient).*$"
-            if [[ $(git log -1 --pretty=format:%s) =~ $REGEX ]]; then  
-              echo "RELEASE TO PYPI!"
-              export $( cat build/ci.properties | xargs )
-              ./gradlew -s --no-daemon publishPython > pypi_output
-            else
-              echo "NO RELEASE NECESSARY"
-            fi
-#              curl -d "token=${SLACK_TOKEN}" \
-#              -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
-#              A new molgenis-emx2-pyclient version is released: $( grep 'View at:' pypi_output -A 1 | grep -v 'View at:' )" \
-#              -d "channel=C02AZDG6QQ7" \
-#              -X POST https://slack.com/api/chat.postMessage
 # jobs for pull request and master
 jobs:
   preview:
@@ -166,7 +141,6 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
-    - release2pypi
 
   test:
     <<: *test_config
@@ -237,7 +211,6 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage  
 
     - post_steps
-    - release2pypi
   e2e-preview:
     docker:
       - image: mcr.microsoft.com/playwright:v1.42.1-jammy
@@ -272,6 +245,32 @@ jobs:
       - store_artifacts:
           path: /root/project/e2e/test-results
 
+  emx2-pyclient:
+    <<: *build_config
+
+    steps:
+      - run:
+          name: Reset TWINE_PASSWORD in case of release to PyPI (default is testPyPI token)
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+               echo "Reset testPyPI token to PyPI token"
+               echo "export TWINE_PASSWORD=$PYPI_PASSWORD" >> "$BASH_ENV"
+            fi
+      - run:
+          name: Release to (test)PyPI based on commit message
+          command: |
+            export REGEX="^.*(emx2-pyclient).*$"
+            if [[ $(git log -1 --pretty=format:%s) =~ $REGEX ]]; then
+              export $( cat build/ci.properties | xargs )
+              ./gradlew -s --no-daemon publishPython > pypi_output
+              curl -d "token=${SLACK_TOKEN}" \
+              -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
+              A new molgenis-emx2-pyclient version is released: $( grep 'View at:' pypi_output -A 1 | grep -v 'View at:' )" \
+              -d "channel=C02AZDG6QQ7" \
+              -X POST https://slack.com/api/chat.postMessage
+            else
+              echo "No release to (test)PyPI needed"
+            fi
 
   delete-helm-preview:
     <<: *build_config
@@ -309,10 +308,21 @@ workflows:
        filters:
          branches:
            ignore: master
+    - emx2-pyclient:
+        filters:
+          branches:
+            ignore: master
     - release:
        filters:
          branches:
            only: master
+    - emx2-pyclient:
+        requires:
+          - release
+        filters:
+          branches:
+            only: master
+
   delete_preview:
     when:
       equal: [ "delete-pr-preview", << pipeline.parameters.GHA_Action >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,10 +123,10 @@ commands:
         type: env_var_name
         default: COMMIT_MESSAGE_ENV
     steps:
-    - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
+    - run: echo "RELEASE2PYPI? ${<< parameters.commit-message >>}
     - when:
         condition:
-          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
+          matches: { pattern: "build(emx2-pyclient): test commit message", value: ${<< parameters.commit-message >>} }
         steps:
         - run: echo "START RELEASE"
         - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,8 +126,7 @@ commands:
               -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
               A new molgenis-emx2-pyclient version is released: $( grep 'View at:' pypi_output -A 1 | grep -v 'View at:' )" \
               -d "channel=C02AZDG6QQ7" \
-              -X POST https://slack.com/api/chat.postMessage
-            
+              -X POST https://slack.com/api/chat.postMessage            
             else
               echo "NO RELEASE NECESSARY"
             fi

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -115,7 +115,7 @@ commands:
           command: |
             export REGEX="^.*(emx2-pyclient).*$"
             if [[ $(git log -1 --pretty=format:%s) =~ $REGEX ]]; then  
-              echo "RELEASE TO PYPI"
+              echo "RELEASE TO PYPI!"
               export $( cat build/ci.properties | xargs )
               ./gradlew -s --no-daemon publishPython > pypi_output
             else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
           echo "COMMIT MESSAGE: $COMMIT_MESSAGE"
-          echo "export COMMIT_MESSAGE_ENV=$(git log -1 --pretty=format:%s)" >> "$BASH_ENV"
+          echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
           echo "COMMIT MESSAGE ENV: $COMMIT_MESSAGE_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,7 +125,7 @@ commands:
         default: ""
     steps:
     - run: echo "PIPELINE BRANCH << pipeline.git.branch >>"
-    - run: echo "commit parameter << parameter.commit-message >>"
+    - run: echo "commit parameter << parameters.commit-message >>"
 #    - run:
 #        command: |
 #          if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -137,11 +137,13 @@ commands:
       - run:
           name: Release to PyPI if needed
           command: |
-            echo $COMMIT_ENV_VAR
+            echo "commit message $COMMIT_ENV_VAR"
             if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then  
               echo "RELEASE TO PYPI"
               export $( cat build/ci.properties | xargs )
               ./gradlew -s --no-daemon publishPython
+            else
+              echo "NO RELEASE NECESSARY"
             fi
 
 # jobs for pull request and master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,7 +61,7 @@ commands:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
           echo "COMMIT MESSAGE: $COMMIT_MESSAGE"
-          export COMMIT_MESSAGE_ENV=$(git log -1 --pretty=format:%s) "$BASH_ENV"
+          export COMMIT_MESSAGE_ENV=$(git log -1 --pretty=format:%s) >> "$BASH_ENV"
           echo "COMMIT MESSAGE ENV: $COMMIT_MESSAGE_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,9 +52,7 @@ commands:
     - run:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
-          echo "COMMIT MESSAGE: $COMMIT_MESSAGE"
           echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
-          echo "COMMIT MESSAGE ENV: $COMMIT_MESSAGE_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user
         command: |
@@ -110,13 +108,12 @@ commands:
           name: reset PyPI credentials
           command: |
             if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-               echo "export TWINE_PASSWORD=$PYPI_PASSWORD" >> "$BASH_ENV"
                echo "Reset PyPI Password"
+               echo "export TWINE_PASSWORD=$PYPI_PASSWORD" >> "$BASH_ENV"
             fi
       - run:
           name: Release to PyPI if needed
           command: |
-            echo "commit message $COMMIT_MESSAGE_ENV"
             export REGEX="^.*(emx2-pyclient).*$"
             if [[ $COMMIT_MESSAGE_ENV =~ $REGEX ]]; then  
               echo "RELEASE TO PYPI"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,6 +124,7 @@ commands:
         type: string
         default: ""
     steps:
+    - run: echot "PIPELINE GIT REVISION << pipeline.git.revision >> "
     - run: echo "PIPELINE BRANCH << pipeline.git.branch >>"
     - run: echo "commit parameter << parameters.commit-message >>"
 #    - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,13 +120,13 @@ commands:
     parameters:
       commit-message:
         description: commit message to check if a new version of the emx2-pyclient needs to be released
-        type: string
-        default: "IETS"
+        type: boolean
+        default: false
     steps:
     - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
     - when:
-        condition:
-          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
+        condition: << parameters.commit-message >>
+          # matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -145,8 +145,8 @@ commands:
     #         ./gradlew -s --no-daemon publishPython
     # ^.*(emx2-pyclient).*$
     - unless:
-        condition:
-          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
+        condition: << parameters.commit-message >>
+        #  matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
         steps:
         - run: echo "RELEASE2PYPI NO RELEASE << parameters.commit-message >>"
 
@@ -196,8 +196,11 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
+    - run:
+        command: |
+          export release=true
     - release2pypi:
-        commit-message: echo "$COMMIT_MESSAGE_ENV"
+        commit-message: $release
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,6 +45,15 @@ definitions:
 
 commands:
   pre_steps:
+    parameters:
+      release2pypi:
+        description: A boolean parameter indicating if a new version of the emx2-pyclient needs to be released
+        type: boolean
+        default: false
+      commit-message:
+        description: commit message to check if a new version of the emx2-pyclient needs to be released
+        type: string
+        default: ""
     steps:
     - checkout
     - run: git fetch --all --tags
@@ -121,25 +130,15 @@ jobs:
   preview:
     <<: *build_config
 
-    parameters:
-      release2pypi:
-        description: A boolean parameter indicating if a new version of the emx2-pyclient needs to be released
-        type: boolean
-        default: false
-      commit-message:
-        description: A boolean parameter indicating if a new version of the emx2-pyclient needs to be released
-        type: string
-        default: ""
-
     steps:
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
 
-    - pre_steps
+    - pre_steps:
+        commit-message: $(git log -1 --pretty=format:%s)
     - run:
         command: |
           echo "COMMIT MESSAGE: $(git log -1 --pretty=format:%s)"
-          commit-message: $(git log -1 --pretty=format:%s)
 #          if [[ $(git log -1 --pretty=format:%s) == *"(emx2-pyclient)"* ]]; then
 #            release2pypi: true
 #          else
@@ -176,15 +175,16 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
-    - when:
-        condition: <<parameters.release2pypi>>
-        steps:
-          - pypi-release
+#    - when:
+#        condition: <<parameters.release2pypi>>
+#        steps:
+#          - pypi-release
     - when:
         condition:
           matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>> }
         steps:
-          - run: echo "MATCH ON MESSAGE"
+          - run: echo "START RELEASE"
+          - pypi-release
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,8 @@ commands:
           name: Release to PyPI if needed
           command: |
             echo "commit message $COMMIT_MESSAGE_ENV"
-            if [[ $COMMIT_MESSAGE_ENV =~ "^.*\(emx2-pyclient\).*$" ]]; then  
+            export REGEX="^.*\(emx2-pyclient\).*$"
+            if [[ $COMMIT_MESSAGE_ENV =~ $REGEX ]]; then  
               echo "RELEASE TO PYPI"
               export $( cat build/ci.properties | xargs )
               ./gradlew -s --no-daemon publishPython

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -45,15 +45,15 @@ definitions:
 
 commands:
   pre_steps:
-#    parameters:
+    parameters:
 #      release2pypi:
 #        description: A boolean parameter indicating if a new version of the emx2-pyclient needs to be released
 #        type: boolean
 #        default: false
-#      commit-message:
-#        description: commit message to check if a new version of the emx2-pyclient needs to be released
-#        type: env_var_name
-#        default: COMMIT_MESSAGE
+      commit-message:
+        description: commit message to check if a new version of the emx2-pyclient needs to be released
+        type: env_var_name
+        default: COMMIT_MESSAGE_ENV
     steps:
     - checkout
     - run: git fetch --all --tags
@@ -138,15 +138,15 @@ jobs:
 #        type: env_var_name
 #        default: COMMIT_MESSAGE
     steps:
-#    - run: echo << parameters.commit-message >>
+    - run: echo << parameters.commit-message >>
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
 #    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
     - pre_steps
     - run:
         command: |
-          echo "COMMIT MESSAGE in preview: $COMMIT_MESSAGE"
           echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"
+          echo << parameters.commit-message >>
 #          if [[ $(git log -1 --pretty=format:%s) == *"(emx2-pyclient)"* ]]; then
 #            release2pypi: true
 #          else

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -124,7 +124,7 @@ commands:
         type: string
         default: ""
     steps:
-    - run: echot "PIPELINE GIT REVISION << pipeline.git.revision >> "
+    - run: echo "PIPELINE GIT REVISION << pipeline.git.revision >> "
     - run: echo "PIPELINE BRANCH << pipeline.git.branch >>"
     - run: echo "commit parameter << parameters.commit-message >>"
 #    - run:
@@ -208,7 +208,7 @@ jobs:
 
     - post_steps
     - release2pypi:
-        commit-message: "build(emx2-pyclient): test commit message"
+        commit-message: $(git log -n 1 --pretty=format:%s $CIRCLE_SHA1)
   # $COMMIT_MESSAGE_ENV
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -127,7 +127,8 @@ commands:
     - when:
         condition:
           matches:
-            pattern: ^.*(emx2-pyclient).*$
+      #      pattern: ^.*(emx2-pyclient).*$
+            pattern: ^.*python-release.*$
             value: << pipeline.git.branch >>
         steps:
         - run: echo "START RELEASE"
@@ -148,7 +149,7 @@ commands:
     # ^.*(emx2-pyclient).*$
     - unless:
         condition:
-          matches: { pattern: test, value: << pipeline.git.branch >>  }
+          matches: { pattern: ^.*python-release.*$, value: << pipeline.git.branch >>  }
         steps:
         - run: echo "RELEASE2PYPI NO RELEASE << pipeline.git.branch >>"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,8 @@ commands:
     steps:
     - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
     - when:
-        condition: << parameters.commit-message >>
-          # matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
+        condition:
+          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -145,8 +145,8 @@ commands:
     #         ./gradlew -s --no-daemon publishPython
     # ^.*(emx2-pyclient).*$
     - unless:
-        condition: << parameters.commit-message >>
-        #  matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
+        condition:
+          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
         steps:
         - run: echo "RELEASE2PYPI NO RELEASE << parameters.commit-message >>"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ commands:
           name: Release to PyPI if needed
           command: |
             echo "commit message $COMMIT_MESSAGE_ENV"
-            if [[ $COMMIT_MESSAGE_ENV =~ "^.*(emx2-pyclient).*$" ]]; then  
+            if [[ $COMMIT_MESSAGE_ENV =~ "^.*\(emx2-pyclient\).*$" ]]; then  
               echo "RELEASE TO PYPI"
               export $( cat build/ci.properties | xargs )
               ./gradlew -s --no-daemon publishPython

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -131,7 +131,7 @@ commands:
           name: reset PyPI credentials
           command: |
             if [ -n "$CIRCLE_PULL_REQUEST" ]; then
-               export TWINE_PASSWORD=$PYPI_PASSWORD
+               echo "export TWINE_PASSWORD=$PYPI_PASSWORD" >> "$BASH_ENV"
                echo "Reset PyPI Password"
             fi
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -272,6 +272,16 @@ jobs:
             else
               echo "No release to (test)PyPI needed"
             fi
+      - run:
+          name: Message slack about a new molgenis-emx2-pyclient version
+          command: |
+            if [[ $(git log -1 --pretty=format:%s) =~ $REGEX ]]; then
+              curl -d "token=${SLACK_TOKEN}" \
+              -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
+              A new molgenis-emx2-pyclient version is released: $( grep 'View at:' pypi_output -A 1 | grep -v 'View at:' )" \
+              -d "channel=C02AZDG6QQ7" \
+              -X POST https://slack.com/api/chat.postMessage
+            fi           
 
   delete-helm-preview:
     <<: *build_config
@@ -310,6 +320,7 @@ workflows:
          branches:
            ignore: master
     - emx2-pyclient:
+        name: testPyPI release
         filters:
           branches:
             ignore: master
@@ -318,6 +329,7 @@ workflows:
          branches:
            only: master
     - emx2-pyclient:
+        name: PyPI release
         requires:
           - release
         filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -249,7 +249,7 @@ jobs:
     <<: *build_config
 
     steps:
-      - pre-steps
+      - pre_steps
       - run:
           name: Reset TWINE_PASSWORD in case of release to PyPI (default is testPyPI token)
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
     - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
     - when:
         condition:
-          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
+          matches: { pattern: "^.*(emx2-pyclient).*$", value: << parameters.commit-message >>  }
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -144,7 +144,7 @@ commands:
     #         ./gradlew -s --no-daemon publishPython
     - unless:
         condition:
-          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
+          matches: { pattern: "^.*(emx2-pyclient).*$", value: << parameters.commit-message >>  }
         steps:
         - run: echo "RELEASE2PYPI NO RELEASE << parameters.commit-message >>"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,10 +48,6 @@ commands:
     steps:
     - checkout
     - run: git fetch --all --tags
-#    - run:
-#        command: |
-#          export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
-#          echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user
         command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,7 +116,7 @@ commands:
     #            steps:
     #              - pypi-release
 
-  pypi-release:
+  release2pypi:
     parameters:
       commit-message:
         description: commit message to check if a new version of the emx2-pyclient needs to be released
@@ -165,8 +165,6 @@ jobs:
 #          else
 #            echo "NO PYPI RELEASE"
 #          fi
-
-
     - run:
         name: build and push emx2 java docker images for the preview
         command: ./gradlew -s --no-daemon shadowJar dockerPush ci -x test
@@ -196,7 +194,7 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
-    - pypi-release:
+    - release2pypi:
         commit-message: $COMMIT_MESSAGE_ENV
 
   test:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -138,7 +138,7 @@ jobs:
 #        type: env_var_name
 #        default: COMMIT_MESSAGE
     steps:
-    - run: echo << parameters.commit-message >>
+#    - run: echo << parameters.commit-message >>
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
 #    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -120,8 +120,8 @@ commands:
     parameters:
       commit-message:
         description: commit message to check if a new version of the emx2-pyclient needs to be released
-        type: boolean
-        default: false
+        type: env_var_name
+        default: COMMIT_MESSAGE_ENV
     steps:
     - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
     - when:
@@ -196,11 +196,8 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
-    - run:
-        command: |
-          export release=true
     - release2pypi:
-        commit-message: $release
+        commit-message: $COMMIT_MESSAGE_ENV
 
   test:
     <<: *test_config

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,9 +133,9 @@ jobs:
     steps:
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
-
+    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
     - pre_steps:
-        commit-message: $(git log -1 --pretty=format:%s)
+        commit-message: COMMIT_MESSAGE
     - run:
         command: |
           echo "COMMIT MESSAGE: $(git log -1 --pretty=format:%s)"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
 #    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
     - pre_steps:
-        - commit-message:"echo ${COMMIT_MESSAGE_ENV}"
+        commit-message: "echo ${COMMIT_MESSAGE_ENV}"
     - run:
         command: |
           echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
 #    - run: COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
     - pre_steps:
-        commit-message: "echo ${COMMIT_MESSAGE_ENV}"
+        commit-message: "IETS"
     - run:
         command: |
           echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -118,15 +118,14 @@ commands:
               echo "RELEASE TO PYPI"
               export $( cat build/ci.properties | xargs )
               ./gradlew -s --no-daemon publishPython > pypi_output
+            else
+              echo "NO RELEASE NECESSARY"
+            fi
 #              curl -d "token=${SLACK_TOKEN}" \
 #              -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
 #              A new molgenis-emx2-pyclient version is released: $( grep 'View at:' pypi_output -A 1 | grep -v 'View at:' )" \
 #              -d "channel=C02AZDG6QQ7" \
 #              -X POST https://slack.com/api/chat.postMessage
-            else
-              echo "NO RELEASE NECESSARY"
-            fi
-
 # jobs for pull request and master
 jobs:
   preview:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,7 +123,7 @@ commands:
         type: string
         default: "IETS"
     steps:
-    - run: echo << parameters.commit-message >>
+    - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
     - when:
         condition:
           matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
@@ -142,6 +142,11 @@ commands:
              echo "RELEASE TO PYPI"
     #         export $( cat build/ci.properties | xargs )
     #         ./gradlew -s --no-daemon publishPython
+    - unless:
+        condition:
+          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
+        steps:
+        - run: echo "RELEASE2PYPI NO RELEASE << parameters.commit-message >>"
 
 # jobs for pull request and master
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -48,7 +48,6 @@ commands:
     steps:
     - checkout
     - run: git fetch --all --tags
-
     - run:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
@@ -132,13 +131,13 @@ commands:
 jobs:
   preview:
     <<: *build_config
+
     steps:
     - run: |
         echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
+
     - pre_steps
-    - run:
-        command: |
-          echo "COMMIT MESSAGE ENV in preview: $COMMIT_MESSAGE_ENV"
+
     - run:
         name: build and push emx2 java docker images for the preview
         command: ./gradlew -s --no-daemon shadowJar dockerPush ci -x test
@@ -307,15 +306,14 @@ workflows:
         filters:
             branches:
               ignore: master
-#    - test:
-#       filters:
-#         branches:
-#           ignore: master
+    - test:
+       filters:
+         branches:
+           ignore: master
     - release:
        filters:
          branches:
            only: master
-
   delete_preview:
     when:
       equal: [ "delete-pr-preview", << pipeline.parameters.GHA_Action >> ]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ commands:
     - when:
         condition:
           matches:
-            pattern: ^.*(emx2-pyclient).*$
+            pattern: ^.*\(emx2-pyclient\).*$
             value: << parameters.commit-message >>
       #      pattern: ^.*python-release.*$
       #      value: << pipeline.git.branch >>

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -181,7 +181,7 @@ jobs:
 #          - pypi-release
     - when:
         condition:
-          matches: { pattern: "^.*(emx2-pyclient).*$", value: ${ <<parameters.commit-message>> } }
+          matches: { pattern: "^.*(emx2-pyclient).*$", value: <<parameters.commit-message>>  }
         steps:
           - run: echo "START RELEASE"
           - pypi-release

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -62,7 +62,7 @@ commands:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
           echo "COMMIT MESSAGE: $COMMIT_MESSAGE"
-          echo "export COMMIT_MESSAGE_ENV=test
+          echo "export COMMIT_MESSAGE_ENV=test"
           echo "COMMIT MESSAGE ENV: $COMMIT_MESSAGE_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,12 +57,12 @@ commands:
     steps:
     - checkout
     - run: git fetch --all --tags
-      # echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
+
     - run:
         command: |
           export COMMIT_MESSAGE=$(git log -1 --pretty=format:%s)
           echo "COMMIT MESSAGE: $COMMIT_MESSAGE"
-          echo "export COMMIT_MESSAGE_ENV=test"
+          echo "export COMMIT_MESSAGE_ENV=\"$(git log -1 --pretty=format:%s)\"" >> "$BASH_ENV"
           echo "COMMIT MESSAGE ENV: $COMMIT_MESSAGE_ENV"
     - run:
         name: Setup git, todo, move to molgenisci user
@@ -119,7 +119,7 @@ commands:
 
   release2pypi:
     steps:
-    - run: echo << pipeline.git.tag >>
+    - run: echo "PIPELINE BRANCH << pipeline.git.branch >>"
 #    - run:
 #        command: |
 #          if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then
@@ -128,7 +128,7 @@ commands:
         condition:
           matches:
             pattern: ^.*(emx2-pyclient).*$
-            value: << pipeline.git.tag >>
+            value: << pipeline.git.branch >>
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -148,9 +148,9 @@ commands:
     # ^.*(emx2-pyclient).*$
     - unless:
         condition:
-          matches: { pattern: test, value: << pipeline.git.tag >>  }
+          matches: { pattern: test, value: << pipeline.git.branch >>  }
         steps:
-        - run: echo "RELEASE2PYPI NO RELEASE << pipeline.git.tag >>"
+        - run: echo "RELEASE2PYPI NO RELEASE << pipeline.git.branch >>"
 
 # jobs for pull request and master
 jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
     - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
     - when:
         condition:
-          matches: { pattern: "^.*(emx2-pyclient).*$", value: << parameters.commit-message >>  }
+          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -142,9 +142,10 @@ commands:
              echo "RELEASE TO PYPI"
     #         export $( cat build/ci.properties | xargs )
     #         ./gradlew -s --no-daemon publishPython
+    # ^.*(emx2-pyclient).*$
     - unless:
         condition:
-          matches: { pattern: "^.*(emx2-pyclient).*$", value: << parameters.commit-message >>  }
+          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
         steps:
         - run: echo "RELEASE2PYPI NO RELEASE << parameters.commit-message >>"
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,54 +112,37 @@ commands:
         path: ~/test-results
 #    - store_artifacts:
 #        path: ./build/libs
-    #        - when:
-    #            condition: <<parameters.release2pypi>>
-    #            steps:
-    #              - pypi-release
 
   release2pypi:
-    parameters:
-      commit-message:
-        description: commit message to check if a new version of the emx2-pyclient needs to be released
-        type: string
-        default: ""
+#    parameters:
+#      commit-message:
+#        description: commit message to check if a new version of the emx2-pyclient needs to be released
+#        type: string
+#        default: ""
+    #    - when:
+    #        condition:
+    #          matches:
+    #            pattern: ^.*\(emx2-pyclient\).*$
+    #            value: << parameters.commit-message >>
+    #      pattern: ^.*python-release.*$
+    #      value: << pipeline.git.branch >>
     steps:
-    - run: echo "PIPELINE GIT REVISION << pipeline.git.revision >> "
-    - run: echo "PIPELINE BRANCH << pipeline.git.branch >>"
-    - run: echo "commit parameter << parameters.commit-message >>"
-#    - run:
-#        command: |
-#          if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then
-#            << parameters.commit-message >>
-    - when:
-        condition:
-          matches:
-            pattern: ^.*\(emx2-pyclient\).*$
-            value: << parameters.commit-message >>
-      #      pattern: ^.*python-release.*$
-      #      value: << pipeline.git.branch >>
-        steps:
-        - run: echo "START RELEASE"
-        - run:
-            name: reset PyPI credentials
-            command: |
-              if [ -z "$CIRCLE_PULL_REQUEST" ]; then
-                 export TWINE_PASSWORD=$PYPI_TOKEN
-                 echo "Reset PyPI Password"
-              fi
-              echo $TWINE_PASSWORD
-        - run:
-           name: Publish to testPyPI or PyPI
-           command: |
-             echo "RELEASE TO PYPI"
-    #         export $( cat build/ci.properties | xargs )
-    #         ./gradlew -s --no-daemon publishPython
-    # ^.*(emx2-pyclient).*$
-    - unless:
-        condition:
-          matches: { pattern: ^.*\(emx2-pyclient\).*$, value: << parameters.commit-message >>  }
-        steps:
-        - run: echo "RELEASE2PYPI NO RELEASE << pipeline.git.branch >>"
+      - run:
+          name: reset PyPI credentials
+          command: |
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then
+               export TWINE_PASSWORD=$PYPI_TOKEN
+               echo "Reset PyPI Password"
+            fi
+            test=$TWINE_PASSWORD
+            echo $test
+      - run:
+          name: Release to PyPI if needed
+          command: |
+            if [[ $COMMIT_ENV_VAR =~ "^.*(emx2-pyclient).*$" ]]; then  
+              echo "RELEASE TO PYPI"
+#         export $( cat build/ci.properties | xargs )
+#         ./gradlew -s --no-daemon publishPython
 
 # jobs for pull request and master
 jobs:
@@ -207,9 +190,8 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
-    - release2pypi:
-        commit-message: $(git log -n 1 --pretty=format:%s $CIRCLE_SHA1)
-  # $COMMIT_MESSAGE_ENV
+    - release2pypi
+
   test:
     <<: *test_config
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -126,7 +126,7 @@ commands:
     - run: echo "RELEASE2PYPI? << parameters.commit-message >>"
     - when:
         condition:
-          matches: { pattern: "test", value: << parameters.commit-message >>  }
+          matches: { pattern: "build(emx2-pyclient): test commit message", value: << parameters.commit-message >>  }
         steps:
         - run: echo "START RELEASE"
         - run:
@@ -197,7 +197,7 @@ jobs:
 
     - post_steps
     - release2pypi:
-        commit-message: "$COMMIT_MESSAGE_ENV"
+        commit-message: echo "$COMMIT_MESSAGE_ENV"
 
   test:
     <<: *test_config


### PR DESCRIPTION
This PR fixes the release of the molgenis-emx2-pyclient to (test)PyPI. Currently only a new version is release if the commit-message contain (emx2-py-client).

Scenarios to test:
- [x] If commit message contains (emx2-pyclient), the molgenis-emx2-pyclient is released to testPyPI. 
- [x] No release is done when the commit message doesn't contain (emx2-pyclient)
- [x] If build is not PR, the PyPI password is changed.
- [x] Slack message is created, with a link to the new molgenis-emx2-pyclient version.
- [ ] An actual release to PyPI cannot be tested (need to be merged first).
