### PR TITLE
Fix: dcat profile (without files add-on) fails

### DIFF
--- a/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/TestLoaders.java
+++ b/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/TestLoaders.java
@@ -22,6 +22,7 @@ public class TestLoaders {
   public static final String JRC_CDE_TEST = "JRCCDETest";
   public static final String FAIR_GENOMES = "FAIRGenomesTest";
   public static final String DCAT = "DCATTest";
+  public static final String DCAT_BASIC = "DCATBasicTest";
   public static final String PROJECT_MANAGER = "ProjectManager";
   public static final String CATALOGUE_ONTOLOGIES = "CatalogueOntologies";
   public static final String DIRECTORY_ONTOLOGIES = "DirectoryOntologies";
@@ -133,5 +134,12 @@ public class TestLoaders {
     Schema directoryStaging = database.createSchema(DIRECTORY_STAGING);
     AvailableDataModels.BIOBANK_DIRECTORY_STAGING.install(directoryStaging, false);
     assertEquals(6, directoryStaging.getTableNames().size());
+  }
+
+  @Test
+  void test16DCATBasic() {
+    Schema DCATSchema = database.createSchema(DCAT_BASIC);
+    new ProfileLoader("_profiles/test-only/DCAT-basic.yaml").load(DCATSchema, true);
+    assertEquals(7, DCATSchema.getTableNames().size());
   }
 }

--- a/data/_models/shared/Distribution.csv
+++ b/data/_models/shared/Distribution.csv
@@ -2,7 +2,7 @@ tableName,tableExtends,columnName,columnType,key,required,refSchema,refTable,ref
 Distribution,,,,,,,,,,,http://www.w3.org/ns/dcat#Distribution,DCAT v2 distribution entries.,DCAT
 Distribution,,name,string,1,TRUE,,,,,,http://schema.org/name,"Unique name of a Table or (set of) File(s).",DCAT
 Distribution,,description,string,,,,,,,,http://purl.org/dc/terms/description,"Description of a Table or (set of) File(s).",DCAT
-Distribution,,type,ontology,,TRUE,,DistributionType,,,,http://purl.allotrope.org/ontologies/result#AFR_0002205,"Distribution type, either Table or File.",DCAT
-Distribution,,files,ref_array,,,,Files,,,,http://purl.obolibrary.org/obo/STATO_0000002,"One or multiple metadata for digital remote files.",DCAT
+Distribution,,type,ontology,,TRUE,,DistributionType,,,,http://purl.allotrope.org/ontologies/result#AFR_0002205,"Distribution type, either Table or File.",DCAT files add-on
+Distribution,,files,ref_array,,,,Files,,,,http://purl.obolibrary.org/obo/STATO_0000002,"One or multiple metadata for digital remote files.",DCAT files add-on
 Distribution,,belongsToDataset,ref_array,,TRUE,,Dataset,,,,http://www.w3.org/ns/dcat#Dataset,Reference to any datasets that contain this distribution.,DCAT
 Distribution,,propertyValue,string_array,,,,,,,,https://schema.org/PropertyValue,"A property-value pair, e.g. representing a feature of a product or place.",DCAT

--- a/data/_profiles/test-only/DCAT-basic.yaml
+++ b/data/_profiles/test-only/DCAT-basic.yaml
@@ -1,0 +1,10 @@
+---
+name: "W3C's Data Catalog Vocabulary (DCAT) - Version 2"
+description: "DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. DCAT enables a publisher to describe datasets and data services in a catalog using a standard model and vocabulary that facilitates the consumption and aggregation of metadata from multiple catalogs. This can increase the discoverability of datasets and data services. It also makes it possible to have a decentralized approach to publishing data catalogs and makes federated search for datasets across catalogs in multiple sites possible using the same query mechanism and structure. Aggregated DCAT metadata can serve as a manifest file as part of the digital preservation process. See: https://www.w3.org/TR/vocab-dcat-2/"
+
+profileTags:  DCAT
+
+demoData: _demodata/shared-examples
+
+# special options
+setViewPermission: anonymous


### PR DESCRIPTION
What are the main changes you did:
- A profile with `DCAT` but without `DCAT files add-on` would fail with an error:
```
Transaction failed: Add column 'Distribution.files' failed: 'refTable' required for columns of type REF, REF_ARRAY, REFBACK (tried to find: dcat_test:Files): Add column 'Distribution.files' failed: 'refTable' required for columns of type REF, REF_ARRAY, REFBACK (tried to find: dcat_test:Files)
```

This PR makes 2 columns belong to `DCAT files add-on` instead of `DCAT`:
- `files` (as there are literally no files without the add-on and caused the error)
- `DistributionType` (as without the files add-on there can only be a single type hence the column is obsolete)

how to test:
- `test16DCATBasic` should fail pre-changes and work post-changes.