### PR TITLE
fix: add keys to server side computed expression

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -330,7 +330,9 @@ class SqlTable implements Table {
     SqlTable table = schema.getTable(subclassName.split("\\.")[1]);
     if (UPDATE.equals(transactionType)) {
       List<Column> updateColumns = getUpdateColumns(table, columnsProvided);
-      List<Row> rows = applyValidationAndComputed(updateColumns, subclassRows.get(subclassName));
+      List<Row> rows =
+          applyValidationAndComputed(
+              table.getMetadata().getColumns(), subclassRows.get(subclassName));
       count.set(count.get() + table.updateBatch(table, rows, updateColumns));
     } else if (SAVE.equals(transactionType) || INSERT.equals(transactionType)) {
       List<Column> insertColumns = getInsertColumns(table, columnsProvided);


### PR DESCRIPTION
What are the main changes you did:
- server side computed and validation expressions did not have the key (and readonly) columns data to use. It's added now.

how to test:
- have computed /validation expression use key or readonly fields.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
