### PR TITLE
fix(pyclient): use 'localhost' as server for Pyclient

### DIFF
--- a/docs/molgenis/use_usingpyclient.md
+++ b/docs/molgenis/use_usingpyclient.md
@@ -12,6 +12,8 @@ pip install molgenis-emx2-pyclient
 
 ## Setting up the client
 The Python client can be integrated in scripts authorized by either a username/password combination or a temporary token.
+URLs of EMX2 servers on remote servers are required to start with `https://`.
+It is possible to use the Pyclient on a server running on a local machine. The URL should then be passed as `http://localhost:PORT`.
 
 Signing in with a username/password combination requires using the client as context manager:
 ```python
@@ -21,7 +23,7 @@ username = 'username'
 password = '********'
 
 # Initialize the client as a context manager
-with Client('https://example.molgeniscloud.org') as client:
+with Client(url='https://example.molgeniscloud.org') as client:
     # Apply the 'signin' method with the username and password
     client.signin(username, password)
     

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -55,7 +55,7 @@ async def main():
         print(var_values.head().to_string())
 
     # Connect to the server and sign in
-    async with Client('https://emx2.dev.molgenis.org/', token=token) as client:
+    async with Client('emx2.dev.molgenis.org/', token=token) as client:
         # Check sign in status
         print(client.__repr__())
         print(client.status)
@@ -81,7 +81,7 @@ async def main():
         client.export(schema='catalogue-demo', table='Cohorts', fmt='csv')
 
     # Connect to server with a default schema specified
-    with Client('https://emx2.dev.molgenis.org/', schema='pet store', token=token) as client:
+    with Client('http://emx2.dev.molgenis.org/', schema='pet store', token=token) as client:
         print(client.__repr__())
         client.export(fmt='csv')
         client.export(table='Pet', fmt='csv')

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -55,7 +55,7 @@ async def main():
         print(var_values.head().to_string())
 
     # Connect to the server and sign in
-    async with Client('emx2.dev.molgenis.org/', token=token) as client:
+    async with Client('http://emx2.dev.molgenis.org/', token=token) as client:
         # Check sign in status
         print(client.__repr__())
         print(client.status)
@@ -81,7 +81,7 @@ async def main():
         client.export(schema='catalogue-demo', table='Cohorts', fmt='csv')
 
     # Connect to server with a default schema specified
-    with Client('http://emx2.dev.molgenis.org/', schema='pet store', token=token) as client:
+    with Client('https://emx2.dev.molgenis.org/', schema='pet store', token=token) as client:
         print(client.__repr__())
         client.export(fmt='csv')
         client.export(table='Pet', fmt='csv')

--- a/tools/pyclient/dev/dev.py
+++ b/tools/pyclient/dev/dev.py
@@ -55,7 +55,7 @@ async def main():
         print(var_values.head().to_string())
 
     # Connect to the server and sign in
-    async with Client('http://emx2.dev.molgenis.org/', token=token) as client:
+    async with Client('https://emx2.dev.molgenis.org/', token=token) as client:
         # Check sign in status
         print(client.__repr__())
         print(client.status)

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -979,6 +979,6 @@ class Client:
                                           f"Perhaps you meant 'https://{self.url}'?")
             raise ServerNotFoundError(f"No connection adapters were found for {self.url!r}.")
         except requests.exceptions.MissingSchema:
-            raise ServerNotFoundError(f"Invalid URL 'emx2.dev.molgenis.org/'. "
+            raise ServerNotFoundError(f"Invalid URL {self.url!r}. "
                                       f"Perhaps you meant 'https://{self.url}'?")
 

--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -44,6 +44,7 @@ class Client:
         self.username: str | None = None
 
         self.session: requests.Session = requests.Session()
+        self.session.headers = {'x-molgenis-token': self.token}
         self._validate_url()
 
         self.schemas: list = self.get_schemas()
@@ -167,8 +168,7 @@ class Client:
 
         response = self.session.post(
             url=self.api_graphql,
-            json={'query': query},
-            headers={'x-molgenis-token': self.token}
+            json={'query': query}
         )
         self._validate_graphql_response(response)
 
@@ -235,8 +235,7 @@ class Client:
 
         response = self.session.post(
             url=f"{self.url}/{current_schema}/api/csv/{table_id}",
-            headers={'x-molgenis-token': self.token,
-                     'Content-Type': 'text/csv'},
+            headers={'Content-Type': 'text/csv'},
             data=import_data
         )
 
@@ -281,8 +280,7 @@ class Client:
         with open(file_path, 'rb') as file:
             response = self.session.post(
                 url=api_url,
-                files={'file': file},
-                headers={'x-molgenis-token': self.token}
+                files={'file': file}
             )
 
         # Check if status is OK
@@ -352,8 +350,7 @@ class Client:
         response = self.session.post(
             url=api_url,
             data=data,
-            headers={'x-molgenis-token': self.token,
-                     'Content-Type': 'text/csv'}
+            headers={'Content-Type': 'text/csv'}
         )
         if response.status_code == 200:
             msg = response.text
@@ -396,8 +393,7 @@ class Client:
 
         response = self.session.delete(
             url=f"{self.url}/{current_schema}/api/csv/{table_id}",
-            headers={'x-molgenis-token': self.token,
-                     'Content-Type': 'text/csv'},
+            headers={'Content-Type': 'text/csv'},
             data=import_data
         )
 
@@ -442,8 +438,7 @@ class Client:
 
         filter_part = self._prepare_filter(query_filter, table, schema)
         query_url = f"{self.url}/{current_schema}/api/csv/{table_id}{filter_part}"
-        response = self.session.get(url=query_url,
-                                    headers={'x-molgenis-token': self.token})
+        response = self.session.get(url=query_url)
 
         self._validate_graphql_response(response=response,
                                         fallback_error_message=f"Failed to retrieve data from {current_schema}::"
@@ -479,8 +474,7 @@ class Client:
             if table is None:
                 # Export the whole schema
                 url = f"{self.url}/{current_schema}/api/excel"
-                response = self.session.get(url=url,
-                                            headers={'x-molgenis-token': self.token})
+                response = self.session.get(url=url)
                 self._validate_graphql_response(response)
 
                 filename = f"{current_schema}.xlsx"
@@ -491,8 +485,7 @@ class Client:
                 # Export the single table
                 table_id = schema_metadata.get_table(by='name', value=table).id
                 url = f"{self.url}/{current_schema}/api/excel/{table_id}"
-                response = self.session.get(url=url,
-                                            headers={'x-molgenis-token': self.token})
+                response = self.session.get(url=url)
                 self._validate_graphql_response(response)
 
                 filename = f"{table}.xlsx"
@@ -503,8 +496,7 @@ class Client:
         if fmt == 'csv':
             if table is None:
                 url = f"{self.url}/{current_schema}/api/zip"
-                response = self.session.get(url=url,
-                                            headers={'x-molgenis-token': self.token})
+                response = self.session.get(url=url)
                 self._validate_graphql_response(response)
 
                 filename = f"{current_schema}.zip"
@@ -515,8 +507,7 @@ class Client:
                 # Export the single table
                 table_id = schema_metadata.get_table(by='name', value=table).id
                 url = f"{self.url}/{current_schema}/api/csv/{table_id}"
-                response = self.session.get(url=url,
-                                            headers={'x-molgenis-token': self.token})
+                response = self.session.get(url=url)
                 self._validate_graphql_response(response)
 
                 filename = f"{table}.csv"
@@ -551,8 +542,7 @@ class Client:
 
         response = self.session.post(
             url=self.api_graphql,
-            json={'query': query, 'variables': variables},
-            headers={'x-molgenis-token': self.token}
+            json={'query': query, 'variables': variables}
         )
 
         self._validate_graphql_response(
@@ -581,8 +571,7 @@ class Client:
 
         response = self.session.post(
             url=self.api_graphql,
-            json={'query': query, 'variables': variables},
-            headers={'x-molgenis-token': self.token}
+            json={'query': query, 'variables': variables}
         )
 
         self._validate_graphql_response(
@@ -613,8 +602,7 @@ class Client:
 
         response = self.session.post(
             url=self.api_graphql,
-            json={'query': query, 'variables': variables},
-            headers={'x-molgenis-token': self.token}
+            json={'query': query, 'variables': variables}
         )
 
         self._validate_graphql_response(

--- a/tools/pyclient/src/molgenis_emx2_pyclient/utils.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/utils.py
@@ -2,22 +2,6 @@
 Utility functions for the Molgenis EMX2 Pyclient package
 """
 
-
-def parse_url(url: str) -> str:
-    """Standardises the host by removing trailing slash
-    and ensuring url starts with 'https://'.
-    
-    :param url: string containing a URL
-    :type url: str
-    :returns: string containing the standardised URL
-    :rtype: str
-    """
-    host = url[:-1] if url.endswith('/') else url
-    if not host.startswith('https://'):
-        return 'https://' + host
-    
-    return host
-
    
 def read_file(file_path: str) -> str:
     """Reads and imports data from a file.


### PR DESCRIPTION
What are the main changes you did:

- I changed the way the URLs are handled in object initialization. I removed the `parse_url` utility function. Instead I added the `_validate_url` method that checks whether the URL as it is passed is valid for Pyclient usage. This enables the usage of `localhost` as an URL. Additionally, it makes the client very strict in enforcing prepending the URL with `https://` by the user for other URLs.
- Besides this change, I moved the token header to the requests.Session header in the initialization and removed it elsewhere from methods

how to test:
- create a script that creates a Pyclient object for a URL both with and without `https://`

todo:
- [x] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
