### PR TITLE
fix: removed bottom margin in breadcrumbs

### DIFF
--- a/apps/molgenis-components/public/theme.css
+++ b/apps/molgenis-components/public/theme.css
@@ -3494,7 +3494,7 @@ input.btn-block[type="button"] {
   display: flex;
   flex-wrap: wrap;
   padding: 0.75rem 1rem;
-  margin-bottom: 1rem;
+  margin-bottom: 0;
   list-style: none;
   background-color: #e9ecef;
   border-radius: 0.25rem; }

--- a/backend/molgenis-emx2-webapi/src/main/resources/theme/bootstrap46/_breadcrumb.scss
+++ b/backend/molgenis-emx2-webapi/src/main/resources/theme/bootstrap46/_breadcrumb.scss
@@ -2,7 +2,6 @@
   display: flex;
   flex-wrap: wrap;
   padding: $breadcrumb-padding-y $breadcrumb-padding-x;
-  margin-bottom: $breadcrumb-margin-bottom;
   @include font-size($breadcrumb-font-size);
   list-style: none;
   background-color: $breadcrumb-bg;

--- a/backend/molgenis-emx2-webapi/src/main/resources/theme/bootstrap46/_breadcrumb.scss
+++ b/backend/molgenis-emx2-webapi/src/main/resources/theme/bootstrap46/_breadcrumb.scss
@@ -2,6 +2,7 @@
   display: flex;
   flex-wrap: wrap;
   padding: $breadcrumb-padding-y $breadcrumb-padding-x;
+  margin: 0;
   @include font-size($breadcrumb-font-size);
   list-style: none;
   background-color: $breadcrumb-bg;


### PR DESCRIPTION
What are the main changes you did:

There is always a white space between breadcrumbs and the main content (router-view)

<img width="792" alt="Screenshot 2024-05-14 at 15 05 57" src="https://github.com/molgenis/molgenis-emx2/assets/13485722/e972d944-413a-4f6d-bb5b-c5db82cac452">

This PR removes the bottom margin so that the main content sits directly below the breadcrumbs.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
