### PR TITLE
feat: Show CATALOGUE_BCC_MSG value if set

### DIFF
--- a/apps/nuxt3-ssr/components/SettingsMessage.vue
+++ b/apps/nuxt3-ssr/components/SettingsMessage.vue
@@ -15,5 +15,7 @@ fetchSetting(CATALOGUE_LANDING_TITLE).then((resp) => {
 });
 </script>
 <template>
-  <div v-if="message" class="pl-3 text-body-base">{{ message }}</div>
+  <div v-if="message" class="pl-3">
+    <p class="text-body-base">{{ message }}</p>
+  </div>
 </template>

--- a/apps/nuxt3-ssr/components/SettingsMessage.vue
+++ b/apps/nuxt3-ssr/components/SettingsMessage.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const CATALOGUE_LANDING_TITLE = "CATALOGUE_BCC_MSG";
+const message = ref();
+
+fetchSetting(CATALOGUE_LANDING_TITLE).then((resp) => {
+  const setting = resp.data["_settings"].find(
+    (setting: { key: string; value: string }) => {
+      return setting.key === CATALOGUE_LANDING_TITLE;
+    }
+  );
+
+  if (setting) {
+    message.value = setting.value;
+  }
+});
+</script>
+<template>
+  <div v-if="message" class="pl-3 text-body-base">{{ message }}</div>
+</template>

--- a/apps/nuxt3-ssr/components/content/ContentBlockIntro.vue
+++ b/apps/nuxt3-ssr/components/content/ContentBlockIntro.vue
@@ -139,7 +139,7 @@ const submitForm = async () => {
         >
           <template v-if="contactMessageFilter">
             <ContactForm :fields="fields" @submit-form="submitForm" />
-            <div class="pl-3 pb-3">
+            <div class="pl-3">
               <span class="text-body-base">or contact us at: </span>
               <a
                 class="text-blue-500 hover:underline"
@@ -158,6 +158,9 @@ const submitForm = async () => {
               {{ contact }}
             </a>
           </template>
+          <ClientOnly>
+            <SettingsMessage />
+          </ClientOnly>
         </ContentBlockModal>
 
         <template #footer>

--- a/docs/molgenis/dev_messageapi.md
+++ b/docs/molgenis/dev_messageapi.md
@@ -46,6 +46,7 @@ query Resources($filter:ResourcesFilter){
 
 ***BBC option***
 To receive a copy of the message create a setting with key: ```contactBccAddress``` and a valid email address as value.
+To notify the user about the message being forwarded create a setting with key ```CATALOGUE_BCC_MSG``` add a message for the user as value 
 ## Sending email
 
 Configurable settings


### PR DESCRIPTION
Closes #3504

how to test:

1. Find cohort with contact email set, and view the contact modal ( click on the Contact button)
2. Sign in as admin and add/edit a setting with key: 'CATALOGUE_BCC_MSG' and some message as value
3. Find cohort with contact email set, and view the contact modal ( click on the Contact button), message should be shown
4. Sign in as admin and remove the setting with key: 'CATALOGUE_BCC_MSG' 
5. Find cohort with contact email set, and view the contact modal ( click on the Contact button), message should no longer be shown

note: the message fetch is only done client side to avoid initial ssr page render performance impact

todo:
- [x] updated docs in case of new feature
- ~[ ] added tests~ skipped, small feature, depends on settings config, settings config is test elsewhere 

Closes #3504
