### PR TITLE
chore: put back loglevel to default (3: Informational logs)

### DIFF
--- a/apps/nuxt3-ssr/server/routes/[schema]/graphql.ts
+++ b/apps/nuxt3-ssr/server/routes/[schema]/graphql.ts
@@ -3,7 +3,7 @@ import { createConsola } from "consola";
 
 export default defineEventHandler((event) => {
   const config = useRuntimeConfig(event);
-  const logger = createConsola({ level: config.logLevel as number ?? 5 });
+  const logger = createConsola({ level: config.logLevel as number ?? 3 });
   if (event.method === "POST") {
     readBody(event).then((body) => {
       if (body.query) {


### PR DESCRIPTION
What are the main changes you did:
- put back (default) loglevel , to avoid massive log output when not debugging 

how to test:
- run in dev mode before and after change , see difference in log output 

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
