### PR TITLE
feat: Add custom numeric collation

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
@@ -21,7 +21,7 @@ import org.slf4j.LoggerFactory;
 
 public class Migrations {
   // version the current software needs to work
-  private static final int SOFTWARE_DATABASE_VERSION = 18;
+  private static final int SOFTWARE_DATABASE_VERSION = 19;
   public static final int THREE_MINUTES = 180;
   private static Logger logger = LoggerFactory.getLogger(Migrations.class);
 
@@ -113,6 +113,10 @@ public class Migrations {
           if (version < 18) {
             executeMigrationFile(
                 tdb, "migration18.sql", "add filename to tables contain FILE datatype");
+          }
+
+          if (version < 19) {
+            executeMigrationFile(tdb, "migration19.sql", "add numeric collation");
           }
 
           // if success, update version to SOFTWARE_DATABASE_VERSION

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQueryBuilderHelpers.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQueryBuilderHelpers.java
@@ -56,7 +56,8 @@ class SqlQueryBuilderHelpers {
       Column column, Order order, SelectConnectByStep<org.jooq.Record> query) {
     final Field<?> field =
         isCaseSensitiveField(column) ? lower(column.getJooqField()) : column.getJooqField();
-    final SortField<?> sortField = ASC.equals(order) ? field.asc() : field.desc();
+    var collatedField = field.collate("numeric");
+    final SortField<?> sortField = ASC.equals(order) ? collatedField.asc() : collatedField.desc();
     return (SelectJoinStep<org.jooq.Record>) query.orderBy(sortField);
   }
 

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQueryBuilderHelpers.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQueryBuilderHelpers.java
@@ -15,6 +15,7 @@ import org.jooq.Record;
 import org.jooq.SelectConnectByStep;
 import org.jooq.SelectJoinStep;
 import org.jooq.SortField;
+import org.jooq.impl.DSL;
 import org.molgenis.emx2.Column;
 import org.molgenis.emx2.ColumnType;
 import org.molgenis.emx2.MolgenisException;
@@ -56,7 +57,10 @@ class SqlQueryBuilderHelpers {
       Column column, Order order, SelectConnectByStep<org.jooq.Record> query) {
     final Field<?> field =
         isCaseSensitiveField(column) ? lower(column.getJooqField()) : column.getJooqField();
-    var collatedField = column.getColumnType().isStringyType() ? field.collate("numeric") : field;
+    var collatedField =
+        column.getColumnType().isStringyType()
+            ? field.collate(DSL.unquotedName("\"MOLGENIS\".numeric"))
+            : field;
     final SortField<?> sortField = ASC.equals(order) ? collatedField.asc() : collatedField.desc();
     return (SelectJoinStep<org.jooq.Record>) query.orderBy(sortField);
   }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQueryBuilderHelpers.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQueryBuilderHelpers.java
@@ -56,7 +56,7 @@ class SqlQueryBuilderHelpers {
       Column column, Order order, SelectConnectByStep<org.jooq.Record> query) {
     final Field<?> field =
         isCaseSensitiveField(column) ? lower(column.getJooqField()) : column.getJooqField();
-    var collatedField = field.collate("numeric");
+    var collatedField = column.getColumnType().isStringyType() ? field.collate("numeric") : field;
     final SortField<?> sortField = ASC.equals(order) ? collatedField.asc() : collatedField.desc();
     return (SelectJoinStep<org.jooq.Record>) query.orderBy(sortField);
   }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
@@ -224,6 +224,8 @@ class SqlSchemaMetadataExecutor {
       Collections.reverse(tables);
       tables.forEach(table -> executeDropTable(db.getJooq(), table.getMetadata()));
 
+      db.getJooq().execute("DROP COLLATION IF EXISTS {0}.numeric;", name(schemaName));
+
       // drop schema
       db.getJooq().dropSchema(name(schemaName)).execute();
 

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
@@ -71,12 +71,6 @@ class SqlSchemaMetadataExecutor {
         .execute("GRANT USAGE ON SCHEMA {0} TO {1}", name(schema.getName()), name(aggregator));
     db.getJooq().execute("GRANT ALL ON SCHEMA {0} TO {1}", name(schema.getName()), name(manager));
 
-    // add collation
-    db.getJooq()
-        .execute(
-            "CREATE COLLATION IF NOT EXISTS {0}.numeric (provider = icu, locale = 'en-u-kn-true');",
-            name(schema.getName()));
-
     MetadataUtils.saveSchemaMetadata(db.getJooq(), schema);
   }
 
@@ -223,8 +217,6 @@ class SqlSchemaMetadataExecutor {
       List<Table> tables = db.getSchema(schemaName).getTablesSorted();
       Collections.reverse(tables);
       tables.forEach(table -> executeDropTable(db.getJooq(), table.getMetadata()));
-
-      db.getJooq().execute("DROP COLLATION IF EXISTS {0}.numeric;", name(schemaName));
 
       // drop schema
       db.getJooq().dropSchema(name(schemaName)).execute();

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
@@ -71,6 +71,12 @@ class SqlSchemaMetadataExecutor {
         .execute("GRANT USAGE ON SCHEMA {0} TO {1}", name(schema.getName()), name(aggregator));
     db.getJooq().execute("GRANT ALL ON SCHEMA {0} TO {1}", name(schema.getName()), name(manager));
 
+    // add collation
+    db.getJooq()
+        .execute(
+            "CREATE COLLATION IF NOT EXISTS {0}.numeric (provider = icu, locale = 'en-u-kn-true');",
+            name(schema.getName()));
+
     MetadataUtils.saveSchemaMetadata(db.getJooq(), schema);
   }
 

--- a/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/migration19.sql
+++ b/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/migration19.sql
@@ -1,0 +1,16 @@
+DO $$
+    DECLARE
+        schema_name text;
+    BEGIN
+        -- Loop through each schema in the current database
+        FOR schema_name IN
+            SELECT s.table_schema
+            FROM "MOLGENIS".schema_metadata s
+            LOOP
+                -- Execute the CREATE COLLATION statement for each schema
+                EXECUTE format(
+                        'CREATE COLLATION IF NOT EXISTS %I.numeric (provider = icu, locale = ''en-u-kn-true'');',
+                        schema_name
+                        );
+            END LOOP;
+    END $$;

--- a/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/migration19.sql
+++ b/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/migration19.sql
@@ -1,16 +1,1 @@
-DO $$
-    DECLARE
-        schema_name text;
-    BEGIN
-        -- Loop through each schema in the current database
-        FOR schema_name IN
-            SELECT s.table_schema
-            FROM "MOLGENIS".schema_metadata s
-            LOOP
-                -- Execute the CREATE COLLATION statement for each schema
-                EXECUTE format(
-                        'CREATE COLLATION IF NOT EXISTS %I.numeric (provider = icu, locale = ''en-u-kn-true'');',
-                        schema_name
-                        );
-            END LOOP;
-    END $$;
+CREATE COLLATION IF NOT EXISTS "MOLGENIS".numeric (provider = icu, locale = 'en-u-kn-true');

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/SqlQueryBuilderHelpersTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/SqlQueryBuilderHelpersTest.java
@@ -81,7 +81,7 @@ class SqlQueryBuilderHelpersTest {
     SelectConnectByStep<Record> ascQuery =
         SqlQueryBuilderHelpers.orderBy(tableMetadata, select, from);
     assertEquals(
-        "select * from \"SqlQueryBuilderHelpersTest\".\"testTable\" order by lower(\"testColumn\") asc",
+        "select * from \"SqlQueryBuilderHelpersTest\".\"testTable\" order by ((lower(\"testColumn\")) collate \"MOLGENIS\".numeric) asc",
         ascQuery.getSQL());
   }
 
@@ -113,7 +113,7 @@ class SqlQueryBuilderHelpersTest {
     SelectConnectByStep<Record> ascQuery =
         SqlQueryBuilderHelpers.orderBy(tableMetadata, select, from);
     assertEquals(
-        "select * from \"SqlQueryBuilderHelpersTest\".\"testTable\" order by lower(\"testColumn\") desc",
+        "select * from \"SqlQueryBuilderHelpersTest\".\"testTable\" order by ((lower(\"testColumn\")) collate \"MOLGENIS\".numeric) desc",
         ascQuery.getSQL());
   }
 
@@ -130,7 +130,7 @@ class SqlQueryBuilderHelpersTest {
         SqlQueryBuilderHelpers.orderBy(
             tableMetadata, select, jooq.select().from(tableMetadata.getJooqTable()));
     assertEquals(
-        "select * from \"SqlQueryBuilderHelpersTest\".\"testTable\" order by lower(\"refColumn\") asc",
+        "select * from \"SqlQueryBuilderHelpersTest\".\"testTable\" order by ((lower(\"refColumn\")) collate \"MOLGENIS\".numeric) asc",
         ascQuery.getSQL());
 
     final SelectColumn selectDesc = new SelectColumn("refColumn");
@@ -139,7 +139,7 @@ class SqlQueryBuilderHelpersTest {
         SqlQueryBuilderHelpers.orderBy(
             tableMetadata, selectDesc, jooq.select().from(tableMetadata.getJooqTable()));
     assertEquals(
-        "select * from \"SqlQueryBuilderHelpersTest\".\"testTable\" order by lower(\"refColumn\") desc",
+        "select * from \"SqlQueryBuilderHelpersTest\".\"testTable\" order by ((lower(\"refColumn\")) collate \"MOLGENIS\".numeric) desc",
         descQuery.getSQL());
   }
 

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestOrderByWithCollation.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestOrderByWithCollation.java
@@ -1,0 +1,47 @@
+package org.molgenis.emx2.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.molgenis.emx2.Column.column;
+import static org.molgenis.emx2.ColumnType.*;
+import static org.molgenis.emx2.SelectColumn.s;
+import static org.molgenis.emx2.TableMetadata.table;
+
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.*;
+
+public class TestOrderByWithCollation {
+  static Database database;
+  static Schema schema;
+  static final String VARS = "VARS";
+
+  @BeforeAll
+  public static void setUp() {
+    database = TestDatabaseFactory.getTestDatabase();
+
+    // createColumn a schema to test with
+    schema = database.dropCreateSchema("TestOrderByWithCollation");
+
+    // createColumn some tables with contents
+    Table vars = schema.create(table(VARS).add(column("NAME").setType(STRING).setPkey()));
+
+    Row var13 = new Row().setString("NAME", "var_13");
+    Row var1 = new Row().setString("NAME", "var_1");
+    Row var10 = new Row().setString("NAME", "var_10");
+    Row var3 = new Row().setString("NAME", "var_3");
+
+    vars.insert(var13, var1, var10, var3);
+  }
+
+  @Test
+  void orderByCollatedColumn() {
+
+    final String result =
+        schema.getTable(VARS).select(s("NAME")).orderBy("NAME", Order.ASC).retrieveRows().stream()
+            .map(r -> r.getString("NAME"))
+            .collect(Collectors.joining(", "));
+
+    assertEquals("var_1, var_3, var_10, var_13", result);
+  }
+}

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/ColumnType.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/ColumnType.java
@@ -155,4 +155,11 @@ public enum ColumnType {
   public boolean isAtomicType() {
     return !isFile() && !isReference() && !isHeading();
   }
+
+  public boolean isStringyType() {
+    return STRING.equals(getBaseType())
+        || STRING_ARRAY.equals(getBaseType())
+        || TEXT.equals(getBaseType())
+        || TEXT_ARRAY.equals(getBaseType());
+  }
 }


### PR DESCRIPTION
What are the main changes you did:
- Add new 'numeric' collation to molgenis schema, via migration 19 
-  Use numeric collation on orderby, this ensures 'var_2' comes before 'var_13'

how to test:
- Create a column ( add rows unsorted), containing string items that are a combination of alphabetical chars and numbers ( for example var_13, var_3 ), fetch this field and sort by the col containing the described string; 'var_3' should now come before 'var_13'

todo:
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
