### PR TITLE
fix: cranio app file handling

### DIFF
--- a/apps/cranio-provider/README.md
+++ b/apps/cranio-provider/README.md
@@ -21,16 +21,38 @@ cranio-provider
 
 Changes can be made to the application by cloning the `molgenis/molgenis-emx2` repository and creating a new branch; use the prefix `feat/...` or `fix/...` when naming the branch.
 
-### Vue config
+### Setting up your development instance
 
-A few items are required to develop the application. These are outlined below.
+Select an EMX2 instance to use as your development instance. Log in as admin and create two schemas:
 
-1. In the `vue.config.js` file, enter a host or schema, or use the defaults.
-2. In the selected host, create a new schema using the template `ERN_DASHBOARDS`. Use the name `CranioStats`. **NOTE**: the name of this schema is hard coded into the Cranio provider application.
-3. Upload the [Cranio dataset](https://github.com/molgenis/projects-rd-erns/blob/main/erns/cranio/cranio_emx2.xlsx) into the `CranioStats` schema.
-4. In the organisations table, select one of the organisations and create a new schema using the value in the `providerInformation` column (e.g., `NL1`, `DK1`, etc).
-5. Next we will import the profile image for the organization. Click the "edit row" button and scroll down to the field for `image`. Find the profile image of the selected organisation in the [provider profiles](https://github.com/molgenis/projects-rd-erns/tree/main/erns/cranio/profiles) folder. (Either download the image or clone the repo.) Back in the update form, click the *browse* button and select the file that you would like to import. Click save.
-6. In the terminal, change directories to `apps/cranio-provider` and run the `yarn dev` command. This will serve the vue app at `localhost:5173`
+1. Public Schema: used to display the `cranio-public` vue application. Use the template `ERN_DASHBOARDS`. Give it a name e.g., `ErnStats`
+2. Provider Schema: An organisation-level schema to display the `cranio-provider` vue application. Use one of the organisations listed in the [Cranio Organisations.csv](https://github.com/molgenis/projects-rd-erns/blob/main/erns/cranio/imports/organisations.csv) file. The name of the schema is listed in the column `schemaName`. For example, use `DK1` to create a schema for `Aarhus University Hospital`.
+
+After creating both schemas, navigate to the settings table in the provider schema. Here we will create a reference to the public schema to link the provider with public schemas. This allows the vue applications to be independent and to avoid hardcoding any schema information. The key is hardcoded.
+
+| Key | Value |
+|-----|-------|
+| CRANIO_PUBLIC_SCHEMA | `<public_schema_name>` |
+
+Using the example schema name created in step one, we would use `ErnStats`.
+
+### Updating the `vue.config.js` file
+
+Open the `vue.config.js` file and update the following information.
+
+1. set the `host`: enter the emx2 instance that you selected in the previous section
+2. set the `schema`: enter the name of the provider schema created in the previous section (e.g., `DK1`)
+
+### Importing the reference datasets
+
+The datasets used in the dashboards are located in the [Cranio Imports folder](https://github.com/molgenis/projects-rd-erns/tree/main/erns/cranio/imports). To make the import process smoother, zip the folder and import it via the browser.
+
+```bash
+cd erns/cranio/imports
+zip -r ../ern_cranio.zip *
+```
+
+In the terminal, change directories to `apps/cranio-provider` and run the `yarn dev` command. This will serve the vue app at `localhost:5173`
 
 ## Troubleshooting
 

--- a/apps/cranio-provider/src/App.vue
+++ b/apps/cranio-provider/src/App.vue
@@ -47,7 +47,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeMount, onMounted, watch } from "vue";
+import { ref, onBeforeMount } from "vue";
 import { Molgenis } from "molgenis-components";
 import {
   Page,

--- a/apps/cranio-provider/src/App.vue
+++ b/apps/cranio-provider/src/App.vue
@@ -73,25 +73,30 @@ let cranioPublicSchema = ref<string | null>(null);
 let schema = ref<object | null>(null);
 let provider = ref<object | null>(null);
 
-
-async function getCranioPublicSchema () {
-  const query = gql`{
-    _settings {
-      key
-      value
+async function getCranioPublicSchema() {
+  const query = gql`
+    {
+      _settings {
+        key
+        value
+      }
     }
-  }`
+  `;
   const response = await request("../api/graphql", query);
-  const result = response._settings?.filter(row => row.key === "CRANIO_PUBLIC_SCHEMA")[0];
+  const result = response._settings?.filter(
+    (row) => row.key === "CRANIO_PUBLIC_SCHEMA"
+  )[0];
   try {
     cranioPublicSchema.value = result.value;
   } catch (err) {
-    error.value = "Missing the name of the schema that controls the vue application `cranio_public`. In the current schema, navigate to the settings table. Add a new setting with the key 'CRANIO_PUBLIC_SCHEMA' and enter the name in the value column. Hit save and refresh the page."
+    error.value =
+      "Missing the name of the schema that controls the vue application `cranio_public`. In the current schema, navigate to the settings table. Add a new setting with the key 'CRANIO_PUBLIC_SCHEMA' and enter the name in the value column. Hit save and refresh the page.";
   }
 }
 
 async function getSchemaMeta() {
-  const query = gql`{
+  const query = gql`
+    {
       _schema {
         name
       }
@@ -125,7 +130,10 @@ async function getProviderMeta() {
     }
   }`;
 
-  const result = await request(`/${cranioPublicSchema.value}/api/graphql`, query);
+  const result = await request(
+    `/${cranioPublicSchema.value}/api/graphql`,
+    query
+  );
   const data = result.Organisations[0];
   data.id = data.providerInformation[0].providerIdentifier;
   delete data.providerInformation;
@@ -138,10 +146,9 @@ async function loadData() {
 }
 
 onBeforeMount(async () => {
-  await getCranioPublicSchema()
+  await getCranioPublicSchema();
   await loadData()
     .catch((err) => (error.value = err))
     .finally(() => (loading.value = false));
 });
-
 </script>

--- a/apps/cranio-provider/src/App.vue
+++ b/apps/cranio-provider/src/App.vue
@@ -4,7 +4,7 @@
       <LoadingScreen v-if="loading && !error" />
       <div class="message-box-container" v-else-if="!loading && error">
         <MessageBox type="error">
-          <p>Unable to retrieve results. {{ error }}</p>
+          <p><{{ error }}</p>
         </MessageBox>
       </div>
       <div v-else>
@@ -86,11 +86,13 @@ async function getCranioPublicSchema() {
   const result = response._settings?.filter(
     (row) => row.key === "CRANIO_PUBLIC_SCHEMA"
   )[0];
-  try {
+
+  if (!result.value) {
+    throw new Error(
+      "Missing the name of the schema that controls the vue application cranio_public. In the current schema, navigate to the settings table. Add a new setting with the key 'CRANIO_PUBLIC_SCHEMA' and enter the name in the value column. Hit save and refresh the page."
+    );
+  } else {
     cranioPublicSchema.value = result.value;
-  } catch (err) {
-    error.value =
-      "Missing the name of the schema that controls the vue application `cranio_public`. In the current schema, navigate to the settings table. Add a new setting with the key 'CRANIO_PUBLIC_SCHEMA' and enter the name in the value column. Hit save and refresh the page.";
   }
 }
 
@@ -146,7 +148,7 @@ async function loadData() {
 }
 
 onBeforeMount(async () => {
-  await getCranioPublicSchema();
+  await getCranioPublicSchema().catch((err) => (error.value = err));
   await loadData()
     .catch((err) => (error.value = err))
     .finally(() => (loading.value = false));

--- a/apps/cranio-provider/src/components/AppFooter.vue
+++ b/apps/cranio-provider/src/components/AppFooter.vue
@@ -6,13 +6,13 @@
           <p><strong>ERN CRANIO</strong></p>
           <UnorderedList listType="none">
             <li>
-              <a href="/CranioStats/cranio-public/#/">Home</a>
+              <a :href="`/${publicSchema}/cranio-public/#/`">Home</a>
             </li>
             <li>
-              <a href="/CranioStats/cranio-public/#/about">About</a>
+              <a :href="`/${publicSchema}/cranio-public/#/about`">About</a>
             </li>
             <li>
-              <a href="/CranioStats/cranio-public/#/dashboard">Dashboard</a>
+              <a :href="`/${publicSchema}/cranio-public/#/dashboard`">Dashboard</a>
             </li>
           </UnorderedList>
         </div>
@@ -20,17 +20,17 @@
           <p><strong>For Members</strong></p>
           <UnorderedList listType="none">
             <li>
-              <a href="/CranioStats/cranio-public/#/Providers">Providers</a>
+              <a :href="`/${publicSchema}/cranio-public/#/Providers`">Providers</a>
             </li>
             <li>
-              <a href="/CranioStats/cranio-public/#/Documents">Documents</a>
+              <a :href="`/${publicSchema}/cranio-public/#/Documents`">Documents</a>
             </li>
           </UnorderedList>
         </div>
         <div class="footer-column footer-logos">
           <UnorderedList listType="none">
             <li id="project-logo-link">
-              <a href="/CranioStats/cranio-public/#/">
+              <a :href="`/${publicSchema}/cranio-public/#/`">
                 <img
                   src="/ern-cranio-logo.png"
                   alt="ERN CRANIO: European Reference Network for rare and/or complex craniofacial anomalies and ear, nose and throat (ENT) disorders"
@@ -58,10 +58,12 @@
   </PageFooter>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { PageFooter, UnorderedList } from "molgenis-viz";
-import viewProps from "../data/props";
-const props = defineProps(viewProps);
+
+const props = defineProps<{
+  publicSchema: string | null
+}>();
 </script>
 
 <style lang="scss">

--- a/apps/cranio-provider/src/components/AppFooter.vue
+++ b/apps/cranio-provider/src/components/AppFooter.vue
@@ -12,7 +12,9 @@
               <a :href="`/${publicSchema}/cranio-public/#/about`">About</a>
             </li>
             <li>
-              <a :href="`/${publicSchema}/cranio-public/#/dashboard`">Dashboard</a>
+              <a :href="`/${publicSchema}/cranio-public/#/dashboard`"
+                >Dashboard</a
+              >
             </li>
           </UnorderedList>
         </div>
@@ -20,10 +22,14 @@
           <p><strong>For Members</strong></p>
           <UnorderedList listType="none">
             <li>
-              <a :href="`/${publicSchema}/cranio-public/#/Providers`">Providers</a>
+              <a :href="`/${publicSchema}/cranio-public/#/Providers`"
+                >Providers</a
+              >
             </li>
             <li>
-              <a :href="`/${publicSchema}/cranio-public/#/Documents`">Documents</a>
+              <a :href="`/${publicSchema}/cranio-public/#/Documents`"
+                >Documents</a
+              >
             </li>
           </UnorderedList>
         </div>
@@ -62,7 +68,7 @@
 import { PageFooter, UnorderedList } from "molgenis-viz";
 
 const props = defineProps<{
-  publicSchema: string | null
+  publicSchema: string | null;
 }>();
 </script>
 

--- a/apps/cranio-provider/vite.config.js
+++ b/apps/cranio-provider/vite.config.js
@@ -1,8 +1,8 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-const host = "https://emx2.dev.molgenis.org";
-const schema = "NL2";
+const host = "https://beta-erncranio.molgeniscloud.org";
+const schema = "DK1";
 const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
 
 export default defineConfig(() => {

--- a/apps/cranio-public/src/views/view-documents.vue
+++ b/apps/cranio-public/src/views/view-documents.vue
@@ -16,7 +16,7 @@
     >
       <h2 id="section-documents-title">Download Documents</h2>
       <p>Download additional information about the CRANIO Registry.</p>
-      <FileList table="Files" filename="name" path="path" />
+      <FileList table="Files" fileColumn="file" />
     </PageSection>
   </Page>
 </template>

--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -3,7 +3,11 @@
     <p><strong>Unable to retrieve files</strong></p>
     <p>{{ error }}</p>
   </MessageBox>
-  <MessageBox type="error" v-else-if="!data.length && !error" class="file-list-error">
+  <MessageBox
+    type="error"
+    v-else-if="!data.length && !error"
+    class="file-list-error"
+  >
     <div class="p-2">
       <p>
         No files are available for download. To import files, follow the steps

--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -3,7 +3,7 @@
     <p><strong>Unable to retrieve files</strong></p>
     <p>{{ error }}</p>
   </MessageBox>
-  <MessageBox type="error" v-else-if="!data && !error" class="file-list-error">
+  <MessageBox type="error" v-else-if="!data.length && !error" class="file-list-error">
     <div class="p-2">
       <p>
         No files are available for download. To import files, follow the steps

--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -3,7 +3,7 @@
     <p><strong>Unable to retrieve files</strong></p>
     <p>{{ error }}</p>
   </MessageBox>
-  <MessageBox type="error" v-else-if="!files && !error" class="file-list-error">
+  <MessageBox type="error" v-else-if="!data && !error" class="file-list-error">
     <div class="p-2">
       <p>
         No files are available for download. To import files, follow the steps
@@ -35,58 +35,51 @@
     </div>
   </MessageBox>
   <ul class="file-list" v-else>
-    <li class="file" v-for="file in files" :key="file[path].id">
-      <p class="file-element file-name">{{ file[filename] }}</p>
+    <li class="file" v-for="file in data" :key="file.id">
+      <p class="file-element file-name">{{ file.filename }}</p>
       <p class="file-element file-format">
-        {{ file[path].extension }}
+        {{ file.extension }}
       </p>
       <p class="file-element file-size">
-        {{ Math.round((file[path].size / 1000) * 100) / 100 }} KB
+        {{ Math.round((file.size / 1000) * 100) / 100 }} KB
       </p>
-      <a class="file-element file-url" :href="file[path].url">
-        <span class="visually-hidden">Download {{ file[filename] }}</span>
+      <a class="file-element file-url" :href="file.url">
+        <span class="visually-hidden">Download {{ file.filename }}</span>
         <ArrowDownTrayIcon class="heroicons" />
       </a>
     </li>
   </ul>
 </template>
 
-<script setup>
+<script setup lang="ts">
 import { ref, onMounted } from "vue";
 import gql from "graphql-tag";
 import { request } from "graphql-request";
 import MessageBox from "./MessageBox.vue";
 import { ArrowDownTrayIcon, PlusIcon } from "@heroicons/vue/24/outline";
 
-let error = ref(null);
-let files = ref([]);
+let error = ref<Error | null>(null);
+let data = ref<Array[]>([]);
 
-const props = defineProps({
-  // name of the table in the schema that contains the file metadata
-  table: {
-    type: String,
-    required: true,
-  },
+interface FileProperties {
+  id: string;
+  filename: string;
+  extension: string;
+  size: int;
+  url: string;
+}
 
-  // name of the column that contains the file names to display
-  filename: {
-    type: String,
-    required: true,
-  },
-
-  // name of the column that contains the location of the file
-  path: {
-    type: String,
-    required: true,
-  },
-});
+const props = defineProps<{
+  table: string;
+  fileColumn: string;
+}>();
 
 async function getFiles() {
-  const query = gql`{
+  const query = gql`query {
     ${props.table} {
-      ${props.filename}
-      ${props.path} {
+      ${props.fileColumn} {
         id
+        filename
         size
         extension
         url
@@ -94,7 +87,9 @@ async function getFiles() {
     }
   }`;
   const response = await request("../api/graphql", query);
-  files.value = response[props.table];
+  data.value = response[props.table].map((row: FileProperties) => {
+    return row[props.fileColumn as string];
+  });
 }
 
 onMounted(() => {


### PR DESCRIPTION
This PR addresses the issues listed in #3550. Specifically, this fixes the handling of images and organisation-level metadata in the `cranio-provider` vue application, as well as the display and download for documents.

- [x] Fix query that retrieves image metadata
- [x] Added setting to manually link CRANIO_PUBLIC_SCHEMA 
- [x] Added set up instructions to README
- [x] add filename to query in `FilesList` component
- [x] update documents page

how to test:
- Go to the preview
- Click on the `ErnCranioStats` schema -> Documents. Note documents displayed on the page
- Click on the `BE1` schema: note the image displayed at the top of the page. This should match the name of the file listed in the table ErnCranioStats >> Organisations
- In the `BE1` schema, go to the advanced settings page. Note the value for the setting `CRANIO_PUBLIC_SCHEMA`. Log in as admin, change the value, and refresh, and navigate back to the home page for the `BE1` schema. There should be no image and an error should be shown. Undo the change and refresh. The page should load as normal

todo:
- [x] updated README
