### PR TITLE
fix(molgenis-components): handle computed with rows not yet loaded

### DIFF
--- a/apps/molgenis-components/src/components/utils.ts
+++ b/apps/molgenis-components/src/components/utils.ts
@@ -202,7 +202,7 @@ function isObject(object: Record<string, any> | null): object is Object {
 }
 
 export function applyComputed(rows: IRow[], tableMetadata: ITableMetaData) {
-  return rows.map((row) => {
+  return rows?.map((row) => {
     return tableMetadata.columns.reduce((accum: IRow, column: IColumn) => {
       if (column.computed && column.columnType !== AUTO_ID) {
         try {


### PR DESCRIPTION
fixes: #4130

What are the main changes you did:
- When the rows are still being loaded the computed expressions handler crashes 

how to test:
- create a new petstore
- successfully try to add a new record in "Pet"
