### PR TITLE
fix: fix resource type list search label

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/[resourceType]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/[resourceType]/index.vue
@@ -26,7 +26,7 @@ let pageFilterTemplate: IFilter[] = [
   {
     id: "search",
     config: {
-      label: "Search in resources",
+      label: `Search in ${resourceType.value.plural.toLowerCase()}`,
       type: "SEARCH",
       searchTables: ["collectionEvents", "subpopulations"],
       initialCollapsed: false,


### PR DESCRIPTION
What are the main changes you did:
- use label from type instead of generic 'resource' label
how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
