### PR TITLE
feat(tasks): added link to job in failure mail

### DIFF
--- a/apps/tasks/src/App.vue
+++ b/apps/tasks/src/App.vue
@@ -1,5 +1,5 @@
 <template>
-  <Molgenis v-model="session">
+  <Molgenis v-model="session" @error="error = $event">
     <div v-if="session && session.email == 'admin'" class="card">
       <div class="card-header">
         <ul class="nav nav-tabs card-header-tabs">

--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/endpoints/Map.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/endpoints/Map.java
@@ -1,6 +1,6 @@
 package org.molgenis.emx2.beaconv2.endpoints;
 
-import static org.molgenis.emx2.rdf.RDFUtils.extractHost;
+import static org.molgenis.emx2.utils.URIUtils.extractHost;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;

--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/requests/BeaconRequestBody.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/requests/BeaconRequestBody.java
@@ -1,6 +1,6 @@
 package org.molgenis.emx2.beaconv2.requests;
 
-import static org.molgenis.emx2.rdf.RDFUtils.extractHost;
+import static org.molgenis.emx2.utils.URIUtils.extractHost;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import org.molgenis.emx2.MolgenisException;

--- a/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPoint.java
+++ b/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPoint.java
@@ -3,7 +3,7 @@ package org.molgenis.emx2.fairdatapoint;
 import static java.util.Map.entry;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
-import static org.molgenis.emx2.rdf.RDFUtils.*;
+import static org.molgenis.emx2.utils.URIUtils.*;
 
 import java.io.StringWriter;
 import java.net.URI;

--- a/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointCatalog.java
+++ b/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointCatalog.java
@@ -2,8 +2,7 @@ package org.molgenis.emx2.fairdatapoint;
 
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
-import static org.molgenis.emx2.rdf.RDFService.*;
-import static org.molgenis.emx2.rdf.RDFUtils.*;
+import static org.molgenis.emx2.utils.URIUtils.*;
 
 import graphql.ExecutionResult;
 import graphql.GraphQL;

--- a/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointDataset.java
+++ b/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointDataset.java
@@ -5,8 +5,7 @@ import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.molgenis.emx2.fairdatapoint.FAIRDataPointCatalog.extractItemAsIRI;
 import static org.molgenis.emx2.fairdatapoint.FormatMimeTypes.FORMATS;
 import static org.molgenis.emx2.fairdatapoint.Queries.queryDataset;
-import static org.molgenis.emx2.rdf.RDFService.*;
-import static org.molgenis.emx2.rdf.RDFUtils.*;
+import static org.molgenis.emx2.utils.URIUtils.*;
 
 import java.io.StringWriter;
 import java.net.URI;

--- a/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointDistribution.java
+++ b/backend/molgenis-emx2-fairdatapoint/src/main/java/org/molgenis/emx2/fairdatapoint/FAIRDataPointDistribution.java
@@ -5,8 +5,7 @@ import static org.eclipse.rdf4j.model.util.Values.literal;
 import static org.molgenis.emx2.fairdatapoint.FormatMimeTypes.FORMATS;
 import static org.molgenis.emx2.fairdatapoint.FormatMimeTypes.formatToMediaType;
 import static org.molgenis.emx2.fairdatapoint.Queries.queryDistribution;
-import static org.molgenis.emx2.rdf.RDFService.*;
-import static org.molgenis.emx2.rdf.RDFUtils.*;
+import static org.molgenis.emx2.utils.URIUtils.*;
 
 import java.io.StringWriter;
 import java.net.URI;

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -4,7 +4,7 @@ import static org.eclipse.rdf4j.model.util.Values.*;
 import static org.molgenis.emx2.Constants.MG_TABLECLASS;
 import static org.molgenis.emx2.FilterBean.f;
 import static org.molgenis.emx2.Operator.EQUALS;
