### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ mvnw.cmd
 release.properties
 tls
 **/**/bin/
+.venv
 
 yarn_error.log
 .nyc_output


### PR DESCRIPTION
.venv is the default folder for Python virtual environments created in VSCode
