### PR TITLE
chore: set jit=off per request instead of global settings to prevent breaking servers

### DIFF
--- a/.docker/initdb.sql
+++ b/.docker/initdb.sql
@@ -1,5 +1,4 @@
 /* use this init script if you want to test EMX2 with non-molgenis user */
 CREATE DATABASE molgenis;
-ALTER DATABASE molgenis SET jit = 'off';
 CREATE USER molgenis WITH LOGIN NOSUPERUSER INHERIT CREATEROLE ENCRYPTED PASSWORD 'molgenis';
 GRANT ALL PRIVILEGES ON DATABASE molgenis TO molgenis;

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -147,17 +147,6 @@ public class SqlDatabase extends HasSettings<Database> implements Database {
             j.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto"); // for password hashing
           });
 
-      // NOSONAR
-      if (!jooq.fetch("SELECT setting FROM pg_settings WHERE name = 'jit';")
-          .get(0)
-          .get(0)
-          .equals("off")) {
-        String error =
-            "Postgresql JIT must be disabled to prevent massive performance issues. Please run 'SET jit = 'off' or set jit = 'off' in your postgresql file. See installation manual";
-        logger.error(error);
-        throw new MolgenisException(error);
-      }
-
       Migrations.initOrMigrate(this);
 
       if (!hasUser(ANONYMOUS)) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlUserAwareConnectionProvider.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlUserAwareConnectionProvider.java
@@ -26,11 +26,12 @@ public class SqlUserAwareConnectionProvider extends DataSourceConnectionProvider
       connection = super.acquire();
       if (getActiveUser().equals(ADMIN_USER)) {
         // as admin you are actually session user
-        DSL.using(connection, SQLDialect.POSTGRES).execute("RESET ROLE;");
+        DSL.using(connection, SQLDialect.POSTGRES).execute("RESET ROLE; SET jit='off';");
       } else {
         // as non admin you are a current user
         DSL.using(connection, SQLDialect.POSTGRES)
-            .execute("RESET ROLE; SET ROLE {0}", name(MG_USER_PREFIX + getActiveUser()));
+            .execute(
+                "RESET ROLE; SET jit='off'; SET ROLE {0}", name(MG_USER_PREFIX + getActiveUser()));
       }
       return connection;
     } catch (DataAccessException dae) {

--- a/docs/molgenis/run_java.md
+++ b/docs/molgenis/run_java.md
@@ -10,7 +10,6 @@ Steps:
 * Then in psql console paste
     ```console
     create database molgenis;
-    alter database molgenis SET jit = 'off'
     create user molgenis with login nosuperuser inherit createrole encrypted password 'molgenis';
     grant all privileges on database molgenis to molgenis;
     ```

--- a/helm-chart/templates/postgres-config.yml
+++ b/helm-chart/templates/postgres-config.yml
@@ -5,6 +5,5 @@ metadata:
 data:
   initdb.sql: |
     CREATE DATABASE {{ .Values.database.name }};
-    ALTER DATABASE {{ .Values.database.name }} SET jit = 'off';
     CREATE USER {{ .Values.database.username }}  WITH LOGIN NOSUPERUSER INHERIT CREATEROLE ENCRYPTED PASSWORD '{{ .Values.database.password }}';
     GRANT ALL PRIVILEGES ON DATABASE {{ .Values.database.name }} TO {{ .Values.database.username }};


### PR DESCRIPTION
What are the main changes you did:
- replace the manual jit=off by a per connection jit=off so we don't have added complexity for sysadmins

how to test:
- see if there are regressions for #3652 
- see if there are regressions for #3476

todo:
- [x] updated docs in case of new feature
