### PR TITLE
fix: quickfix filter undefined error

### DIFF
--- a/apps/directory/src/stores/biobanksStore.js
+++ b/apps/directory/src/stores/biobanksStore.js
@@ -124,7 +124,7 @@ export const useBiobanksStore = defineStore("biobanksStore", () => {
           filtersStore.hasActiveFilters &&
           !filtersStore.hasActiveBiobankOnlyFilters
         ) {
-          foundBiobanks = foundBiobanks.filter(
+          foundBiobanks = foundBiobanks?.filter(
             (biobank) => biobank.collections
           );
         }


### PR DESCRIPTION
fixes: #3782

What are the main changes you did:
- filtering certain filters fail if there are no results

how to test:
- Filter on directory demo set on "Australia" 
- We will now not have a error show.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
