### PR TITLE
feat: enable group by on non-ref fields. closes #3822

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -322,10 +322,12 @@ public class GraphqlTableFieldFactory {
 
       for (Column column : table.getColumns()) {
         // for now only 'ref' types. We might want to have truncating actions for the other types.
-        if (column.isReference()
-                && (hasViewPermission(table) && hasViewPermission(column.getRefTable())
-                    || column.isOntology())
-            || (!column.isReference() && hasViewPermission(table))) {
+        if (column.isReference() && (hasViewPermission(table) || column.isOntology())) {
+          groupByBuilder.field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name(column.getIdentifier())
+                  .type(createTableObjectType(column.getRefTable())));
+        } else if (!column.isReference() && hasViewPermission(table)) {
           createTableField(column, groupByBuilder);
         }
       }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -147,138 +147,141 @@ public class GraphqlTableFieldFactory {
       // build the object
       GraphQLObjectType.Builder tableBuilder = GraphQLObjectType.newObject().name(tableObjectType);
       for (Column col : table.getColumnsWithoutHeadings()) {
-        String id = col.getIdentifier();
-        switch (col.getColumnType().getBaseType()) {
-          case HEADING:
-            // nothing to do
-            break;
-          case FILE:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition().name(id).type(fileDownload));
-            break;
-          case BOOL:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLBoolean));
-            break;
-          case BOOL_ARRAY:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition()
-                    .name(id)
-                    .type(GraphQLList.list(Scalars.GraphQLBoolean)));
-            break;
-          case STRING:
-          case TEXT:
-          case LONG:
-          case UUID:
-          case DATE:
-          case DATETIME:
-          case EMAIL:
-          case HYPERLINK:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLString));
-            break;
-          case STRING_ARRAY:
-          case EMAIL_ARRAY:
-          case HYPERLINK_ARRAY:
-          case TEXT_ARRAY:
-          case LONG_ARRAY:
-          case DATE_ARRAY:
-          case DATETIME_ARRAY:
-          case UUID_ARRAY:
-          case JSONB_ARRAY:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition()
-                    .name(id)
-                    .type(GraphQLList.list(Scalars.GraphQLString)));
-            break;
-          case DECIMAL:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLFloat));
-            break;
-          case DECIMAL_ARRAY:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition()
-                    .name(id)
-                    .type(GraphQLList.list(Scalars.GraphQLFloat)));
-            break;
-          case INT:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLInt));
-            break;
-          case INT_ARRAY:
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition()
-                    .name(id)
-                    .type(GraphQLList.list(Scalars.GraphQLInt)));
-            break;
-          case REF:
-            if (hasViewPermission(table)) {
-              tableBuilder.field(
-                  GraphQLFieldDefinition.newFieldDefinition()
-                      .name(id)
-                      .type(createTableObjectType(col.getRefTable()))
-                      .argument(
-                          GraphQLArgument.newArgument()
-                              .name(GraphqlConstants.FILTER_ARGUMENT)
-                              .type(getTableFilterInputType(col.getRefTable()))
-                              .build()));
-            }
-            break;
-          case REF_ARRAY:
-          case REFBACK:
-            if (hasViewPermission(table)) {
-              tableBuilder.field(
-                  GraphQLFieldDefinition.newFieldDefinition()
-                      .name(id)
-                      .type(GraphQLList.list(createTableObjectType(col.getRefTable())))
-                      .argument(
-                          GraphQLArgument.newArgument()
-                              .name(GraphqlConstants.FILTER_ARGUMENT)
-                              .type(getTableFilterInputType(col.getRefTable()))
-                              .build())
-                      .argument(
-                          GraphQLArgument.newArgument()
-                              .name(GraphqlConstants.LIMIT)
-                              .type(Scalars.GraphQLInt)
-                              .build())
-                      .argument(
-                          GraphQLArgument.newArgument()
-                              .name(GraphqlConstants.OFFSET)
-                              .type(Scalars.GraphQLInt)
-                              .build())
-                      .argument(
-                          GraphQLArgument.newArgument()
-                              .name(GraphqlConstants.ORDERBY)
-                              .type(createTableOrderByInputType(col.getRefTable()))
-                              .build()));
-            }
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition()
-                    .name(id + "_agg")
-                    .type(createTableAggregationType(col.getRefTable()))
-                    .argument(
-                        GraphQLArgument.newArgument()
-                            .name(GraphqlConstants.FILTER_ARGUMENT)
-                            .type(getTableFilterInputType(col.getRefTable()))
-                            .build()));
-            tableBuilder.field(
-                GraphQLFieldDefinition.newFieldDefinition()
-                    .name(id + "_groupBy")
-                    .type(GraphQLList.list(createTableGroupByType(col.getRefTable())))
-                    .argument(
-                        GraphQLArgument.newArgument()
-                            .name(GraphqlConstants.FILTER_ARGUMENT)
-                            .type(getTableFilterInputType(col.getRefTable()))
-                            .build()));
-            break;
-          default:
-            throw new UnsupportedOperationException(
-                "Not yet implemented type " + col.getColumnType());
-        }
+        createTableField(col, tableBuilder);
       }
       tableTypes.put(tableObjectType, tableBuilder.build());
     }
     return tableTypes.get(tableObjectType);
