### PR TITLE
fix: 3533 erroneously labelled "Population"

### DIFF
--- a/apps/nuxt3-ssr/components/SubCohortDisplay.vue
+++ b/apps/nuxt3-ssr/components/SubCohortDisplay.vue
@@ -99,7 +99,7 @@ if (subcohort?.comorbidity) {
 
 if (subcohort?.countries) {
   items.push({
-    label: "Population",
+    label: "Countries",
     type: "ONTOLOGY",
     content: subcohort.countries,
   });

--- a/apps/nuxt3-ssr/components/content/cohort/GeneralDesign.vue
+++ b/apps/nuxt3-ssr/components/content/cohort/GeneralDesign.vue
@@ -63,7 +63,7 @@ function setData() {
       content: filters.startEndYear(cohort?.startYear, cohort?.endYear),
     },
     {
-      label: "Population",
+      label: "Countries",
       content: cohort?.countries
         ? [...cohort?.countries]
             .sort((a, b) => b.order - a.order)

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/cohorts/[cohort]/subcohorts/[subcohort].vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/cohorts/[cohort]/subcohorts/[subcohort].vue
@@ -86,7 +86,7 @@ if (subcohort?.inclusionStart || subcohort?.inclusionEnd) {
 
 if (subcohort?.countries) {
   items.push({
-    label: "Population",
+    label: "Countries",
     content: renderList(
       subcohort.countries.sort((a, b) => b.order - a.order),
       toName


### PR DESCRIPTION
Rename Population to Counties

Closes #3533

how to test:
- see issue details
