### PR TITLE
fix: allow charts to query data in other schemas

### DIFF
--- a/apps/molgenis-viz/lib/main.js
+++ b/apps/molgenis-viz/lib/main.js
@@ -30,16 +30,23 @@ import PageSection from "../src/components/layouts/PageSection.vue";
 
 // visualisations
 import BarChart from "../src/components/viz/BarChart.vue";
+import BarChartEmx from "../src/components/viz/BarChartEmx.vue"
 import ChartLegend from "../src/components/viz/ChartLegend.vue";
 import ColumnChart from "../src/components/viz/ColumnChart.vue";
+import ColumnChartEmx from "../src/components/viz/ColumnChartEmx.vue";
 import DataTable from "../src/components/viz/DataTable.vue";
+import DataTableEmx from "../src/components/viz/DataTableEmx.vue";
 import DataValueHighlights from "../src/components/viz/DataHighlights.vue";
 import GeoMercator from "../src/components/viz/GeoMercator.vue";
+import GeoMercatorEmx from "../src/components/viz/GeoMercatorEmx.vue";
 import GroupedColumnChart from "../src/components/viz/GroupedColumnChart.vue";
+import GroupedColumnChartEmx from "../src/components/viz/GroupedColumnChartEmx.vue";
 import PieChart from "../src/components/viz/PieChart.vue";
 import PieChart2 from "../src/components/viz/PieChart2.vue";
+import PieChart2Emx from "../src/components/viz/PieChart2Emx.vue";
 import ProgressMeter from "../src/components/viz/ProgressMeter.vue";
 import ScatterPlot from "../src/components/viz/ScatterPlot.vue";
+import ScatterPlotEmx from "../src/components/viz/ScatterPlotEmx.vue";
 
 // data
 import WorldGeoJson from "../src/data/world.geo.json";
