### PR TITLE
fix(directory): change redirect_uri to redirectUrl

### DIFF
--- a/apps/directory/src/stores/checkoutStore.js
+++ b/apps/directory/src/stores/checkoutStore.js
@@ -249,7 +249,7 @@ export const useCheckoutStore = defineStore("checkoutStore", () => {
     }
 
     const body = await response.json();
-    window.location.href = body.redirect_uri;
+    window.location.href = body.redirectUrl;
   }
 
   return {


### PR DESCRIPTION
What are the main changes you did:
- Negotiator V3 Api response includes a redirectUrl instead of redirect_uri which was in the preview API version. 

old:
![image](https://github.com/user-attachments/assets/6daa3cff-b54e-4337-899f-ecbf6c33381e)

new:
![image](https://github.com/user-attachments/assets/307ecc30-b062-48bd-b3ec-dd69a613306b)

Hopefully this solves the issue that sending a request fails with negotiator V3 API (redirect does not work).

how to test:
- Check the code => unfortunately sending requests to the negotiator doesn't work in a preview.

todo:
- [nvt] updated docs in case of new feature
- [nvt] added/updated tests
- [nvt] added/updated testplan to include a test for this fix, including ref to bug using # notation
