### PR TITLE
fix(directory): asterisks in fact table cause wrong number of sampl… closes #3970

### DIFF
--- a/apps/directory/src/components/report-components/FactsTable.vue
+++ b/apps/directory/src/components/report-components/FactsTable.vue
@@ -379,11 +379,15 @@ export default {
        * order matters!
        */
       const baseFacts = this.hardcopy(this.factsData());
+
       const groupedFacts = [];
 
       const criteriaMet = [];
 
       for (const baseFact of baseFacts) {
+        if (Object.values(baseFact).includes("*")) {
+          continue;
+        }
         const criteria = {};
 
         let newCriteria = "";
@@ -410,12 +414,15 @@ export default {
           groupedFacts.push(critGroup);
         }
       }
+
       const collapsedFacts = [];
 
       for (const factGroup of groupedFacts) {
         let collapsedFact = {};
-
         for (const fact of factGroup) {
+          if (Object.values(fact).includes("*")) {
+            continue;
+          }
           if (!Object.keys(collapsedFact).length) {
             collapsedFact = fact;
             continue;
@@ -449,6 +456,10 @@ export default {
                       collapsedFact[column],
                       fact[column],
                     ];
+                  }
+                } else {
+                  if (column == "number_of_samples") {
+                    collapsedFact[column] = 2 * collapsedFact[column];
                   }
                 }
               }


### PR DESCRIPTION
closes #3970

What are the main changes you did:
- explain what you changed and essential considerations.
I removed from the computation the rows where asterisk is present
how to test:
- explain here what to do to test this (or point to unit tests)
load Ontologies.zip (that contain the ontologies from github emx2+*
load Fact.zip that contains the fact table with (3 and 4) asterisks
[Fact.zip](https://github.com/user-attachments/files/16111711/Fact.zip)
[Ontologies.zip](https://github.com/user-attachments/files/16111712/Ontologies.zip)

when all Split by are enabled:
select * on all dimensions. The result is 620 samples for biobank 76823
Now uncheck "Split by" in all columns.
Leaves "all" for all the dimensions. The result should be 620 and no asterisks should be shown. In the incorrect version the result is 3720 and * are shown in the row.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
