### PR TITLE
docs: fixed docs & updated with apps cache reset (when running through gradle)

### DIFF
--- a/docs/molgenis/dev_quickstart.md
+++ b/docs/molgenis/dev_quickstart.md
@@ -128,7 +128,7 @@ Sometimes it helps to stop the gradle daemon and reset the gradle cache.
 ./gradlew --stop && rm -rf $HOME/.gradle/
 ```
 
-When making changes to `molgenis-components` or similar that other apps depend on without changing those apps themselves,
+When making changes to `apps/molgenis-components` or similar that other apps depend on without changing those apps themselves,
 clearing the cache of all the apps will force gradle to rebuild these again (as these are not stored in the general gradle cache!).
 
 ```bash

--- a/docs/molgenis/dev_quickstart.md
+++ b/docs/molgenis/dev_quickstart.md
@@ -120,12 +120,19 @@ To skip slow tests that are marked in junit @Tag('slow') switch from 'All in pac
 When you get error "java.lang.reflect.InaccessibleObjectException: Unable to make field private final java.util.Map java.util.Collections$UnmodifiableMap.m accessible: module java.base does not "opens java.util" to unnamed module @5cee5251"
 that is because you need JVM parameter `--add-opens=java.base/java.util=ALL-UNNAMED`
 
-### Reset gradle cache/deamon
+### Reset cache/deamon
 
-Sometimes it help to reset gradle cache and stop the gradle daemon
+Sometimes it helps to stop the gradle daemon and reset the gradle cache.
 
+```bash
+./gradlew --stop && rm -rf $HOME/.gradle/
 ```
-./gradlew --stop rm -rf $HOME/.gradle/
+
+When making changes to `molgenis-components` or similar that other apps depend on without changing those apps themselves,
+clearing the cache of all the apps will force gradle to rebuild these again (as these are not stored in the general gradle cache!).
+
+```bash
+rm -rf ./apps/*/dist/
 ```
 
 ### Delete all schemas (destroys all your data!)


### PR DESCRIPTION
What are the main changes you did:
* docs command was missing `&&` for clearing gradle cache.
* clearing gradle cache was insufficient if changing something in an app that other apps build on, so added section about clearing cache of all apps (as clearing gradle cache does not work for this).

how to test:
1. Run `./gradlew run`
2. Make a change, f.e. `molgenis-emx2/apps/molgenis-components/src/components/forms/InputString.vue` the line `@input="updateModelValue($event.target.value)"` to `@input="updateModelValue('test')"`
3. Run `./gradlew run`
http://localhost:8080/apps/molgenis-components/#/component/InputString: new behaviour
http://localhost:8080/apps/central/#/ -> login: old behaviour
4. Run `rm -rf ./apps/*/dist/`
5. Run `./gradlew run`
http://localhost:8080/apps/molgenis-components/#/component/InputString: new behaviour
http://localhost:8080/apps/central/#/ -> login: new behaviour

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
