### PR TITLE
fix: dropped main element

### DIFF
--- a/apps/molgenis-viz/src/components/layouts/Page.vue
+++ b/apps/molgenis-viz/src/components/layouts/Page.vue
@@ -1,8 +1,8 @@
 <template>
-  <main class="app-page">
+  <div class="app-page">
     <!-- Main app content -->
     <slot></slot>
-  </main>
+  </div>
 </template>
 
 <script>


### PR DESCRIPTION
What are the main changes you did:

In the molgenis-viz library, the page component generates a `<main>` element. This was done as it did not exist in the general molgenis components library. In PR #3683, the main element was added. A html page should only have one main element. This PR removes the main element that is created by the page component.

how to test:
- Navigate to the preview
- View any app using the pet store schema: `/pet store/cranio-public/`, `/pet store/gportal/` etc.
- Right click and go to "Inspect the element". In the html inspector, you will have to expand the body > div#app > div > div > div. If you expand the last div, you will see the main element. Expand the main element and you will see another div rather than a main element.
- Alternatively, you can run this js code in the console: `document.getElementsByTagName("main")`

todo:
- ~~updated docs in case of new feature~~
- ~~added/updated tests~~
- ~~added/updated testplan to include a test for this fix, including ref to bug using # notation~~
