### PR TITLE
fix(directory): replace privacy policy link in footer

### DIFF
--- a/apps/directory/src/components/Footer.vue
+++ b/apps/directory/src/components/Footer.vue
@@ -83,7 +83,7 @@
             <div v-if="isFooterFollowUsVisible" class="ms-md-2 mt-2">
               <a
                 class="link-dark text-primary-text me-5"
-                href="https://www.bbmri-eric.eu/wp-content/uploads/AoM_10_8_Access-Policy_FINAL_EU.pdf"
+                href="https://www.bbmri-eric.eu/privacy-notice/"
               >
                 Privacy Policy
               </a>


### PR DESCRIPTION
What are the main changes you did:
- Replaced the privacy policy link in the footer

how to test:
- Goto the preview and click on the privacy policy and see that it resolves to https://www.bbmri-eric.eu/privacy-notice/

todo:
- [na] updated docs in case of new feature
- [na] added/updated tests
- [na] added/updated testplan to include a test for this fix, including ref to bug using # notation
