### PR TITLE
chore(directory): staging areas by default private

### DIFF
--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/BiobankDirectoryLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/BiobankDirectoryLoader.java
@@ -34,7 +34,10 @@ public class BiobankDirectoryLoader extends AbstractDataLoader {
 
     // create biobank-directory or staging schema (which will create tables in ontology schema)
     createSchema(schema, location + "molgenis.csv");
-    schema.addMember(SqlDatabase.ANONYMOUS, Privileges.VIEWER.toString());
+
+    if (!this.staging) {
+      schema.addMember(SqlDatabase.ANONYMOUS, Privileges.VIEWER.toString());
+    }
 
     if (ontologySchema == null || !this.staging) {
       // load data into ontology schema


### PR DESCRIPTION
What are the main changes you did:
- Currently the anonymous viewer role was set both for staging areas as well as the Directory schema when using the templates. In this PR, this default setting for the staging areas template has been removed.

how to test:
- Goto https://preview-emx2-pr-3668.dev.molgenis.org/
- Create a schema using the BIOBANK_DIRECTORY template => check that it's available in the list with schema when not logging in.
- Create a schema using the BIOBANK_DIRECTORY_STAGING template => check that it's not visible when not logged in.

todo:
- [na] updated docs in case of new feature
- [na] added/updated tests
- [na] added/updated testplan to include a test for this fix, including ref to bug using # notation
