### PR TITLE
fix(beacon): get information endpoint data via sql query

### DIFF
--- a/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/Beaconv2_InfoTest.java
+++ b/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/Beaconv2_InfoTest.java
@@ -11,10 +11,10 @@ public class Beaconv2_InfoTest extends BeaconModelEndPointTest {
 
   @Test
   public void testInfoRootEndpoint() {
-    Info info = new Info(beaconSchema);
-    JsonNode response = info.getResponse();
+    Info info = new Info(database);
+    JsonNode response = info.getResponse(beaconSchema);
 
-    assertEquals("UMCG", response.get("response").get("organization").get("name").asText());
+    assertEquals("https://molgenis.org/", response.get("response").get("welcomeUrl").asText());
     assertEquals("MOLGENIS EMX2 Beacon v2", response.get("response").get("name").asText());
   }
 }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/BeaconApi.java
@@ -87,6 +87,7 @@ public class BeaconApi {
   private static Object getInfo(Request request, Response response) {
     Schema schema = getSchema(request);
 
-    return new Info(schema).getResponse();
+    Database database = sessionManager.getSession(request).getDatabase();
+    return new Info(database).getResponse(schema);
   }
 }


### PR DESCRIPTION
What are the main changes you did:
- To always make the informational endpoint available, data is fetch directly via sql

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
