### PR TITLE
Add support for file names

### DIFF
--- a/apps/cranio-public/src/views/view-documents.vue
+++ b/apps/cranio-public/src/views/view-documents.vue
@@ -16,7 +16,7 @@
     >
       <h2 id="section-documents-title">Download Documents</h2>
       <p>Download additional information about the CRANIO Registry.</p>
-      <FileList table="Files" fileColumn="file" />
+      <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>
 </template>

--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -42,7 +42,7 @@
     <li class="file" v-for="file in data" :key="file.id">
       <p class="file-element file-name">
         <span v-if="labelsColumn && Object.hasOwn(file, labelsColumn)">
-          {{ file[labelsColumn as string] }}
+          {{ file[labelsColumn] }}
         </span>
         <span v-else>
           {{ file[fileColumn].filename }}
@@ -71,22 +71,22 @@ import { request } from "graphql-request";
 import MessageBox from "./MessageBox.vue";
 import { ArrowDownTrayIcon, PlusIcon } from "@heroicons/vue/24/outline";
 
-let error = ref<Error | null>(null);
-let data = ref<Array[]>([]);
-
-interface FileProperties {
-  id: string;
-  filename: string;
-  extension: string;
-  size: int;
-  url: string;
-}
-
 const props = defineProps<{
   table: string;
   labelsColumn?: string;
   fileColumn: string;
 }>();
+
+interface FileProperties {
+  id: string;
+  filename: string;
+  extension: string;
+  size: number;
+  url: string;
+}
+
+const error = ref<Error | null>(null);
+const data: Record<string, FileProperties>[] = ref([]);
 
 async function getFiles() {
   const query = gql`query {
@@ -102,7 +102,7 @@ async function getFiles() {
     }
   }`;
   const response = await request("../api/graphql", query);
-  data.value = response[props.table as string];
+  data.value = response[props.table];
 }
 
 onMounted(() => {

--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -41,7 +41,7 @@
   <ul class="file-list" v-else>
     <li class="file" v-for="file in data" :key="file.id">
       <p class="file-element file-name">
-        <span v-if="Object.hasOwn(file, labelsColumn)">
+        <span v-if="labelsColumn && Object.hasOwn(file, labelsColumn)">
           {{ file[labelsColumn as string] }}
         </span>
         <span v-else>

--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -55,9 +55,9 @@
         {{ (file[fileColumn].size / Math.pow(1024, 2)).toFixed(2) }} MB
       </p>
       <a class="file-element file-url" :href="file[fileColumn].url">
-        <span class="visually-hidden"
-          >Download {{ file[fileColumn].filename }}</span
-        >
+        <span class="visually-hidden">
+          Download {{ file[fileColumn].filename }}
+        </span>
         <ArrowDownTrayIcon class="heroicons" />
       </a>
     </li>
@@ -91,7 +91,7 @@ const props = defineProps<{
 async function getFiles() {
   const query = gql`query {
     ${props.table} {
-      ${props.labelsColumn ? props.labelsColumn : ""}
+      ${props.labelsColumn || ""}
       ${props.fileColumn} {
         id
         filename

--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -51,11 +51,13 @@
       <p class="file-element file-format">
         {{ file[fileColumn].extension }}
       </p>
-      <p class="file-element file-size"> 
-        {{ (file[fileColumn].size / Math.pow(1024,2)).toFixed(2) }} MB
+      <p class="file-element file-size">
+        {{ (file[fileColumn].size / Math.pow(1024, 2)).toFixed(2) }} MB
       </p>
       <a class="file-element file-url" :href="file[fileColumn].url">
-        <span class="visually-hidden">Download {{ file[fileColumn].filename }}</span>
+        <span class="visually-hidden"
+          >Download {{ file[fileColumn].filename }}</span
+        >
         <ArrowDownTrayIcon class="heroicons" />
       </a>
     </li>
@@ -89,7 +91,7 @@ const props = defineProps<{
 async function getFiles() {
   const query = gql`query {
     ${props.table} {
-      ${props.labelsColumn ? props.labelsColumn : ''}
+      ${props.labelsColumn ? props.labelsColumn : ""}
       ${props.fileColumn} {
         id
         filename

--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -40,15 +40,22 @@
   </MessageBox>
   <ul class="file-list" v-else>
     <li class="file" v-for="file in data" :key="file.id">
-      <p class="file-element file-name">{{ file.filename }}</p>
+      <p class="file-element file-name">
+        <span v-if="Object.hasOwn(file, labelsColumn)">
+          {{ file[labelsColumn as string] }}
+        </span>
+        <span v-else>
+          {{ file[fileColumn].filename }}
+        </span>
+      </p>
       <p class="file-element file-format">
-        {{ file.extension }}
+        {{ file[fileColumn].extension }}
       </p>
-      <p class="file-element file-size">
-        {{ Math.round((file.size / 1000) * 100) / 100 }} KB
+      <p class="file-element file-size"> 
+        {{ (file[fileColumn].size / Math.pow(1024,2)).toFixed(2) }} MB
       </p>
-      <a class="file-element file-url" :href="file.url">
-        <span class="visually-hidden">Download {{ file.filename }}</span>
+      <a class="file-element file-url" :href="file[fileColumn].url">
+        <span class="visually-hidden">Download {{ file[fileColumn].filename }}</span>
         <ArrowDownTrayIcon class="heroicons" />
       </a>
     </li>
@@ -75,12 +82,14 @@ interface FileProperties {
 
 const props = defineProps<{
   table: string;
+  labelsColumn?: string;
   fileColumn: string;
 }>();
 
 async function getFiles() {
   const query = gql`query {
     ${props.table} {
+      ${props.labelsColumn ? props.labelsColumn : ''}
       ${props.fileColumn} {
         id
         filename
@@ -91,9 +100,7 @@ async function getFiles() {
     }
   }`;
   const response = await request("../api/graphql", query);
-  data.value = response[props.table].map((row: FileProperties) => {
-    return row[props.fileColumn as string];
-  });
+  data.value = response[props.table as string];
 }
 
 onMounted(() => {

--- a/apps/molgenis-viz/tsconfig.json
+++ b/apps/molgenis-viz/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "include": ["./src/**/*"],
+  "exclude": ["node_modules"],
+  "compilerOptions": {
+    "strict": true,
+    "isolatedModules": true,
+    "allowJs": true,
+    "types": ["vite/client"],
+    "lib": ["es2022", "dom"]
+  }
+}


### PR DESCRIPTION
In the molgenis-viz library, the component `FileList` is used to display files listed in any table. The one limitation is that the displayed file name is dependent on the name of the file that is uploaded. It would be nice to give users the option to change the name of the file without having to re-upload the file.

how to test:
- Navigate to the preview
- And open the demo documents page: `/demo/cranio-public/#/documents`
- Sign in and navigate to the files table: `/demo/tables/#/Files`
- Create a blank text file or import and random file into the table. Give the record a name that is different than the file name
- Navigate back to the documents (`demo/cranio-public/#/documents`) to view the new file(s)

