### PR TITLE
chore: update playwright version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -246,7 +246,7 @@ jobs:
     - post_steps
   e2e-test:
     docker:
-      - image: mcr.microsoft.com/playwright:v1.46.0-jammy
+      - image: mcr.microsoft.com/playwright:v1.47.0-jammy
     steps:
       - checkout
       - run: npm i -D @playwright/test


### PR DESCRIPTION
What are the main changes you did:
- updated the playwright version from 1.46.0 to 1.47.0.

how to test:
- e2e tests should work again

todo:
- [nvt] updated docs in case of new feature
- [nvt] added/updated tests
- [nvt] added/updated testplan to include a test for this fix, including ref to bug using # notation
