### PR TITLE
fix(molgenis-components): Fix inputRefList toggle function

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -214,9 +214,9 @@ export default {
       this.showSelect = true;
     },
     toggle(value: IRow) {
-      if (this.selection?.includes(value)) {
+      if (this.selection?.some((selection) => deepEqual(selection, value))) {
         this.selection = this.selection.filter(
-          (selectedValue: IRow) => selectedValue !== value
+          (selectedValue: IRow) => !deepEqual(selectedValue, value)
         );
       } else {
         this.selection = [...this.selection, value];


### PR DESCRIPTION
fix toggle, use identity fuction instead of string compare to find (duplicate) object in list

Closes https://github.com/molgenis/molgenis-emx2/issues/4205


related to: [4139](https://github.com/molgenis/molgenis-emx2/issues/4139) (note: this fixes the second part of the issue described, but does not explain the first part ( might be due to equal label ( but different key )) need to fix reproducible case as the playground does not in include one)

note: Need to decide if we want to keep infesting in bootstrap-components or focus on tailwind components ( and include e2e tests from the start)

What are the main changes you did:
- explain what you changed and essential considerations.

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
