### PR TITLE
fix: triples having the FDP as subject instead of the catalog

### DIFF
--- a/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointCatalog.java
+++ b/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointCatalog.java
@@ -141,14 +141,11 @@ public class FAIRDataPointCatalog {
     builder.add(reqUrl, DCTERMS.PUBLISHER, publisher);
     builder.add(publisher, RDF.TYPE, FOAF.AGENT);
     builder.add(publisher, FOAF.NAME, catalogFromJSON.get("publisher"));
-    builder.add(
-        apiFdpEnc, DCTERMS.LICENSE, iri(TypeUtils.toString(catalogFromJSON.get("license"))));
-    builder.add(apiFdpEnc, DCTERMS.CONFORMS_TO, apiFdpCatalogProfileEnc);
+    builder.add(reqUrl, DCTERMS.LICENSE, iri(TypeUtils.toString(catalogFromJSON.get("license"))));
+    builder.add(reqUrl, DCTERMS.CONFORMS_TO, apiFdpCatalogProfileEnc);
     builder.add(reqUrl, DCTERMS.IS_PART_OF, apiFdpEnc);
     builder.add(
-        apiFdpEnc,
-        DCAT.THEME_TAXONOMY,
-        iri(TypeUtils.toString(catalogFromJSON.get("themeTaxonomy"))));
+        reqUrl, DCAT.THEME_TAXONOMY, iri(TypeUtils.toString(catalogFromJSON.get("themeTaxonomy"))));
     builder.add(apiFdpEnc, iri("https://w3id.org/fdp/fdp-o#metadataIdentifier"), reqUrl);
 
     builder.add(
@@ -203,28 +200,28 @@ public class FAIRDataPointCatalog {
     }
 
     builder.add(
-        apiFdpEnc,
+        reqUrl,
         DCTERMS.ISSUED,
         literal(
             TypeUtils.toString(catalogFromJSON.get("mg_insertedOn")).substring(0, 19),
             XSD.DATETIME));
     builder.add(
-        apiFdpEnc,
+        reqUrl,
         DCTERMS.MODIFIED,
         literal(
             TypeUtils.toString(catalogFromJSON.get("mg_updatedOn")).substring(0, 19),
             XSD.DATETIME));
     BNode rights = vf.createBNode();
-    builder.add(apiFdpEnc, DCTERMS.RIGHTS, rights);
+    builder.add(reqUrl, DCTERMS.RIGHTS, rights);
     builder.add(rights, RDF.TYPE, DCTERMS.RIGHTS_STATEMENT);
     builder.add(rights, DCTERMS.DESCRIPTION, "Rights are provided on a per-dataset basis.");
     BNode accessRights = vf.createBNode();
-    builder.add(apiFdpEnc, DCTERMS.ACCESS_RIGHTS, accessRights);
+    builder.add(reqUrl, DCTERMS.ACCESS_RIGHTS, accessRights);
     builder.add(accessRights, RDF.TYPE, DCTERMS.RIGHTS_STATEMENT);
     builder.add(
         accessRights, DCTERMS.DESCRIPTION, "Access rights are provided on a per-dataset basis.");
     builder.add(
-        apiFdpEnc, FOAF.HOMEPAGE, encodedIRI(host + "/" + schema.getName() + "/tables/#/Catalog"));
+        reqUrl, FOAF.HOMEPAGE, encodedIRI(host + "/" + schema.getName() + "/tables/#/Catalog"));
 
     // Write model
     Model model = builder.build();


### PR DESCRIPTION
## What are the main changes you did:
Fixed triples being assigned to subject `/api/fdp` in `/api/fdp/catalog/<fair_database_name>/<catalogId>` instead of the individual catalogs. In some cases it’s also very clear that these referred to columns belonging to the catalog table. 

References:
  * [DCAT-summary-all-attributes](https://www.w3.org/TR/vocab-dcat-2/images/DCAT-summary-all-attributes.png)
  * https://specs.fairdatapoint.org/images/FDPmetadatadiagram.png


**The triples that were moved from `/api/fdp` to the individual catalog (using the `catalogId01` from the example data)**
```
  dcterms:license <https://www.gnu.org/licenses/lgpl-3.0.rdf>;
  dcterms:conformsTo <http://localhost:8080/api/fdp/catalog/profile>;
  dcat:themeTaxonomy <http://purl.obolibrary.org/obo/NCIT_C71899>;
  dcterms:issued "2024-05-28T13:49:57"^^xsd:dateTime;
  dcterms:modified "2024-05-28T13:49:57"^^xsd:dateTime;
  dcterms:rights [ a dcterms:RightsStatement;
      dcterms:description "Rights are provided on a per-dataset basis."
    ];
  dcterms:accessRights [ a dcterms:RightsStatement;
      dcterms:description "Access rights are provided on a per-dataset basis."
    ];
  foaf:homepage <http://localhost:8080/my_FAIR/tables/#/Catalog> .
```

how to test:
- Check the output of `curl http://localhost:8080/api/fdp/catalog/<FAIR_DATA_HUB_DATABASE>/catalogId01`

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
