### PR TITLE
fix: race condition in directory app

### DIFF
--- a/apps/directory/src/stores/biobanksStore.js
+++ b/apps/directory/src/stores/biobanksStore.js
@@ -23,6 +23,8 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
   let biobankCards = ref([]);
   let waitingForResponse = ref(false);
 
+  let lastRequestTime = 0;
+
   const collectionColumns = collectionStore.getCollectionColumns();
   const biobankProperties = biobankColumns
     .flatMap((biobankColumn) => biobankColumn.column)
@@ -102,8 +104,6 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
     return facetBiobankColumnDetails;
   }
 
-  let lastRequestTime = 0;
-
   /** GraphQL query to get all the data necessary for the home screen 'aka biobank card view */
   async function getBiobankCards() {
     if (!filtersStore.bookmarkWaitingForApplication) {
@@ -116,9 +116,9 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
 
       /* Update biobankCards only if the result is the most recent one*/
       if (requestTime === lastRequestTime) {
-        let foundBiobanks = biobankResult.Biobanks;
+        let biobanksWithCollections = biobankResult.Biobanks;
         if (filtersStore.hasActiveFilters) {
-          foundBiobanks = foundBiobanks.filter(
+          biobanksWithCollections = biobanksWithCollections.filter(
             (biobank) => biobank.collections
           );
         }

--- a/apps/directory/src/stores/biobanksStore.js
+++ b/apps/directory/src/stores/biobanksStore.js
@@ -104,7 +104,8 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
     return facetBiobankColumnDetails;
   }
 
-  /** GraphQL query to get all the data necessary for the home screen 'aka biobank card view */
+  /** This method is called upon page load and when a filter is applied. */
+  /** Therefore it can be executed multiple times in parallel. */
   async function getBiobankCards() {
     if (!filtersStore.bookmarkWaitingForApplication) {
       waitingForResponse.value = true;

--- a/apps/directory/src/stores/filtersStore.js
+++ b/apps/directory/src/stores/filtersStore.js
@@ -13,7 +13,7 @@ export const useFiltersStore = defineStore("filtersStore", () => {
   const biobankStore = useBiobanksStore();
   const checkoutStore = useCheckoutStore();
 
-  const { baseQuery, updateBiobankCards } = biobankStore;
+  const { baseQuery, getBiobankCards } = biobankStore;
 
   const settingsStore = useSettingsStore();
 
@@ -98,7 +98,7 @@ export const useFiltersStore = defineStore("filtersStore", () => {
         }
         bookmarkTriggeredFilter.value = false;
 
-        await updateBiobankCards();
+        await getBiobankCards();
         clearTimeout(queryDelay);
       }, 750);
     },
@@ -130,7 +130,7 @@ export const useFiltersStore = defineStore("filtersStore", () => {
         bookmarkTriggeredFilter.value = false;
 
         if (hasActiveFilters.value) {
-          await updateBiobankCards();
+          await getBiobankCards();
           clearTimeout(queryDelay);
         }
       }, 750);


### PR DESCRIPTION
fixes: #3324

When loading the initial page of the directory app, the filters would be available for use. If a filter was applied while the home page was still loading, the directory app would display all the biobanks and not the results matching the selected filter. Note: to test the initial issue you need to simulate a slower internet connection.
The issue is fixed by timestamping the requests. This is used to ensure that only the most recent request updates the page, preventing race conditions where older requests (e.g., loading the initial page) might overwrite newer ones (applying filters).
In addition, the functions getBiobankCards() and updateBiobankCards() have been refactored. 
