### PR TITLE
fix: network report in directory app

### DIFF
--- a/apps/directory/src/functions/viewmodelMapper.js
+++ b/apps/directory/src/functions/viewmodelMapper.js
@@ -306,7 +306,9 @@ export const collectionReportInformation = (collection) => {
   }
 
   if (collection.also_known) {
-    collectionReport.also_known = mapAlsoKnownIn(collection);
+    collectionReport.also_known = collection.also_known
+      ? mapAlsoKnownIn(collection)
+      : undefined;
   }
 
   if (collection.biobank) {
@@ -365,9 +367,11 @@ export const mapNetworkInfo = (data) => {
 };
 
 export const mapAlsoKnownIn = (instance) => {
-  return instance.also_known.map((item) => {
-    return { value: item.url, type: "url", label: item.name_system };
-  });
+  return (
+    instance.also_known?.map((item) => {
+      return { value: item.url, type: "url", label: item.name_system };
+    }) || []
+  );
 };
 
 export const mapQualityStandards = (instance) => {


### PR DESCRIPTION
fixes: #3687

What are the main changes you did:
- The network overview link on the side cards prompts you to the network report instead of getting stuck on a loading spinner and throwing errors on the console. 

how to test:
- Click on a biobank
- Click on the network overview link
- The link prompts you to the network report 
