### PR TITLE
fix: 3605 sort repeats by name ( bestEffort)

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/[variable].vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/[variable].vue
@@ -25,9 +25,30 @@ const { data, pending, error, refresh } = await useFetch(
   }
 );
 
-const variable = computed(
-  () => data.value.data.Variables[0] as VariableDetailsWithMapping
-);
+const endsWithNumbers = new RegExp("\\d+$");
+
+function bestEffortNameSort(a: IVariable, b: IVariable) {
+  if (endsWithNumbers.exec(a.name) && endsWithNumbers.exec(a.name)) {
+    const aName = a.name.replace(endsWithNumbers, "");
+    const bName = b.name.replace(endsWithNumbers, "");
+    if (aName === bName) {
+      return (
+        parseInt(a.name.match(endsWithNumbers)![0]) -
+        parseInt(b.name.match(endsWithNumbers)![0])
+      );
+    }
+    return aName.localeCompare(bName);
+  }
+  return a.name.localeCompare(b.name);
+}
+
+const variable = computed(() => {
+  const variable = data.value.data.Variables[0] as VariableDetailsWithMapping;
+  if (variable.repeats) {
+    variable.repeats.sort(bestEffortNameSort);
+  }
+  return variable;
+});
 const nRepeats = computed(() => data.value.data.RepeatedVariables_agg.count);
 const cohorts = computed(() => data.value.data.Cohorts as { id: string }[]);
 const isRepeating = computed(() => variable.value.repeats);


### PR DESCRIPTION
Closes #3605

What are the main changes you did:
- sort variable repeats based on name , if the variable name end with a number sort the number part separately ( i.e. var_2 should come before var_10) 

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
