### PR TITLE
feat(beacon): OR filtering for filters with multiple arguments as value.

### DIFF
--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/filter/Filter.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/filter/Filter.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
 import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.beaconv2.requests.Similarity;
 
@@ -156,14 +157,37 @@ public class Filter {
 
   @JsonIgnore
   public String getGraphQlFilter() {
-    StringBuilder filter = new StringBuilder();
+    if (concept == null) return null;
 
-    if (concept != null) {
-      String graphQlQuery = concept.getGraphQlQuery().formatted(values);
-      filter.append(graphQlQuery).append(",");
+    String graphQlQuery = concept.getGraphQlQuery();
+    int argumentCount = (int) graphQlQuery.chars().filter(ch -> ch == '%').count();
+
+    if (argumentCount == values.length) {
+      return graphQlQuery.formatted((Object[]) values);
+    } else if (values.length % argumentCount == 0) {
+      List<String> result = new ArrayList<>();
+      for (int i = 0; i < values.length; i += argumentCount) {
+        Object[] arguments = Arrays.copyOfRange(values, i, i + argumentCount);
+        result.add(concept.getGraphQlQuery().formatted(arguments));
+      }
+      return createOrFilter(result);
+    } else {
+      throw new MolgenisException(
+          "Number of filter arguments does not match query for Concept: " + concept.getId());
     }
+  }
 
-    filter.deleteCharAt(filter.length() - 1);
-    return filter.toString();
+  private String createOrFilter(List<String> filters) {
+    StringBuilder query = new StringBuilder();
+    query.append("{ _or: [");
+    for (String filter : filters) {
+      query.append(filter).append(",");
+    }
+    if (!filters.isEmpty()) {
+      query.deleteCharAt(query.length() - 1);
+    }
+    query.append("] }");
+
+    return query.toString();
   }
 }

--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/filter/FilterParser.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/filter/FilterParser.java
@@ -15,8 +15,6 @@ public interface FilterParser {
 
   boolean hasWarnings();
 
-  List<Filter> getPostFetchFilters();
-
   List<String> getGraphQlFilters();
 
   default String getUrlPathFilter(BeaconQuery beaconQuery) {

--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/filter/FilterParserVP.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/filter/FilterParserVP.java
@@ -13,7 +13,6 @@ public class FilterParserVP implements FilterParser {
   final BeaconQuery beaconQuery;
   final List<Filter> unsupportedFilters = new ArrayList<>();
   final List<Filter> graphQlFilters = new ArrayList<>();
-  final List<Filter> postFetchFilters = new ArrayList<>();
 
   public FilterParserVP(BeaconQuery beaconQuery) {
     this.beaconQuery = beaconQuery;
@@ -61,11 +60,6 @@ public class FilterParserVP implements FilterParser {
   @Override
   public boolean hasWarnings() {
     return !getUnsupportedFilters().isEmpty();
-  }
-
-  @Override
-  public List<Filter> getPostFetchFilters() {
-    return postFetchFilters;
   }
 
   @Override

--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/filter/VariantFilterParser.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/filter/VariantFilterParser.java
@@ -68,11 +68,6 @@ public class VariantFilterParser implements FilterParser {
   }
 
   @Override
-  public List<Filter> getPostFetchFilters() {
-    return List.of();
-  }
-
-  @Override
   public List<String> getGraphQlFilters() {
     List<String> filters = new ArrayList<>(graphQlFilters);
     String urlPathFilter = getUrlPathFilter(beaconQuery);

--- a/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/entrytypes/BeaconIndividualsTests.java
+++ b/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/entrytypes/BeaconIndividualsTests.java
@@ -102,6 +102,28 @@ public class BeaconIndividualsTests extends BeaconModelEndPointTest {
   }
 
   @Test
+  public void FilterOnGenderAtBirth_MultipleTerms_twoResult() throws Exception {
+    BeaconRequestBody beaconRequest =
+        mockIndividualsPostRequestRegular(
+            """
+                          {
+                            "query": {
+                              "filters": [
+                                {
+                                  "id": "NCIT:C28421",
+                                  "value": ["GSSO_000124", "GSSO_000123"],
+                                  "operator": "="
+                                }
+                              ]
+                            }
+                          }""");
+    QueryEntryType queryEntryType = new QueryEntryType(beaconRequest);
+    JsonNode json = queryEntryType.query(beaconSchema);
+    assertTrue(json.get("response").get("resultSets").get(0).get("exists").booleanValue());
+    assertEquals(2, json.get("response").get("resultSets").get(0).get("resultsCount").intValue());
+  }
+
+  @Test
   public void FilterOnGenderAtBirthGssoTerm_oneResult() throws Exception {
     BeaconRequestBody beaconRequest =
         mockIndividualsPostRequestRegular(


### PR DESCRIPTION
What are the main changes you did:
- When filters have an array with multiple arguments as values, OR queries wil be created by default.

how to test:
- See added unit test 

todo:
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
