### PR TITLE
chore(directory): change default negotiator URL

### DIFF
--- a/apps/directory/src/stores/settingsStore.js
+++ b/apps/directory/src/stores/settingsStore.js
@@ -24,7 +24,7 @@ export const useSettingsStore = defineStore("settingsStore", () => {
     graphqlEndpoint: "graphql",
     negotiatorType: "eric-negotiator",
     negotiatorUrl:
-      "https://negotiator-dev.bbmri-eric.eu/api/directory/create_query",
+      "https://negotiator.acc.bbmri-eric.eu/api/directory/create_query",
     biobankColumns: initialBiobankColumns,
     biobankReportColumns: initialBiobankReportColumns,
     collectionColumns: initialCollectionColumns,


### PR DESCRIPTION
What are the main changes you did:
- changed negotiator url from negotiator-dev to negotiator.acc as the dev server does not work properly.

how to test:
- GoTo the directory-demo schema, select one or more collections, push the request button and check that (after login) you get to the negotiator

todo:
- [nvt] updated docs in case of new feature
- [nvt] added/updated tests
- [nvt] added/updated testplan to include a test for this fix, including ref to bug using # notation
