### PR TITLE
fix: 3592 Catalogue List page layout gets shifted on macbook screen

### DIFF
--- a/apps/nuxt3-ssr/components/layouts/SearchPage.vue
+++ b/apps/nuxt3-ssr/components/layouts/SearchPage.vue
@@ -18,7 +18,7 @@ const variableCount = headerData.variableCount;
       <aside class="xl:min-w-95 xl:w-95 hidden xl:block">
         <slot name="side"></slot>
       </aside>
-      <div class="xl:pl-7.5 xl:max-w-[54rem] 2xl:grow 2xl:max-w-none">
+      <div class="xl:pl-7.5 xl:grow">
         <slot name="main"></slot>
       </div>
     </div>


### PR DESCRIPTION
Closes #3592

What are the main changes you did:
- remove max width 

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
