### PR TITLE
build: block release until other releases are completed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ parameters:
 
 orbs:
   slack: circleci/slack@4.4.4
+  queue: eddiewebb/queue@volatile
 
 definitions:
   build_config: &build_config
@@ -193,6 +194,12 @@ jobs:
     <<: *release_config
 
     steps:
+    - queue/until_front_of_line:
+        name: wait until any other release jobs are completed
+        limit-branch-name: main
+        max-wait-time: '10'
+        my-pipeline: <<pipeline.number>>
+        
     - pre_steps
     
     - run:


### PR DESCRIPTION
using the circleci queue orb

to test we need two quick merges to master.
Then you should see the last one wait until first is complete
