### PR TITLE
fix(catalogue): variables from other projets linked using network variables table should be shown in variables view of that network

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
@@ -272,8 +272,20 @@ const fetchData = async () => {
   const variables = scoped
     ? {
         variablesFilter: {
-          ...filter.value,
-          ...(await buildScopedModelFilter()),
+          _or: [
+            {
+              ...filter.value,
+              ...(await buildScopedModelFilter()),
+            },
+            {
+              ...filter.value,
+              ...{
+                networkVariables: {
+                  network: { id: { equals: catalogueRouteParam } },
+                },
+              },
+            },
+          ],
         },
         cohortsFilter,
       }

--- a/data/_demodata/applications/datacatalogue/Network variables.csv
+++ b/data/_demodata/applications/datacatalogue/Network variables.csv
@@ -1007,3 +1007,4 @@ LifeCycle,LifeCycle_CDM,core,SCL_anx_score_t1
 LifeCycle,LifeCycle_CDM,outcome,adhd_instr_0
 LifeCycle,LifeCycle_CDM,outcome,adhd_pc_0
 LifeCycle,LifeCycle_CDM,outcome,adhd_pro_0
+testNetwork1,LifeCycle_CDM,core,ga_lmp

--- a/data/_demodata/applications/datacatalogue/Variable mappings.csv
+++ b/data/_demodata/applications/datacatalogue/Variable mappings.csv
@@ -27438,3 +27438,4 @@ testCohort4,test dataset for testCohort4,var8,,,testNetwork1_CDM,cdm_1,testVarRe
 testCohort4,test dataset for testCohort4,var9,,,testNetwork1_CDM,cdm_1,testVarRepeats_9,partial,,some description,some syntax,
 testCohort4,test dataset for testCohort4,var10,,,testNetwork1_CDM,cdm_1,testVarRepeats_10,na,,some description,,
 testCohort4,test dataset for testCohort4,var11,,,testNetwork1_CDM,cdm_1,testVarNoRepeats,partial,,some description,some syntax,
+testCohort2,test dataset for testCohort2,var2,,,LifeCycle_CDM,core,ga_lmp,complete,final,In original variable was reported in weeks and was recalculated for days,COMPUTE ga_lmp= C6600Q_F12v095 * 7 + 3.5.,


### PR DESCRIPTION
closes molgenis/GCC:#477

What are the main changes you did:
- [x] updated demo data to include network variables for testNetwork1
- [x] updated demo data to have a mapping for that variable for testCohort2 in testNetwork1
- [x] extended catalogue/variables filter to include matches based on network variables 
- [ ] updated e2e test for this 
- [ ] updated acceptance tests protocols

how to test:
- go to testNetwork1 and see extra variable 'ga_lmp' 

