### PR TITLE
fix: update schema modal

### DIFF
--- a/apps/central/src/components/SchemaEditModal.vue
+++ b/apps/central/src/components/SchemaEditModal.vue
@@ -63,7 +63,7 @@ export default {
     InputText,
   },
   props: {
-    schemaName: String,
+    schemaId: String,
     schemaDescription: String,
   },
   data: function () {
@@ -92,7 +92,7 @@ export default {
         this.endpoint,
         `mutation updateSchema($name:String, $description:String){updateSchema(name:$name, description: $description){message}}`,
         {
-          name: this.schemaName,
+          name: this.schemaId,
           description: this.newSchemaDescription,
         }
       )


### PR DESCRIPTION
The edit schema modal has been broken for some time. The only way to update the description is through the GraphQL interface. This has created a blockage for some projects. I had a look into this and it is an easy fix.

The issue was caused by a conflict in the prop names. In the `apps/central`, the component `Groups` uses the component `SchemaEditModal`. Here the prop `schemaId` is declared, but it isn't defined in the component. I'm guessing this is leftover from the ID-name fixes. I'm guessing the use of ID is preferred so I changed the prop to `schemaId` instead of `schemaName`.


It looks like this addresses the following issues: #3468, #3107, and #3336

how to test:
- Log in to the preview
- Sign in as admin
- Click the edit button for any schema and add/change the description.
- Save 

todo:
- [ ] updated docs in case of new feature
- [ ] added tests
