### PR TITLE
try: one to one mapping of semantic color names 

### DIFF
--- a/apps/tailwind-components/assets/css/main.css
+++ b/apps/tailwind-components/assets/css/main.css
@@ -45,6 +45,7 @@
     --color-blue-500: #017FFD;
     --color-blue-700: #1D4ED8;
     --color-blue-800: #014F9E;
+    --color-blue-900: #013F7E;
     --color-gray-100: #F4F4F4;
     --color-gray-200: #E2E2E2;
     --color-gray-400: #C0C0C0;
@@ -53,6 +54,7 @@
     --color-yellow-200: #FFF4CB;
     --color-yellow-500: #FFF500;
     --color-yellow-800: #C89B00;
+    --color-green-200: #C7FFE2;
     --color-green-500: #72F6B2;
     --color-green-800: #349D63;
     --color-orange-500: #E1B53E;
@@ -180,6 +182,26 @@
     --outline-color-select: var(--color-gray-200);
 
   }
+
+  :root[data-theme="light"] {
+    --color-blue-500: #0173E4;
+    /* sames as 500 posible copy paste error in design docs ? */
+    --color-blue-700: #0173E4;
+
+    --colors-light-background-for-buttons-and-hovers: var(--color-blue-50); 
+    --colors-floating-scrollbar: var(--color-blue-100);
+    --colors-passive-clickable-elements: var(--color-blue-200);
+    --colors-light-background-for-buttons-and-hovers: var(--color-blue-50);
+    --colors-primary-call-to-action-and-links: var(--color-blue-500);
+    --colors-blue-for-buttons-links-and-hovers-that-have-a-light-blue-backgrounds: var(--color-blue-700);
+    --colors-default-text-dark-buttons-and-hovers: var(--color-blue-800);
+    --colors-background-dark-hovers: var(--color-blue-900);
+    --colors-light-backgrounds: var(--color-grey-100);
+    --colors-borders: var(--color-grey-200);
+    --colors-input-border-checkboxes-and-radiobutton-border-border-that-contrast-the-regular-border-info-icons: var(--color-grey-400);
+    --colors-placeholders-light-text: var(--color-grey-600);
+  }
+
   :root[data-theme="umcg"] {
     --color-white: #fff;
     --color-orange-200: #ff6a00;


### PR DESCRIPTION
Not to merge , just to discuss theme implementation, options i see; 1) one to one mapping between css vars and tailwind config ( more like me have now ), 2) more semantic/wordy/descriptive ( see pr ) and then use these to set multiple tailwind config values ( more like this pr ). 
One to one mapping of semantic color names from design doc to the theme file


What are the main changes you did:
- add the semantic variables and color definitions to the css file.

This is to explore a way to define the theme settings and lik these to the (figma) design deliverables.
