### PR TITLE
fix(migration): migration 22 removing refback requires also migration…

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
@@ -6,6 +6,7 @@ import static org.molgenis.emx2.Constants.MG_TABLECLASS;
 import static org.molgenis.emx2.sql.MetadataUtils.*;
 import static org.molgenis.emx2.sql.SqlDatabase.TEN_SECONDS;
 import static org.molgenis.emx2.sql.SqlTableMetadataExecutor.MG_TABLECLASS_UPDATE;
+import static org.molgenis.emx2.sql.SqlTableMetadataExecutor.updateSearchIndexTriggerFunction;
 
 import java.io.IOException;
 import java.util.List;
@@ -21,7 +22,7 @@ import org.slf4j.LoggerFactory;
 
 public class Migrations {
   // version the current software needs to work
-  private static final int SOFTWARE_DATABASE_VERSION = 21;
+  private static final int SOFTWARE_DATABASE_VERSION = 22;
   public static final int THREE_MINUTES = 180;
   private static Logger logger = LoggerFactory.getLogger(Migrations.class);
 
@@ -127,11 +128,25 @@ public class Migrations {
             executeMigrationFile(
                 tdb, "migration21.sql", "add exist and range role to schemas and metadata");
 
-          if (version < 22)
+          if (version < 22) {
             executeMigrationFile(
                 tdb,
                 "migration22.sql",
                 "remove physical refback triggerfunctions (cascade to include triggers) and then the columns");
+
+            // doing this in java here might make next migrations impossible
+            // however the migration is impossible in sql because of the complex composite key name
+            // logic
+            for (String schemaName : tdb.getSchemaNames()) {
+              Schema schema = tdb.getSchema(schemaName);
+              for (TableMetadata tableMetadata : schema.getMetadata().getTables()) {
+                {
+                  updateSearchIndexTriggerFunction(
+                      ((SqlDatabase) tdb).getJooq(), tableMetadata, tableMetadata.getTableName());
+                }
+              }
+            }
+          }
 
           // if success, update version to SOFTWARE_DATABASE_VERSION
           updateDatabaseVersion((SqlDatabase) tdb, SOFTWARE_DATABASE_VERSION);


### PR DESCRIPTION
should get rid of `record "new" has no field "children" ` error when deploying migration from database version 21 to 22 in release [v11.15.0](https://github.com/molgenis/molgenis-emx2/releases/v11.15.0)