### PR TITLE
fix: don't break when no biobanks are found

### DIFF
--- a/apps/directory/src/stores/biobanksStore.js
+++ b/apps/directory/src/stores/biobanksStore.js
@@ -41,8 +41,10 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
   );
 
   const biobankCardsBiobankCount = computed(() => {
-    return biobankCards.value.filter((biobankCard) => !biobankCard.withdrawn)
-      .length;
+    return (
+      biobankCards.value?.filter((biobankCard) => !biobankCard.withdrawn)
+        .length || 0
+    );
   });
 
   const biobankCardsSubcollectionCount = computed(() => {
@@ -222,7 +224,7 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
 });
 
 function filterWithdrawn(biobanks) {
-  let filteredBanks = biobanks.filter((biobank) => !biobank.withdrawn);
+  let filteredBanks = biobanks?.filter((biobank) => !biobank.withdrawn) || [];
   filteredBanks.forEach((biobank) => {
     biobank.collections = biobank.collections?.filter(
       (collection) => !collection.withdrawn

--- a/apps/directory/vite.config.js
+++ b/apps/directory/vite.config.js
@@ -5,9 +5,8 @@ import { createHtmlPlugin } from "vite-plugin-html";
 import monacoEditorPlugin from "vite-plugin-monaco-editor";
 
 const HOST =
-  process.env.MOLGENIS_APPS_HOST ||
-  "https://preview-emx2-pr-3694.dev.molgenis.org";
-const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "directory-demo";
+  process.env.MOLGENIS_APPS_HOST || "https://bbmri-emx2-test.molgeniscloud.org";
+const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "ERIC";
 
 const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
 

--- a/apps/directory/vite.config.js
+++ b/apps/directory/vite.config.js
@@ -5,8 +5,9 @@ import { createHtmlPlugin } from "vite-plugin-html";
 import monacoEditorPlugin from "vite-plugin-monaco-editor";
 
 const HOST =
-  process.env.MOLGENIS_APPS_HOST || "https://bbmri-emx2-test.molgeniscloud.org";
-const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "ERIC";
+  process.env.MOLGENIS_APPS_HOST ||
+  "https://preview-emx2-pr-3694.dev.molgenis.org";
+const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "directory-demo";
 
 const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
 


### PR DESCRIPTION
What are the main changes you did:
- fixed the directory app breaking when no biobanks where found

how to test:
- go to the directory-demo
- select Biobanks Services filter
- select the first option
- On master this break, on the preview it no longer does.