### PR TITLE
fix(beacon): added mapping for root path without "/"

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
@@ -33,6 +33,7 @@ public class BeaconApi {
         basePath,
         () -> {
           before("/*", BeaconApi::processRequest);
+          get("", BeaconApi::getInfo);
           get("/", BeaconApi::getInfo);
           get("/info", BeaconApi::getInfo);
           get("/service-info", BeaconApi::getInfo);


### PR DESCRIPTION
What are the main changes you did:
- Added a mapping for the beacon root api without a trailing /

how to test:
- Create a schema with a beacon data template
- Go to "severpath/schema_name/api/beacon" and see it working
