### PR TITLE
feat(tailwind-components): persist theme state

### DIFF
--- a/apps/tailwind-components/app.vue
+++ b/apps/tailwind-components/app.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
-
-const theme = ref('');
+const theme = useCookie("theme", {
+  default: () => "",
+});
 useHead({
   title: "Tailwind components",
   meta: [


### PR DESCRIPTION
What are the main changes you did:

- chosen theme state persists after reload, making the workflow of adding new components less of a hassle

how to test:
set the theme in the menu, reload the page.
The same theme should still be active