### PR TITLE
chore(directory): add asterisks to ontology tables

### DIFF
--- a/apps/directory/src/components/report-components/FactsTable.vue
+++ b/apps/directory/src/components/report-components/FactsTable.vue
@@ -385,7 +385,7 @@ export default {
       const criteriaMet = [];
 
       for (const baseFact of baseFacts) {
-        if (Object.values(baseFact).includes("*")) {
+        if (Object.values(baseFact).includes("Any")) {
           continue;
         }
         const criteria = {};
@@ -420,7 +420,7 @@ export default {
       for (const factGroup of groupedFacts) {
         let collapsedFact = {};
         for (const fact of factGroup) {
-          if (Object.values(fact).includes("*")) {
+          if (Object.values(fact).includes("Any")) {
             continue;
           }
           if (!Object.keys(collapsedFact).length) {

--- a/data/biobank-directory/ontologies/AgeRanges.csv
+++ b/data/biobank-directory/ontologies/AgeRanges.csv
@@ -10,4 +10,4 @@ order,name,label,parent,codesystem,code,ontologyTermURI,definition
 ,Adult,Adult (25-44 years),,,,,
 ,Infant,Infant (2-23 months),,,,,
 ,Child,Child (2-12 years),,,,,
-,*,*,,,*
+,*,Any,,,*,,Any age range

--- a/data/biobank-directory/ontologies/AgeRanges.csv
+++ b/data/biobank-directory/ontologies/AgeRanges.csv
@@ -10,3 +10,4 @@ order,name,label,parent,codesystem,code,ontologyTermURI,definition
 ,Adult,Adult (25-44 years),,,,,
 ,Infant,Infant (2-23 months),,,,,
 ,Child,Child (2-12 years),,,,,
+,*,*,,,*

--- a/data/biobank-directory/ontologies/DiseaseTypes.csv
+++ b/data/biobank-directory/ontologies/DiseaseTypes.csv
@@ -1,4 +1,5 @@
 order,name,label,parent,codesystem,code,ontologyTermURI,definition,exact_mapping,btnt_mapping,ntbt_mapping
+,*,*,,,*,,,,,
 ,ORPHA:50918,Kikuchi-Fujimoto disease,ORPHA:182222,orphanet,ORPHA:50918,https://identifiers.org/orphanet:50918,,,,urn:miriam:icd:I88.1
 ,ORPHA:599507,Acquired factor XI deficiency,ORPHA:166775,orphanet,ORPHA:599507,https://identifiers.org/orphanet:599507,,,,urn:miriam:icd:D68.4
 ,ORPHA:599501,Acquired factor X deficiency,ORPHA:166775,orphanet,ORPHA:599501,https://identifiers.org/orphanet:599501,,,,urn:miriam:icd:D68.4

--- a/data/biobank-directory/ontologies/DiseaseTypes.csv
+++ b/data/biobank-directory/ontologies/DiseaseTypes.csv
@@ -1,5 +1,5 @@
 order,name,label,parent,codesystem,code,ontologyTermURI,definition,exact_mapping,btnt_mapping,ntbt_mapping
-,*,*,,,*,,,,,
+,*,Any,,,*,,Any disease,,,
 ,ORPHA:50918,Kikuchi-Fujimoto disease,ORPHA:182222,orphanet,ORPHA:50918,https://identifiers.org/orphanet:50918,,,,urn:miriam:icd:I88.1
 ,ORPHA:599507,Acquired factor XI deficiency,ORPHA:166775,orphanet,ORPHA:599507,https://identifiers.org/orphanet:599507,,,,urn:miriam:icd:D68.4
 ,ORPHA:599501,Acquired factor X deficiency,ORPHA:166775,orphanet,ORPHA:599501,https://identifiers.org/orphanet:599501,,,,urn:miriam:icd:D68.4

--- a/data/biobank-directory/ontologies/MaterialTypes.csv
+++ b/data/biobank-directory/ontologies/MaterialTypes.csv
@@ -20,4 +20,4 @@ order,name,label,parent,codesystem,code,ontologyTermURI,definition
 ,TISSUE_PARAFFIN_EMBEDDED,Tissue (paraffin preserved),,,TISSUE_PARAFFIN_EMBEDDED,,Tissue that is preserved and embedded in paraffin. (NCI)
 ,URINE,Urine,,,URINE,,The fluid that is excreted by the kidneys. It is stored in the bladder and discharged through the urethra. (NCI)
 ,WHOLE_BLOOD,Whole Blood,,,WHOLE_BLOOD,http://purl.obolibrary.org/obo/OBI_0000655,Blood that has not been separated into its various components; blood that has not been modified except for the addition of an anticoagulant (NCI)
-,*,*,,,*
+,*,Any,,,*,,Any material type

--- a/data/biobank-directory/ontologies/MaterialTypes.csv
+++ b/data/biobank-directory/ontologies/MaterialTypes.csv
@@ -20,3 +20,4 @@ order,name,label,parent,codesystem,code,ontologyTermURI,definition
 ,TISSUE_PARAFFIN_EMBEDDED,Tissue (paraffin preserved),,,TISSUE_PARAFFIN_EMBEDDED,,Tissue that is preserved and embedded in paraffin. (NCI)
 ,URINE,Urine,,,URINE,,The fluid that is excreted by the kidneys. It is stored in the bladder and discharged through the urethra. (NCI)
 ,WHOLE_BLOOD,Whole Blood,,,WHOLE_BLOOD,http://purl.obolibrary.org/obo/OBI_0000655,Blood that has not been separated into its various components; blood that has not been modified except for the addition of an anticoagulant (NCI)
+,*,*,,,*

--- a/data/biobank-directory/ontologies/SexTypes.csv
+++ b/data/biobank-directory/ontologies/SexTypes.csv
@@ -7,4 +7,4 @@ order,name,label,parent,codesystem,code,ontologyTermURI,definition
 ,MALE,Male,,Miabis,MALE,http://purl.obolibrary.org/obo/PATO_0000384,Male
 ,FEMALE,Female,,Miabis,FEMALE,http://purl.obolibrary.org/obo/PATO_0000383,Female
 ,NASK,Not asked,,,NASK,,
-,*,*,,,*
+,*,Any,,,*,,Any sex

--- a/data/biobank-directory/ontologies/SexTypes.csv
+++ b/data/biobank-directory/ontologies/SexTypes.csv
@@ -7,3 +7,4 @@ order,name,label,parent,codesystem,code,ontologyTermURI,definition
 ,MALE,Male,,Miabis,MALE,http://purl.obolibrary.org/obo/PATO_0000384,Male
 ,FEMALE,Female,,Miabis,FEMALE,http://purl.obolibrary.org/obo/PATO_0000383,Female
 ,NASK,Not asked,,,NASK,,
+,*,*,,,*


### PR DESCRIPTION
What are the main changes you did:
- Added asterisks (*) as codes to AgeRanges, DiseaseTypes, MaterialTypes and SexTypes biobank-directory ontology tables

how to test:
- Go to the preview and check the above mentioned tables and see the * as a record

todo:
- [na] updated docs in case of new feature
- [na] added/updated tests
- [na] added/updated testplan to include a test for this fix, including ref to bug using # notation
