### PR TITLE
fix: Search results disappears when moving to page two

### DIFF
--- a/apps/nuxt3-ssr/components/Pagination.vue
+++ b/apps/nuxt3-ssr/components/Pagination.vue
@@ -82,9 +82,8 @@ function changeCurrentPage(event) {
     class="pt-12.5 flex items-center justify-center font-display text-heading-xl -mx-2.5"
   >
     <a
-      :href="currentPage > 1 ? '' : undefined"
       role="button"
-      @click="onPrevClick"
+      @click.prevent="onPrevClick"
       class="flex justify-center transition-colors border border-pagination rounded-pagination bg-pagination text-pagination h-15 w-15"
       :class="{
         'hover:bg-pagination-hover hover:text-pagination-hover':
@@ -107,9 +106,8 @@ function changeCurrentPage(event) {
       OF {{ totalPages }}
     </div>
     <a
-      :href="currentPage < totalPages ? '' : undefined"
       role="button"
-      @click="onNextClick"
+      @click.prevent="onNextClick"
       class="flex justify-center transition-colors border border-pagination rounded-pagination bg-pagination text-pagination h-15 w-15"
       :class="{
         'hover:bg-pagination-hover hover:text-pagination-hover':


### PR DESCRIPTION
Closes #3516

remove browser page action ( href ) and only handle using javascript

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
