### PR TITLE
fix: relative import of exceptions in metadata.py

### DIFF
--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -9,11 +9,11 @@ import requests
 
 from . import graphql_queries as queries
 from . import utils
-from .metadata import Schema
 from .exceptions import (NoSuchSchemaException, ServiceUnavailableError, SigninError,
                          ServerNotFoundError, PyclientException, NoSuchTableException,
                          NoContextManagerException, GraphQLException, InvalidTokenException,
                          PermissionDeniedException, TokenSigninException, NonExistentTemplateException)
+from .metadata import Schema
 
 log = logging.getLogger("Molgenis EMX2 Pyclient")
 

--- a/tools/pyclient/src/molgenis_emx2_pyclient/metadata.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/metadata.py
@@ -4,10 +4,7 @@ Classes for the data types Schema, Table and Column.
 from itertools import starmap
 from typing import Literal
 
-import requests
-
-from tools.pyclient.src.molgenis_emx2_pyclient.exceptions import NoSuchColumnException, NoSuchTableException
-from tools.pyclient.src.molgenis_emx2_pyclient.graphql_queries import list_schema_meta
+from .exceptions import NoSuchColumnException, NoSuchTableException
 
 
 class Column:


### PR DESCRIPTION
I forgot to make the imports of the exceptions in metadata.py relative.
This causes an import error when using the client, as parts of metadata.py are automatically imported in the client.py module

how to test:
- build and install the Python package
- run the dev.py script
- see that it is possible to import the exceptions from the correct file within the package again

todo:

- [x] point import statement to relative file
- [x] optimize imports