### PR TITLE
build: add 'gradle dev' task to run in headless mode without building javascript

### DIFF
--- a/backend/molgenis-emx2-run/src/test/java/org/molgenis/emx2/AToolToGenerateTypeScriptTypesTest.java
+++ b/backend/molgenis-emx2-run/src/test/java/org/molgenis/emx2/AToolToGenerateTypeScriptTypesTest.java
@@ -6,6 +6,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.typescript.AToolToGenerateTypeScriptTypes;
 
 class AToolToGenerateTypeScriptTypesTest {
 

--- a/backend/molgenis-emx2-sql/build.gradle
+++ b/backend/molgenis-emx2-sql/build.gradle
@@ -6,3 +6,10 @@ dependencies {
     testImplementation project(':backend:molgenis-emx2-datamodels')
     testImplementation project(':backend:molgenis-emx2-tasks')
 }
+
+//tool should be here otherwise requires build of unnecessary modules
+task cleandb(type: JavaExec) {
+    group = 'application'
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.molgenis.emx2.sql.AToolToCleanDatabase'
+}

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/AToolToCleanDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/AToolToCleanDatabase.java
@@ -1,4 +1,4 @@
-package org.molgenis.emx2;
+package org.molgenis.emx2.sql;
 
 import static org.jooq.impl.DSL.name;
 
@@ -7,8 +7,6 @@ import org.jooq.DSLContext;
 import org.jooq.ForeignKey;
 import org.jooq.Schema;
 import org.jooq.Table;
-import org.molgenis.emx2.sql.MetadataUtils;
-import org.molgenis.emx2.sql.SqlDatabase;
 
 public class AToolToCleanDatabase {
   private static DSLContext jooq;

--- a/backend/molgenis-emx2-typescript/build.gradle
+++ b/backend/molgenis-emx2-typescript/build.gradle
@@ -4,3 +4,9 @@ dependencies {
     implementation project(':backend:molgenis-emx2-datamodels')
     testImplementation project(':backend:molgenis-emx2-tasks')
 }
+
+task generateTypes(type: JavaExec) {
+    group = 'application'
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.molgenis.emx2.typescript.AToolToGenerateTypeScriptTypes'
+}

--- a/backend/molgenis-emx2-typescript/src/main/java/org/molgenis/emx2/typescript/AToolToGenerateTypeScriptTypes.java
+++ b/backend/molgenis-emx2-typescript/src/main/java/org/molgenis/emx2/typescript/AToolToGenerateTypeScriptTypes.java
@@ -1,7 +1,7 @@
-package org.molgenis.emx2;
+package org.molgenis.emx2.typescript;
 
+import org.molgenis.emx2.Schema;
 import org.molgenis.emx2.sql.SqlDatabase;
-import org.molgenis.emx2.typescript.Generator;
 
 public class AToolToGenerateTypeScriptTypes {
 

--- a/backend/molgenis-emx2-typescript/src/test/java/org/molgenis/emx2/typescript/AToolToGenerateTypeScriptTypesTest.java
+++ b/backend/molgenis-emx2-typescript/src/test/java/org/molgenis/emx2/typescript/AToolToGenerateTypeScriptTypesTest.java
@@ -1,4 +1,4 @@
-package org.molgenis.emx2;
+package org.molgenis.emx2.typescript;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -6,7 +6,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.Charset;
 import org.junit.jupiter.api.Test;
-import org.molgenis.emx2.typescript.AToolToGenerateTypeScriptTypes;
 
 class AToolToGenerateTypeScriptTypesTest {
 

--- a/backend/molgenis-emx2-webapi/build.gradle
+++ b/backend/molgenis-emx2-webapi/build.gradle
@@ -23,3 +23,9 @@ dependencies {
     implementation 'com.github.dfabulich:sitemapgen4j:1.1.2'
     implementation 'de.larsgrefer.sass:sass-embedded-host:1.15.4'
 }
+
+task dev(type: JavaExec) {
+    group = 'application'
+    classpath = sourceSets.main.runtimeClasspath
+    main = 'org.molgenis.emx2.RunMolgenisEmx2'
+}

--- a/build.gradle
+++ b/build.gradle
@@ -120,20 +120,6 @@ jar {
     }
 }
 
-task cleandb(type: JavaExec) {
-    group = "Execution"
-    description = "Clean database. Carefull, will delete all MOLGENIS stuff"
-    classpath = sourceSets.main.runtimeClasspath
-    main = "org.molgenis.emx2.AToolToCleanDatabase"
-}
-
-task generateTypes(type: JavaExec) {
-    group = "Execution"
-    description = "Generated type-script interfaces from schema metadata"
-    classpath = sourceSets.main.runtimeClasspath
-    main = "org.molgenis.emx2.AToolToGenerateTypeScriptTypes"
-}
-
 //task to install pre-commit hook that applies formatting
 task installPreCommitGitFormatApplyHook(type: Copy) {
     from new File(rootProject.rootDir, 'pre-commit-format-apply')

--- a/docs/molgenis/dev_basics.md
+++ b/docs/molgenis/dev_basics.md
@@ -8,7 +8,10 @@ We use:
 * [gradle](https://gradle.org/) for build (with yarn 'workspaces' for web app)
     * `gradle build` => builds all
     * `gradle clean` => removes all build artifacts
-    * `gradle run` => launches the app
+    * `gradle run` => launches the app including user interface
+    * `gradle dev` => launches only the backend (useful when developing frontend using yarn dev)
+    * `gradle cleandb` => will empty your postgresql database (MAKE SURE YOU WANT IT)
+    * `gradle generateTypes <schema> <file>` => generates typescript types for schema to file
     * `gradle test` => runs all tests.
     * `gradle testFast` => runs tests excluding those marged using @Tag("slow").
 
@@ -81,12 +84,18 @@ gradlew         # platform independent build file
 
 ## Backend modules
 
-* emx2: interface and base classes
-* emx2-sql: implementation into postgresql
-* emx2-io: emx2 format, csv import/export of data, legacy import
-* emx2-graphql: all for generating the graphql on top of sql
-* emx2-semantics: endpoint for linked data serving in json-ld and ttl
-* emx2-webapi: ties it all together onto SparkJava embedded web server
-* emx2-exampledata: test data models and data, used in various test
-* emx2-run: packages all into one fat jar Work in step
-* emx2-taskList: toward asynchronous calls for long running transactions/queries
+* molgenis-emx2: interface and base classes
+* molgenis-emx2-sql: implementation into postgresql
+* molgenis-emx2-io: emx2 format, csv import/export of data, legacy import
+* molgenis-emx2-graphql: all for generating the graphql on top of sql
+* molgenis-emx2-semantics: endpoint for linked data serving in json-ld and ttl
+* molgenis-emx2-webapi: ties it all together onto SparkJava embedded web server
+* molgenis-emx2-datamodels: reusable data models and test data
+* molgenis-emx2-run: packages all into one fat jar Work in step
+* molgenis-emx2-tasks: toward asynchronous calls for long running transactions/queries
+* molgenis-emx2-beacon-v2: beacon services
+* molgenis-emx2-rdf: rdf exports
+* molgenis-emx2-typescript: generates typescript from schemas
+* molgenis-emx2-email: email services
+* molgenis-emx2-analytics: services for user analytics
+* molgenis-emx2-nonparallel-tests: helper module for tests that cannot be run in parallel

--- a/docs/molgenis/dev_quickstart.md
+++ b/docs/molgenis/dev_quickstart.md
@@ -65,20 +65,21 @@ Alternatively you can run inside [IntelliJ IDEA](https://www.jetbrains.com/idea/
 * Right click on `RunMolgenisEmx2Full` and select 'run'
 
 ## Build one 'app'
+Usefull for app development without need to rebuild all apps all the time.
 
-Requires only [docker compose](https://docs.docker.com/compose/) and [yarn 1.x](https://yarnpkg.com/)
+Requires postgresql, gradle and [yarn 1.x](https://yarnpkg.com/)
 
-* Start molgenis using docker-compose
-  ```console
-  cd molgenis-emx2
-  docker-compose up
-  ```
-  You can verify that it's running by looking at http://localhost:8080
-* Build the app workspace as a whole
+* Build the app workspace as a whole (once)
   ```console
   cd apps
   yarn install
   ```
+* Start molgenis 'headless' (i.e. without apps) using gradle (restart on java changes)
+  ```console
+  cd molgenis-emx2
+  ./gradlew dev
+  ```
+  You can verify that it's running by looking at http://localhost:8080
 * Serve only the app you want to look at
   ```console
   cd <yourapp>

--- a/docs/molgenis/run_updates.md
+++ b/docs/molgenis/run_updates.md
@@ -16,7 +16,7 @@ below. Caution: this will delete all MOLGENIS generated roles (MG_ROLE*, MG_USER
 
 Download the appropriate *.jar release and run command:
 
-```java -cp molgenis-emx2-<version>-all.jar org.molgenis.emx2.AToolToCleanDatabase```
+```java -cp molgenis-emx2-<version>-all.jar org.molgenis.emx2.sql.AToolToCleanDatabase```
 
 If you have the sourcecode you can also run:
 ```gradle cleandb```


### PR DESCRIPTION
What are the main changes you did:
- added 'dev' tasks
-  moved dev, cleandb and generateTypes to modules to make them start faster again bypassing javascript build

how to test:
- see docs changes

