### PR TITLE
fix: floating vue hydration mismatch

### DIFF
--- a/apps/nuxt3-ssr/components/BottomModal.vue
+++ b/apps/nuxt3-ssr/components/BottomModal.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+const ariaId = useId();
 const preAnimation = () => {
   document.body.classList.add("v-popper_bottom");
 };
@@ -29,6 +30,7 @@ const emit = defineEmits(["close"]);
 
 <template>
   <VDropdown
+    :aria-id="ariaId"
     :shown="show"
     :positioning-disabled="true"
     @show="preAnimation()"

--- a/apps/nuxt3-ssr/components/FilterWell.vue
+++ b/apps/nuxt3-ssr/components/FilterWell.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+const ariaId = useId();
 const props = defineProps<{
   filters: [];
 }>();
@@ -51,7 +52,7 @@ function isAFilterSet(filters) {
       Active filters
     </div>
     <div class="flex flex-wrap gap-3 content-around p-3">
-      <template v-for="filter in filters">
+      <template v-for="(filter, index) in filters">
         <Button
           v-if="filter?.columnType === '_SEARCH' && isFilterSet(filter)"
           @click="clearSearch(filter)"
@@ -64,6 +65,7 @@ function isAFilterSet(filters) {
         </Button>
 
         <VDropdown
+          :aria-id="ariaId + '_' + index"
           :triggers="['hover', 'focus']"
           :distance="12"
           theme="tooltip"

--- a/apps/nuxt3-ssr/components/SideModal.vue
+++ b/apps/nuxt3-ssr/components/SideModal.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { INotificationType } from "~/interfaces/types";
+const ariaId = useId();
 const props = withDefaults(
   defineProps<{
     slideInRight?: boolean;
@@ -81,6 +82,7 @@ const bgClass = computed(() => {
 
 <template>
   <VDropdown
+    :aria-id="ariaId"
     :shown="show"
     :positioning-disabled="true"
     @show="preAnimation()"

--- a/apps/nuxt3-ssr/components/harmonization/HarmonizationLegendDetailed.vue
+++ b/apps/nuxt3-ssr/components/harmonization/HarmonizationLegendDetailed.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { HarmonizationIconSize } from "../../interfaces/types";
+const ariaId = useId();
 
 const props = withDefaults(
   defineProps<{
@@ -28,7 +29,12 @@ const props = withDefaults(
         No data
       </li>
     </ul>
-    <VDropdown :triggers="['hover', 'focus']" :distance="12" theme="tooltip">
+    <VDropdown
+      :aria-id="ariaId"
+      :triggers="['hover', 'focus']"
+      :distance="12"
+      theme="tooltip"
+    >
       <div class="flex gap-1 text-blue-500 hover:underline cursor-pointer">
         <BaseIcon name="info" />
         <span> About statuses </span>

--- a/apps/nuxt3-ssr/components/harmonization/HarmonizationLegendMatrix.vue
+++ b/apps/nuxt3-ssr/components/harmonization/HarmonizationLegendMatrix.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import type { HarmonizationIconSize } from "../../interfaces/types";
+const ariaId = useId();
 
 const props = withDefaults(
   defineProps<{
@@ -24,7 +25,12 @@ const props = withDefaults(
         No data
       </li>
     </ul>
-    <VDropdown :triggers="['hover', 'focus']" :distance="12" theme="tooltip">
+    <VDropdown
+      :aria-id="ariaId"
+      :triggers="['hover', 'focus']"
+      :distance="12"
+      theme="tooltip"
+    >
       <div class="flex gap-1 text-blue-500 hover:underline cursor-pointer">
         <BaseIcon name="info" />
         <span> About statuses </span>


### PR DESCRIPTION
The VDropdown component from the floating-vue lib results in a hydration errors due to the way the lib edits the dom issue is reported: https://github.com/Akryum/floating-vue/issues/1006

Workaround implemented as proposed in: https://github.com/Akryum/floating-vue/issues/1006#issuecomment-2007638042

how to test:
- load nuxt app page that contains VDropdown component in dev mode before this pr and check the console log; lots of warnings about hydration mismatch in vdropdown ( popper )
something like: <img width="627" alt="Screenshot 2024-03-20 at 14 53 02" src="https://github.com/molgenis/molgenis-emx2/assets/47183404/d9013e83-ead3-4e05-a643-f6a0ab5f26bc">

- load nuxt app page that contains VDropdown component in dev mode from pr and check the console log; hydration error related to vdropdown should be gone

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
