### PR TITLE
fix(beacon): added granularity for get requests

### DIFF
--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/requests/BeaconQuery.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/requests/BeaconQuery.java
@@ -81,10 +81,12 @@ public class BeaconQuery {
     }
     if (request.queryMap() != null) {
       for (var queryParam : request.queryMap().toMap().entrySet()) {
-        if (queryParam.getKey().equals("limit")) {
+        if (queryParam.getKey().equalsIgnoreCase("limit")) {
           pagination.setLimit(Integer.parseInt(queryParam.getValue()[0]));
-        } else if (queryParam.getKey().equals("skip")) {
+        } else if (queryParam.getKey().equalsIgnoreCase("skip")) {
           pagination.setSkip(Integer.parseInt(queryParam.getValue()[0]));
+        } else if (queryParam.getKey().equalsIgnoreCase("requestedGranularity")) {
+          requestedGranularity = Granularity.fromString(queryParam.getValue()[0]);
         } else {
           requestParameters.put(
               queryParam.getKey(),

--- a/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/entrytypes/BeaconGranularityTests.java
+++ b/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/entrytypes/BeaconGranularityTests.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.beaconv2.QueryEntryType;
 import org.molgenis.emx2.beaconv2.requests.BeaconRequestBody;
-import spark.Request;
 
 public class BeaconGranularityTests extends BeaconModelEndPointTest {
 
@@ -48,8 +47,8 @@ public class BeaconGranularityTests extends BeaconModelEndPointTest {
   @Test
   public void testRequestedGranularity_getRequestCount() {
     Map<String, String[]> params = Map.of("requestedGranularity", new String[] {"count"});
-    Request request = mockEntryTypeRequestRegular("Individuals", params);
-    BeaconRequestBody requestBody = new BeaconRequestBody(request);
+    BeaconRequestBody requestBody =
+        new BeaconRequestBody(mockEntryTypeRequestRegular("Individuals", params));
 
     QueryEntryType queryEntryType = new QueryEntryType(requestBody);
     JsonNode json = queryEntryType.query(beaconSchema);

--- a/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/entrytypes/BeaconGranularityTests.java
+++ b/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/entrytypes/BeaconGranularityTests.java
@@ -4,9 +4,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.beaconv2.QueryEntryType;
 import org.molgenis.emx2.beaconv2.requests.BeaconRequestBody;
+import spark.Request;
 
 public class BeaconGranularityTests extends BeaconModelEndPointTest {
 
@@ -38,6 +40,18 @@ public class BeaconGranularityTests extends BeaconModelEndPointTest {
                             }
                           }""");
     QueryEntryType queryEntryType = new QueryEntryType(beaconRequest);
+    JsonNode json = queryEntryType.query(beaconSchema);
+    assertEquals(5, json.get("response").get("resultSets").get(0).get("resultsCount").intValue());
+    assertNull(json.get("response").get("resultSets").get(0).get("results"));
+  }
+
+  @Test
+  public void testRequestedGranularity_getRequestCount() {
+    Map<String, String[]> params = Map.of("requestedGranularity", new String[] {"count"});
+    Request request = mockEntryTypeRequestRegular("Individuals", params);
+    BeaconRequestBody requestBody = new BeaconRequestBody(request);
+
+    QueryEntryType queryEntryType = new QueryEntryType(requestBody);
     JsonNode json = queryEntryType.query(beaconSchema);
     assertEquals(5, json.get("response").get("resultSets").get(0).get("resultsCount").intValue());
     assertNull(json.get("response").get("resultSets").get(0).get("results"));

--- a/docs/molgenis/dev_beaconv2.md
+++ b/docs/molgenis/dev_beaconv2.md
@@ -87,7 +87,7 @@ Model endpoints for which record-level GET and POST requests are implemented are
 
 ### Permissions
 
-By default, a new database will have **VIEWER** permission for all users including anonymous requests. How to set up
+By default, a new database with a Beacon profile will have **VIEWER** permission for all users including anonymous requests. How to set up
 permissions for a database is found [here](use_permissions.md).
 
 Request are **Record** requests by default and therefor **VIEWER** permission on the data is needed to perform the queries.

--- a/docs/molgenis/dev_beaconv2.md
+++ b/docs/molgenis/dev_beaconv2.md
@@ -84,13 +84,24 @@ Model endpoints for which record-level GET and POST requests are implemented are
   Data is retrieved from the _Individuals_ table.
 - `/filtering_terms` returns a list of the filtering terms accepted by that Beacon instance.
 
-GET request are record requests by default and therefor viewer permission on the data is needed to perform the queries.
-For post requests a
 
 ### Permissions
 
-By default, a new database will have VIEWER permission for all users including anonymous requests. How to set up
+By default, a new database will have **VIEWER** permission for all users including anonymous requests. How to set up
 permissions for a database is found [here](use_permissions.md).
+
+Request are **Record** requests by default and therefor **VIEWER** permission on the data is needed to perform the queries.
+For GET request this can be altered via de requestedGranularity parameter:
+
+`<server>/<database>/api/beacon/individuals/requestedsGranulariy=count`
+
+For post request via query.requestedGranularity:
+```{
+"query": {
+  "requestedGranularity": "count"
+}
+```
+
 
 Beacon offers 3 different response types
 


### PR DESCRIPTION
What are the main changes you did:
- Added the requestedGranularity parameter for get GET request to beacon api
- Added tests en docs

how to test:
- load a beacon data profile
- <schema>/api/beacon/individuals?requestedGranularity=count 
- <schema>/api/beacon/individuals?requestedGranularity=boolean 
now also works

todo:
- [x] updated docs in case of new feature
- [x] added/updated tests