### PR TITLE
fix: Arrays failed to validate using their `validationRegexp`

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTypeUtils.java
@@ -279,7 +279,7 @@ public class SqlTypeUtils extends TypeUtils {
   }
 
   static Map<String, Object> convertRowToMap(List<Column> columns, Row row) {
-    Map<String, Object> map = new LinkedHashMap<>(row.getValueMap());
+    Map<String, Object> map = new LinkedHashMap<>();
     for (Column c : columns) {
       if (c.isReference()) {
         map.put(c.getIdentifier(), getRefFromRow(row, c));

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
@@ -58,14 +58,14 @@ class TestSqlTypeUtils {
 
   @Test
   void testArrayConversionToMap() {
-    List<Column> columns = List.of(column("string array", ColumnType.STRING_ARRAY));
-    Row row = row("string array", "aa,bb");
+    List<Column> columns = List.of(column("STRING array", ColumnType.STRING_ARRAY));
+    Row row = row("STRING array", "aa,bb");
 
     Map<String, Object> output = convertRowToMap(columns, row);
 
     assertAll(
-        () -> assertEquals(1, output.size()),
+        () -> assertEquals(Set.of("sTRINGArray"), output.keySet()),
         () ->
-            assertEquals(List.of("aa", "bb"), Arrays.asList((String[]) output.get("stringArray"))));
+            assertEquals(List.of("aa", "bb"), Arrays.asList((String[]) output.get("sTRINGArray"))));
   }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
@@ -1,9 +1,13 @@
 package org.molgenis.emx2.sql;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.molgenis.emx2.Column.column;
+import static org.molgenis.emx2.Row.row;
 import static org.molgenis.emx2.TableMetadata.table;
 import static org.molgenis.emx2.sql.SqlTypeUtils.applyValidationAndComputed;
+import static org.molgenis.emx2.sql.SqlTypeUtils.convertRowToMap;
 
+import java.util.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.*;
@@ -52,14 +56,16 @@ class TestSqlTypeUtils {
     assertEquals(row.getString("myCol"), row.getString("myCol"));
   }
 
-  /**
-   * Ensure the {@link ColumnType} used has a `validationRegexp` and triggers {@link ColumnType#isArray()}
-   */
   @Test
-  void testIdenticalColumnNameAndTypeArrayWithValidationString() {
-    TableMetadata tableMetadata =
-        table("Test", new Column("EMAIL_ARRAY").setType(ColumnType.EMAIL_ARRAY));
-    final Row row = new Row("EMAIL_ARRAY", "bob@example.com,ross@example.com");
-    applyValidationAndComputed(tableMetadata.getColumns(), row);
+  void testArrayConversionToMap() {
+    List<Column> columns = List.of(column("string array", ColumnType.STRING_ARRAY));
+    Row row = row("string array", "aa,bb");
+
+    Map<String, Object> output = convertRowToMap(columns, row);
+
+    assertAll(
+        () -> assertEquals(1, output.size()),
+        () ->
+            assertEquals(List.of("aa", "bb"), Arrays.asList((String[]) output.get("stringArray"))));
   }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
@@ -68,4 +68,11 @@ class TestSqlTypeUtils {
         () ->
             assertEquals(List.of("aa", "bb"), Arrays.asList((String[]) output.get("sTRINGArray"))));
   }
+
+  @Test
+  void testWorkingValidationForEmailArray() {
+    List<Column> columns = List.of(column("SPAM blocklist", ColumnType.EMAIL_ARRAY));
+    Row row = row("SPAM blocklist", "bob@example.com,ros@example.com");
+    assertDoesNotThrow(() -> applyValidationAndComputed(columns, row));
+  }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
@@ -73,6 +73,7 @@ class TestSqlTypeUtils {
   void testWorkingValidationForEmailArray() {
     List<Column> columns = List.of(column("SPAM blocklist", ColumnType.EMAIL_ARRAY));
     Row row = row("SPAM blocklist", "bob@example.com,ros@example.com");
+    
     assertDoesNotThrow(() -> applyValidationAndComputed(columns, row));
   }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSqlTypeUtils.java
@@ -51,4 +51,15 @@ class TestSqlTypeUtils {
     applyValidationAndComputed(tableMetadata.getColumns(), copy);
     assertEquals(row.getString("myCol"), row.getString("myCol"));
   }
+
+  /**
+   * Ensure the {@link ColumnType} used has a `validationRegexp` and triggers {@link ColumnType#isArray()}
+   */
+  @Test
+  void testIdenticalColumnNameAndTypeArrayWithValidationString() {
+    TableMetadata tableMetadata =
+        table("Test", new Column("EMAIL_ARRAY").setType(ColumnType.EMAIL_ARRAY));
+    final Row row = new Row("EMAIL_ARRAY", "bob@example.com,ross@example.com");
+    applyValidationAndComputed(tableMetadata.getColumns(), row);
+  }
 }


### PR DESCRIPTION
What are the main changes you did:
- Fixed the bug
- Added test:
  - Pre-fix keySet: `[STRING array, sTRINGArray]`
  - Post-fix keySet: `[sTRINGArray]`

how to test:
- Ensure all tests succeed

Sidenote: Weird camelCasing. Would expect `stringArray` instead. Perhaps worth fixing as well, though not sure if this would break things. Either way, out-of-scope for this PR.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
