### PR TITLE
fix: proper handling of 'na' values

### DIFF
--- a/tools/pyclient/dev/demodata/Pet.csv
+++ b/tools/pyclient/dev/demodata/Pet.csv
@@ -1,2 +1,3 @@
 name,category,status,weight,tags
 Woofie,dog,available,6.8,"brown,canis"
+NA,ant,,23.6,"purple,insect"

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -91,11 +91,17 @@ async def main():
         ]
 
         new_pets = [{
-            'name': 'NA',
+            'name': 'Woofie',
             'category': 'dog',
-            'status': numpy.nan,
+            'status': 'available',
             'weight': 6.8,
             'tags': 'brown,canis'
+        }, {
+            'name': 'NA',
+            'category': 'ant',
+            'status': numpy.nan,
+            'weight': 23.6,
+            'tags': 'purple,insect'
         }]
 
         # Import new data
@@ -132,6 +138,12 @@ async def main():
             'status': 'available',
             'weight': 6.8,
             'tags': 'brown,canis'
+        }, {
+            'name': 'NA',
+            'category': 'ant',
+            'status': numpy.nan,
+            'weight': 23.6,
+            'tags': 'purple,insect'
         }])
 
         # Import new data

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -17,6 +17,7 @@ import asyncio
 import logging
 import os
 
+import numpy
 import pandas as pd
 from dotenv import load_dotenv
 
@@ -90,9 +91,9 @@ async def main():
         ]
 
         new_pets = [{
-            'name': 'Woofie',
+            'name': 'NA',
             'category': 'dog',
-            'status': 'available',
+            'status': numpy.nan,
             'weight': 6.8,
             'tags': 'brown,canis'
         }]

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -609,7 +609,7 @@ class Client:
             return utils.read_file(file_path=file_path)
 
         if data is not None:
-            if type(data) is pd.DataFrame:
+            if isinstance(data, pd.DataFrame):
                 return data.to_csv(index=False, quoting=csv.QUOTE_NONNUMERIC, encoding='UTF-8')
             else:
                 return pd.DataFrame(data, dtype=str).to_csv(index=False, quoting=csv.QUOTE_NONNUMERIC, encoding='UTF-8')

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -179,8 +179,10 @@ class Client:
             headers={'x-molgenis-token': self.token}
         )
 
+        if response.status_code == 503:
+            raise ServiceUnavailableError(f"Server with url {self.url!r} (temporarily) unavailable.")
         if response.status_code == 404:
-            raise ServerNotFoundError(f"Server with url {self.url!r}")
+            raise ServerNotFoundError(f"Server with url {self.url!r} not found.")
         if response.status_code == 400:
             if 'Invalid token or token expired' in response.text:
                 raise InvalidTokenException("Invalid token or token expired.")

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -132,12 +132,12 @@ class Client:
 
         status = response.json().get('data', {}).get('signout', {}).get('status')
         if status == 'SUCCESS':
-            print(f"User {self.username!r} is signed out of {self.url!r}.")
+            log.info(f"User {self.username!r} is signed out of {self.url!r}.")
             self.signin_status = 'signed out'
         else:
-            print(f"Unable to sign out of {self.url}.")
+            log.error(f"Unable to sign out of {self.url}.")
             message = response.json().get('errors')[0].get('message')
-            print(message)
+            log.error(message)
 
     @property
     def status(self):
@@ -535,7 +535,6 @@ class Client:
         except GraphQLException:
             message = f"Failed to recreate {current_schema!r}"
             log.error(message)
-            print(message)
 
         self.schemas = self.get_schemas()
 

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -323,8 +323,8 @@ class Client:
                                     headers={'x-molgenis-token': self.token})
 
         self._validate_graphql_response(response=response,
-                                        fallback_error_message=f"Failed to retrieve data from {current_schema}::{table!r}." \
-                                                               f"\nStatus code: {response.status_code}.")
+                                        fallback_error_message=f"Failed to retrieve data from {current_schema}::"
+                                                               f"{table!r}.\nStatus code: {response.status_code}.")
 
         response_data = pd.read_csv(io.BytesIO(response.content), keep_default_na=False)
 
