### PR TITLE
fix: dont crash on empty result set

### DIFF
--- a/apps/directory/src/stores/biobanksStore.js
+++ b/apps/directory/src/stores/biobanksStore.js
@@ -118,6 +118,7 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
       /* Update biobankCards only if the result is the most recent one*/
       if (requestTime === lastRequestTime) {
         let biobanksWithCollections = biobankResult.Biobanks;
+        if (!biobanksWithCollections) biobanksWithCollections = [];
         if (filtersStore.hasActiveFilters) {
           biobanksWithCollections = biobanksWithCollections.filter(
             (biobank) => biobank.collections?.length


### PR DESCRIPTION
fixes: #3622

how to test:
1) Filter strongly resulting in zero results. 
2) Notice that now "No biobanks were found" is shown

todo:
- [ ] added tests
- [ ] updated testplan to include a test for this fix, including ref to bug using # notation
