### PR TITLE
chore: wait for server install

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -155,7 +155,7 @@ jobs:
                       echo "preview is not ready yet, waiting 10 seconds...";
                   fi; 
                   sleep 10; 
-              done`
+              done
 
     - run:
         name: message slack about preview


### PR DESCRIPTION
- only signal that the preview is ready when it is ready
- remove check from test job
- add check to preview deploy job

how to test:
- inspect the circle job 