@@ -426,7 +426,6 @@ class Client:
             headers={'x-molgenis-token': self.token}
         )
 
-        response_json = response.json()
         self._validate_graphql_response(
             response=response,
             mutation='createSchema',
@@ -456,7 +455,6 @@ class Client:
             headers={'x-molgenis-token': self.token}
         )
 
-        response_json = response.json()
         self._validate_graphql_response(
             response=response,
             mutation='deleteSchema',
@@ -488,7 +486,6 @@ class Client:
             headers={'x-molgenis-token': self.token}
         )
 
-        response_json = response.json()
         self._validate_graphql_response(
             response=response,
             mutation='updateSchema',
@@ -545,7 +542,7 @@ class Client:
         :param name: the name of the schema
         :type name: str
 
-        :returns: schema metadata
+        :returns: metadata of the schema
         :rtype: metadata.Schema
         """
         current_schema = name if name is not None else self.default_schema
@@ -635,6 +632,12 @@ class Client:
             if 'permission denied' in response.text:
                 raise PermissionDeniedException(f"Transaction failed: permission denied.")
             raise PyclientException("An unknown error occurred when trying to reach this server.")
+
+        if response.request.method == 'GET':
+            return
+
+        if response.status_code == 200:
+            return
 
         response_json = response.json()
         response_keys = response_json.keys()

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -6,6 +6,7 @@ from typing import TypeAlias, Literal
 
 import pandas as pd
 import requests
+from requests import Response
 
 from . import graphql_queries as queries
 from . import utils
@@ -100,16 +101,7 @@ class Client:
             url=self.api_graphql,
             json={'query': query, 'variables': variables}
         )
-
-        if response.status_code == 404:
-            raise ServerNotFoundError(f"Server {self.url!r} could not be found. "
-                                      f"Ensure the spelling of the url is correct.")
-        if response.status_code == 503:
-            raise ServiceUnavailableError(f"Server {self.url!r} not available. "
-                                          f"Try again later.")
-        if response.status_code != 200:
-            raise PyclientException(f"Server {self.url!r} could not be reached due to a connection problem."
-                                    f"\nStatus code: {response.status_code}. Reason: {response.reason!r}.")
+        self._validate_graphql_response(response, mutation='signin')
 
         response_json: dict = response.json().get('data', {}).get('signin', {})
 
@@ -117,7 +109,6 @@ class Client:
             self.signin_status = 'success'
             message = f"User {self.username!r} is signed in to {self.url!r}."
             log.info(message)
-            print(message)
         elif response_json.get('status') == 'FAILED':
             self.signin_status = 'failed'
             message = f"Error: Unable to sign in to {self.url} as {self.username}." \
@@ -179,15 +170,7 @@ class Client:
             headers={'x-molgenis-token': self.token}
         )
 
-        if response.status_code == 503:
-            raise ServiceUnavailableError(f"Server with url {self.url!r} (temporarily) unavailable.")
-        if response.status_code == 404:
-            raise ServerNotFoundError(f"Server with url {self.url!r} not found.")
-        if response.status_code == 400:
-            if 'Invalid token or token expired' in response.text:
-                raise InvalidTokenException("Invalid token or token expired.")
-            raise PyclientException("An unknown error occurred when trying to reach this server.")
-
+        self._validate_graphql_response(response)
         response_json: dict = response.json()
         schemas = [Schema(**s) for s in response_json['data']['_schemas']]
         return schemas
@@ -255,17 +238,11 @@ class Client:
             data=import_data
         )
 
-        if response.status_code == 200:
+        try:
+            self._validate_graphql_response(response)
             log.info("Imported data into %s::%s.", current_schema, table)
-        elif response.status_code == 400:
-            if 'permission denied' in response.text:
-                raise PermissionDeniedException(f"Transaction failed: permission denied for table {table}.")
+        except PyclientException:
             errors = '\n'.join([err['message'] for err in response.json().get('errors')])
-            # log.error(f"Failed to import data into {current_schema}::{table}\n{errors}.")
-            log.error("Failed to import data into %s::%s\n%s", current_schema, table, errors)
-        else:
-            errors = '\n'.join([err['message'] for err in response.json().get('errors')])
-            # log.error(f"Failed to import data into {current_schema}::{table}\n{errors}.")
             log.error("Failed to import data into %s::%s\n%s", current_schema, table, errors)
 
     def delete_records(self, table: str, schema: str = None, file: str = None, data: list | pd.DataFrame = None):
@@ -305,6 +282,9 @@ class Client:
             data=import_data
         )
 
+        self._validate_graphql_response(response, mutation='delete',
+                                        fallback_error_message=f"Failed to delete data from {current_schema}::{table}.")
+
         if response.status_code == 200:
             log.info("Deleted data from %s::%s.", current_schema, table)
         else:
@@ -342,11 +322,9 @@ class Client:
         response = self.session.get(url=f"{self.url}/{current_schema}/api/csv/{table_id}",
                                     headers={'x-molgenis-token': self.token})
 
-        if response.status_code != 200:
-            message = f"Failed to retrieve data from {current_schema}::{table!r}." \
-                      f"\nStatus code: {response.status_code}."
-            log.error(message)
-            raise PyclientException(message)
+        self._validate_graphql_response(response=response,
+                                        fallback_error_message=f"Failed to retrieve data from {current_schema}::{table!r}." \
+                                                               f"\nStatus code: {response.status_code}.")
 
         response_data = pd.read_csv(io.BytesIO(response.content), keep_default_na=False)
 
@@ -450,7 +428,7 @@ class Client:
 
         response_json = response.json()
         self._validate_graphql_response(
-            response_json=response_json,
+            response=response,
             mutation='createSchema',
             fallback_error_message=f"Failed to create schema {name!r}"
         )
@@ -480,7 +458,7 @@ class Client:
 
         response_json = response.json()
         self._validate_graphql_response(
-            response_json=response_json,
+            response=response,
             mutation='deleteSchema',
             fallback_error_message=f"Failed to delete schema {current_schema!r}"
         )
@@ -512,7 +490,7 @@ class Client:
 
         response_json = response.json()
         self._validate_graphql_response(
-            response_json=response_json,
+            response=response,
             mutation='updateSchema',
             fallback_error_message=f"Failed to update schema {current_schema!r}"
         )
@@ -634,25 +612,36 @@ class Client:
 
         return name
 
-    @staticmethod
-    def _validate_graphql_response(response_json: dict, mutation: str, fallback_error_message: str):
+    def _validate_graphql_response(self, response: Response, mutation: str = None, fallback_error_message: str = None):
         """Validates a GraphQL response and prints the appropriate message.
 
-        :param response_json: a graphql response from the server
-        :type response_json: dict
-        :param mutation: the name of the graphql mutation executed
+        :param response: a graphql response from the server
+        :type response: requests.Response
+        :param mutation: the name of the graphql mutation executed, optional
         :type mutation: str
-        :param fallback_error_message: a fallback error message
+        :param fallback_error_message: a fallback error message, optional
         :type fallback_error_message: str
 
         :returns: a success or error message
         :rtype: string
         """
+
+        if response.status_code == 503:
+            raise ServiceUnavailableError(f"Server with url {self.url!r} (temporarily) unavailable.")
+        if response.status_code == 404:
+            raise ServerNotFoundError(f"Server with url {self.url!r} not found.")
+        if response.status_code == 400:
+            if 'Invalid token or token expired' in response.text:
+                raise InvalidTokenException("Invalid token or token expired.")
+            if 'permission denied' in response.text:
+                raise PermissionDeniedException(f"Transaction failed: permission denied.")
+            raise PyclientException("An unknown error occurred when trying to reach this server.")
+
+        response_json = response.json()
         response_keys = response_json.keys()
         if 'errors' not in response_keys and 'data' not in response_keys:
             message = fallback_error_message
             log.error(message)
-            print(message)
 
         elif 'errors' in response_keys:
             message = response_json.get('errors')[0].get('message')
@@ -665,15 +654,13 @@ class Client:
             log.error(message)
             raise GraphQLException(message)
 
-        else:
+        elif mutation is not None:
             if response_json.get('data').get(mutation).get('status') == 'SUCCESS':
                 message = response_json.get('data').get(mutation).get('message')
                 log.info(message)
-                print(message)
             else:
-                message = f"Failed to validate response for {mutation}"
+                message = f"Failed to validate response for {mutation!r}"
                 log.error(message)
-                print(message)
 
     @staticmethod
     def _format_optional_params(**kwargs):

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -346,7 +346,7 @@ class Client:
             log.error(message)
             raise PyclientException(message)
 
-        response_data = pd.read_csv(io.BytesIO(response.content))
+        response_data = pd.read_csv(io.BytesIO(response.content), keep_default_na=False)
 
         if not as_df:
             return response_data.to_dict('records')
@@ -610,7 +610,7 @@ class Client:
             if type(data) is pd.DataFrame:
                 return data.to_csv(index=False, quoting=csv.QUOTE_NONNUMERIC, encoding='UTF-8')
             else:
-                return pd.DataFrame(data).to_csv(index=False, quoting=csv.QUOTE_NONNUMERIC, encoding='UTF-8')
+                return pd.DataFrame(data, dtype=str).to_csv(index=False, quoting=csv.QUOTE_NONNUMERIC, encoding='UTF-8')
 
         message = "No data to import. Specify a file location or a dataset."
         log.error(message)

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -129,6 +129,7 @@ class Client:
             url=self.api_graphql,
             json={'query': queries.signout()}
         )
+        self._validate_graphql_response(response)
 
         status = response.json().get('data', {}).get('signout', {}).get('status')
         if status == 'SUCCESS':
@@ -169,8 +170,8 @@ class Client:
             json={'query': query},
             headers={'x-molgenis-token': self.token}
         )
-
         self._validate_graphql_response(response)
+
         response_json: dict = response.json()
         schemas = [Schema(**s) for s in response_json['data']['_schemas']]
         return schemas
@@ -199,6 +200,7 @@ class Client:
             url=self.api_graphql,
             json={'query': query}
         )
+        self._validate_graphql_response(response)
         return response.json().get('data').get('_manifest').get('SpecificationVersion')
 
     def save_schema(self, table: str, name: str = None, file: str = None, data: list | pd.DataFrame = None):
@@ -358,6 +360,7 @@ class Client:
                 url = f"{self.url}/{current_schema}/api/excel"
                 response = self.session.get(url=url,
                                             headers={'x-molgenis-token': self.token})
+                self._validate_graphql_response(response)
 
                 filename = f"{current_schema}.xlsx"
                 with open(filename, "wb") as file:
@@ -369,6 +372,7 @@ class Client:
                 url = f"{self.url}/{current_schema}/api/excel/{table_id}"
                 response = self.session.get(url=url,
                                             headers={'x-molgenis-token': self.token})
+                self._validate_graphql_response(response)
 
                 filename = f"{table}.xlsx"
                 with open(filename, "wb") as file:
@@ -380,6 +384,7 @@ class Client:
                 url = f"{self.url}/{current_schema}/api/zip"
                 response = self.session.get(url=url,
                                             headers={'x-molgenis-token': self.token})
+                self._validate_graphql_response(response)
 
                 filename = f"{current_schema}.zip"
                 with open(filename, "wb") as file:
@@ -391,6 +396,7 @@ class Client:
                 url = f"{self.url}/{current_schema}/api/csv/{table_id}"
                 response = self.session.get(url=url,
                                             headers={'x-molgenis-token': self.token})
+                self._validate_graphql_response(response)
 
                 filename = f"{table}.csv"
                 with open(filename, "wb") as file:
@@ -555,6 +561,7 @@ class Client:
             json={'query': query},
             headers={'x-molgenis-token': self.token}
         )
+        self._validate_graphql_response(response)
 
         response_json = response.json()
 


### PR DESCRIPTION
What are the main changes you did:
- changed the way `pandas` handles 'na' values when creating a DataFrame from either a csv or list/dict data
- the values 'NA', 'na', 'Na' are now processed as they are
- actual _not available_ values are stored as empty strings
- float and int values are not affected
- additionally, the handling of errors in request responses is improved by including more checks in the `_validate_graphql_response` method

how to test:
- the dev script now includes an extra pet that is saved (and deleted) in a schema in the `save_schema` tests, named 'NA' with status `numpy.nan`. You can verify that the name is stored as 'NA', and the status is left empty 

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
