### PR TITLE
docs: Added expressions for validating if a field is empty or not

### DIFF
--- a/docs/molgenis/use_schema.md
+++ b/docs/molgenis/use_schema.md
@@ -282,6 +282,14 @@ expression itself is shown. Otherwise, the return value of the expression will b
 | `/^([a-z]+)$/.test(name)`                                                  | Application of validation rule failed: /^([a-z]+)$/.test(name)                    |
 | `if(!/^([a-z]+)$/.test(name))'name should contain only lowercase letters'` | Application of validation rule failed: name should contain only lowercase letters |
 
+Special attention needs to be paid when validating if a field is empty or not (as filled in fields that get emptied are different from never filled in fields).
+To ensure correct behaviour, use the following:
+
+| validation                 | functioning              |
+|----------------------------|--------------------------|
+| `mustBeFilled?.length > 0` | Fails if field is empty  |
+| `!(mustBeEmpty?.length)`   | Fails if field is filled |
+
 Visible expressions must return a value that is not false or undefined, otherwise the column stays hidden in the user interface. In the event that javascript
 throws an exception, this is shown in user interface/error message. For example:
 

--- a/docs/molgenis/use_schema.md
+++ b/docs/molgenis/use_schema.md
@@ -283,12 +283,12 @@ expression itself is shown. Otherwise, the return value of the expression will b
 | `if(!/^([a-z]+)$/.test(name))'name should contain only lowercase letters'` | Application of validation rule failed: name should contain only lowercase letters |
 
 Special attention needs to be paid when validating if a field is empty or not (as filled in fields that get emptied are different from never filled in fields).
-To ensure correct behaviour, use the following:
+While [required](#required) should be used to ensure a field itself is filled, when creating expressions (that include other fields), use the following:
 
-| validation                 | functioning              |
-|----------------------------|--------------------------|
-| `mustBeFilled?.length > 0` | Fails if field is empty  |
-| `!(mustBeEmpty?.length)`   | Fails if field is filled |
+| validation               | functioning                       |
+|--------------------------|-----------------------------------|
+| `columnName?.length > 0` | Field 'columnName' must be filled |
+| `!(columnName?.length)`  | Field 'columnName' must be empty  |
 
 Visible expressions must return a value that is not false or undefined, otherwise the column stays hidden in the user interface. In the event that javascript
 throws an exception, this is shown in user interface/error message. For example:


### PR DESCRIPTION
What are the main changes you did:

Added docs describing the following scenarios:
1. Validating that a field must be filled

https://github.com/user-attachments/assets/967ed813-acb9-4db9-9e1f-6ef13707a3f3

2. Validating that a field must be empty

https://github.com/user-attachments/assets/3f3637e9-374e-4e54-a7ae-0fdddfbabd9d


how to test:
- Create schema/table where `c2` has the validation as mentioned in the docs referring to `c1` (see also videos where the error message also shows the used expression).

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
