### PR TITLE
fix: show application tokens and allow deletion for users

### DIFF
--- a/apps/molgenis-components/src/components/account/Interfaces.ts
+++ b/apps/molgenis-components/src/components/account/Interfaces.ts
@@ -5,7 +5,7 @@ export interface ISession {
   locale?: string;
   roles?: string[];
   schemas?: any;
-  settings?: Record<string, string>;
+  settings?: ISetting[];
   manifest?: IManifest;
   token?: string;
 }

--- a/apps/molgenis-components/src/components/account/TokenManager.vue
+++ b/apps/molgenis-components/src/components/account/TokenManager.vue
@@ -75,7 +75,7 @@ export default defineComponent({
     accessTokens(): string[] {
       const tokens: ISetting | undefined = this.session?.settings?.find(
         (setting: ISetting): boolean =>
-          setting.key === "access-tokes" && Boolean(setting.value)
+          setting.key === "access-tokens" && Boolean(setting.value)
       );
       return tokens
         ? tokens.value

--- a/apps/molgenis-components/src/components/tables/TableExplorer.vue
+++ b/apps/molgenis-components/src/components/tables/TableExplorer.vue
@@ -405,7 +405,7 @@
 </style>
 
 <script lang="ts">
-import { IColumn, ISetting, ITableMetaData } from "meta-data-utils";
+import { IColumn, ISetting, ITableMetaData } from "metadata-utils";
 import Client from "../../client/client";
 import FilterSidebar from "../filters/FilterSidebar.vue";
 import FilterWells from "../filters/FilterWells.vue";

--- a/apps/molgenis-components/src/components/utils.ts
+++ b/apps/molgenis-components/src/components/utils.ts
@@ -1,7 +1,7 @@
 import type { IRow } from "../Interfaces/IRow";
 import constants from "./constants";
 import Client from "../client/client";
-import type { IColumn, ITableMetaData } from "meta-data-utils";
+import type { IColumn, ITableMetaData } from "metadata-utils";
 import { executeExpression } from "./forms/formUtils/formUtils";
 
 const { CODE_0, CODE_9, CODE_PERIOD, MIN_LONG, MAX_LONG, AUTO_ID } = constants;


### PR DESCRIPTION
What are the main changes you did:
- fix: #3700 (show tokens and allow deletion
- fix: no longer allow user to create tokens with already existing names. Swapped the create button and the input due to error message layout. Didn't want to spend a lot of time on the layout so went for the easy fix (keeping the upcoming tailwind migration in mind).

how to test:
- see issue, tokens should now show and be deletable (refresh not needed).
- enter a token name that already exists and see that the button is disabled and an errormessage is displayed.

