### PR TITLE
fix: Changelog not reloading

### DIFF
--- a/apps/central/src/components/Groups.vue
+++ b/apps/central/src/components/Groups.vue
@@ -302,7 +302,7 @@ export default {
     },
   },
   watch: {
-    showChangeColumn: (val) => {
+    showChangeColumn(val) {
       if (val) {
         this.getSchemaList();
       }


### PR DESCRIPTION
Changelog not reloading after show changelog button being clicked fix 'this; context scope

Closes #4184

What are the main changes you did:
- changed function scope from anonymous to component scope to acces the this.methodName

how to test:
- signin as admin
- enable change log via settings ( see docs for details , set 'isChangelogEnabled' to true)
- make a change 
- go to the central app 
- click the show changelog button ,
- the changelog is now loaded for all schema's that have the change log enabled


