### PR TITLE
fix: empty array input

### DIFF
--- a/apps/molgenis-components/src/components/forms/ArrayInput.vue
+++ b/apps/molgenis-components/src/components/forms/ArrayInput.vue
@@ -3,7 +3,7 @@
     :id="id + '-0'"
     :label="label"
     :required="required"
-    description="description"
+    :description="description"
     :errorMessage="errorMessage"
   >
     <div v-for="(value, index) in values" :key="index">
@@ -108,6 +108,7 @@ export default {
           id="array-string"
           columnType="STRING_ARRAY"
           v-model="stringValue"
+          description="this is the description"
         />
       </div>
       <div>

--- a/apps/molgenis-components/src/components/forms/ArrayInput.vue
+++ b/apps/molgenis-components/src/components/forms/ArrayInput.vue
@@ -53,7 +53,7 @@ export default {
   extends: BaseInput,
   components: { FormGroup },
   data() {
-    return { values: this.modelValue || [null] };
+    return { values: this.modelValue?.length ? this.modelValue : [null] };
   },
   props: {
     columnType: {
@@ -108,11 +108,23 @@ export default {
           id="array-string"
           columnType="STRING_ARRAY"
           v-model="stringValue"
-          description="this is the description"
         />
       </div>
       <div>
         {{ stringValue }}
+      </div> 
+    </DemoItem>   
+    <DemoItem>
+      <div>
+        <h3><label>Empty String array</label></h3>
+        <ArrayInput
+          id="array-empty-string"
+          columnType="STRING_ARRAY"
+          v-model="emptyStringValue"
+        />
+      </div>
+      <div>
+        {{ emptyStringValue }}
       </div> 
     </DemoItem>
     <DemoItem>
@@ -250,6 +262,7 @@ export default {
   data() {
     return {
       stringValue: ["String array value"],
+      emptyStringValue: [],
       intValue: [1, 3, 3, 7],
       decimalValue: [3.7, 4.2],
       longValue: ["1234567890123456789"],


### PR DESCRIPTION
fixes an issue in which array inputs (for e.g. strings/numbers) would not show if there wasn't an initial input

how to test: 
 - Go to the pet store
 - In the schema editor add a string_array column to one of the tables and save
 - Got the the table and add a column
 - See that nothing can be input to the string_array 

todo:
- [x] added tests
