### PR TITLE
fix: added 'mg_tableclass' for expressions in de backend

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTypeUtils.java
@@ -62,7 +62,12 @@ public class SqlTypeUtils extends TypeUtils {
           row.set(c.getName(), c.getDefaultValue());
         }
       } else if (c.getComputed() != null) {
-        row.set(c.getName(), executeJavascriptOnMap(c.getComputed(), graph));
+        Object result = executeJavascriptOnMap(c.getComputed(), graph);
+        if (c.isReference() && c.isOntology()) {
+          Map<String, Object> resultMap = (Map<String, Object>) result;
+          result = resultMap.get("name");
+        }
+        row.set(c.getName(), result);
       } else if (columnIsVisible(c, graph)) {
         checkRequired(c, row, graph);
         checkValidation(c, graph);

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTypeUtils.java
@@ -282,7 +282,7 @@ public class SqlTypeUtils extends TypeUtils {
   }
 
   static Map<String, Object> convertRowToMap(List<Column> columns, Row row) {
-    Map<String, Object> map = new LinkedHashMap<>();
+    Map<String, Object> map = new LinkedHashMap<>(row.getValueMap());
     for (Column c : columns) {
       if (c.isReference()) {
         map.put(c.getIdentifier(), getRefFromRow(row, c));

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTypeUtils.java
@@ -62,12 +62,8 @@ public class SqlTypeUtils extends TypeUtils {
           row.set(c.getName(), c.getDefaultValue());
         }
       } else if (c.getComputed() != null) {
-        Object result = executeJavascriptOnMap(c.getComputed(), graph);
-        if (c.isReference() && c.isOntology()) {
-          Map<String, Object> resultMap = (Map<String, Object>) result;
-          result = resultMap.get("name");
-        }
-        row.set(c.getName(), result);
+        Object computedValue = executeJavascriptOnMap(c.getComputed(), graph);
+        TypeUtils.addFieldObjectToRow(c, computedValue, row);
       } else if (columnIsVisible(c, graph)) {
         checkRequired(c, row, graph);
         checkValidation(c, graph);

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -488,32 +488,35 @@ public class TypeUtils {
 
   public static Iterable<Row> convertToRows(TableMetadata metadata, List<Map<String, Object>> map) {
     List<Row> rows = new ArrayList<>();
-    for (Map<String, Object> object : map) {
+    for (Map<String, Object> field : map) {
       Row row = new Row();
       for (Column column : metadata.getColumns()) {
-        if (object.containsKey(column.getIdentifier())) {
-          if (column.isRef()) {
-            convertRefToRow((Map<String, Object>) object.get(column.getIdentifier()), row, column);
-          } else if (column.isReference()) {
-            // REFBACK, REF_ARRAY
-            convertRefArrayToRow(
-                (List<Map<String, Object>>) object.get(column.getIdentifier()), row, column);
-          } else if (column.isFile()) {
-            BinaryFileWrapper bfw = (BinaryFileWrapper) object.get(column.getIdentifier());
-            if (bfw == null || !bfw.isSkip()) {
-              // also necessary in case of 'null' to ensure all file metadata fields are made empty
-              // skip is used when use submitted only metadata (that they received in query)
-              row.setBinary(
-                  column.getName(), (BinaryFileWrapper) object.get(column.getIdentifier()));
-            }
-          } else {
-            row.set(column.getName(), object.get(column.getIdentifier()));
-          }
+        if (field.containsKey(column.getIdentifier())) {
+          Object fieldValue = field.get(column.getIdentifier());
+          addFieldObjectToRow(column, fieldValue, row);
         }
       }
       rows.add(row);
     }
     return rows;
+  }
+
+  public static void addFieldObjectToRow(Column column, Object object, Row row) {
+    if (column.isRef()) {
+      convertRefToRow((Map<String, Object>) object, row, column);
+    } else if (column.isReference()) {
+      // REFBACK, REF_ARRAY
+      convertRefArrayToRow((List<Map<String, Object>>) object, row, column);
+    } else if (column.isFile()) {
+      BinaryFileWrapper bfw = (BinaryFileWrapper) object;
+      if (bfw == null || !bfw.isSkip()) {
+        // also necessary in case of 'null' to ensure all file metadata fields are made empty
+        // skip is used when use submitted only metadata (that they received in query)
+        row.setBinary(column.getName(), (BinaryFileWrapper) object);
+      }
+    } else {
+      row.set(column.getName(), object);
+    }
   }
 
   protected static void convertRefArrayToRow(


### PR DESCRIPTION
Fixes [#4156](https://github.com/molgenis/molgenis-emx2/issues/4156)
What are the main changes you did:
- Added the mg_tableclass to the variable map/graph before validation.
- It is available on the row but is ignored because it's not in the column list
- Added extra handling for a computed value when the column is an ontology

how to test:
- Use the mg_tableclass variable for an expression on a column.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
