### PR TITLE
fix: added missing label and identifier in `FilterSearch` component

### DIFF
--- a/apps/tailwind-components/components/filter/Search.vue
+++ b/apps/tailwind-components/components/filter/Search.vue
@@ -4,10 +4,12 @@ const props = withDefaults(
     modelValue: string;
     placeholder?: string;
     inverted?: boolean;
+    label?: string;
   }>(),
   {
     placeholder: "Type to search..",
     inverted: false,
+    label: "Search",
   }
 );
 
@@ -24,10 +26,14 @@ function handleInput(input: string) {
     emit("update:modelValue", input);
   }, 500);
 }
+
+const inputId: string = useId();
 </script>
 <template>
   <form class="relative" @submit.prevent="submitSearch()">
+    <label :for="`search-input-${inputId}`" class="sr-only">{{ label }}</label>
     <input
+      :id="`search-input-${inputId}`"
       type="search"
       :value="modelValue"
       @input="(event) => handleInput((event.target as HTMLInputElement).value)"


### PR DESCRIPTION
What are the main changes you did:

- Created a unique identifier for the `FilterSearch` component
- Added a visually hidden label that describes the input and linked the elements using a unique identifier

how to test:
- Install the [WAVE Browser Extension](https://wave.webaim.org/extension/)
- Open the preview and navigate to the tableEmx2 story: https://preview-emx2-pr-4192.dev.molgenis.org/apps/tailwind-components/#/FilterSearch.story
- Open the WAVE Browser Extension. No errors should appear on the FilterSearch component
- Alternatively, click inspect element on the filter search component. In the HTML structure, note the unique ID and the label for the input

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
