### PR TITLE
chore(directory): change formatting hotkey

### DIFF
--- a/apps/directory/src/components/configuration/FilterEditor.vue
+++ b/apps/directory/src/components/configuration/FilterEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div @keyup.ctrl.f="format">
+  <div @keyup.ctrl.alt.f="format">
     <div ref="filter-editor" class="filter-editor" @keyup="dirty = true"></div>
 
     <button class="btn btn-info mt-3" :disabled="!dirty" @click="apply">

--- a/apps/directory/src/components/configuration/JsonEditor.vue
+++ b/apps/directory/src/components/configuration/JsonEditor.vue
@@ -25,7 +25,10 @@
           Upload config
         </button>
       </div>
-      <small class="ml-auto">To format your file press ctrl + alt + f</small>
+      <small class="ml-auto">
+        To format your file press <kbd>ctrl</kbd> + <kbd>alt</kbd> +
+        <kbd>f</kbd>
+      </small>
     </div>
   </div>
 </template>

--- a/apps/directory/src/components/configuration/JsonEditor.vue
+++ b/apps/directory/src/components/configuration/JsonEditor.vue
@@ -1,5 +1,5 @@
 <template>
-  <div @keyup.ctrl.f="format">
+  <div @keyup.ctrl.alt.f="format">
     <div>
       <div ref="editorDiv" class="editor" @keyup="setDirty()"></div>
     </div>
@@ -25,7 +25,7 @@
           Upload config
         </button>
       </div>
-      <small class="ml-auto">To format your file press ctrl + f</small>
+      <small class="ml-auto">To format your file press ctrl + alt + f</small>
     </div>
   </div>
 </template>

--- a/apps/directory/src/views/ConfigurationScreen.vue
+++ b/apps/directory/src/views/ConfigurationScreen.vue
@@ -79,7 +79,7 @@
         <h3>{{ getFacetTitle(filterIndex) }} filter configuration</h3>
         <div class="editor-alignment">
           <small v-if="filterIndex !== -1">
-            To format your file press ctrl + f
+            To format your file press ctrl + alt + f
           </small>
         </div>
         <FilterEditor

--- a/apps/directory/src/views/ConfigurationScreen.vue
+++ b/apps/directory/src/views/ConfigurationScreen.vue
@@ -79,7 +79,8 @@
         <h3>{{ getFacetTitle(filterIndex) }} filter configuration</h3>
         <div class="editor-alignment">
           <small v-if="filterIndex !== -1">
-            To format your file press ctrl + alt + f
+            To format your file press <kbd>ctrl</kbd> + <kbd>alt</kbd> +
+            <kbd>f</kbd>
           </small>
         </div>
         <FilterEditor


### PR DESCRIPTION
What are the main changes you did:
- Changed the hotkey for formatting to ctrl-alt-f because ctrl-f opens the search box of the browser for non-mac users.
- closes #4089 

how to test:
- go to the directory app
- login
- press settings
- go to the json editor tab
- add some whitespace
- press ctrl + alt + f
- see that it formats
