### PR TITLE
build: make e2e test wait until data loaded into ssr-catalogue

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,7 +143,7 @@ jobs:
     - run:
         name: Wait for preview to be up, poll every 10 seconds
         command: |
-          GETURL="https://preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}.dev.molgenis.org/"
+          GETURL="https://preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}.dev.molgenis.org/catalogue-demo/ssr-catalogue/testNetwork1"
           while true; 
               do 
                   STATUS=$(curl --silent --head $GETURL | awk '/^HTTP/{print $2}')
@@ -238,7 +238,7 @@ jobs:
           -X POST https://slack.com/api/chat.postMessage  
 
     - post_steps
-  e2e-preview:
+  e2e-test:
     docker:
       - image: mcr.microsoft.com/playwright:v1.43.0-jammy
     steps:
@@ -321,7 +321,7 @@ workflows:
         filters:
           branches:
             ignore: master
-    - e2e-preview:
+    - e2e-test:
         requires:
           - preview
         filters:


### PR DESCRIPTION
What are the main changes you did:
- e2e test failed because the data was not yet loaded
- fixed waiting until data is there

how to test:
- see that e2e test is not failing