@@ -82,16 +89,23 @@ export {
 
   // visualisations
   BarChart,
+  BarChartEmx,
   ChartLegend,
   ColumnChart,
+  ColumnChartEmx,
   DataTable,
+  DataTableEmx,
   DataValueHighlights,
   GeoMercator,
+  GeoMercatorEmx,
   GroupedColumnChart,
+  GroupedColumnChartEmx,
   PieChart,
   PieChart2,
+  PieChart2Emx,
   ProgressMeter,
   ScatterPlot,
+  ScatterPlotEmx,
 
   // datasets
   WorldGeoJson,

--- a/apps/molgenis-viz/src/components/viz/BarChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/BarChartEmx.vue
@@ -35,6 +35,8 @@ import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 import type { BarChartParams } from "../../interfaces/viz.ts";
+
+import { setGraphQlEndpoint } from "../../utils";
 import {
   buildQuery,
   gqlExtractSelectionName,
@@ -51,10 +53,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = computed<string>(() => {
-  const root: string = props.schema ? `/${props.schema}` : "..";
-  return `${root}/api/graphql`;
-});
+const graphqlEndpoint = ref<string|null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -68,6 +67,8 @@ const xSubSelection = ref<string | null>(null);
 const ySubSelection = ref<string | null>(null);
 
 function setChartVariables() {
+  graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
+  
   xVar.value = gqlExtractSelectionName(props.xvar);
   yVar.value = gqlExtractSelectionName(props.yvar);
   xSubSelection.value = gqlExtractSubSelectionNames(props.xvar);
@@ -108,7 +109,6 @@ function onClick(data: object): object | null {
 }
 
 onBeforeMount(() => setChartVariables());
-
 watch(props, () => setChartVariables());
 
 watch([chartDataQuery, xSubSelection, ySubSelection], async () => {

--- a/apps/molgenis-viz/src/components/viz/BarChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/BarChartEmx.vue
@@ -53,7 +53,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = ref<string|null>(null);
+const graphqlEndpoint = ref<string | null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -68,7 +68,7 @@ const ySubSelection = ref<string | null>(null);
 
 function setChartVariables() {
   graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
-  
+
   xVar.value = gqlExtractSelectionName(props.xvar);
   yVar.value = gqlExtractSelectionName(props.yvar);
   xSubSelection.value = gqlExtractSubSelectionNames(props.xvar);

--- a/apps/molgenis-viz/src/components/viz/BarChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/BarChartEmx.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeMount, watch } from "vue";
+import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 import type { BarChartParams } from "../../interfaces/viz.ts";
@@ -50,6 +50,11 @@ const props = defineProps<BarChartParams>();
 const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
+
+const graphqlEndpoint = computed<string>(() => {
+  const root: string = props.schema ? `/${props.schema}` : "..";
+  return `${root}/api/graphql`;
+});
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -79,7 +84,7 @@ async function fetchChartData() {
   chartError.value = null;
 
   try {
-    const response = await request("../api/graphql", chartDataQuery.value);
+    const response = await request(graphqlEndpoint.value, chartDataQuery.value);
     const data = await response[props.table as string];
     chartData.value = await prepareChartData({
       data: data,

--- a/apps/molgenis-viz/src/components/viz/ColumnChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/ColumnChartEmx.vue
@@ -35,6 +35,8 @@ import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 import type { ColumnChartParams } from "../../interfaces/viz.ts";
+
+import { setGraphQlEndpoint } from "../../utils";
 import {
   buildQuery,
   gqlExtractSelectionName,
@@ -51,10 +53,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = computed<string>(() => {
-  const root: string = props.schema ? `/${props.schema}` : "..";
-  return `${root}/api/graphql`;
-});
+const graphqlEndpoint = ref<string|null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -68,6 +67,8 @@ const xSubSelection = ref<string | null>(null);
 const ySubSelection = ref<string | null>(null);
 
 function setChartVariables() {
+  graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
+  
   xVar.value = gqlExtractSelectionName(props.xvar);
   yVar.value = gqlExtractSelectionName(props.yvar);
   xSubSelection.value = gqlExtractSubSelectionNames(props.xvar);

--- a/apps/molgenis-viz/src/components/viz/ColumnChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/ColumnChartEmx.vue
@@ -53,7 +53,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = ref<string|null>(null);
+const graphqlEndpoint = ref<string | null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -68,7 +68,7 @@ const ySubSelection = ref<string | null>(null);
 
 function setChartVariables() {
   graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
-  
+
   xVar.value = gqlExtractSelectionName(props.xvar);
   yVar.value = gqlExtractSelectionName(props.yvar);
   xSubSelection.value = gqlExtractSubSelectionNames(props.xvar);

--- a/apps/molgenis-viz/src/components/viz/ColumnChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/ColumnChartEmx.vue
@@ -31,7 +31,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeMount, watch } from "vue";
+import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 import type { ColumnChartParams } from "../../interfaces/viz.ts";
@@ -50,6 +50,11 @@ const props = defineProps<ColumnChartParams>();
 const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
+
+const graphqlEndpoint = computed<string>(() => {
+  const root: string = props.schema ? `/${props.schema}` : "..";
+  return `${root}/api/graphql`;
+});
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -79,7 +84,7 @@ async function fetchChartData() {
   chartError.value = null;
 
   try {
-    const response = await request("../api/graphql", chartDataQuery.value);
+    const response = await request(graphqlEndpoint.value, chartDataQuery.value);
     const data = await response[props.table as string];
     chartData.value = await prepareChartData({
       data: data,

--- a/apps/molgenis-viz/src/components/viz/DataTableEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/DataTableEmx.vue
@@ -16,7 +16,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeMount, watch } from "vue";
+import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
@@ -43,6 +43,11 @@ const props = withDefaults(defineProps<DataTableParams>(), {
 const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
+
+const graphqlEndpoint = computed<string>(() => {
+  const root: string = props.schema ? `/${props.schema}` : "..";
+  return `${root}/api/graphql`;
+});
 
 const tableLoading = ref<boolean>(true);
 const tableSuccess = ref<boolean>(false);
@@ -78,7 +83,7 @@ async function fetchChartData() {
   tableError.value = null;
 
   try {
-    const response = await request("../api/graphql", tableDataQuery.value);
+    const response = await request(graphqlEndpoint.value, tableDataQuery.value);
     const data = await response[props.table as string];
     tableData.value = await prepareChartData({
       data: data,

--- a/apps/molgenis-viz/src/components/viz/DataTableEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/DataTableEmx.vue
@@ -45,7 +45,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = ref<string|null>(null);
+const graphqlEndpoint = ref<string | null>(null);
 
 const tableLoading = ref<boolean>(true);
 const tableSuccess = ref<boolean>(false);
@@ -58,7 +58,7 @@ const columnOrder = ref<string[] | null>(null);
 
 function setChartVariables() {
   graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
-  
+
   tableDataQuery.value = buildQuery({
     table: props.table,
     selections: [props.columns],

--- a/apps/molgenis-viz/src/components/viz/DataTableEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/DataTableEmx.vue
@@ -20,6 +20,7 @@ import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
+import { setGraphQlEndpoint } from "../../utils";
 import type {
   DataTableParams,
   gqlVariableSubSelectionIF,
@@ -44,10 +45,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = computed<string>(() => {
-  const root: string = props.schema ? `/${props.schema}` : "..";
-  return `${root}/api/graphql`;
-});
+const graphqlEndpoint = ref<string|null>(null);
 
 const tableLoading = ref<boolean>(true);
 const tableSuccess = ref<boolean>(false);
@@ -59,6 +57,8 @@ const tableColumnMappings = ref<gqlVariableSubSelectionIF[] | null>(null);
 const columnOrder = ref<string[] | null>(null);
 
 function setChartVariables() {
+  graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
+  
   tableDataQuery.value = buildQuery({
     table: props.table,
     selections: [props.columns],

--- a/apps/molgenis-viz/src/components/viz/GeoMercatorEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/GeoMercatorEmx.vue
@@ -35,7 +35,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeMount, watch } from "vue";
+import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
@@ -70,6 +70,11 @@ const props = withDefaults(defineProps<GeoMercatorEmxParams>(), {
 const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
+
+const graphqlEndpoint = computed<string>(() => {
+  const root: string = props.schema ? `/${props.schema}` : "..";
+  return `${root}/api/graphql`;
+});
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -131,7 +136,7 @@ async function fetchChartData() {
   chartError.value = null;
 
   try {
-    const response = await request("../api/graphql", chartDataQuery.value);
+    const response = await request(graphqlEndpoint.value, chartDataQuery.value);
     const data = await response[props.table as string];
 
     const chartColumns = [

--- a/apps/molgenis-viz/src/components/viz/GeoMercatorEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/GeoMercatorEmx.vue
@@ -73,7 +73,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = ref<string|null>(null);
+const graphqlEndpoint = ref<string | null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);

--- a/apps/molgenis-viz/src/components/viz/GeoMercatorEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/GeoMercatorEmx.vue
@@ -39,10 +39,12 @@ import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
+import { setGraphQlEndpoint } from "../../utils";
 import type {
   GeoMercatorParams,
   gqlVariableSubSelectionIF,
 } from "../../interfaces/viz";
+
 import {
   buildQuery,
   gqlExtractSelectionName,
@@ -71,10 +73,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = computed<string>(() => {
-  const root: string = props.schema ? `/${props.schema}` : "..";
-  return `${root}/api/graphql`;
-});
+const graphqlEndpoint = ref<string|null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -95,6 +94,8 @@ const legendData = ref<object | null>(null);
 let tooltipVars = ref<gqlVariableSubSelectionIF[] | null>(null);
 
 function setChartVariables() {
+  graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
+
   rowId.value = gqlExtractSelectionName(props.rowId);
   latVar.value = gqlExtractSelectionName(props.latitude);
   lngVar.value = gqlExtractSelectionName(props.longitude);

--- a/apps/molgenis-viz/src/components/viz/GroupedColumnChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/GroupedColumnChartEmx.vue
@@ -60,7 +60,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = ref<string|null>(null);
+const graphqlEndpoint = ref<string | null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);

--- a/apps/molgenis-viz/src/components/viz/GroupedColumnChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/GroupedColumnChartEmx.vue
@@ -33,7 +33,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onBeforeMount, watch } from "vue";
+import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
@@ -58,6 +58,11 @@ const props = withDefaults(defineProps<GroupedColumnChartParams>(), {
 const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
+
+const graphqlEndpoint = computed<string>(() => {
+  const root: string = props.schema ? `/${props.schema}` : "..";
+  return `${root}/api/graphql`;
+});
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -91,7 +96,7 @@ async function fetchChartData() {
   chartError.value = null;
 
   try {
-    const response = await request("../api/graphql", chartDataQuery.value);
+    const response = await request(graphqlEndpoint.value, chartDataQuery.value);
     const data = await response[props.table as string];
     const preppedData = await prepareChartData({
       data: data,

--- a/apps/molgenis-viz/src/components/viz/GroupedColumnChartEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/GroupedColumnChartEmx.vue
@@ -37,6 +37,7 @@ import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
+import { setGraphQlEndpoint } from "../../utils";
 import type { GroupedColumnChartParams } from "../../interfaces/viz";
 import {
   buildQuery,
@@ -59,10 +60,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = computed<string>(() => {
-  const root: string = props.schema ? `/${props.schema}` : "..";
-  return `${root}/api/graphql`;
-});
+const graphqlEndpoint = ref<string|null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -78,6 +76,8 @@ const ySubSelection = ref<string | null>(null);
 const groupSubSelection = ref<string | null>(null);
 
 function setChartVariables() {
+  graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
+
   xVar.value = gqlExtractSelectionName(props.xvar);
   yVar.value = gqlExtractSelectionName(props.yvar);
   groupVar.value = gqlExtractSelectionName(props.group);

--- a/apps/molgenis-viz/src/components/viz/PieChart2Emx.vue
+++ b/apps/molgenis-viz/src/components/viz/PieChart2Emx.vue
@@ -58,7 +58,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = ref<string|null>(null);
+const graphqlEndpoint = ref<string | null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);

--- a/apps/molgenis-viz/src/components/viz/PieChart2Emx.vue
+++ b/apps/molgenis-viz/src/components/viz/PieChart2Emx.vue
@@ -34,6 +34,7 @@ import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
+import { setGraphQlEndpoint } from "../../utils";
 import {
   buildQuery,
   gqlExtractSelectionName,
@@ -57,10 +58,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = computed<string>(() => {
-  const root: string = props.schema ? `/${props.schema}` : "..";
-  return `${root}/api/graphql`;
-});
+const graphqlEndpoint = ref<string|null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -74,6 +72,8 @@ const categoriesSubSelection = ref<string | null>(null);
 const valuesSubSelection = ref<string | null>(null);
 
 function setChartVariables() {
+  graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
+
   categoriesVar.value = gqlExtractSelectionName(props.categories);
   valuesVar.value = gqlExtractSelectionName(props.values);
   categoriesSubSelection.value = gqlExtractSubSelectionNames(props.categories);

--- a/apps/molgenis-viz/src/components/viz/PieChart2Emx.vue
+++ b/apps/molgenis-viz/src/components/viz/PieChart2Emx.vue
@@ -30,7 +30,7 @@
 </template>
 
 <script lang="ts" setup>
-import { ref, onBeforeMount, watch } from "vue";
+import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
@@ -56,6 +56,11 @@ const props = withDefaults(defineProps<PieChartParams>(), {
 const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
+
+const graphqlEndpoint = computed<string>(() => {
+  const root: string = props.schema ? `/${props.schema}` : "..";
+  return `${root}/api/graphql`;
+});
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -85,7 +90,7 @@ async function fetchChartData() {
   chartError.value = null;
 
   try {
-    const response = await request("../api/graphql", chartDataQuery.value);
+    const response = await request(graphqlEndpoint.value, chartDataQuery.value);
     const data = await response[props.table as string];
     const preppedData = await prepareChartData({
       data: data,

--- a/apps/molgenis-viz/src/components/viz/ScatterPlotEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/ScatterPlotEmx.vue
@@ -40,6 +40,8 @@ import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
+import { setGraphQlEndpoint } from "../../utils";
+import type { ScatterPlotParams } from "../../interfaces/viz";
 import {
   buildQuery,
   gqlExtractSelectionName,
@@ -47,7 +49,6 @@ import {
   prepareChartData,
 } from "../../utils/emxViz";
 
-import type { ScatterPlotParams } from "../../interfaces/viz";
 import ScatterPlot from "./ScatterPlot.vue";
 import LoadingScreen from "../display/LoadingScreen.vue";
 import MessageBox from "../display/MessageBox.vue";
@@ -60,10 +61,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = computed<string>(() => {
-  const root: string = props.schema ? `/${props.schema}` : "..";
-  return `${root}/api/graphql`;
-});
+const graphqlEndpoint = ref<string|null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -79,6 +77,8 @@ const ySubSelection = ref<string | null>(null);
 const groupSubSelection = ref<string | null>(null);
 
 function setChartVariables() {
+  graphqlEndpoint.value = setGraphQlEndpoint(props.schema);
+
   xVar.value = gqlExtractSelectionName(props.xvar);
   yVar.value = gqlExtractSelectionName(props.yvar);
   xSubSelection.value = gqlExtractSubSelectionNames(props.xvar);

--- a/apps/molgenis-viz/src/components/viz/ScatterPlotEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/ScatterPlotEmx.vue
@@ -61,7 +61,7 @@ const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
 
-const graphqlEndpoint = ref<string|null>(null);
+const graphqlEndpoint = ref<string | null>(null);
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);

--- a/apps/molgenis-viz/src/components/viz/ScatterPlotEmx.vue
+++ b/apps/molgenis-viz/src/components/viz/ScatterPlotEmx.vue
@@ -36,7 +36,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, onBeforeMount, watch } from "vue";
+import { ref, onBeforeMount, watch, computed } from "vue";
 import { gql } from "graphql-tag";
 import { request } from "graphql-request";
 
@@ -59,6 +59,11 @@ const props = withDefaults(defineProps<ScatterPlotParams>(), {
 const emit = defineEmits<{
   (e: "viz-data-clicked", row: object): void;
 }>();
+
+const graphqlEndpoint = computed<string>(() => {
+  const root: string = props.schema ? `/${props.schema}` : "..";
+  return `${root}/api/graphql`;
+});
 
 const chartLoading = ref<boolean>(true);
 const chartSuccess = ref<boolean>(false);
@@ -96,7 +101,7 @@ async function fetchChartData() {
   chartError.value = null;
 
   try {
-    const response = await request("../api/graphql", chartDataQuery.value);
+    const response = await request(graphqlEndpoint.value, chartDataQuery.value);
     const data = await response[props.table as string];
     chartData.value = await prepareChartData({
       data: data,

--- a/apps/molgenis-viz/src/interfaces/viz.ts
+++ b/apps/molgenis-viz/src/interfaces/viz.ts
@@ -25,7 +25,7 @@ export interface ChartOptions {
 export type vizLegendPosition = "top" | "right" | "bottom" | "left";
 
 export interface vizChartMargins {
-  top: number;
+  top?: number;
   right?: number;
   bottom?: number;
   left?: number;
@@ -37,6 +37,7 @@ export interface BarChartParams {
   description?: string;
   table: string;
   chartData?: object[];
+  schema?: string;
   xvar: string;
   yvar: string;
   xAxisLabel?: string;
@@ -60,6 +61,7 @@ export interface ColumnChartParams {
   chartId: string;
   title?: string;
   description?: string;
+  schema?: string;
   table: string;
   chartData?: object[];
   xvar: string;
@@ -85,6 +87,7 @@ export interface GroupedColumnChartParams {
   chartId: string;
   title?: string;
   description?: string;
+  schema?: string;
   table: string;
   chartData?: object[];
   xvar: string;
@@ -112,6 +115,7 @@ export interface GroupedColumnChartParams {
 
 export interface DataTableParams {
   tableId: string;
+  schema?: string;
   table: string;
   columns: string;
   caption?: string;
@@ -124,6 +128,7 @@ export interface PieChartParams {
   chartId: string;
   title?: string;
   description?: string;
+  schema?: string;
   table: string;
   categories: string;
   values: string;
@@ -149,6 +154,7 @@ export interface ScatterPlotParams {
   chartId: string;
   title?: string;
   description?: string;
+  schema?: string;
   table: string;
   xvar: string;
   yvar: string;
@@ -178,6 +184,7 @@ export interface GeoMercatorParams {
   chartId: string;
   title?: string;
   description?: string;
+  schema?: string;
   table: string;
   rowId: string;
   latitude: string;

--- a/apps/molgenis-viz/src/utils/index.ts
+++ b/apps/molgenis-viz/src/utils/index.ts
@@ -86,7 +86,7 @@ export function setChartType(xType: string, yType: string): string[] | null {
  */
 export function setGraphQlEndpoint(schema: string) {
   if (schema) {
-    return `/${schema}/api/graphql`
+    return `/${schema}/api/graphql`;
   }
   return "../api/graphql";
 }

--- a/apps/molgenis-viz/src/utils/index.ts
+++ b/apps/molgenis-viz/src/utils/index.ts
@@ -81,6 +81,17 @@ export function setChartType(xType: string, yType: string): string[] | null {
 }
 
 /**
+ * Set GraphQL Endpoint based on props.schema
+ * @param schema input value containing a name of a schema
+ */
+export function setGraphQlEndpoint(schema: string) {
+  if (schema) {
+    return `/${schema}/api/graphql`
+  }
+  return "../api/graphql";
+}
+
+/**
  * Check to see if number is between 0 and 1
  * @param value a value that is between 0 and 1
  * @returns boolean


### PR DESCRIPTION
What are the main changes you did:

In a previous PR, a new set of components were introduced to establish a connection between a chart and a table in a schema. However, this limited users to a specific schema making it difficult to build visualisations where data is stored in different schemas. This PR adds the parameter `schema` to all emx visualisation components allowing developers to pull data from a known schemas. 

how to test:

Note: this PR adds the functionality to connect to schemas/tables. The PR referenced below will provide an example. A code review is needed here.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
