### PR TITLE
fix(client): reduce default expandLevel to 1 to prevend unnecessary huge queries

### DIFF
--- a/apps/molgenis-components/src/client/IQueryMetaData.ts
+++ b/apps/molgenis-components/src/client/IQueryMetaData.ts
@@ -4,4 +4,5 @@ export interface IQueryMetaData {
   searchTerms?: string;
   filter?: Object;
   orderby?: Object;
+  expandLevel?: number;
 }

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -38,23 +38,20 @@ const client: IClient = {
       },
       fetchTableData: async (
         tableId: string,
-        properties: IQueryMetaData = {},
-        expandLevel: number = 1
+        properties: IQueryMetaData = {}
       ) => {
         const schemaMetaData = await fetchSchemaMetaData(schemaId);
-        return fetchTableData(tableId, properties, schemaMetaData, expandLevel);
+        return fetchTableData(tableId, properties, schemaMetaData);
       },
       fetchTableDataValues: async (
         tableId: string,
-        properties: IQueryMetaData = {},
-        expandLevel: number = 1
+        properties: IQueryMetaData = {}
       ) => {
         const schemaMetaData = await fetchSchemaMetaData(schemaId);
         const dataResp = await fetchTableData(
           tableId,
           properties,
-          schemaMetaData,
-          expandLevel
+          schemaMetaData
         );
         return dataResp[tableId];
       },
@@ -79,9 +76,9 @@ const client: IClient = {
             tableId,
             {
               filter,
+              expandLevel,
             },
-            schemaMetaData,
-            expandLevel
+            schemaMetaData
           )
         )[tableId];
 
