### PR TITLE
fix(central): link to the last update details

### DIFF
--- a/apps/central/src/components/LastUpdateField.vue
+++ b/apps/central/src/components/LastUpdateField.vue
@@ -1,6 +1,6 @@
 <template>
   <span>
-    <a :href="`/${lastUpdate.schema}/settings/#/changelog`">
+    <a :href="`/${lastUpdate.schemaName}/settings/#/changelog`">
       {{ timeStamp }} ({{ lastUpdate.tableName }})
     </a>
   </span>
@@ -11,9 +11,11 @@ import { computed } from "vue";
 
 const props = defineProps<{
   lastUpdate: {
-    stamp: number;
+    stamp: string;
     tableName: string;
-    schema: string;
+    schemaName: string;
+    userId: string;
+    operation: string;
   };
 }>();
 


### PR DESCRIPTION
This fixes the 'undefined' instead of the schema name in the lastUpsdate details link 

What are the main changes you did:
- The prop struct changed therefore update the type and  usage, generate correct link

how to test:
- explain here what to do to test this (or point to unit tests)

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
