### PR TITLE
fix: footer version URL

### DIFF
--- a/apps/molgenis-components/src/components/layout/Molgenis.vue
+++ b/apps/molgenis-components/src/components/layout/Molgenis.vue
@@ -35,7 +35,7 @@
           Software version:
           <a
             :href="
-              'https://github.com/molgenis/molgenis-emx2/releases/tag/v' +
+              'https://github.com/molgenis/molgenis-emx2/releases/tag/' +
               session.manifest.SpecificationVersion
             "
           >


### PR DESCRIPTION
What are the main changes you did:
- Removed the extra prefixed `v` for the version URL going to github (as version already contains the `v` this turned into https://github.com/molgenis/molgenis-emx2/releases/tag/vv10.73.0 which should have been https://github.com/molgenis/molgenis-emx2/releases/tag/v10.73.0)

how to test:
- Check if Github tag URL contains exactly 1 `v` in the version

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
