### PR TITLE
fix: instead of becomeAdmin has asAdmin to prevent reloading (smaller version of #3524)

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -271,17 +271,11 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     // need elevated privileges, so clear user and run as root
     // this is not thread safe therefore must be in a transaction
     getDatabase()
-        .tx(
+        .asAdmin(
             tdb -> {
-              String current = tdb.getActiveUser();
-              try {
-                tdb.becomeAdmin(); // elevate privileges
-                result.addAll(
-                    SqlSchemaMetadataExecutor.getInheritedRoleForUser(
-                        ((SqlDatabase) tdb).getJooq(), getName(), username));
-              } finally {
-                tdb.setActiveUser(current); // reset privileges
-              }
+              result.addAll(
+                  SqlSchemaMetadataExecutor.getInheritedRoleForUser(
+                      ((SqlDatabase) tdb).getJooq(), getName(), username));
             });
     return result;
   }


### PR DESCRIPTION
When I tested this I didn't see all the 'load schema' statements that I used to see before.

However, I would like to refactor this so we don't use transactions for this, at least not for the 'getrolesforuser'

I think for these functions we could sacrifice transactionality and instead create a dedicated 'jooq' instance that is set to use the admin user.