-import static org.molgenis.emx2.rdf.RDFUtils.*;
+import static org.molgenis.emx2.utils.URIUtils.*;
 
 import com.google.common.net.UrlEscapers;
 import java.io.OutputStream;

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
@@ -4,6 +4,7 @@ import static org.apache.commons.text.StringEscapeUtils.escapeXSI;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.*;
+import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -31,7 +32,7 @@ public class ScriptTask extends Task {
   private String dependencies;
   private Process process;
   private byte[] output;
-  private String serverUrl;
+  private URL serverUrl;
 
   public ScriptTask(String name) {
     super("Executing script '" + name + "'");
@@ -240,14 +241,18 @@ public class ScriptTask extends Task {
   }
 
   private String getJobUrl() {
-    return this.serverUrl + "/" + Constants.SYSTEM_SCHEMA + "/tasks/#/jobs?id=" + this.getId();
+    return this.serverUrl.toExternalForm()
+        + "/"
+        + Constants.SYSTEM_SCHEMA
+        + "/tasks/#/jobs?id="
+        + this.getId();
   }
 
-  public void setServerUrl(String url) {
+  public void setServerUrl(URL url) {
     this.serverUrl = url;
   }
 
-  public String getServerUrl() {
+  public URL getServerUrl() {
     return serverUrl;
   }
 }

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
@@ -13,6 +13,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.molgenis.emx2.ColumnType;
+import org.molgenis.emx2.Constants;
 import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Row;
 import org.molgenis.emx2.email.EmailMessage;
@@ -30,6 +31,7 @@ public class ScriptTask extends Task {
   private String dependencies;
   private Process process;
   private byte[] output;
+  private String serverUrl;
 
   public ScriptTask(String name) {
     super("Executing script '" + name + "'");
@@ -166,10 +168,15 @@ public class ScriptTask extends Task {
   private void sendFailureMail() {
     if (this.getFailureAddress() != null && !this.getFailureAddress().isEmpty()) {
       EmailService emailService = new EmailService();
-      String subject = "Molgenis script %s failed".formatted(this.getName());
+      String subject =
+          "Molgenis script %s failed on %s".formatted(this.getName(), this.getServerUrl());
       String text =
-          "Molgenis script %s failed with error:\n%s"
-              .formatted(this.getName(), this.getDescription());
+          """
+            Molgenis script %s failed with error:
+            %s
+
+            %s"""
+              .formatted(this.getName(), this.getDescription(), this.getJobUrl());
       EmailMessage emailMessage =
           new EmailMessage(List.of(this.getFailureAddress()), subject, text, Optional.empty());
       emailService.send(emailMessage);
@@ -230,5 +237,17 @@ public class ScriptTask extends Task {
   @JsonIgnore
   public byte[] getOutput() {
     return this.output;
+  }
+
+  private String getJobUrl() {
+    return this.serverUrl + "/" + Constants.SYSTEM_SCHEMA + "/tasks/#/jobs?id=" + this.getId();
+  }
+
+  public void setServerUrl(String url) {
+    this.serverUrl = url;
+  }
+
+  public String getServerUrl() {
+    return serverUrl;
   }
 }

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
@@ -248,8 +248,9 @@ public class ScriptTask extends Task {
         + this.getId();
   }
 
-  public void setServerUrl(URL url) {
+  public ScriptTask setServerUrl(URL url) {
     this.serverUrl = url;
+    return this;
   }
 
   public URL getServerUrl() {

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/Task.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/Task.java
@@ -314,10 +314,6 @@ public class Task implements Runnable, Iterable<Task> {
     return failureAddress;
   }
 
-  public void setFailureAddress(String failureAddress) {
-    this.failureAddress = failureAddress;
-  }
-
   @Override
   public boolean equals(Object o) {
     if (this == o) return true;

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskService.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskService.java
@@ -1,5 +1,6 @@
 package org.molgenis.emx2.tasks;
 
+import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -11,7 +12,7 @@ public interface TaskService {
 
   String submitTaskFromName(String name, String parameters);
 
-  String submitTaskFromName(String name, String parameters, String url);
+  String submitTaskFromName(String name, String parameters, URL host);
 
   Set<String> getJobIds();
 

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskService.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskService.java
@@ -11,6 +11,8 @@ public interface TaskService {
 
   String submitTaskFromName(String name, String parameters);
 
+  String submitTaskFromName(String name, String parameters, String url);
+
   Set<String> getJobIds();
 
   Task getTask(String id);

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInDatabase.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInDatabase.java
@@ -89,7 +89,7 @@ public class TaskServiceInDatabase extends TaskServiceInMemory {
   }
 
   @Override
-  public String submitTaskFromName(final String scriptName, final String parameters) {
+  public String submitTaskFromName(String scriptName, String parameters, String url) {
     StringBuilder result = new StringBuilder();
     String defaultUser = database.getActiveUser();
     database.tx(
@@ -98,6 +98,7 @@ public class TaskServiceInDatabase extends TaskServiceInMemory {
           Schema systemSchema = db.getSchema(this.systemSchemaName);
 
           ScriptTask scriptTask = retrieveTaskFromDatabase(systemSchema, scriptName);
+          scriptTask.setServerUrl(url);
           String user =
               scriptTask.getCronUserName() == null ? defaultUser : scriptTask.getCronUserName();
 
@@ -114,6 +115,11 @@ public class TaskServiceInDatabase extends TaskServiceInMemory {
                       .submitUser(user)));
         });
     return result.toString();
+  }
+
+  @Override
+  public String submitTaskFromName(final String scriptName, final String parameters) {
+    return submitTaskFromName(scriptName, parameters, null);
   }
 
   private ScriptTask retrieveTaskFromDatabase(Schema systemSchema, String scriptName) {

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInDatabase.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInDatabase.java
@@ -11,6 +11,7 @@ import static org.molgenis.emx2.utils.TypeUtils.millisecondsToLocalDateTime;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
+import java.net.URL;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -89,7 +90,7 @@ public class TaskServiceInDatabase extends TaskServiceInMemory {
   }
 
   @Override
-  public String submitTaskFromName(String scriptName, String parameters, String url) {
+  public String submitTaskFromName(String scriptName, String parameters, URL url) {
     StringBuilder result = new StringBuilder();
     String defaultUser = database.getActiveUser();
     database.tx(

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInMemory.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInMemory.java
@@ -2,6 +2,7 @@ package org.molgenis.emx2.tasks;
 
 import static org.molgenis.emx2.tasks.TaskStatus.RUNNING;
 
+import java.net.URL;
 import java.util.*;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
@@ -39,7 +40,7 @@ public class TaskServiceInMemory implements TaskService {
   }
 
   @Override
-  public String submitTaskFromName(String name, String parameters, String url) {
+  public String submitTaskFromName(String name, String parameters, URL url) {
     throw new UnsupportedOperationException("Not supported when using in memory task service");
   }
 

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInMemory.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInMemory.java
@@ -39,6 +39,11 @@ public class TaskServiceInMemory implements TaskService {
   }
 
   @Override
+  public String submitTaskFromName(String name, String parameters, String url) {
+    throw new UnsupportedOperationException("Not supported when using in memory task service");
+  }
+
+  @Override
   public Set<String> getJobIds() {
     return tasks.keySet();
   }

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
@@ -5,6 +5,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.molgenis.emx2.tasks.TaskStatus.COMPLETED;
 import static org.molgenis.emx2.tasks.TaskStatus.ERROR;
 
+import java.net.MalformedURLException;
+import java.net.URL;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -55,7 +57,7 @@ print('Error message', file=sys.stderr)
   }
 
   @Test
-  public void testPythonScript_shouldFail() {
+  public void testPythonScript_shouldFail() throws MalformedURLException {
     Task task =
         new ScriptTask("error")
             .script(
@@ -64,6 +66,7 @@ import sys
 failureVariable = fail
 print('unreachable')
 """)
+            .setServerUrl(new URL("http://localhost:8080/"))
             .failureAddress("test@test.com");
     task.run();
     assertEquals(task.getStatus(), ERROR);

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
@@ -53,4 +53,18 @@ print('Error message', file=sys.stderr)
     // System.out.println(r2);
     r2.run();
   }
+
+  @Test
+  public void testPythonScript_shouldFail() {
+    ScriptTask task =
+        new ScriptTask("error")
+            .script(
+                """
+import sys
+failureVariable = fail
+print('unreachable')
+""");
+    task.run();
+    assertEquals(task.getStatus(), ERROR);
+  }
 }

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
@@ -56,14 +56,15 @@ print('Error message', file=sys.stderr)
 
   @Test
   public void testPythonScript_shouldFail() {
-    ScriptTask task =
+    Task task =
         new ScriptTask("error")
             .script(
                 """
 import sys
 failureVariable = fail
 print('unreachable')
-""");
+""")
+            .failureAddress("test@test.com");
     task.run();
     assertEquals(task.getStatus(), ERROR);
   }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/TaskApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/TaskApi.java
@@ -3,6 +3,7 @@ package org.molgenis.emx2.web;
 import static org.molgenis.emx2.Constants.SYSTEM_SCHEMA;
 import static org.molgenis.emx2.FilterBean.f;
 import static org.molgenis.emx2.SelectColumn.s;
+import static org.molgenis.emx2.rdf.RDFUtils.extractHost;
 import static org.molgenis.emx2.web.FileApi.addFileColumnToResponse;
 import static org.molgenis.emx2.web.MolgenisWebservice.getSchema;
 import static org.molgenis.emx2.web.MolgenisWebservice.sessionManager;
@@ -86,7 +87,9 @@ public class TaskApi {
       }
       String name = URLDecoder.decode(request.params("name"), StandardCharsets.UTF_8);
       String parameters = request.body();
-      String id = taskService.submitTaskFromName(name, parameters);
+
+      String url = extractHost(request.url());
+      String id = taskService.submitTaskFromName(name, parameters, url);
       return new TaskReference(id).toString();
     }
     throw new MolgenisException("Schema doesn't exist or permission denied");

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/TaskApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/TaskApi.java
@@ -3,7 +3,7 @@ package org.molgenis.emx2.web;
 import static org.molgenis.emx2.Constants.SYSTEM_SCHEMA;
 import static org.molgenis.emx2.FilterBean.f;
 import static org.molgenis.emx2.SelectColumn.s;
-import static org.molgenis.emx2.rdf.RDFUtils.extractHost;
+import static org.molgenis.emx2.utils.URIUtils.extractHost;
 import static org.molgenis.emx2.web.FileApi.addFileColumnToResponse;
 import static org.molgenis.emx2.web.MolgenisWebservice.getSchema;
 import static org.molgenis.emx2.web.MolgenisWebservice.sessionManager;
@@ -13,6 +13,8 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
+import java.net.MalformedURLException;
+import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import org.molgenis.emx2.*;
@@ -78,7 +80,8 @@ public class TaskApi {
     return new ObjectMapper().writeValueAsString(taskSchedulerService.scheduledTaskNames());
   }
 
-  private static String postScript(Request request, Response response) {
+  private static String postScript(Request request, Response response)
+      throws MalformedURLException {
     if (request.params("schema") == null || getSchema(request) != null) {
       MolgenisSession session = sessionManager.getSession(request);
       String user = session.getSessionUser();
@@ -88,8 +91,8 @@ public class TaskApi {
       String name = URLDecoder.decode(request.params("name"), StandardCharsets.UTF_8);
       String parameters = request.body();
 
-      String url = extractHost(request.url());
-      String id = taskService.submitTaskFromName(name, parameters, url);
+      URL host = new URL(extractHost(request.url()));
+      String id = taskService.submitTaskFromName(name, parameters, host);
       return new TaskReference(id).toString();
     }
     throw new MolgenisException("Schema doesn't exist or permission denied");

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/URIUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/URIUtils.java
@@ -1,12 +1,12 @@
-package org.molgenis.emx2.rdf;
+package org.molgenis.emx2.utils;
 
 import java.net.URI;
 import org.eclipse.rdf4j.common.net.ParsedIRI;
 import org.eclipse.rdf4j.model.IRI;
 import org.molgenis.emx2.MolgenisException;
 
-public class RDFUtils {
-  private RDFUtils() {
+public class URIUtils {
+  private URIUtils() {
     // static only
   }
 


### PR DESCRIPTION
Fixes [#4177](https://github.com/molgenis/molgenis-emx2/issues/4177)
To provided more context on failing jobs a link to the job is provided in the failure mail

What are the main changes you did:
- Added the server url to ScriptTasks
- Added a link to to job in the failure email template

The title of the mail is:
`Molgenis script <script name> failed on <server name>`

The content is:
```
Molgenis script <script name> failed with error:
<error>

<link to the job>
```
Preview link:
https://preview-emx2-pr-4179.dev.molgenis.org/_SYSTEM_/tasks/#/jobs?id=9a5c51c9-d5e3-4d53-9bb2-995ae35bbc12

how to test:
- Submit a job with an error and a failureAddress
- Receive an email with a link to the job
