### PR TITLE
chore: add the schema listing to the dev root page

### DIFF
--- a/apps/nuxt3-ssr/pages/index.vue
+++ b/apps/nuxt3-ssr/pages/index.vue
@@ -1,4 +1,53 @@
+<script setup lang="ts">
+type Resp<T> = {
+  data: Record<string, T[]>;
+};
+
+interface Schema {
+  id: string;
+  label: string;
+  description: string;
+}
+
+const { data } = await useFetch<Resp<Schema>>("/api/graphql", {
+  key: "databases",
+  method: "POST",
+  body: { query: `{ _schemas { id,label,description } }` },
+});
+
+const databases = computed(
+  () =>
+    data.value?.data?._schemas.sort((a, b) => a.label.localeCompare(b.label)) ??
+    []
+);
+</script>
+
 <template>
-  <h1>Catalogue root page</h1>
-  <CustomTooltip label="my-label" content="my content" hover-color="white" />
+  <Container>
+    <PageHeader title="SSR Catalogue DEV " />
+
+    <ContentBlock
+      class="mt-1"
+      title="Schema"
+      description="Note this is for dev setup only"
+    >
+      <Table>
+        <template #head>
+          <TableHeadRow>
+            <TableHead>name</TableHead>
+            <TableHead>description</TableHead>
+          </TableHeadRow>
+        </template>
+        <template #body>
+          <TableRow
+            v-for="database in databases"
+            @click="navigateTo(`/${database.id}/ssr-catalogue`)"
+          >
+            <TableCell>{{ database.label }}</TableCell>
+            <TableCell>{{ database.description }}</TableCell>
+          </TableRow>
+        </template>
+      </Table>
+    </ContentBlock>
+  </Container>
 </template>


### PR DESCRIPTION
- note in prod this is bypassed by the proxy

What are the main changes you did:
- explain what you changed and essential considerations.

how to test:
- on local machine goto [projecroot]/apps/ssr-catalogue
- run : yarn dev ( or run gradle build if project has never been build , this used the lock file to fetch dependencies )
- goto http://localhost:3000 ( or whatever port you use )
- there should not be a listing of schema's, clicking on a schema open the catalogue at the catalogue root ( not this only work for schema's that are implementing the catalogue profile, note 2 this is dev only in prod( acc / preview) that nginx proxy picksup te requests.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
