### PR TITLE
fix(catalogue): resource logo was not shown

### DIFF
--- a/apps/nuxt3-ssr/components/SideNavigation.vue
+++ b/apps/nuxt3-ssr/components/SideNavigation.vue
@@ -19,18 +19,15 @@ function setSideMenuStyle(hash: string) {
   >
     <div v-if="title || image" class="mb-6 font-display text-heading-4xl">
       <NuxtLink
-        :to="{ ...route, hash: headerTarget }"
-        tag="img"
         v-if="image"
-        :src="image"
-      />
-      <NuxtLink
         :to="{ ...route, hash: headerTarget }"
-        tag="h2"
-        v-else
-        if="title"
-        >{{ title }}</NuxtLink
+        :src="image"
       >
+        <img :src="image" :alt="title" />
+      </NuxtLink>
+      <NuxtLink v-else :to="{ ...route, hash: headerTarget }">
+        {{ title }}
+      </NuxtLink>
     </div>
     <ul>
       <li v-for="item in items">

--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/[resourceType]/[resource]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/[resourceType]/[resource]/index.vue
@@ -173,6 +173,9 @@ const query = gql`
             name
         }
         website
+        logo {
+          url
+        }
       }
     }
   }


### PR DESCRIPTION
What are the main changes you did:
- fix props for sidemenu logo
- fix query for networks card logo

how to test:
- note due to preview file/image issue, it can not be tested on the preview
- locally ( proxy to prod or similar backend) or on server, run the pr branch and check logo's ( detail page sidemenu and networks card ) against prod.
 for example check 'EUChildNetwork/cohorts/ABCD' it has both a sidemenu log and networks logo's
todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
