### PR TITLE
fix(catalogue): in variables screen rename filter 'resources' to 'sources'

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/variables/index.vue
@@ -77,7 +77,7 @@ const pageFilterTemplate: IFilter[] = [
   {
     id: "resources",
     config: {
-      label: "Resources",
+      label: "Sources",
       type: "REF_ARRAY",
       refTableId: "Resources",
       initialCollapsed: false,

--- a/apps/nuxt3-ssr/tests/network-of-networks.spec.ts
+++ b/apps/nuxt3-ssr/tests/network-of-networks.spec.ts
@@ -25,8 +25,8 @@ test("show network of networks", async ({ page, goto }) => {
   await page.getByRole("button", { name: "Variables" }).click();
   await expect(page.getByText("7 variables")).toBeVisible();
   //todo check if not should be 9
-  await page.getByRole("heading", { name: "Resources" }).click();
-  await page.getByRole("heading", { name: "Resources" }).click();
+  await page.getByRole("heading", { name: "Sources" }).click();
+  await page.getByRole("heading", { name: "Sources" }).click();
   await expect(page.getByText("testCohort4")).toBeVisible();
   await page.getByRole("button", { name: "Harmonisations" }).click();
   await expect(


### PR DESCRIPTION
to test:
- go to variables screen and see that filter name is named 'sources' (matching the 'source' in mappings table)