### PR TITLE
fix: state messages in directory app

### DIFF
--- a/apps/directory/src/stores/biobanksStore.js
+++ b/apps/directory/src/stores/biobanksStore.js
@@ -21,7 +21,7 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
 
   let facetBiobankColumnDetails = ref([]);
   let biobankCards = ref([]);
-  let waitingForResponse = ref(false);
+  let waitingForResponse = ref(true);
 
   let lastRequestTime = 0;
 


### PR DESCRIPTION
fixes: #3697

What are the main changes you did:
- Adjusted the waitingForResponse ref in the biobank store.

how to test:
- Select a filter in the directory app
- Copy the url with the filter parameter in a new tab
- Check that the directory app displays the biobanks matching the filter without displaying "Loading state" and "No biobanks found" messages upfront. 

