### PR TITLE
feat: only use email service if message selector is configured

### DIFF
--- a/apps/nuxt3-ssr/components/content/ContentBlockIntro.vue
+++ b/apps/nuxt3-ssr/components/content/ContentBlockIntro.vue
@@ -179,7 +179,7 @@ const submitForm = async () => {
 
         <template #footer>
           <Button
-            v-if="contactMessageFilter"
+            v-if="contactMessageFilter && useEmailService"
             type="primary"
             size="small"
             label="Send"

--- a/apps/nuxt3-ssr/components/content/ContentBlockIntro.vue
+++ b/apps/nuxt3-ssr/components/content/ContentBlockIntro.vue
@@ -29,6 +29,20 @@ const props = defineProps({
   },
 });
 
+const useEmailService = ref(false);
+
+fetchSetting("contactRecipientsQuery").then((resp) => {
+  const setting = resp.data["_settings"].find(
+    (setting: { key: string; value: string }) => {
+      return setting.key === "contactRecipientsQuery";
+    }
+  );
+
+  if (setting) {
+    useEmailService.value = !!setting.value;
+  }
+});
+
 let showContactInformation = ref(false);
 
 const fields = reactive([
@@ -137,7 +151,7 @@ const submitForm = async () => {
           :sub-title="contactName"
           class="flex flex-col gap-3"
         >
-          <template v-if="contactMessageFilter">
+          <template v-if="contactMessageFilter && useEmailService">
             <ContactForm :fields="fields" @submit-form="submitForm" />
             <div class="pl-3">
               <span class="text-body-base">or contact us at: </span>

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/cohorts/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/cohorts/index.vue
@@ -151,20 +151,7 @@ watch(filters, () => {
 
 let activeName = ref("detailed");
 
-const NOTICE_SETTING_KEY = "CATALOGUE_NOTICE";
 const underConstructionNotice = ref();
-
-fetchSetting(NOTICE_SETTING_KEY).then((resp) => {
-  const setting = resp.data["_settings"].find(
-    (setting: { key: string; value: string }) => {
-      return setting.key === NOTICE_SETTING_KEY;
-    }
-  );
-
-  if (setting) {
-    underConstructionNotice.value = setting.value;
-  }
-});
 
 const cohortOnly = computed(() => {
   const routeSetting = route.query["cohort-only"] as string;
@@ -194,18 +181,6 @@ crumbs[
               <BreadCrumbs :crumbs="crumbs" current="cohorts" />
             </template>
             <template #suffix>
-              <div
-                v-if="underConstructionNotice"
-                class="mt-1 mb-5 text-left bg-yellow-200 rounded-lg text-black py-5 px-5 flex"
-              >
-                <BaseIcon
-                  name="info"
-                  :width="55"
-                  class="hidden md:block mr-3"
-                />
-                <div class="inline-block">{{ underConstructionNotice }}</div>
-              </div>
-
               <SearchResultsViewTabs
                 class="hidden xl:flex"
                 buttonLeftLabel="Detailed"

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/datasources/index.vue
@@ -116,20 +116,7 @@ watch(filters, () => {
 
 let activeName = ref("detailed");
 
-const NOTICE_SETTING_KEY = "CATALOGUE_NOTICE";
 const underConstructionNotice = ref();
-
-fetchSetting(NOTICE_SETTING_KEY).then((resp) => {
-  const setting = resp.data["_settings"].find(
-    (setting: { key: string; value: string }) => {
-      return setting.key === NOTICE_SETTING_KEY;
-    }
-  );
-
-  if (setting) {
-    underConstructionNotice.value = setting.value;
-  }
-});
 
 const crumbs: any = {};
 crumbs[
@@ -155,18 +142,6 @@ crumbs[
               <BreadCrumbs :crumbs="crumbs" current="data sources" />
             </template>
             <template #suffix>
-              <div
-                v-if="underConstructionNotice"
-                class="mt-1 mb-5 text-left bg-yellow-200 rounded-lg text-black py-5 px-5 flex"
-              >
-                <BaseIcon
-                  name="info"
-                  :width="55"
-                  class="hidden md:block mr-3"
-                />
-                <div class="inline-block">{{ underConstructionNotice }}</div>
-              </div>
-
               <SearchResultsViewTabs
                 class="hidden xl:flex"
                 buttonLeftLabel="Detailed"


### PR DESCRIPTION
Closes #3551

how to test:
- Check that 'contactRecipientsQuery' has been set for this server and schema; click the contact btn, a message should be send.
- optional , save the value from 'contactRecipientsQuery' to put back later
- remove the 'contactRecipientsQuery'  setting for this server and schema; click the contact btn, a adress to send an email to should be shown.
- Add / putback the 'contactRecipientsQuery' values ( make sure it is a valid value)  for this server and schema; click the contact btn, a message should be send.
-
todo:
- [ ] updated docs in case of new feature
- [ ] added tests
- [ ] updated testplan to include a test for this fix, including ref to bug using # notation
