### PR TITLE
fix: query for ontology filter in directory app

### DIFF
--- a/apps/directory/src/functions/applyFiltersToQuery.js
+++ b/apps/directory/src/functions/applyFiltersToQuery.js
@@ -104,8 +104,10 @@ export async function applyFiltersToQuery(
           filterType[filterDetail.facetIdentifier] === "all" ||
           values.length === 1
         ) {
+          baseQuery.where(filterDetail.applyToColumn).in(values);
           baseQuery.filter(filterDetail.applyToColumn).in(values);
         } else {
+          baseQuery.orWhere(filterDetail.applyToColumn).in(values);
           baseQuery.orFilter(filterDetail.applyToColumn).in(values);
         }
         break;


### PR DESCRIPTION
fixes: #3682
When initially applying a "diagnosis available" filter, the directory app would retrieve all the existing biobanks. The query of the ontology filter has been fixed, so that the application retrieves only the biobanks matching the applied filter.
