### PR TITLE
fix: directory app retrieving empty biobanks

### DIFF
--- a/apps/directory/src/stores/biobanksStore.js
+++ b/apps/directory/src/stores/biobanksStore.js
@@ -117,7 +117,14 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
 
       /* Update biobankCards only if the result is the most recent one*/
       if (requestTime === lastRequestTime) {
-        biobankCards.value = filterWithdrawn(biobankResult.Biobanks || []);
+        let biobanksWithCollections = biobankResult.Biobanks;
+        if (!biobanksWithCollections) biobanksWithCollections = [];
+        if (filtersStore.hasActiveFilters) {
+          biobanksWithCollections = biobanksWithCollections.filter(
+            (biobank) => biobank.collections?.length
+          );
+        }
+        biobankCards.value = filterWithdrawn(biobanksWithCollections);
         waitingForResponse.value = false;
         filtersStore.bookmarkWaitingForApplication = false;
       }


### PR DESCRIPTION
fixes: #3733

What are the main changes you did:
- fixed the async getBiobankCards() function

how to test:
- Go to 'https://directory-emx2-acc.molgenis.net/
- Click on 'Categories' filter
- Select "Cancer" and "Covid" under "match all" filtering
- Check the results of the application


