### PR TITLE
fix: search should work as (term1 and term2)

### DIFF
--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -10,6 +10,7 @@ import { applyBookmark, createBookmark } from "../functions/bookmarkMapper";
 import { QueryEMX2 } from "molgenis-components";
 import { convertArrayToChunks } from "../functions/arrayUtilities";
 import { IOntologyItem } from "../interfaces/interfaces";
+import * as _ from "lodash";
 
 export const useFiltersStore = defineStore("filtersStore", () => {
   const biobankStore = useBiobanksStore();
@@ -78,44 +79,22 @@ export const useFiltersStore = defineStore("filtersStore", () => {
     return !!getFilterValue("Biobankservices") || !!getFilterValue("Countries");
   });
 
-  let queryDelay: NodeJS.Timeout;
-  watch(
-    filters,
-    (newFilters) => {
-      if (queryDelay) {
-        clearTimeout(queryDelay);
-      }
-
+  const debouncedFiltersWatch = _.debounce(
+    ([newFilters, newFilterType]: [
+      Record<string, any>,
+      Record<string, any>
+    ]) => {
       settingsStore.currentPage = 1;
-
-      queryDelay = setTimeout(async () => {
-        updateQueryAndBookmark(newFilters, filterType.value);
-        await getBiobankCards();
-        clearTimeout(queryDelay);
-      }, 750);
+      updateQueryAndBookmark(newFilters, newFilterType);
+      getBiobankCards();
     },
-    { deep: true }
+    750
   );
 
-  watch(
-    filterType,
-    (newFilterType) => {
-      if (queryDelay) {
-        clearTimeout(queryDelay);
-      }
-
-      settingsStore.currentPage = 1;
-
-      queryDelay = setTimeout(async () => {
-        updateQueryAndBookmark(filters.value, newFilterType);
-        if (hasActiveFilters.value) {
-          await getBiobankCards();
-          clearTimeout(queryDelay);
-        }
-      }, 750);
-    },
-    { deep: true, immediate: true }
-  );
+  watch([filters, filterType], debouncedFiltersWatch, {
+    deep: true,
+    immediate: true,
+  });
 
   watch(filtersReady, (filtersReady) => {
     if (filtersReady) {

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -531,7 +531,7 @@ public class GraphqlTableFieldFactory {
           subFilters.add(and(nestedFilters.toArray(new Filter[nestedFilters.size()])));
         }
       } else if (entry.getKey().equals(FILTER_SEARCH)) {
-        if (entry.getValue() instanceof String && entry.getValue().toString().trim() != "") {
+        if (entry.getValue() instanceof String && !entry.getValue().toString().trim().equals("")) {
           subFilters.add(
               f(
                   Operator

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -534,7 +534,9 @@ public class GraphqlTableFieldFactory {
         if (entry.getValue() instanceof String && entry.getValue().toString().trim() != "") {
           subFilters.add(
               f(
-                  Operator.TRIGRAM_SEARCH,
+                  Operator
+                      .TEXT_SEARCH, // might change to trigram search if we learn how to tune for
+                  // short terms
                   Arrays.stream(entry.getValue().toString().split(" ")).toArray(String[]::new)));
         }
       } else if (entry.getKey().equals(FILTER_EQUALS)) {

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -531,7 +531,12 @@ public class GraphqlTableFieldFactory {
           subFilters.add(and(nestedFilters.toArray(new Filter[nestedFilters.size()])));
         }
       } else if (entry.getKey().equals(FILTER_SEARCH)) {
-        subFilters.add(f(Operator.TRIGRAM_SEARCH, entry.getValue()));
+        if (entry.getValue() instanceof String && entry.getValue().toString().trim() != "") {
+          subFilters.add(
+              f(
+                  Operator.TRIGRAM_SEARCH,
+                  Arrays.stream(entry.getValue().toString().split(" ")).toArray(String[]::new)));
+        }
       } else if (entry.getKey().equals(FILTER_EQUALS)) {
         //  complex filter, should be an list of maps per graphql contract
         if (entry.getValue() != null) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -519,8 +519,9 @@ public class SqlQuery extends QueryBean {
   private Condition jsonSearchConditions(
       SqlTableMetadata table, String subAlias, String[] searchTerms) {
     // create search
-    List<Condition> search = new ArrayList<>();
+    List<Condition> searchCondition = new ArrayList<>();
     for (String term : searchTerms) {
+      List<Condition> search = new ArrayList<>();
       search.add(
           field(name(alias(subAlias), searchColumnName(table.getTableName())))
               .likeIgnoreCase("%" + term + "%"));
@@ -570,8 +571,9 @@ public class SqlQuery extends QueryBean {
                 .likeIgnoreCase("%" + term + "%"));
         parent = parent.getInheritedTable();
       }
+      searchCondition.add(or(search));
     }
-    return or(search);
+    return and(searchCondition);
   }
 
   private Collection<Field<?>> jsonSubselectFields(

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -424,7 +424,7 @@ public class SqlQuery extends QueryBean {
         } else if (Operator.AND.equals(f.getOperator())) {
           conditions.add(
               and(jsonFilterQueryConditions(table, column, tableAlias, subAlias, f, searchTerms)));
-        } else if (TRIGRAM_SEARCH.equals(f.getOperator())) {
+        } else if (TRIGRAM_SEARCH.equals(f.getOperator()) || TEXT_SEARCH.equals(f.getOperator())) {
           conditions.add(
               jsonSearchConditions(table, subAlias, TypeUtils.toStringArray(f.getValues())));
         } else {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -1384,7 +1384,7 @@ public class SqlQuery extends QueryBean {
         searchConditions.add(and(subConditions));
       }
     }
-    return searchConditions.isEmpty() ? null : or(searchConditions);
+    return searchConditions.isEmpty() ? null : and(searchConditions);
   }
 
   private static SelectJoinStep<org.jooq.Record> limitOffsetOrderBy(

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestFullTextSearch.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestFullTextSearch.java
@@ -106,6 +106,21 @@ public class TestFullTextSearch {
     // would exclude approved order
     assertTrue(!json.contains("approved"));
 
+    // test term1 AND term2
+    json = schema.query("Pet").where(f(Operator.TEXT_SEARCH, "red", "green")).retrieveJSON();
+    // would be spike and fire ant
+    assertTrue(json.contains("spike"));
+    assertTrue(json.contains("fire ant"));
+    assertTrue(!json.contains("tweety"));
+
+    json =
+        schema
+            .query("Order")
+            .where(f("pet", f(Operator.TEXT_SEARCH, "red", "green")))
+            .retrieveJSON();
+    // would be only spike
+    assertTrue(json.contains("spike"));
+
     // nesting example 2
     json =
         schema


### PR DESCRIPTION
closes #3850 

What are the main changes you did:
- when using search as filter (not as part of seperate search parameter) it returned (term1 OR term2). Desire is to have it term1 AND term2
- TEXT_SEARCH operator should be used in graphql api until TRIGRAM_SEARCH is better understood

how to test:
- test search in variables user interface which uses this feature
- see unit test

todo:
- [x] added/updated tests
- [x] added/updated testplan to include a test for this fix, including ref to bug using # notation