@@ -263,11 +260,11 @@ const fetchSchemaMetaData = async (
 const fetchTableData = async (
   tableId: string,
   properties: IQueryMetaData,
-  metaData: ISchemaMetaData,
-  expandLevel: number
+  metaData: ISchemaMetaData
 ) => {
   const limit = properties.limit ? properties.limit : 20;
   const offset = properties.offset ? properties.offset : 0;
+  const expandLevel = properties.expandLevel ? properties.expandLevel : 1;
 
   const search = properties.searchTerms
     ? ',search:"' + properties.searchTerms.trim() + '"'

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -38,10 +38,11 @@ const client: IClient = {
       },
       fetchTableData: async (
         tableId: string,
-        properties: IQueryMetaData = {}
+        properties: IQueryMetaData = {},
+        expandLevel: number = 1
       ) => {
         const schemaMetaData = await fetchSchemaMetaData(schemaId);
-        return fetchTableData(tableId, properties, schemaMetaData);
+        return fetchTableData(tableId, properties, schemaMetaData, expandLevel);
       },
       fetchTableDataValues: async (
         tableId: string,

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -264,7 +264,10 @@ const fetchTableData = async (
 ) => {
   const limit = properties.limit ? properties.limit : 20;
   const offset = properties.offset ? properties.offset : 0;
-  const expandLevel = properties.expandLevel || properties.expandLevel == 0 ? properties.expandLevel : 1;
+  const expandLevel =
+    properties.expandLevel || properties.expandLevel == 0
+      ? properties.expandLevel
+      : 1;
   const search = properties.searchTerms
     ? ',search:"' + properties.searchTerms.trim() + '"'
     : "";

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -264,8 +264,7 @@ const fetchTableData = async (
 ) => {
   const limit = properties.limit ? properties.limit : 20;
   const offset = properties.offset ? properties.offset : 0;
-  const expandLevel = properties.expandLevel ? properties.expandLevel : 1;
-
+  const expandLevel = properties.expandLevel || properties.expandLevel == 0 ? properties.expandLevel : 1;
   const search = properties.searchTerms
     ? ',search:"' + properties.searchTerms.trim() + '"'
     : "";

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -46,13 +46,15 @@ const client: IClient = {
       },
       fetchTableDataValues: async (
         tableId: string,
-        properties: IQueryMetaData = {}
+        properties: IQueryMetaData = {},
+        expandLevel: number = 1
       ) => {
         const schemaMetaData = await fetchSchemaMetaData(schemaId);
         const dataResp = await fetchTableData(
           tableId,
           properties,
-          schemaMetaData
+          schemaMetaData,
+          expandLevel
         );
         return dataResp[tableId];
       },
@@ -262,7 +264,7 @@ const fetchTableData = async (
   tableId: string,
   properties: IQueryMetaData,
   metaData: ISchemaMetaData,
-  expandLevel: number = 1
+  expandLevel: number
 ) => {
   const limit = properties.limit ? properties.limit : 20;
   const offset = properties.offset ? properties.offset : 0;

--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -261,7 +261,7 @@ const fetchTableData = async (
   tableId: string,
   properties: IQueryMetaData,
   metaData: ISchemaMetaData,
-  expandLevel: number = 2
+  expandLevel: number = 1
 ) => {
   const limit = properties.limit ? properties.limit : 20;
   const offset = properties.offset ? properties.offset : 0;

--- a/apps/molgenis-components/src/client/queryBuilder.ts
+++ b/apps/molgenis-components/src/client/queryBuilder.ts
@@ -21,8 +21,8 @@ export const getColumnIds = (
   let result = "";
   getTable(schemaId, tableId, metaData.tables)?.columns?.forEach(
     (col: IColumn) => {
-      //we always expand the subfields of key=1, but other 'ref' fields only if they do not break server
-      if (expandLevel > 0 || col.key == 1) {
+      //we always expand the subfields of key, but other 'ref' fields only if they do not break server
+      if (expandLevel > 0 || col.key) {
         if (
           !rootLevel &&
           ["REF_ARRAY", "REFBACK", "ONTOLOGY_ARRAY"].includes(col.columnType)

--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -234,7 +234,7 @@ export default {
         filter: this.filter,
         orderby: this.orderby,
       };
-      const response = await this.client.fetchTableData(this.tableId, options);
+      const response = await this.client.fetchTableData(this.tableId, options, 0); //0 = only keys
       this.data = response[this.tableId] || [];
       this.count = response[this.tableId + "_agg"].count;
 

--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -233,12 +233,9 @@ export default {
         limit: this.maxNum,
         filter: this.filter,
         orderby: this.orderby,
+        expandLevel: 0,
       };
-      const response = await this.client.fetchTableData(
-        this.tableId,
-        options,
-        0
-      );
+      const response = await this.client.fetchTableData(this.tableId, options);
       this.data = response[this.tableId] || [];
       this.count = response[this.tableId + "_agg"].count;
 

--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -234,7 +234,7 @@ export default {
         filter: this.filter,
         orderby: this.orderby,
       };
-      const response = await this.client.fetchTableData(this.tableId, options, 0); //0 = only keys
+      const response = await this.client.fetchTableData(this.tableId, options, 0);
       this.data = response[this.tableId] || [];
       this.count = response[this.tableId + "_agg"].count;
 

--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -234,7 +234,11 @@ export default {
         filter: this.filter,
         orderby: this.orderby,
       };
-      const response = await this.client.fetchTableData(this.tableId, options, 0);
+      const response = await this.client.fetchTableData(
+        this.tableId,
+        options,
+        0
+      );
       this.data = response[this.tableId] || [];
       this.count = response[this.tableId + "_agg"].count;
 

--- a/docs/molgenis/use_schema.md
+++ b/docs/molgenis/use_schema.md
@@ -300,16 +300,17 @@ the current schema. This is because in practice, the table from the other schema
 ### refLabel
 
 Using 'refLabel' you can change the way on how a reference is being shown on the screen. By default the key=1 fields of the refTable are used. Caveat: you
-should make sure that the refLabel is unique and not null. To make sure, we recommend you make the fields required and part of a secondary key.
+should make sure that the refLabel is unique and not null and only uses fields that are part of a key. To make sure, we recommend you make the fields required 
+and part of a secondary key, or that you use 'computed' to produce you ref_label as a key=x field.
 
 Example:
 
-| tableName | columnName | type | key | required | refTable                 | refLabel |
-| --------- | ---------- | ---- | --- | -------- | ------------------------ | -------- |
-| person    | id         |      | 1   | true     |                          |          |
-| person    | firstName  |      | 2   | true     |                          |          |
-| person    | lastName   |      | 2   | true     |                          |          |
-| person    | mother     | ref  |     | person   | ${firstName} ${lastName} |          |
+| tableName | columnName | type | key | required | refTable | refLabel                 |
+| --------- | ---------- | ---- | --- |----------|----------|--------------------------|
+| person    | id         |      | 1   | true     |          |                          |
+| person    | firstName  |      | 2   | true     |          |                          |
+| person    | lastName   |      | 2   | true     |          |                          |
+| person    | mother     | ref  |     |          | Person   | ${firstName} ${lastName} |
 
 ## Simple migrations
 


### PR DESCRIPTION
partial solution to #3652 (probably need to combine with other PR to fix completely => I suppose limits on ref_array and ref_back would help a lot)

What are the main changes you did:
- added expandLevel to functions where it might be used
- to reduce performance issues set default expandLevel = 1 (was 2!!!!)
- refactor expandLevel to be in properties
- include all key fields in level 0 so labels can be based on key fields (e.g. a hidden computed field)

how to test:
- should create much smaller graphql queries everywhere, in particular in refInput/refBack lookups

todo:
- [ ] we might need to have larger expand levels for ERN where we have ref_labels on relationship values, lets test that after this is merged, ok?
- [ ] when we go to the 'more details' of a refInputList then it is still slow: should we add paging/limit to this screen?
