### PR TITLE
chore: add updates check tool

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,8 @@ plugins {
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'application'
     id 'com.palantir.docker' version '0.35.0'
+    id 'se.patrikerdes.use-latest-versions' version '0.2.18'
+    id 'com.github.ben-manes.versions' version '0.51.0'
 }
 
 allprojects {


### PR DESCRIPTION
This tool made Armadillo's renovate board half in size

how to test:

### Run the report 

```bash
./gradlew useLatestVersionsCheck
```

to see a report like

```log
> Task :dependencyUpdates

------------------------------------------------------------
: Project Dependency Updates (report to plain text file)
------------------------------------------------------------

The following dependencies are using the latest milestone version:
 - com.diffplug.spotless:com.diffplug.spotless.gradle.plugin:6.25.0
...

The following dependencies exceed the version found at the milestone revision level:
 - org.jacoco:org.jacoco.agent [0.8.11 <- 0.8.9]
     http://jacoco.org
...

The following dependencies have later milestone versions:
 - com.fasterxml.jackson.core:jackson-annotations [2.16.1 -> 2.17.0]
     https://github.com/FasterXML/jackson
...
```

### Apply the updates

```bash
./gradlew useLatestVersions
```

this did more on Armadillo ... I had to do most manually but helped a lot still.

### todo

- [ ] add the commands in the docs ... we have them in [CONTRIBUTING.md](https://github.com/molgenis/molgenis-service-armadillo/blob/master/CONTRIBUTING.md?plain=1#L37-L44)
