### PR TITLE
fix(jobs): default sorting of jobs in ui

### DIFF
--- a/apps/molgenis-components/src/components/tables/RoutedTableExplorer.vue
+++ b/apps/molgenis-components/src/components/tables/RoutedTableExplorer.vue
@@ -73,6 +73,14 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    showOrderBy: {
+      type: String,
+      default: "",
+    },
+    showOrder: {
+      type: String,
+      default: "ASC",
+    },
     showFilters: {
       type: Array,
       default: () => [],
@@ -87,14 +95,14 @@ export default {
       if (this.$route.query._orderBy) {
         return this.$route.query._orderBy;
       } else {
-        return "";
+        return this.showOrderBy;
       }
     },
     getOrder() {
       if (this.$route.query._order) {
         return this.$route.query._order;
       } else {
-        return "ASC";
+        return this.showOrder;
       }
     },
     getColumns() {

--- a/apps/tasks/src/components/ListJobs.vue
+++ b/apps/tasks/src/components/ListJobs.vue
@@ -3,6 +3,8 @@
   <RoutedTableExplorer
     tableId="Jobs"
     schemaId="_SYSTEM_"
+    showOrderBy="submitDate"
+    showOrder="DESC"
     :canEdit="true"
     :canManage="true"
   >


### PR DESCRIPTION
Fixes https://github.com/molgenis/GCC/issues/571

What are the main changes you did:
- Made sorting in the RoutedTableExplorer configurable
- Added default sorting to ListJobs.vue

how to test:
- Start a few jobs (e.g. by loading some data profile)
- Go to Jobs&Scripts > Jobs
- See the default ordering of the jobs

