### PR TITLE
fix: incoherency allowed characters tableName/columnName (+ improved regex)

### DIFF
--- a/apps/central/src/components/SchemaCreateModal.vue
+++ b/apps/central/src/components/SchemaCreateModal.vue
@@ -167,7 +167,7 @@ export default {
   },
   methods: {
     validate(name) {
-      const simpleName = /^[a-zA-Z][-a-zA-Z0-9_ ]*$/;
+      const simpleName = /^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$/;
       if (name === null) {
         return undefined;
       }
@@ -178,7 +178,7 @@ export default {
       ) {
         return undefined;
       } else {
-        return "Table name must start with a letter, followed by letters, underscores, a space or numbers, i.e. [a-zA-Z][a-zA-Z0-9_]*. Maximum length: 31 characters";
+        return "Table name must start with a letter, followed by letters/underscores/spaces/numbers (though no underscore preceded/followed by a space), i.e. ^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$. Maximum length: 31 characters";
       }
     },
     executeCreateSchema() {

--- a/apps/schema/src/components/ColumnEditModal.vue
+++ b/apps/schema/src/components/ColumnEditModal.vue
@@ -445,8 +445,8 @@ export default {
       if (this.column.name === undefined || this.column.name === "") {
         return "Name is required";
       }
-      if (!this.column.name.match(/^[a-zA-Z][a-zA-Z0-9_ ]+$/)) {
-        return "Name should start with letter, followed by letter, number, whitespace or underscore ([a-zA-Z][a-zA-Z0-9_ ]*)";
+      if (!this.column.name.match(/^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$/)) {
+        return "Name should start with a letter, followed by letters/underscores/spaces/numbers (though no underscore preceded/followed by a space), i.e. ^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$";
       }
       if (
         (this.modelValue === undefined ||

--- a/apps/schema/src/components/TableEditModal.vue
+++ b/apps/schema/src/components/TableEditModal.vue
@@ -143,9 +143,9 @@ export default {
       if (
         this.table.name === undefined ||
         this.table.name.trim() === "" ||
-        this.table.name.search(/^[a-zA-Z0-9 _]*$/)
+        this.table.name.search(/^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$/)
       ) {
-        return "Name is required and can only contain 'azAZ_ '";
+        return "Name is required and must start with a letter, followed by letters/underscores/spaces/numbers (though no underscore preceded/followed by a space), i.e. ^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$";
       }
       if (
         this.modelValue?.name !== this.table.name &&

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Column.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Column.java
@@ -17,7 +17,7 @@ public class Column extends HasLabelsDescriptionsAndSettings<Column> implements 
 
   // basics
   private TableMetadata table; // table this column is part of
-  private String columnName; // short name, first character A-Za-z followed by AZ-a-z_0-1
+  private String columnName; // short name, should adhere to: ^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$
   private ColumnType columnType = STRING; // type of the column
 
   // transient for enabling migrations
@@ -85,15 +85,11 @@ public class Column extends HasLabelsDescriptionsAndSettings<Column> implements 
   }
 
   private String validateName(String columnName, boolean skipValidation) {
-    if (!skipValidation && !columnName.matches("[a-zA-Z][a-zA-Z0-9_ ]*")) {
+    if (!skipValidation && !columnName.matches("^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$")) {
       throw new MolgenisException(
           "Invalid column name '"
               + columnName
-              + "': Column must start with a letter, followed by letters, underscores, a space or numbers, i.e. [a-zA-Z][a-zA-Z0-9_]*");
-    }
-    if (!skipValidation && (columnName.contains("_ ") || columnName.contains(" _"))) {
-      throw new MolgenisException(
-          "Invalid column name '" + columnName + "': column names cannot contain '_ ' or '_ '");
+              + "': Column must start with a letter, followed by letters/underscores/spaces/numbers (though no underscore preceded/followed by a space), i.e. ^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$");
     }
     return columnName.trim();
   }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -15,7 +15,7 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
     implements Comparable {
 
   public static final String TABLE_NAME_MESSAGE =
-      ": Table name must start with a letter, followed by letters, underscores, a space or numbers, i.e. [a-zA-Z][a-zA-Z0-9_ ]*. Maximum length: 31 characters (so it fits in Excel sheet names)";
+      ": Table name must start with a letter, followed by letters/underscores/spaces/numbers (though no underscore preceded/followed by a space), i.e. ^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$. Maximum length: 31 characters (so it fits in Excel sheet names)";
   // if a table extends another table (optional)
   public String inheritName = null;
   // to allow indicate that a table should be dropped
@@ -62,7 +62,7 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
   private String validateName(String tableName) {
     // max length 31 because of Excel
     // we allow only graphql compatible names PLUS spaces
-    if (!tableName.matches("[a-zA-Z][a-zA-Z0-9_ ]*")) {
+    if (!tableName.matches("^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$")) {
       throw new MolgenisException("Invalid table name '" + tableName + TABLE_NAME_MESSAGE);
     }
     if (tableName.length() > 31) {

--- a/docs/molgenis/use_schema.md
+++ b/docs/molgenis/use_schema.md
@@ -23,12 +23,16 @@ You can describe basic columns using:
 
 ### tableName
 
-Will be the name of the table. Must start with one of a-zAZ followed by zero or more of \_a-zAZ1-3. Maximum length 31 characters. If you leave columnName empty
+Regular expression requirement: `^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$`
+
+Will be the name of the table. Must start with one of `a-zA-Z` followed by zero or more of `a-zA-Z0-9 _`, though an underscore directly preceded/followed by a space is not allowed. Maximum length 31
 then all other settings will apply to the table instead of the column.
 
 ### columnName
 
-Will be the name of the column. Must be unique per tableName. Must start with one of a-zAZ followed by zero or more of \_ a-zAZ1-3. Maximum length 31
+Regular expression requirement: `^(?!.* _|.*_ )[a-zA-Z][a-zA-Z0-9 _]*$`
+
+Will be the name of the column. Must be unique per tableName. Must start with one of `a-zA-Z` followed by zero or more of `a-zA-Z0-9 _`, though an underscore directly preceded/followed by a space is not allowed. Maximum length 31
 characters. Default value: empty
 
 ### columnType


### PR DESCRIPTION
What are the main changes you did:
- Fixed incoherency for what is allowed for tableName/columnName
- Improved regex: https://regex101.com/r/DD7c6W/1


how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
