### PR TITLE
fix: corrected catalogue status mappings

### DIFF
--- a/apps/nuxt3-ssr/components/harmonization/HarmonizationLegendDetailed.vue
+++ b/apps/nuxt3-ssr/components/harmonization/HarmonizationLegendDetailed.vue
@@ -37,16 +37,16 @@ const props = withDefaults(
         <ul class="list-none [&_li]:flex [&_li]:gap-1">
           <li>
             <HarmonizationStatusIcon size="small" status="complete" />
-            <span>Completed</span>
             <span
-              >cohort was able to fully map to the harmonized variables</span
+              >Completed: cohort was able to fully map to the harmonized
+              variables</span
             >
           </li>
           <li>
             <HarmonizationStatusIcon size="small" status="partial" />
-            <span>Partial</span>
             <span
-              >cohort was able to partially map to the harmonized variable</span
+              >Partial: cohort was able to partially map to the harmonized
+              variable</span
             >
           </li>
           <li>
@@ -55,8 +55,7 @@ const props = withDefaults(
               status="unmapped"
               class="bg-white"
             />
-            <span>No data</span>
-            <span>no harmonization information is available</span>
+            <span>No data: no harmonization information is available</span>
           </li>
         </ul>
       </template>

--- a/apps/nuxt3-ssr/components/harmonization/HarmonizationLegendMatrix.vue
+++ b/apps/nuxt3-ssr/components/harmonization/HarmonizationLegendMatrix.vue
@@ -33,8 +33,7 @@ const props = withDefaults(
         <ul class="list-none [&_li]:flex [&_li]:gap-1">
           <li>
             <HarmonizationStatusIcon size="small" status="available" />
-            <span>Available</span>
-            <span>cohort has data available for the variable</span>
+            <span>Available: cohort has data available for the variable</span>
           </li>
           <li>
             <HarmonizationStatusIcon
@@ -42,8 +41,10 @@ const props = withDefaults(
               status="unmapped"
               class="bg-white"
             />
-            <span>No data</span>
-            <span>cohort does not have data available for the variable</span>
+            <span
+              >No data: cohort does not have data available for the
+              variable</span
+            >
           </li>
         </ul>
       </template>

--- a/apps/nuxt3-ssr/utils/harmonization.ts
+++ b/apps/nuxt3-ssr/utils/harmonization.ts
@@ -75,7 +75,7 @@ const calcStatusForSingleVariable = (
     case "na":
       return "unmapped";
     case "partial":
-      return "complete";
+      return "partial";
     case "complete":
       return "complete";
     default:


### PR DESCRIPTION
This PR addresses issue #3491 where some statuses were incorrectly mapped. For example, *partial* cases were marked as *complete*. In the function `calcStatusForSingleVariable`, *partials* were remapped as *completed*. This regrouping was perhaps necessary, but this PR fixes this mapping to make sure the harmonisation matrix is the same as the source data.

how to test:
- Navigate to the preview

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
