### PR TITLE
fix: hide networks block if there are no networks to show

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/[resourceType]/[resource]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/[resourceType]/[resource]/index.vue
@@ -651,6 +651,7 @@ const showPopulation = computed(
         </TableContent>
 
         <ContentBlock
+          v-if="networks.length"
           title="Networks"
           id="Networks"
           description="Part of networks"


### PR DESCRIPTION
fix: hide networks block if there are no networks to show