### PR TITLE
fix: hide link to non existent about route

### DIFF
--- a/apps/nuxt3-ssr/components/header/Catalogue.vue
+++ b/apps/nuxt3-ssr/components/header/Catalogue.vue
@@ -51,7 +51,7 @@ if (cohortOnly.value) {
     label: "About",
     link: `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/about`,
   });
-} else {
+} else if (catalogueRouteParam && catalogueRouteParam !== "all") {
   menu.push({
     label: "About",
     link: `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/networks/${catalogueRouteParam}`,

--- a/e2e/tests/catalogue/about-link-visibility.spec.ts
+++ b/e2e/tests/catalogue/about-link-visibility.spec.ts
@@ -1,0 +1,13 @@
+import { test, expect } from '@playwright/test';
+
+test('should not show about menu item on non catalogue spesific page', async ({ page }) => {
+  await page.goto('/catalogue-demo/ssr-catalogue/all');
+  await page.getByRole('button', { name: 'Accept' }).click();
+  await expect(page.getByRole('link', { name: 'About' })).toHaveCount(0);
+});
+
+test('should show about menu item on catalogue spesific page', async ({ page }) => {
+  await page.goto('/catalogue-demo/ssr-catalogue/IPEC');
+  await page.getByRole('button', { name: 'Accept' }).click();
+  await expect(page.getByRole('link', { name: 'About' })).toHaveCount(1);
+});


### PR DESCRIPTION
Only show link if about page existest and info in page is describes catalogue

Closes #3555

how to test:
- tested via e2e test in pr
