### PR TITLE
fix: always show molgenis footer

### DIFF
--- a/apps/molgenis-components/src/components/layout/Molgenis.vue
+++ b/apps/molgenis-components/src/components/layout/Molgenis.vue
@@ -30,7 +30,7 @@
     </div>
     <footer>
       <slot v-if="$slots.footer" name="footer" />
-      <MolgenisFooter v-else>
+      <MolgenisFooter>
         <span v-if="session?.manifest">
           Software version:
           <a


### PR DESCRIPTION
What are the main changes you did:
- make sure the molgenis footer is always shown under custom footers.

how to test:
- see components styleguide example of Molgenis.vue

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
