### PR TITLE
docs: explained behavior of validation field for columns with spaces in the name

### DIFF
--- a/docs/molgenis/use_schema.md
+++ b/docs/molgenis/use_schema.md
@@ -276,6 +276,8 @@ throws an exception, this is shown in user interface/error message. For example:
 | ----------------------------------------- | ---------------------------------------------------------------- |
 | `pets?.some(pet => pet.name === 'pooky')` | will only be shown when 'pooky' was selected in 'pets' ref_array |
 
+If a `columnName` contains spaces, one should refer to it as if it is written in camelCase within the validation field. So `first name` would be defined in the validation field as `firstName`.  
+
 ## Table inheritance
 
 You can reuse table definitions, and make more specialized tables using 'tableExtends'.


### PR DESCRIPTION

What are the main changes you did:
- updated docs to explain the following behavior (regarding fields `columnName` & `validation`):
<img width="1136" alt="Scherm­afbeelding 2024-08-29 om 16 26 29" src="https://github.com/user-attachments/assets/70d1cb80-55bd-4dea-b024-4302a366b796">
<img width="1091" alt="Scherm­afbeelding 2024-08-29 om 16 26 52" src="https://github.com/user-attachments/assets/25aa1ab8-fd79-422b-a9e9-fdef9eddb8e8">

how to test:
- n.a.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
