### PR TITLE
chore: e2e admin login + improved README

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ apps/nuxt3-ssr/utils/fingerprint.js
 #playwright
 playwright-report
 CHANGELOG.md
+e2e/.auth/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -38,7 +38,7 @@ To make the plugin use a local running version of EMX2, add the following to you
     }, 
 ```
 
-When running tests in files named `admin!`, be sure to run `auth.setup.spec.ts` first to ensure login session is defined. See also: https://playwright.dev/docs/auth#authenticating-in-ui-mode
+When running tests in files which name start with `admin!`, be sure to run `auth.setup.spec.ts` first to ensure login session is defined. See also: https://playwright.dev/docs/auth#authenticating-in-ui-mode
 
 ## Adding tests
 

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,28 +1,49 @@
 We have e2e tests using playwright
 
-To install:
-```yarn install```
+#### To install
+```bash
+yarn install
+```
 
-To test against a localhost:8080 run:
+#### To test against a localhost:8080 run
+```bash
+npx playwright test
+```
 
-```npx playwright test```
+#### You can also make the test start/stop emx2
+```bash
+set CI=true && npx playwright test
+```
 
-You can also make the test start/stop emx2:
+#### You can also run from the molgenis-emx2 project root as follows
+```bash
+npx playwright test --config e2e --project=chromium
+```
 
-```set CI=true && npx playwright test```
-
-You can also run from the molgenis-emx2 project root as follows
-
-```npx playwright test --config e2e --project=chromium```
-
-The test is part of .circleci/config.yml running that same command
+The test is part of .circleci/config.yml running that same command.  
+When running this on a local emx2 server, run the following first (or add it to `.bash_profile`):
+```bash
+export E2E_BASE_URL=http://localhost:8080/
+```
 
 ## playwright vscode plugin
 
 [Playwright: Getting started - VS Code](https://playwright.dev/docs/getting-started-vscode)
+
+To make the plugin use a local running version of EMX2, add the following to your `settings.json`:
+
+```json
+"playwright.env": {
+        "E2E_BASE_URL":"http://localhost:8080/"
+    }, 
+```
+
+When running tests in files named `admin!`, be sure to run `auth.setup.spec.ts` first to ensure login session is defined. See also: https://playwright.dev/docs/auth#authenticating-in-ui-mode
 
 ## Adding tests
 
 We suggest to use the vscode plugin for [creating/recording](https://playwright.dev/docs/codegen) new tests. The `playwright.config.ts` file contains the test configuration including the default server path. It is suggested to use relative server paths ( instead of `https://my-server.com/my-page` use `/my-page` ) to make it possible for test to run against different servers.
 
 By default tests are run for all pull requests, on the server connected to the pull request preview ( i.e. test for pr `007` will  by ( default ) run on `https://preview-emx2-pr-007.dev.molgenis.org/`
+
+If creating tests that require being logged in, ensure the filename starts with `admin!`. For more information about this, see https://playwright.dev/docs/auth#basic-shared-account-in-all-tests.

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -25,6 +25,7 @@ When running this on a local emx2 server, run the following first (or add it to 
 ```bash
 export E2E_BASE_URL=http://localhost:8080/
 ```
+IMPORTANT: Do note that some tests will fail unless the local server is set up correctly!
 
 ## playwright vscode plugin
 

--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -39,6 +39,15 @@ export default defineConfig({
     {
       name: 'chromium',
       use: { ...devices['Desktop Chrome'] },
+      testIgnore: '*/admin!*.spec.ts'
+    },
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/user.json'
+       },
+      testMatch: '*/admin!*.spec.ts'
     },
 
     // {

--- a/e2e/tests/admin!example.spec.ts
+++ b/e2e/tests/admin!example.spec.ts
@@ -1,0 +1,8 @@
+import { test, expect } from "@playwright/test";
+
+
+test("go to admin settings webpage", async ({ page }) => {
+await page.goto('http://localhost:8080/apps/central/');
+await page.getByRole('link', { name: 'Admin' }).click();
+await page.getByRole('link', { name: 'Settings' }).click();
+});

--- a/e2e/tests/admin!example.spec.ts
+++ b/e2e/tests/admin!example.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from "@playwright/test";
 
 
 test("go to admin settings webpage", async ({ page }) => {
-await page.goto('http://localhost:8080/apps/central/');
-await page.getByRole('link', { name: 'Admin' }).click();
-await page.getByRole('link', { name: 'Settings' }).click();
+  await page.goto('/apps/central/');
+  await page.getByRole('link', { name: 'Admin' }).click();
+  await page.getByRole('link', { name: 'Settings' }).click();
 });

--- a/e2e/tests/auth.setup.spec.ts
+++ b/e2e/tests/auth.setup.spec.ts
@@ -1,0 +1,19 @@
+import { test as setup, expect } from '@playwright/test';
+
+// Needs to be run manually in UI mode before tests are ran.
+// See also: https://playwright.dev/docs/auth#authenticating-in-ui-mode
+
+const authFile = 'e2e/.auth/user.json';
+
+setup('authenticate', async ({ page }) => {
+    await page.goto('/apps/central/');
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.getByPlaceholder('Enter username').click();
+    await page.getByPlaceholder('Enter username').fill('admin');
+    await page.getByPlaceholder('Password').click();
+    await page.getByPlaceholder('Password').fill('admin');
+    await page.getByRole('dialog').getByRole('button', { name: 'Sign in' }).click();
+    await expect(page.getByRole('navigation')).toContainText('Hi admin');
+
+    await page.context().storageState({ path: authFile });
+});


### PR DESCRIPTION
What are the main changes you did:
- e2e tests now don't have to login manually (which would need to be done for each test individually), but can use a shared authentication
- updated README regarding the above & some general fixes/improvements I ran into while trying to get it to work

how to test:
- In VS code, run `auth.setup.spec.ts` and then `admin!example.spec.ts`
- Check if `admin!example.spec.ts` succeeds in CI

todo:
- [X] updated docs in case of new feature
- [X] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
