### PR TITLE
feat: expanded dev proxy

### DIFF
--- a/apps/.gitignore
+++ b/apps/.gitignore
@@ -20,3 +20,5 @@ yarn-error.log*
 *.sln
 *.sw?
 /nuxt-ssr/.nuxt/
+
+.env

--- a/apps/central/vite.config.js
+++ b/apps/central/vite.config.js
@@ -7,8 +7,7 @@ export default defineConfig({
   plugins: [vue()],
   base: "",
   server: {
-    proxy:
-        {
+    proxy: {
       "/graphql": { target: "http://localhost:8080/api", ...opts },
       "/api": { target: "http://localhost:8080/", ...opts },
       "/theme.css": { target: "http://localhost:8080/apps/central", ...opts },

--- a/apps/central/vite.config.js
+++ b/apps/central/vite.config.js
@@ -7,7 +7,8 @@ export default defineConfig({
   plugins: [vue()],
   base: "",
   server: {
-    proxy: {
+    proxy:
+        {
       "/graphql": { target: "http://localhost:8080/api", ...opts },
       "/api": { target: "http://localhost:8080/", ...opts },
       "/theme.css": { target: "http://localhost:8080/apps/central", ...opts },

--- a/apps/cranio-provider/vite.config.js
+++ b/apps/cranio-provider/vite.config.js
@@ -22,32 +22,7 @@ export default defineConfig(() => {
     plugins: [vue()],
     base: "",
     server: {
-      proxy: {
-        "/api/graphql": {
-          target: `${host}/${schema}`,
-          ...opts,
-        },
-        "^/[a-zA-Z0-9_.%-]+/api/graphql": {
-          target: host,
-          ...opts,
-        },
-        "^/[a-zA-Z0-9_.%-]+/api/file": {
-          target: host,
-          ...opts,
-        },
-        "/api": {
-          target: `${host}/api`,
-          ...opts,
-        },
-        "/apps": {
-          target: host,
-          ...opts,
-        },
-        "/theme.css": {
-          target: `${host}/apps/central`,
-          ...opts,
-        },
-      },
+      proxy: require("../dev-proxy.config"),
     },
   };
 });

--- a/apps/cranio-provider/vite.config.js
+++ b/apps/cranio-provider/vite.config.js
@@ -1,11 +1,9 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-const host = "https://beta-erncranio.molgeniscloud.org";
-const schema = "DK1";
-const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
-
 export default defineConfig(() => {
+  require("dotenv").config({ path: `./.env` });
+
   return {
     css: {
       preprocessorOptions: {

--- a/apps/cranio-public/vite.config.js
+++ b/apps/cranio-public/vite.config.js
@@ -22,32 +22,7 @@ export default defineConfig(() => {
     plugins: [vue()],
     base: "",
     server: {
-      proxy: {
-        "/api/graphql": {
-          target: `${host}/${schema}`,
-          ...opts,
-        },
-        "^/[a-zA-Z0-9_.%-]+/api/graphql": {
-          target: host,
-          ...opts,
-        },
-        "/api": {
-          target: `${host}/api`,
-          ...opts,
-        },
-        "/graphql": {
-          target: `${host}/api/graphql`,
-          ...opts,
-        },
-        "/apps": {
-          target: host,
-          ...opts,
-        },
-        "/theme.css": {
-          target: `${host}/apps/central`,
-          ...opts,
-        },
-      },
+      proxy: require("../dev-proxy.config"),
     },
   };
 });

--- a/apps/cranio-public/vite.config.js
+++ b/apps/cranio-public/vite.config.js
@@ -1,11 +1,10 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-const host = "https://beta-erncranio.molgeniscloud.org";
-const schema = "CranioPublic";
-const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
 
 export default defineConfig(() => {
+  require("dotenv").config({ path: `./.env` });
+  
   return {
     css: {
       preprocessorOptions: {

--- a/apps/dev-proxy.config.js
+++ b/apps/dev-proxy.config.js
@@ -4,25 +4,32 @@ const SCHEMA = process.env.MOLGENIS_APPS_SCHEMA || "pet store";
 const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
 
 module.exports = {
-  "/graphql": {
-    target: `${HOST}/${SCHEMA}`,
-    ...opts,
-  },
-  "^/apps/central/graphql$": {
-    target: `${HOST}`,
-    changeOrigin: true,
-    secure: false,
-  },
-  "/apps/central/theme.css": {
-    target: `${HOST}/${SCHEMA}`,
-    ...opts,
-  },
-  /* should match only '/schema_name/graphql', previous ** was to eager also matching if graphql was /graphql or /a/b/graphql */
-  "^/[a-zA-Z0-9_.%-]+/graphql": {
-    target: `${HOST}`,
-    ...opts,
-  },
-  "/api": { target: `${HOST}`, ...opts },
-  "/apps": { target: `${HOST}`, ...opts },
-  "/theme.css": { target: `${HOST}/${SCHEMA}`, ...opts },
+    "/api/graphql": {
+        target: `${HOST}/${SCHEMA}`,
+        ...opts,
+    },
+    "^/[a-zA-Z0-9_.%-]+/api/graphql": {
+        target: HOST,
+        ...opts,
+    },
+    "^/[a-zA-Z0-9_.%-]+/api/file": {
+        target: HOST,
+        ...opts,
+    },
+    "/api": {
+        target: `${HOST}/api`,
+        ...opts,
+    },
+    "/graphql": {
+        target: `${HOST}/api/graphql`,
+        ...opts,
+    },
+    "/apps": {
+        target: HOST,
+        ...opts,
+    },
+    "/theme.css": {
+        target: `${HOST}/apps/central`,
+        ...opts,
+    }
 };

--- a/apps/dev-proxy.config.js
+++ b/apps/dev-proxy.config.js
@@ -12,6 +12,10 @@ module.exports = {
         target: HOST,
         ...opts,
     },
+    "^/[a-zA-Z0-9_.%-]+/graphql": {
+        target: HOST,
+        ...opts,
+    },
     "^/[a-zA-Z0-9_.%-]+/api/file": {
         target: HOST,
         ...opts,
@@ -21,7 +25,7 @@ module.exports = {
         ...opts,
     },
     "/graphql": {
-        target: `${HOST}/api/graphql`,
+        target: `${HOST}/${SCHEMA}/graphql`,
         ...opts,
     },
     "/apps": {
@@ -29,7 +33,6 @@ module.exports = {
         ...opts,
     },
     "/theme.css": {
-        target: `${HOST}/apps/central`,
-        ...opts,
-    }
+        target: `${HOST}/${SCHEMA}/theme.css`, ...opts
+    },
 };

--- a/apps/ern-genturis/vite.config.js
+++ b/apps/ern-genturis/vite.config.js
@@ -22,32 +22,7 @@ export default defineConfig(() => {
     plugins: [vue()],
     base: "",
     server: {
-      proxy: {
-        "/api/graphql": {
-          target: `${host}/${schema}`,
-          ...opts,
-        },
-        "^/[a-zA-Z0-9_.%-]+/api/graphql": {
-          target: host,
-          ...opts,
-        },
-        "/api": {
-          target: `${host}/api`,
-          ...opts,
-        },
-        "/graphql": {
-          target: `${host}/api/graphql`,
-          ...opts,
-        },
-        "/apps": {
-          target: host,
-          ...opts,
-        },
-        "/theme.css": {
-          target: `${host}/apps/central`,
-          ...opts,
-        },
-      },
+      proxy: require("../dev-proxy.config"),
     },
   };
 });

--- a/apps/ern-genturis/vite.config.js
+++ b/apps/ern-genturis/vite.config.js
@@ -1,11 +1,9 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-const host = "https://beta-erngenturis.molgeniscloud.org";
-const schema = "GenturisStats";
-const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
-
 export default defineConfig(() => {
+  require("dotenv").config({ path: `./.env` });
+  
   return {
     css: {
       preprocessorOptions: {

--- a/apps/ern-ithaca/vite.config.js
+++ b/apps/ern-ithaca/vite.config.js
@@ -22,32 +22,7 @@ export default defineConfig(() => {
     plugins: [vue()],
     base: "",
     server: {
-      proxy: {
-        "/api/graphql": {
-          target: `${host}/${schema}`,
-          ...opts,
-        },
-        "^/[a-zA-Z0-9_.%-]+/api/graphql": {
-          target: host,
-          ...opts,
-        },
-        "/api": {
-          target: `${host}/api`,
-          ...opts,
-        },
-        "/graphql": {
-          target: `${host}/api/graphql`,
-          ...opts,
-        },
-        "/apps": {
-          target: host,
-          ...opts,
-        },
-        "/theme.css": {
-          target: `${host}/${schema}`,
-          ...opts,
-        },
-      },
+      proxy: require("../dev-proxy.config"),
     },
   };
 });

--- a/apps/ern-ithaca/vite.config.js
+++ b/apps/ern-ithaca/vite.config.js
@@ -1,11 +1,9 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-const host = "https://beta-ernithaca.molgeniscloud.org/";
-const schema = "ErnStats";
-const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
-
 export default defineConfig(() => {
+  require("dotenv").config({ path: `./.env` });
+
   return {
     css: {
       preprocessorOptions: {

--- a/apps/ern-reconnet/vite.config.js
+++ b/apps/ern-reconnet/vite.config.js
@@ -1,20 +1,24 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-export default defineConfig({
-  plugins: [vue()],
-  base: "",
-  server: {
-    proxy: require("../dev-proxy.config"),
-  },
-  css: {
-    preprocessorOptions: {
-      scss: {
-        additionalData: `
-          @import "../../molgenis-viz/src/styles/palettes.scss";
-          @import "../../molgenis-viz/src/styles/mixins.scss";
-          @import "./src/styles/index.scss";
-        `
+export default defineConfig(() => {
+  require("dotenv").config({ path: `./.env` });
+
+  return {
+    plugins: [vue()],
+    base: "",
+    server: {
+      proxy: require("../dev-proxy.config"),
+    },
+    css: {
+      preprocessorOptions: {
+        scss: {
+          additionalData: `
+            @import "../../molgenis-viz/src/styles/palettes.scss";
+            @import "../../molgenis-viz/src/styles/mixins.scss";
+            @import "./src/styles/index.scss";
+          `
+        }
       }
     }
   }

--- a/apps/ern-skin/vite.config.js
+++ b/apps/ern-skin/vite.config.js
@@ -22,32 +22,7 @@ export default defineConfig(() => {
     plugins: [vue()],
     base: "",
     server: {
-      proxy: {
-        "/api/graphql": {
-          target: `${host}/${schema}`,
-          ...opts,
-        },
-        "^/[a-zA-Z0-9_.%-]+/api/graphql": {
-          target: host,
-          ...opts,
-        },
-        "/api": {
-          target: `${host}/api`,
-          ...opts,
-        },
-        "/graphql": {
-          target: `${host}/api/graphql`,
-          ...opts,
-        },
-        "/apps": {
-          target: host,
-          ...opts,
-        },
-        "/theme.css": {
-          target: `${host}/apps/central`,
-          ...opts,
-        },
-      },
+      proxy: require("../dev-proxy.config"),
     },
   };
 });

--- a/apps/ern-skin/vite.config.js
+++ b/apps/ern-skin/vite.config.js
@@ -1,11 +1,9 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-const host = "https://beta-ernskin.molgeniscloud.org";
-const schema = "ErnStats";
-const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
-
 export default defineConfig(() => {
+  require("dotenv").config({ path: `./.env` });
+
   return {
     css: {
       preprocessorOptions: {

--- a/apps/imdhub-public/vite.config.js
+++ b/apps/imdhub-public/vite.config.js
@@ -1,11 +1,9 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 
-const host = "https://demo-recon4imd.molgeniscloud.org";
-const schema = "IMDhub Refs";
-const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
-
 export default defineConfig(() => {
+  require("dotenv").config({ path: `./.env` });
+
   return {
     css: {
       preprocessorOptions: {

--- a/apps/imdhub-public/vite.config.js
+++ b/apps/imdhub-public/vite.config.js
@@ -23,32 +23,7 @@ export default defineConfig(() => {
     plugins: [vue()],
     base: "",
     server: {
-      proxy: {
-        "/api/graphql": {
-          target: `${host}/${schema}`,
-          ...opts,
-        },
-        "^/[a-zA-Z0-9_.%-]+/api/graphql": {
-          target: host,
-          ...opts,
-        },
-        "/api": {
-          target: `${host}/api`,
-          ...opts,
-        },
-        "/graphql": {
-          target: `${host}/api/graphql`,
-          ...opts,
-        },
-        "/apps": {
-          target: host,
-          ...opts,
-        },
-        "/theme.css": {
-          target: `${host}/apps/central`,
-          ...opts,
-        },
-      },
+      proxy: require("../dev-proxy.config"),
     },
   };
 });

--- a/apps/molgenis-viz/vite.config.js
+++ b/apps/molgenis-viz/vite.config.js
@@ -2,10 +2,6 @@ import { defineConfig } from "vite";
 import path from "path";
 import vue from "@vitejs/plugin-vue";
 
-const host = "https://emx2.dev.molgenis.org";
-const schema = "DASHBOARD_TEST";
-const opts = { changeOrigin: true, secure: false, logLevel: "debug" };
-
 // basic build conf fo both library
 let conf = {
   plugins: [vue()],
@@ -33,6 +29,7 @@ let conf = {
 };
 
 export default defineConfig(({ command, mode }) => { 
+  require("dotenv").config({ path: `./.env` });
   
   if (command === 'serve') {
     return {

--- a/apps/molgenis-viz/vite.config.js
+++ b/apps/molgenis-viz/vite.config.js
@@ -38,32 +38,7 @@ export default defineConfig(({ command, mode }) => {
     return {
       ...conf,
       server: {
-        proxy: {
-          "/api/graphql": {
-            target: `${host}/${schema}`,
-            ...opts,
-          },
-          "^/[a-zA-Z0-9_.%-]+/api/graphql": {
-            target: host,
-            ...opts,
-          },
-          "/api": {
-            target: `${host}/api`,
-            ...opts,
-          },
-          "/graphql": {
-            target: `${host}/api/graphql`,
-            ...opts,
-          },
-          "/apps": {
-            target: host,
-            ...opts,
-          },
-          "/theme.css": {
-            target: `${host}/apps/central`,
-            ...opts,
-          },
-        },
+        proxy: require("../dev-proxy.config"),
       },
     }
   } else {


### PR DESCRIPTION
What are the main changes you did:

The purpose of this PR is to expand the current dev proxy to eliminate the number of per-app configurations. This includes:

- Revised graphql and file endpoints
- Added support for cross schema querying when developing UIs
- Added proxy for file endpoint

To use, import it into your `vite.config.js` file. In your request, you can write your URLs like so:

1. `../api/graphql`: query within the current schema (`/graphql` should also work)
2. `/<schema>/api/graphql`: query a table in another schema

how to test:

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation


Considerations:
I would love to turn this into a function rather than using module.exports. This would eliminate the need to configure the dev-proxy server for every PR and allow me to avoid using `.env` files to change the host/schema. 

```js
// vite.config.js
import newDevProxy from "../dev-proxy.js"

export default defineConfig(() => {
    return {
        server: {
            proxy: newDevProxy({host: "....", schema: "...."}),
        }
    }
})

```
