### PR TITLE
chore(tailwind-components): Fix props warning in debug console

### DIFF
--- a/apps/tailwind-components/app.vue
+++ b/apps/tailwind-components/app.vue
@@ -123,7 +123,7 @@ const stories = Object.keys(modules)
           </aside>
           <div class="xl:pl-7.5 grow p-6">
             <slot name="main">
-              <NuxtPage :theme="theme" :invertTheme="invert" />
+              <NuxtPage :invertTheme="invert" />
             </slot>
           </div>
         </div>


### PR DESCRIPTION
Nuxt page generated a list of pages and does not know where the place the non defined 'theme' prop, resulting in a dev console warning . Removed the prop as it not needed on in the child pages ( theme is set at the root/html level)

how to test:
- check the debug console warnings with and without the fix/pr , the warning should be gone. 

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
