### PR TITLE
fix: eager circular errors when superclass points to subclass

### DIFF
--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRefBack.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRefBack.java
@@ -290,5 +290,20 @@ public class TestRefBack {
     // verify the reference has indeed been updated.
     assertEquals(
         "s1", schema.getTable("treatmentxyz").retrieveRows().get(0).getString("partOfSubject"));
+
+    // test circular dependency don't fail on refback
+    schema
+        .getTable("treatments")
+        .getMetadata()
+        .add(column("treatmentxyz").setType(REF_ARRAY).setRefTable("treatmentxyz"));
+    SchemaMetadata migration = new SchemaMetadata();
+    migration.create(
+        table(
+            "treatmentsxyz",
+            column("treatments")
+                .setType(REFBACK)
+                .setRefTable("treatments")
+                .setRefBack("treatmentxyz")));
+    schema.migrate(migration);
   }
 }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TableSort.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TableSort.java
@@ -5,10 +5,12 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.molgenis.emx2.Column;
-import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.TableMetadata;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class TableSort {
+  private static Logger logger = LoggerFactory.getLogger(TableSort.class);
 
   private TableSort() {
     // hide constructor
@@ -61,9 +63,11 @@ public class TableSort {
       }
       // check for circular relationship
       if (size == todo.size()) {
-        throw new MolgenisException(
-            "circular dependency error: following tables have circular dependency: "
+        logger.warn(
+            "Following tables have circular dependency which might lead to errors: "
                 + todo.stream().map(TableMetadata::getTableName).collect(Collectors.joining(",")));
+        result.addAll(todo);
+        break;
       }
     }
     tableList.clear();


### PR DESCRIPTION
What are the main changes you did:
- remove circular check (it is actually too eager)

how to test:
- see test
- upload DataCatalogueTODO.csv

todo:
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
