### PR TITLE
feat(molgenis-components): expressions recreate mg_tableclass

### DIFF
--- a/apps/molgenis-components/src/components/forms/formUtils/formUtils.ts
+++ b/apps/molgenis-components/src/components/forms/formUtils/formUtils.ts
@@ -164,10 +164,6 @@ export function executeExpression(
   values: Record<string, any>,
   tableMetaData: ITableMetaData
 ) {
-  if (!values.mg_tableclass) {
-    values.mg_tableclass = `${tableMetaData.schemaId}.${tableMetaData.label}`;
-  }
-
   //make sure all columns have keys to prevent reference errors
   const copy: Record<string, any> = deepClone(values);
   tableMetaData.columns.forEach((column: IColumn) => {
@@ -175,6 +171,9 @@ export function executeExpression(
       copy[column.id] = null;
     }
   });
+  if (!copy.mg_tableclass) {
+    copy.mg_tableclass = `${tableMetaData.schemaId}.${tableMetaData.label}`;
+  }
 
   // A simple client for scripts to use to request data.
   // Note: don't overuse this, the API call is blocking.

--- a/apps/molgenis-components/src/components/forms/formUtils/formUtils.ts
+++ b/apps/molgenis-components/src/components/forms/formUtils/formUtils.ts
@@ -164,6 +164,10 @@ export function executeExpression(
   values: Record<string, any>,
   tableMetaData: ITableMetaData
 ) {
+  if (!values.mg_tableclass) {
+    values.mg_tableclass = `${tableMetaData.schemaId}.${tableMetaData.label}`;
+  }
+
   //make sure all columns have keys to prevent reference errors
   const copy: Record<string, any> = deepClone(values);
   tableMetaData.columns.forEach((column: IColumn) => {


### PR DESCRIPTION
fixes: #3752

What are the main changes you did:
- when creating a new record, expressions did not have access to "mg_tableclass" property
- Now if it does not exists it will be recreated (for the expressions).

How to test:
- have in a string field the validation expression:`mg_tableclass`
- update the string field, it will return the current `mg_tableclass` value in the error field.
- make sure mg_tableclass is a valid value on a new record and on a preexisting record.
