### PR TITLE
fix(catalogue): show sub catalogue logo

### DIFF
--- a/apps/nuxt3-ssr/composables/useHeaderData.ts
+++ b/apps/nuxt3-ssr/composables/useHeaderData.ts
@@ -22,8 +22,8 @@ export async function useHeaderData() {
       method: "POST",
       body: {
         query: `
-            query HeaderQuery($resourceFilter:ResourcesFilter, $variablesFilter:VariablesFilter) {
-              Resources(filter:$resourceFilter) {
+            query HeaderQuery($resourceFilter:ResourcesFilter, $variablesFilter:VariablesFilter, $networksFilter:ResourcesFilter) {
+              Resources(filter:$networksFilter) {
                 id,
                 logo { url }
               }
@@ -36,6 +36,9 @@ export async function useHeaderData() {
               }
             }`,
         variables: {
+          networksFilter: scoped
+            ? { id: { equals: catalogueRouteParam } }
+            : undefined,
           resourceFilter: scoped
             ? {
                 _or: [


### PR DESCRIPTION
fix(catalogue): show sub catalogue logo

What are the main changes you did:
- fix header data query, if in subnetwork , fetch the logo from the resource that matches the sub catalogue id

how to test:
- see .../ssr-catalogue/ATHLETE/cohorts/BIB 

note images a not loaded in preview, run locally to test image loading

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
