### PR TITLE
fix(sql): change insert/update batch size from 100 to 1000

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/ImportTableTask.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/ImportTableTask.java
@@ -186,7 +186,7 @@ public class ImportTableTask extends Task {
         }
         batch.add(row);
         index++;
-        if (batch.size() >= 100) {
+        if (batch.size() >= 1000) {
           table.save(batch);
           task.setProgress(index);
           task.setDescription("Imported " + task.getProgress() + " rows into " + table.getName());

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -266,7 +266,7 @@ class SqlTable implements Table {
 
             // execute batch; or columns provided changes
             if (columnsProvidedAreDifferent(columnsProvided.get(subclassName), row)
-                || subclassRows.get(subclassName).size() >= 100) {
+                || subclassRows.get(subclassName).size() >= 1000) {
               executeBatch(
                   (SqlSchema) db2.getSchema(subclassName.split("\\.")[0]),
                   transactionType,


### PR DESCRIPTION
What are the main changes you did:
- change batch size from 100 to 1000

how to test:
- uploads should be a bit faster, however chance on timeouts increases

Expected results:

<img width="1114" alt="image" src="https://github.com/user-attachments/assets/4582608f-0824-421a-94d4-82ab41b013d5">