+  }
+
+  private void createTableField(Column col, GraphQLObjectType.Builder tableBuilder) {
+    String id = col.getIdentifier();
+    TableMetadata table = col.getTable();
+    switch (col.getColumnType().getBaseType()) {
+      case HEADING:
+        // nothing to do
+        break;
+      case FILE:
+        tableBuilder.field(GraphQLFieldDefinition.newFieldDefinition().name(id).type(fileDownload));
+        break;
+      case BOOL:
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLBoolean));
+        break;
+      case BOOL_ARRAY:
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition()
+                .name(id)
+                .type(GraphQLList.list(Scalars.GraphQLBoolean)));
+        break;
+      case STRING:
+      case TEXT:
+      case LONG:
+      case UUID:
+      case DATE:
+      case DATETIME:
+      case EMAIL:
+      case HYPERLINK:
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLString));
+        break;
+      case STRING_ARRAY:
+      case EMAIL_ARRAY:
+      case HYPERLINK_ARRAY:
+      case TEXT_ARRAY:
+      case LONG_ARRAY:
+      case DATE_ARRAY:
+      case DATETIME_ARRAY:
+      case UUID_ARRAY:
+      case JSONB_ARRAY:
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition()
+                .name(id)
+                .type(GraphQLList.list(Scalars.GraphQLString)));
+        break;
+      case DECIMAL:
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLFloat));
+        break;
+      case DECIMAL_ARRAY:
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition()
+                .name(id)
+                .type(GraphQLList.list(Scalars.GraphQLFloat)));
+        break;
+      case INT:
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition().name(id).type(Scalars.GraphQLInt));
+        break;
+      case INT_ARRAY:
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition()
+                .name(id)
+                .type(GraphQLList.list(Scalars.GraphQLInt)));
+        break;
+      case REF:
+        if (hasViewPermission(table)) {
+          tableBuilder.field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name(id)
+                  .type(createTableObjectType(col.getRefTable()))
+                  .argument(
+                      GraphQLArgument.newArgument()
+                          .name(GraphqlConstants.FILTER_ARGUMENT)
+                          .type(getTableFilterInputType(col.getRefTable()))
+                          .build()));
+        }
+        break;
+      case REF_ARRAY:
+      case REFBACK:
+        if (hasViewPermission(table)) {
+          tableBuilder.field(
+              GraphQLFieldDefinition.newFieldDefinition()
+                  .name(id)
+                  .type(GraphQLList.list(createTableObjectType(col.getRefTable())))
+                  .argument(
+                      GraphQLArgument.newArgument()
+                          .name(GraphqlConstants.FILTER_ARGUMENT)
+                          .type(getTableFilterInputType(col.getRefTable()))
+                          .build())
+                  .argument(
+                      GraphQLArgument.newArgument()
+                          .name(GraphqlConstants.LIMIT)
+                          .type(Scalars.GraphQLInt)
+                          .build())
+                  .argument(
+                      GraphQLArgument.newArgument()
+                          .name(GraphqlConstants.OFFSET)
+                          .type(Scalars.GraphQLInt)
+                          .build())
+                  .argument(
+                      GraphQLArgument.newArgument()
+                          .name(GraphqlConstants.ORDERBY)
+                          .type(createTableOrderByInputType(col.getRefTable()))
+                          .build()));
+        }
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition()
+                .name(id + "_agg")
+                .type(createTableAggregationType(col.getRefTable()))
+                .argument(
+                    GraphQLArgument.newArgument()
+                        .name(GraphqlConstants.FILTER_ARGUMENT)
+                        .type(getTableFilterInputType(col.getRefTable()))
+                        .build()));
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition()
+                .name(id + "_groupBy")
+                .type(GraphQLList.list(createTableGroupByType(col.getRefTable())))
+                .argument(
+                    GraphQLArgument.newArgument()
+                        .name(GraphqlConstants.FILTER_ARGUMENT)
+                        .type(getTableFilterInputType(col.getRefTable()))
+                        .build()));
+        break;
+      default:
+        throw new UnsupportedOperationException("Not yet implemented type " + col.getColumnType());
+    }
   }
 
   private boolean hasViewPermission(TableMetadata table) {
@@ -319,11 +322,11 @@ public class GraphqlTableFieldFactory {
 
       for (Column column : table.getColumns()) {
         // for now only 'ref' types. We might want to have truncating actions for the other types.
-        if (column.isReference() && (hasViewPermission(table) || column.isOntology())) {
-          groupByBuilder.field(
-              GraphQLFieldDefinition.newFieldDefinition()
-                  .name(column.getIdentifier())
-                  .type(createTableObjectType(column.getRefTable())));
+        if (column.isReference()
+                && (hasViewPermission(table) && hasViewPermission(column.getRefTable())
+                    || column.isOntology())
+            || (!column.isReference() && hasViewPermission(table))) {
+          createTableField(column, groupByBuilder);
         }
       }
       tableGroupByTypes.put(tableGroupByType, groupByBuilder.build());

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestSumQuery.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestSumQuery.java
@@ -96,8 +96,9 @@ public class TestSumQuery {
   public void testSumQueryGroupByRefArray() {
     Table table = schema.getTable(SAMPLES).getMetadata().getTable();
     Query query1 = table.groupBy();
-    query1.select(s(SUM_FIELD, s(N)), s(TYPE, s(NAME)));
+    query1.select(s(SUM_FIELD, s(N)), s(TYPE_ARRAY, s(NAME)));
     final String json = query1.retrieveJSON();
+    // note, should return identifier not name of column as key!
     assertTrue(json.contains("n\": 37")); // for Type A
     assertTrue(json.contains("34")); // for Type B
   }
@@ -108,11 +109,6 @@ public class TestSumQuery {
     Query query1 = table.groupBy();
     query1.select(s(SUM_FIELD, s(N)), s(TAG));
     final String json = query1.retrieveJSON();
-    assertTrue(json.contains("n\": 28")); // for Type A
-    assertTrue(json.contains("green")); // green
-    assertTrue(json.contains("red")); // red
-    assertTrue(json.contains("n\": 28")); // for green
-    assertTrue(json.contains("11")); // for red
     assertEquals(
         "{\"Samples_groupBy\": [{\"tag\": \"green\", \"_sum\": {\"n\": 28}}, {\"tag\": \"red\", \"_sum\": {\"n\": 11}}]}",
         json);

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestSumQuery.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestSumQuery.java
@@ -117,7 +117,8 @@ public class TestSumQuery {
         "{\"Samples_groupBy\": [{\"tag\": \"green\", \"_sum\": {\"n\": 28}}, {\"tag\": \"red\", \"_sum\": {\"n\": 11}}]}",
         json);
 
-    //todo, we need a permission test!
+    // todo, we need a permission test to ensure this cannot be done unless you have view permssion
+    // on the table
   }
 
   @Test

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestSumQuery.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestSumQuery.java
@@ -7,6 +7,7 @@ import static org.molgenis.emx2.ColumnType.*;
 import static org.molgenis.emx2.Row.row;
 import static org.molgenis.emx2.SelectColumn.s;
 import static org.molgenis.emx2.TableMetadata.table;
+import static org.molgenis.emx2.datamodels.PetStoreLoader.COLORS;
 import static org.molgenis.emx2.datamodels.PetStoreLoader.TAG;
 import static org.molgenis.emx2.sql.SqlQuery.SUM_FIELD;
 
@@ -53,6 +54,7 @@ public class TestSumQuery {
                 column(TYPE).setType(REF).setRefTable(TYPE).setPkey(),
                 column(TYPE_ARRAY).setType(REF_ARRAY).setRefTable(TYPE),
                 column(GENDER).setType(REF).setRefTable(GENDER).setPkey(),
+                column(COLORS).setType(STRING_ARRAY),
                 column(TAG).setType(STRING)));
 
     samplesTable.insert(
@@ -65,10 +67,36 @@ public class TestSumQuery {
             "M",
             TYPE_ARRAY,
             List.of("Type a", "Type b"),
+            COLORS,
+            "green,red",
             TAG,
-            "green"),
-        row(N, 5, TYPE, "Type a", GENDER, "F", TYPE_ARRAY, List.of("Type a"), TAG, "green"),
-        row(N, 2, TYPE, "Type b", GENDER, "M", TYPE_ARRAY, List.of("Type b"), TAG, "red"),
+            "a"),
+        row(
+            N,
+            5,
+            TYPE,
+            "Type a",
+            GENDER,
+            "F",
+            TYPE_ARRAY,
+            List.of("Type a"),
+            COLORS,
+            "green",
+            TAG,
+            "a"),
+        row(
+            N,
+            2,
+            TYPE,
+            "Type b",
+            GENDER,
+            "M",
+            TYPE_ARRAY,
+            List.of("Type b"),
+            COLORS,
+            "red",
+            TAG,
+            "b"),
         row(
             N,
             9,
@@ -78,8 +106,10 @@ public class TestSumQuery {
             "F",
             TYPE_ARRAY,
             List.of("Type a", "Type b"),
+            COLORS,
+            "red",
             TAG,
-            "red"));
+            "b"));
   }
 
   @Test
