### PR TITLE
fix: all user roles can see 'Signed in' menu items

### DIFF
--- a/apps/molgenis-components/src/components/layout/MolgenisMenu.vue
+++ b/apps/molgenis-components/src/components/layout/MolgenisMenu.vue
@@ -154,8 +154,8 @@ export default {
         if (this.session.email === "admin") {
           return true;
         }
-        if (item.role === "Signed in" && this.session.email === "anonymous") {
-          return false;
+        if (item.role === "Signed in" && this.session.email !== "anonymous") {
+          return true;
         }
         if (item.role === "Viewer") {
           return this.session.roles.some((r) =>


### PR DESCRIPTION
Fixes #4195

Changed front-end logic so that al users roles can see 'Signed in' menu items.