### PR TITLE
fix: use InputEmail instead of InputString for email

### DIFF
--- a/apps/molgenis-components/src/components/forms/ArrayInput.vue
+++ b/apps/molgenis-components/src/components/forms/ArrayInput.vue
@@ -42,6 +42,7 @@ import InputBoolean from "./InputBoolean.vue";
 import InputDate from "./InputDate.vue";
 import InputDateTime from "./InputDateTime.vue";
 import InputDecimal from "./InputDecimal.vue";
+import InputEmail from "./InputEmail.vue";
 import InputInt from "./InputInt.vue";
 import InputLong from "./InputLong.vue";
 import InputString from "./InputString.vue";
@@ -69,7 +70,7 @@ export default {
         DATETIME_ARRAY: InputDateTime,
         DECIMAL_ARRAY: InputDecimal,
         PERIOD_ARRAY: InputString,
-        EMAIL_ARRAY: InputString,
+        EMAIL_ARRAY: InputEmail,
         HYPERLINK_ARRAY: InputString,
         INT_ARRAY: InputInt,
         LONG_ARRAY: InputLong,

--- a/apps/molgenis-components/src/components/forms/FormInput.vue
+++ b/apps/molgenis-components/src/components/forms/FormInput.vue
@@ -32,12 +32,13 @@ import InputRefSelect from "../forms/InputRefSelect.vue";
 import InputString from "../forms/InputString.vue";
 import InputText from "../forms/InputText.vue";
 import BaseInput from "../forms/baseInputs/BaseInput.vue";
+import InputEmail from "./InputEmail.vue";
 import InputRefList from "./InputRefList.vue";
 
 const typeToInputMap = {
   AUTO_ID: InputString,
   HEADING: InputHeading,
-  EMAIL: InputString,
+  EMAIL: InputEmail,
   HYPERLINK: InputString,
   STRING: InputString,
   TEXT: InputText,


### PR DESCRIPTION
What are the main changes you did:
- FormInput now uses InputEmail for email inputs (#3823)

how to test:
- Go to the pet store
- Go to the pet table
- Enter a new row
- Check that the email input field validates the entered adres

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
