### PR TITLE
fix: FDP API various fixes

### DIFF
--- a/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPoint.java
+++ b/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPoint.java
@@ -1,5 +1,6 @@
 package org.molgenis.emx2.fairdatapoint;
 
+import static java.util.Map.entry;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.molgenis.emx2.rdf.RDFUtils.*;
@@ -7,10 +8,8 @@ import static org.molgenis.emx2.rdf.RDFUtils.*;
 import java.io.StringWriter;
 import java.net.URI;
 import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import org.apache.commons.io.IOUtils;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Model;
 import org.eclipse.rdf4j.model.ValueFactory;
@@ -21,13 +20,31 @@ import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.rio.WriterConfig;
 import org.eclipse.rdf4j.rio.helpers.BasicWriterSettings;
+import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Schema;
 import org.molgenis.emx2.Version;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import spark.Request;
 
 public class FAIRDataPoint {
 
+  private static final Logger logger = LoggerFactory.getLogger(FAIRDataPoint.class);
+
   private static final String FDP_ROOT_METADATA = "FAIR Data Point root metadata";
+
+  private static final Map<String, String> PREFIX_TO_NAMESPACE =
+      Map.ofEntries(
+          entry("dcterms", "http://purl.org/dc/terms/"),
+          entry("dcat", "http://www.w3.org/ns/dcat#"),
+          entry("foaf", "http://xmlns.com/foaf/0.1/"),
+          entry("xsd", "http://www.w3.org/2001/XMLSchema#"),
+          entry("ldp", "http://www.w3.org/ns/ldp#"),
+          entry("fdp-o", "https://w3id.org/fdp/fdp-o#"),
+          entry("rdfs", "http://www.w3.org/2000/01/rdf-schema#"),
+          entry("vc", "http://www.w3.org/2006/vcard/ns#"),
+          entry("r3d", "http://www.re3data.org/schema/3-0#"),
+          entry("lang", "http://lexvo.org/id/iso639-3/"));
 
   /**
    * Constructor
@@ -94,27 +111,14 @@ public class FAIRDataPoint {
     Map<String, List<Map<String, Object>>> allCatalogFromJSON =
         FAIRDataPointCatalog.getFDPCatalogRecords(null, schemas);
 
-    // All prefixes and namespaces
-    Map<String, String> prefixToNamespace = new HashMap<>();
-    prefixToNamespace.put("dcterms", "http://purl.org/dc/terms/");
-    prefixToNamespace.put("dcat", "http://www.w3.org/ns/dcat#");
-    prefixToNamespace.put("foaf", "http://xmlns.com/foaf/0.1/");
-    prefixToNamespace.put("xsd", "http://www.w3.org/2001/XMLSchema#");
-    prefixToNamespace.put("ldp", "http://www.w3.org/ns/ldp#");
-    prefixToNamespace.put("fdp-o", "https://w3id.org/fdp/fdp-o#");
-    prefixToNamespace.put("rdfs", "http://www.w3.org/2000/01/rdf-schema#");
-    prefixToNamespace.put("vc", "http://www.w3.org/2006/vcard/ns#");
-    prefixToNamespace.put("r3d", "http://www.re3data.org/schema/3-0#");
-    prefixToNamespace.put("lang", "http://lexvo.org/id/iso639-3/");
-
     // Main model builder
     ModelBuilder builder = new ModelBuilder();
     RDFFormat applicationOntologyFormat = RDFFormat.TURTLE;
     ValueFactory vf = SimpleValueFactory.getInstance();
     WriterConfig config = new WriterConfig();
     config.set(BasicWriterSettings.INLINE_BLANK_NODES, true);
-    for (String prefix : prefixToNamespace.keySet()) {
-      builder.setNamespace(prefix, prefixToNamespace.get(prefix));
+    for (String prefix : PREFIX_TO_NAMESPACE.keySet()) {
+      builder.setNamespace(prefix, PREFIX_TO_NAMESPACE.get(prefix));
     }
 
     // reconstruct server:port URL to prevent problems with double encoding of schema/table names
@@ -197,9 +201,11 @@ public class FAIRDataPoint {
 
     // Write model
     Model model = builder.build();
+    model.addAll(
+        Rio.parse(
+            IOUtils.toInputStream(getFDPRootMetadata(apiFdpEnc.toString())), RDFFormat.TURTLE));
     StringWriter stringWriter = new StringWriter();
     Rio.write(model, stringWriter, applicationOntologyFormat, config);
-    stringWriter.append(getFDPRootMetadata(apiFdpEnc.toString()));
     return stringWriter.toString();
   }
 
@@ -261,17 +267,28 @@ public class FAIRDataPoint {
         return schema.getSettingValue(FDP_ROOT_METADATA);
       }
     }
-    Schema schema = addFDPRootMetadataIfMissing(apiFdpEnc);
-    return schema.getSettingValue(FDP_ROOT_METADATA);
+    String defaultMetadata = generateDefaultMetaData(apiFdpEnc);
+    try {
+      addFDPRootMetadataIfMissing(defaultMetadata);
+    } catch (MolgenisException e) {
+      logger.warn(
+          "\"FAIR Data Point root metadata\" has not been set yet and cannot be initialized by non-MANAGER");
+    }
+    return defaultMetadata;
   }
 
-  private Schema addFDPRootMetadataIfMissing(String apiFdpEnc) {
-    schemas[0]
-        .getMetadata()
-        .setSetting(
-            FDP_ROOT_METADATA,
-            """
-            %s
+  private void addFDPRootMetadataIfMissing(String defaultMetadata) {
+    schemas[0].getMetadata().setSetting(FDP_ROOT_METADATA, defaultMetadata);
+  }
+
+  private String generateDefaultMetaData(String apiFdpEnc) {
+    StringBuilder builder = new StringBuilder();
+    PREFIX_TO_NAMESPACE.forEach(
+        (key, value) ->
+            builder.append("@prefix " + key + ": <" + value + "> ." + System.lineSeparator()));
+    builder.append(
+        """
+
             <%s>
               dcterms:title "FAIR Data Point hosted by MOLGENIS-EMX2";
               dcterms:publisher [ a foaf:Agent;
@@ -294,7 +311,7 @@ public class FAIRDataPoint {
               fdp-o:uiLanguage lang:eng;
               rdfs:label "FAIR Data Point hosted by MOLGENIS-EMX2" .
               """
-                .formatted(System.lineSeparator(), apiFdpEnc));
-    return schemas[0];
+            .formatted(apiFdpEnc));
+    return builder.toString();
   }
 }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FAIRDataPointApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FAIRDataPointApi.java
@@ -21,35 +21,37 @@ public class FAIRDataPointApi {
   public static void create(MolgenisSessionManager sm) {
     sessionManager = sm;
 
-    head("/api/fdp", FAIRDataPointApi::getHead);
-    redirect.any("/api/fdp", "/api/fdp/");
+    redirect.any("/api/fdp/", "/api/fdp");
     path(
-        "/api/fdp/",
+        "/api/fdp",
         () -> {
-          head("*", FAIRDataPointApi::getHead);
+          head("", FAIRDataPointApi::getHead);
           get("", FAIRDataPointApi::getFDP);
-          get("", FAIRDataPointApi::getFDP);
-          get("profile", FAIRDataPointApi::getFDPProfile);
+          head("/profile", FAIRDataPointApi::getHead);
+          get("/profile", FAIRDataPointApi::getFDPProfile);
 
           path(
-              "catalog/",
+              "/catalog/",
               () -> {
                 head(":schema/:id", FAIRDataPointApi::getHead);
                 get(":schema/:id", FAIRDataPointApi::getCatalog);
+                head("profile", FAIRDataPointApi::getHead);
                 get("profile", FAIRDataPointApi::getCatalogProfile);
               });
           path(
-              "dataset/",
+              "/dataset/",
               () -> {
                 head(":schema/:id", FAIRDataPointApi::getHead);
                 get(":schema/:id", FAIRDataPointApi::getDataset);
+                head("profile", FAIRDataPointApi::getHead);
                 get("profile", FAIRDataPointApi::getDatasetProfile);
               });
           path(
-              "distribution/",
+              "/distribution/",
               () -> {
                 head(":schema/:distribution/:format", FAIRDataPointApi::getHead);
                 get(":schema/:distribution/:format", FAIRDataPointApi::getDistribution);
+                head("profile", FAIRDataPointApi::getHead);
                 get("profile", FAIRDataPointApi::getDistributionProfile);
               });
         });

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -849,6 +849,16 @@ public class WebApiSmokeTests {
   }
 
   @Test
+  public void testNonDefinedFDPHead() {
+    given()
+        .sessionId(SESSION_ID)
+        .expect()
+        .contentType("text/html;charset=utf-8")
+        .when()
+        .head("http://localhost:" + PORT + "/api/fdp/");
+  }
+
+  @Test
   public void testFDPRedirect() {
     given()
         .sessionId(SESSION_ID)

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -845,7 +845,7 @@ public class WebApiSmokeTests {
         .expect()
         .contentType("text/turtle")
         .when()
-        .head("http://localhost:" + PORT + "/api/fdp/");
+        .head("http://localhost:" + PORT + "/api/fdp");
   }
 
   @Test
@@ -855,9 +855,9 @@ public class WebApiSmokeTests {
         .redirects()
         .follow(false)
         .expect()
-        .header("Location", "http://localhost:" + PORT + "/api/fdp/")
+        .header("Location", "http://localhost:" + PORT + "/api/fdp")
         .when()
-        .get("http://localhost:" + PORT + "/api/fdp");
+        .get("http://localhost:" + PORT + "/api/fdp/");
   }
 
   @Test


### PR DESCRIPTION
**Sidenote:** Not that familiar with sparkjava yet, so if there's something obvious I overlooked, do let me know.

What are the main changes you did:
1. Fixed a bug where `/api/fdp` didn’t work if metadata was missing and being accessed by non-MANAGER. New behaviour simply returns the default String (and has a try-catch to set the metadata that fails until a MANAGER tried accessing it at least once).
2. Fixed a bug where `/api/fdp/` returned the output instead of `/api/fdp`  (the latter one should be the actual URL according to the [MOLGENIS documentation](http://localhost:8080/apps/docs/#/molgenis/dev_fairdatapoint?id=api-structure-and-traversal)). Additionally, **the non-slash version is used as IRI within the triples to indicate the FAIR data point**.
    * OLD behaviour:
      * wget http://localhost:8080/api/fdp -> data
      * wget http://localhost:8080/api/fdp/ -> data
      * curl http://localhost:8080/api/fdp -> nothing
      * curl http://localhost:8080/api/fdp/ -> data
    * NEW behaviour:
      * wget http://localhost:8080/api/fdp -> data
      * wget http://localhost:8080/api/fdp/ -> data
      * curl http://localhost:8080/api/fdp -> data
      * curl http://localhost:8080/api/fdp/ -> nothing
3. Changed head with `text/turtle` content type to be only triggered where a GET response is present returning Turtle data (=removed wildcard head call). This way a non `text/turtle` should indicate the user is using an invalid API URL.
4. Fixed a bug where the triples belonging to the same subject weren’t outputted together.
    * Current fix requires the `FAIR Data Point root metadata` “Advanced settings” key to contain fully valid Turtle data. **This will break instances where metadata is already stored in this variable!** It will return an error message like “Namespace prefix 'lang' used but not defined [line 8]” and can easily be fixed by removing the keypair, as this will generate a new one which is valid.

how to test:
1. On a FRESH INSTALL: Create a FAIR_DATA_HUB database with example data & check if `/api/fdp` works out-of-the-box while anonymous (f.e. `curl http://localhost:8080/api/fdp`)
2. `curl http://localhost:8080/api/fdp` should now return data instead of `curl http://localhost:8080/api/fdp/`
3. `curl -I http://localhost:8080/api/fdp` & `curl -I http://localhost:8080/api/fdp/catalog/<fair_data_hub_database>/catalogId01` should still return `Content-Type: text/turtle` but f.e. `curl -I http://localhost:8080/api/fdp/` or `curl -I http://localhost:8080/api/fdp/catalog` should not.
4. `curl -I http://localhost:8080/api/fdp` should now have all triples belonging to `http://localhost:8080/api/fdp` together instead of some extra triples being pasted at the end.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