@@ -104,13 +134,27 @@ public class TestSumQuery {
   }
 
   @Test
-  public void testSumQueryGroupByNonRef() {
+  public void testSumQueryGroupByString() {
     Table table = schema.getTable(SAMPLES).getMetadata().getTable();
     Query query1 = table.groupBy();
     query1.select(s(SUM_FIELD, s(N)), s(TAG));
     final String json = query1.retrieveJSON();
     assertEquals(
-        "{\"Samples_groupBy\": [{\"tag\": \"green\", \"_sum\": {\"n\": 28}}, {\"tag\": \"red\", \"_sum\": {\"n\": 11}}]}",
+        "{\"Samples_groupBy\": [{\"tag\": \"a\", \"_sum\": {\"n\": 28}}, {\"tag\": \"b\", \"_sum\": {\"n\": 11}}]}",
+        json);
+
+    // todo, we need a permission test to ensure this cannot be done unless you have view permssion
+    // on the table
+  }
+
+  @Test
+  public void testSumQueryGroupByStringArray() {
+    Table table = schema.getTable(SAMPLES).getMetadata().getTable();
+    Query query1 = table.groupBy();
+    query1.select(s(SUM_FIELD, s(N)), s(COLORS));
+    final String json = query1.retrieveJSON();
+    assertEquals(
+        "{\"Samples_groupBy\": [{\"_sum\": {\"n\": 28}, \"colors\": \"green\"}, {\"_sum\": {\"n\": 34}, \"colors\": \"red\"}]}",
         json);
 
     // todo, we need a permission test to ensure this cannot be done unless you have view permssion


### PR DESCRIPTION
closes #3822

What are the main changes you did:
- enable group by to work on non-ref fields. Required only extension of the graphql api
- efactored graphql api so the field creation can be reused (future: merge the sample and sample_groupBy)

how to test:
- see test

todo:
- [ ] updated docs in case of new feature 
- [ ] added/updated tests (need permission test)
