### PR TITLE
Chore: clear postgres test warning message

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
     - ./.docker/initdb.sql:/docker-entrypoint-initdb.d/initdb.sql
     command: -c 'shared_buffers=256MB' -c 'max_locks_per_transaction=1024'
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready", "-d", "molgenis"]
+      test: ["CMD-SHELL", "pg_isready -U $$POSTGRES_USER"]
       interval: 5s
       timeout: 60s
       retries: 5


### PR DESCRIPTION
clear postgres test/healtcheck warning message while running docker compose

#3685

What are the main changes you did:
- Pass the user `POSTGRES_USER` to pg_ready instead of the database `molgenis`

how to test:
- run the docker compose: `docker compose up -d`
- You should **not** get the messages like: _FATAL: role "root" does not exists_
- `docker ps` to check the health status of postgres

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
