### PR TITLE
fix: oidc is failing after pac4j upgrade

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -48,12 +48,12 @@ subprojects {
         implementation 'com.graphql-java:graphql-java:21.1'
         implementation 'com.graphql-java:graphql-java-extended-scalars:20.2'
         implementation 'com.sparkjava:spark-core:2.9.4'
-        implementation 'org.pac4j:pac4j-core:5.7.5'
-        implementation 'org.pac4j:pac4j-oidc:5.7.5'
-        implementation 'org.pac4j:pac4j-http:5.7.5'
+        implementation 'org.pac4j:pac4j-core:5.6.1'
+        implementation 'org.pac4j:pac4j-oidc:5.6.1'
+        implementation 'org.pac4j:pac4j-http:5.6.1'
         implementation 'org.pac4j:spark-pac4j:5.0.1'
         implementation 'org.javers:javers-core:6.14.0'
-        implementation 'com.nimbusds:nimbus-jose-jwt:9.37'
+        implementation 'com.nimbusds:nimbus-jose-jwt:9.40'
         implementation 'com.schibsted.spt.data:jslt:0.1.14'
 
         //also used outside test


### PR DESCRIPTION
fixes #3964 

What are the main changes you did:
- Downgraded the pac4j dependencies to the latest working libs
- Upgraded the nimbusds:nimbus-jose-jwt to the latest version


how to test:
- Configure OIDC.
- Attempt to log in via OIDC.
- See it working

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
