### PR TITLE
fix: use correct force aggregate button link

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/index.vue
@@ -329,7 +329,7 @@ const aboutLink = `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}/
         image="image-data-warehouse"
         title="Aggregates"
         callToAction="Aggregates"
-        :link="`/Aggregates/aggregates/`"
+        :link="`/Aggregates/aggregates/#/`"
       />
     </LandingPrimary>
 


### PR DESCRIPTION
Changes force link from `/Aggregates/aggregates/` to `/Aggregates/aggregates/#/`