### PR TITLE
chore(directory): adjust material type codes

### DIFF
--- a/data/biobank-directory/ontologies/MaterialTypes.csv
+++ b/data/biobank-directory/ontologies/MaterialTypes.csv
@@ -1,22 +1,22 @@
 order,name,label,parent,codesystem,code,ontologyTermURI,definition
-,NAV,Not available,,,PATHOGEN,,Not available
-,PATHOGEN,Pathogen,,,RNA,,"A biological agent causing disease; a disease producer e.g. virus, bacterium, prion, other microorganism etc."
-,RNA,RNA,,,FECES,,"One of two types of nucleic acid made by cells. RNA contains information that has been copied from DNA (the other type of nucleic acid). Cells make several different forms of RNA, and each form has a specific job in the cell. Many forms of RNA have functions related to making proteins. RNA is also the genetic material of some viruses instead of DNA. RNA can be made in the laboratory and used in research studies. Also called ribonucleic acid."
-,FECES,Feces,,,THROAT_SWAB,http://purl.obolibrary.org/obo/OBI_0002503,"The material discharged from the bowel during defecation. It consists of undigested food, intestinal mucus, epithelial cells, and bacteria. (NCI)"
-,THROAT_SWAB,Throat swab,,,CELL_LINES,,
-,CELL_LINES,Cell lines,,,SERUM,,"Cells of a single type (human, animal, or plant) that have been adapted to grow continuously in the laboratory and are used in research. (NCI)"
-,SERUM,Serum,,,CDNA,http://purl.obolibrary.org/obo/OBI_0100017,The clear portion of the blood that remains after the removal of the blood cells and the clotting proteins. (NCI)
-,CDNA,cDNA / mRNA,,,TISSUE_FROZEN,,Single-stranded DNA that is complementary to messenger RNA or DNA that has been synthesized from messenger RNA by reverse transcriptase/A class of RNA molecule containing protein-coding information in its nucleotide sequence that can be translated into the amino acid sequence of a protein. (NCI)
-,TISSUE_FROZEN,Tissue (frozen),,,SALIVA,http://purl.obolibrary.org/obo/OBI_0000922,"An anatomical structure consisting of similarly specialized cells and intercellular matrix, aggregated according to genetically determined spatial relationships, performing a specific function. (NCI), preserved by freezing in liquid nitrogen"
-,SALIVA,Saliva,,,BUFFY_COAT,http://purl.obolibrary.org/obo/OBI_0002507,A clear liquid secreted into the mouth by the salivary glands and mucous glands of the mouth; moistens the mouth and starts the digestion of starches. (NCI)
-,BUFFY_COAT,Buffy Coat,,,NASAL_SWAB,,The middle layer of an anticoagulated blood specimen following separation by centrifugation. It contains most of the white blood cells and platelets. (NCI)
-,NASAL_SWAB,Nasal swab,,,OTHER,,A method used to collect biological material from within the nasal passages. A cotton swab is inserted into the nasal opening and rotated against the anterior nasal mucosa and them withdrawn. (NCI)
-,OTHER,Other,,,TISSUE_STAINED,,"any other type of material taken from a biological entity, e.g. amniotic fluid,  cerebrospinal fluid, mitochondrial RNA,"
-,TISSUE_STAINED,Tissue (stained sections/slides),,,PLASMA,,
-,PLASMA,Plasma,,,PERIPHERAL_BLOOD_CELLS,http://purl.obolibrary.org/obo/OBI_0100016,"Plasma is the fluid (acellular) portion of the circulating blood, as distinguished from the serum that is the fluid portion of the blood obtained by removal of the fibrin clot and blood cells after coagulation. (NCI)"
-,PERIPHERAL_BLOOD_CELLS,Peripheral blood cells,,,MICRO_RNA,,"A general term describing the three cellular components of blood (white blood cells, red blood cells, and platelets), all which are made in the bone marrow. (Lymphoma Information Network Glossary)"
-,MICRO_RNA,microRNA,,,DNA,,A type of RNA found in cells and in blood. MicroRNAs are smaller than many other types of RNA and can bind to messenger RNAs (mRNAs) to block them from making proteins. MicroRNAs are being studied in the diagnosis (NCI) and treatment of cancer.
-,DNA,DNA,,,TISSUE_PARAFFIN_EMBEDDED,,A long linear double-stranded polymer formed from nucleotides attached to a deoxyribose backbone and found in the nucleus of a cell; associated with the transmission of genetic information. (NCI)
-,TISSUE_PARAFFIN_EMBEDDED,Tissue (paraffin preserved),,,URINE,,Tissue that is preserved and embedded in paraffin. (NCI)
-,URINE,Urine,,,WHOLE_BLOOD,,The fluid that is excreted by the kidneys. It is stored in the bladder and discharged through the urethra. (NCI)
-,WHOLE_BLOOD,Whole Blood,,,,http://purl.obolibrary.org/obo/OBI_0000655,Blood that has not been separated into its various components; blood that has not been modified except for the addition of an anticoagulant (NCI)
+,NAV,Not available,,,NAV,,Not available
+,PATHOGEN,Pathogen,,,PATHOGEN,,"A biological agent causing disease; a disease producer e.g. virus, bacterium, prion, other microorganism etc."
+,RNA,RNA,,,RNA,,"One of two types of nucleic acid made by cells. RNA contains information that has been copied from DNA (the other type of nucleic acid). Cells make several different forms of RNA, and each form has a specific job in the cell. Many forms of RNA have functions related to making proteins. RNA is also the genetic material of some viruses instead of DNA. RNA can be made in the laboratory and used in research studies. Also called ribonucleic acid."
+,FECES,Feces,,,FECES,http://purl.obolibrary.org/obo/OBI_0002503,"The material discharged from the bowel during defecation. It consists of undigested food, intestinal mucus, epithelial cells, and bacteria. (NCI)"
+,THROAT_SWAB,Throat swab,,,THROAT_SWAB,,
+,CELL_LINES,Cell lines,,,CELL_LINES,,"Cells of a single type (human, animal, or plant) that have been adapted to grow continuously in the laboratory and are used in research. (NCI)"
+,SERUM,Serum,,,SERUM,http://purl.obolibrary.org/obo/OBI_0100017,The clear portion of the blood that remains after the removal of the blood cells and the clotting proteins. (NCI)
+,CDNA,cDNA / mRNA,,,CDNA,,Single-stranded DNA that is complementary to messenger RNA or DNA that has been synthesized from messenger RNA by reverse transcriptase/A class of RNA molecule containing protein-coding information in its nucleotide sequence that can be translated into the amino acid sequence of a protein. (NCI)
+,TISSUE_FROZEN,Tissue (frozen),,,TISSUE_FROZEN,http://purl.obolibrary.org/obo/OBI_0000922,"An anatomical structure consisting of similarly specialized cells and intercellular matrix, aggregated according to genetically determined spatial relationships, performing a specific function. (NCI), preserved by freezing in liquid nitrogen"
+,SALIVA,Saliva,,,SALIVA,http://purl.obolibrary.org/obo/OBI_0002507,A clear liquid secreted into the mouth by the salivary glands and mucous glands of the mouth; moistens the mouth and starts the digestion of starches. (NCI)
+,BUFFY_COAT,Buffy Coat,,,BUFFY_COAT,,The middle layer of an anticoagulated blood specimen following separation by centrifugation. It contains most of the white blood cells and platelets. (NCI)
+,NASAL_SWAB,Nasal swab,,,NASAL_SWAB,,A method used to collect biological material from within the nasal passages. A cotton swab is inserted into the nasal opening and rotated against the anterior nasal mucosa and them withdrawn. (NCI)
+,OTHER,Other,,,OTHER,,"any other type of material taken from a biological entity, e.g. amniotic fluid,  cerebrospinal fluid, mitochondrial RNA,"
+,TISSUE_STAINED,Tissue (stained sections/slides),,,TISSUE_STAINED,,
+,PLASMA,Plasma,,,PLASMA,http://purl.obolibrary.org/obo/OBI_0100016,"Plasma is the fluid (acellular) portion of the circulating blood, as distinguished from the serum that is the fluid portion of the blood obtained by removal of the fibrin clot and blood cells after coagulation. (NCI)"
+,PERIPHERAL_BLOOD_CELLS,Peripheral blood cells,,,PERIPHERAL_BLOOD_CELLS,,"A general term describing the three cellular components of blood (white blood cells, red blood cells, and platelets), all which are made in the bone marrow. (Lymphoma Information Network Glossary)"
+,MICRO_RNA,microRNA,,,MICRO_RNA,,A type of RNA found in cells and in blood. MicroRNAs are smaller than many other types of RNA and can bind to messenger RNAs (mRNAs) to block them from making proteins. MicroRNAs are being studied in the diagnosis (NCI) and treatment of cancer.
+,DNA,DNA,,,DNA,,A long linear double-stranded polymer formed from nucleotides attached to a deoxyribose backbone and found in the nucleus of a cell; associated with the transmission of genetic information. (NCI)
+,TISSUE_PARAFFIN_EMBEDDED,Tissue (paraffin preserved),,,TISSUE_PARAFFIN_EMBEDDED,,Tissue that is preserved and embedded in paraffin. (NCI)
+,URINE,Urine,,,URINE,,The fluid that is excreted by the kidneys. It is stored in the bladder and discharged through the urethra. (NCI)
+,WHOLE_BLOOD,Whole Blood,,,WHOLE_BLOOD,http://purl.obolibrary.org/obo/OBI_0000655,Blood that has not been separated into its various components; blood that has not been modified except for the addition of an anticoagulant (NCI)


### PR DESCRIPTION
What are the main changes you did:
- The content of the "code" column in material types was not correct (probably wrongly copy/pasted). In this PR the content is moved one row down and now the codes belong to the corresponding type again.

how to test:
- Goto the MaterialTypes table in the DirectoryOntologies schema and check that f.e. PATHOGEN has PATHOGEN code and not RNA code (as is https://directory-emx2-acc.molgenis.net/DirectoryOntologies/tables/#/MaterialTypes).

todo:
- [nvt] updated docs in case of new feature
- [nvt] added/updated tests
- [nvt] added/updated testplan to include a test for this fix, including ref to bug using # notation
