### PR TITLE
fix: updated css resets; changed footer element

### DIFF
--- a/apps/molgenis-viz/src/App.vue
+++ b/apps/molgenis-viz/src/App.vue
@@ -19,9 +19,11 @@
       </nav>
     </div>
     <RouterView :session="session" :page="page" />
-    <PageFooter>
-      <MolgenisLogo />
-    </PageFooter>
+    <template v-slot:footer>
+      <PageFooter>
+        <MolgenisLogo />
+      </PageFooter>
+    </template>
   </Molgenis>
 </template>
 

--- a/apps/molgenis-viz/src/components/layouts/PageFooter.vue
+++ b/apps/molgenis-viz/src/components/layouts/PageFooter.vue
@@ -1,9 +1,9 @@
 <template>
-  <footer class="page-footer">
+  <div class="page-footer">
     <!-- main footer content -->
     <slot></slot>
     <PageFooterMolgenisCitation />
-  </footer>
+  </div>
 </template>
 
 <script>

--- a/apps/molgenis-viz/src/styles/resets.scss
+++ b/apps/molgenis-viz/src/styles/resets.scss
@@ -6,7 +6,7 @@
 
     // reset padding & overwrite inline styles
     & > div {
-      div.container-fluid.p-3 {
+      main.container-fluid.p-3 {
         padding: 0 !important;
         padding-bottom: 0 !important;
       }

--- a/apps/molgenis-viz/src/styles/resets.scss
+++ b/apps/molgenis-viz/src/styles/resets.scss
@@ -13,8 +13,10 @@
     }
 
     // hide footer/citation
-    & > div.text-center {
-      display: none;
+    & > footer {
+      & div.text-center {
+        display: none;
+      }
     }
   }
 }


### PR DESCRIPTION
What are the main changes you did:

In PR #3683, the primary router view was changed to a `<main>` element and a primary `<footer>` element was added. This was important for other reasons listed in the PR. As a result, a few changes to molgenis-viz library is needed. These are -

- Update `resets.scss`: need to be make sure the css selector points to the main element
- Remove footer element generated by the `<PageFooter>` component.

how to test:
- navigate to the preview.
- in the pet store schema, navigate to any of the dashboard apps. (e.g., `pet store/gportal`, `pet store/cranio-public`, etc.)
- There should be: 1) no more left and right padding, 2) the custom footer should be displayed instead of the default molgenis one

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
