### PR TITLE
fix: 3630 fix header query builder

### DIFF
--- a/apps/nuxt3-ssr/composables/useHeaderData.ts
+++ b/apps/nuxt3-ssr/composables/useHeaderData.ts
@@ -87,8 +87,6 @@ export async function useHeaderData() {
     throw new Error(contextMsg);
   }
 
-  console.log("header data: ", data.value);
-
   const catalogue = data.value.data.Networks[0];
   const variableCount = data.value.data.Variables_agg.count || 0;
 

--- a/apps/nuxt3-ssr/composables/useHeaderData.ts
+++ b/apps/nuxt3-ssr/composables/useHeaderData.ts
@@ -24,43 +24,50 @@ const headerQuery = `
 export async function useHeaderData() {
   const route = useRoute();
 
-  // no need to do fetch if we are on the home page or on the all catalogues pages
-  if (!route.params.catalogue || route.params.catalogue == "all") {
-    return { catalogue: null, variableCount: 0 };
-  }
-
   const apiPath = `/${route.params.schema}/graphql`;
+
   const { data, error } = await useAsyncData<any, IMgError>(
     `catalogue-${route.params.catalogue}`,
     async () => {
-      const modelsResp = await $fetch<{
-        data: { Networks: { models: { id: string }[] }[] };
-      }>(apiPath, {
-        method,
-        body: {
-          query: modelQuery,
-          variables: {
-            networksFilter: { id: { equals: route.params.catalogue } },
+      let variables:
+        | {
+            networksFilter: { id: { equals: string | string[] } };
+            variablesFilter?: {
+              resource: { id: { equals: string | string[] } };
+            };
+          }
+        | undefined = undefined;
+      if (route.params.catalogue && route.params.catalogue !== "all") {
+        const modelsResp = await $fetch<{
+          data: { Networks: { models: { id: string }[] }[] };
+        }>(apiPath, {
+          method,
+          body: {
+            query: modelQuery,
+            variables: {
+              networksFilter: { id: { equals: route.params.catalogue } },
+            },
           },
-        },
-      }).catch((e) => {
-        console.log("models error: ", e);
-        return { e };
-      });
+        }).catch((e) => {
+          console.log("models error: ", e);
+          return { e };
+        });
 
-      if ("e" in modelsResp) {
-        const contextMsg = "Error on fetching page header data";
-        throw new Error(contextMsg);
-      }
+        if ("e" in modelsResp) {
+          const contextMsg = "Error on fetching page header data";
+          throw new Error(contextMsg);
+        }
 
-      const models = modelsResp.data.Networks[0].models;
-      const modelIds = models ? models.map((m) => m.id) : [];
-      let variables: {
-        networksFilter: { id: { equals: string | string[] } };
-        variablesFilter?: { resource: { id: { equals: string | string[] } } };
-      } = { networksFilter: { id: { equals: route.params.catalogue } } };
-      if (modelIds) {
-        variables.variablesFilter = { resource: { id: { equals: modelIds } } };
+        const models = modelsResp.data.Networks[0].models;
+        const modelIds = models ? models.map((m) => m.id) : [];
+        variables = {
+          networksFilter: { id: { equals: route.params.catalogue } },
+        };
+        if (modelIds) {
+          variables.variablesFilter = {
+            resource: { id: { equals: modelIds } },
+          };
+        }
       }
 
       return $fetch(apiPath, {
@@ -79,6 +86,8 @@ export async function useHeaderData() {
     logError(error.value, contextMsg);
     throw new Error(contextMsg);
   }
+
+  console.log("header data: ", data.value);
 
   const catalogue = data.value.data.Networks[0];
   const variableCount = data.value.data.Variables_agg.count || 0;

--- a/e2e/tests/catalogue/header-items.spec.ts
+++ b/e2e/tests/catalogue/header-items.spec.ts
@@ -1,0 +1,10 @@
+import { test, expect } from '@playwright/test';
+
+test.beforeEach(async ({ context, baseURL }) => {
+  await context.addCookies([{ name: 'mg_allow_analytics', value: 'false', domain: new URL(baseURL as string).hostname, path: '/'}])
+});
+
+test('should show variables in menu if there are variables', async ({ page }) => {
+  await page.goto('/catalogue-demo/ssr-catalogue/all');
+  await expect(page.getByRole('navigation')).toContainText('Variables');
+});


### PR DESCRIPTION
Closes #3630

What are the main changes you did:
- if not subcatalogue is selected still to the query, just skip the models part

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
