### PR TITLE
fix: added session db listener to sessions based on tokens

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlDatabaseFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlDatabaseFieldFactory.java
@@ -78,6 +78,8 @@ public class GraphqlDatabaseFieldFactory {
                 Task task = DataModels.getImportTask(schema, template, includeDemoData);
                 String id = taskService.submit(task);
                 result.setTaskId(id);
+              } else {
+                database.getListener().afterCommit();
               }
 
               return result;

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManager.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManager.java
@@ -54,7 +54,6 @@ public class MolgenisSessionManager {
           session.getSessionUser(),
           request.session().id());
     }
-    session.getDatabase().becomeAdmin();
     return session;
   }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManager.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSessionManager.java
@@ -54,6 +54,7 @@ public class MolgenisSessionManager {
           session.getSessionUser(),
           request.session().id());
     }
+    session.getDatabase().becomeAdmin();
     return session;
   }
 
@@ -62,7 +63,9 @@ public class MolgenisSessionManager {
     database.addTableListener(new ScriptTableListener(TaskApi.taskSchedulerService));
     String user = JWTgenerator.getUserFromToken(database, request.headers(authTokenKey));
     database.setActiveUser(user);
-    return new MolgenisSession(database);
+    MolgenisSession session = new MolgenisSession(database);
+    database.setListener(new MolgenisSessionManagerDatabaseListener(this, session));
+    return session;
   }
 
   /**


### PR DESCRIPTION
Fixes [#3902](https://github.com/molgenis/molgenis-emx2/issues/3902)

What are the main changes you did:
- The MolgenisSessionManagerDatabaseListener was not added to Session based on tokens I added this
- Therefore the python client - when used via a token - did not update the meta data when changes were made

how to test:
- Go to the webinterface
- Add metadata using the py client using token based authorization
- See the meta data update without needing to log in again

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
