### PR TITLE
fix: dont lock settings screen via theme script

### DIFF
--- a/apps/molgenis-components/src/components/layout/Molgenis.vue
+++ b/apps/molgenis-components/src/components/layout/Molgenis.vue
@@ -193,10 +193,11 @@ export default {
         if (this.session?.settings?.logoURL) {
           this.logoURL = this.session.settings.logoURL;
         }
-        const additionalJs = this.session?.settings?.additionalJs;
+        const additionalJs: string = this.session?.settings?.additionalJs;
         if (additionalJs) {
           try {
-            return eval?.(`"use strict";(${additionalJs})`);
+            ("use strict");
+            eval?.(`(function() {"use strict"; ${additionalJs}})()`);
           } catch (error) {
             console.log(error);
           }


### PR DESCRIPTION
What are the main changes you did:
A working theme settings scripts logs you out of the settings page only, this fixes it

how to test:
- add to settings->theme->Additional javascript:
`console.log('hello world')`
- Save and notice that you can still reach the settings screen after
