### PR TITLE
fix: PERIOD datatype not working in the RDF API

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -410,6 +410,7 @@ public class RDFService {
           REFBACK -> CoreDatatype.XSD.ANYURI;
       case INT, INT_ARRAY -> CoreDatatype.XSD.INT;
       case LONG, LONG_ARRAY -> CoreDatatype.XSD.LONG;
+      case PERIOD, PERIOD_ARRAY -> CoreDatatype.XSD.DURATION;
       default -> throw new MolgenisException("ColumnType not mapped: " + columnType);
     };
   }
@@ -657,6 +658,9 @@ public class RDFService {
           .map(value -> (Value) literal(value))
           .toList();
       case LONG -> Arrays.stream(row.getLongArray(column.getName()))
+          .map(value -> (Value) literal(value))
+          .toList();
+      case DURATION -> Arrays.stream(row.getPeriodArray(column.getName()))
           .map(value -> (Value) literal(value))
           .toList();
       default -> throw new MolgenisException("XSD type formatting not supported for: " + xsdType);


### PR DESCRIPTION
## What are the main changes you did:
Using RDF API where `PERIOD` datatype was used caused an error:
```
Transaction failed: RDF export failed due to an exception: ColumnType not mapped: PERIOD
```

Literal should now return something like:
```
"P89Y"^^xsd:duration
```

## how to test:
- Calling RDF API on f.e. demodata filled FAIR_DATA_HUB should not throw an error anymore but contain `xsd:duration` literals

## todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
