### PR TITLE
fix: collection details not shown in the directory app

### DIFF
--- a/apps/directory/src/functions/viewmodelMapper.js
+++ b/apps/directory/src/functions/viewmodelMapper.js
@@ -266,9 +266,7 @@ export const getBiobankDetails = (biobank) => {
     );
     biobank.collectionDetails = [];
 
-    const parentCollections = biobank.collections.filter(
-      (collection) => !collection.parent_collection
-    );
+    const parentCollections = biobank.collections;
 
     const sortedParentCollections = sortCollectionsByName(parentCollections);
 


### PR DESCRIPTION
fixes #3497
When certain filters would be applied, the directory app would not retrieve collection details for some biobanks due to parent collections being filtered away. The fix solves the issue by filtering also parent collections.