### PR TITLE
fix(catalogue):  4367 format date as year

### DIFF
--- a/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/[resourceType]/[resource]/index.vue
+++ b/apps/nuxt3-ssr/pages/[schema]/ssr-catalogue/[catalogue]/[resourceType]/[resource]/index.vue
@@ -232,7 +232,10 @@ function collectionEventMapper(item: any) {
     name: item.name,
     description: item.description,
     startAndEndYear: (() => {
-      return dateUtils.startEndYear(item.startDate, item.endDate);
+      return dateUtils.startEndYear(
+        new Date(item.startDate).getFullYear().toString(),
+        new Date(item.endDate).getFullYear().toString()
+      );
     })(),
     numberOfParticipants: item.numberOfParticipants,
     _renderComponent: "CollectionEventDisplay",
@@ -638,7 +641,7 @@ const showPopulation = computed(
           description="List of collection events defined for this resource"
           :headers="[
             { id: 'name', label: 'Name' },
-            { id: 'description', label: 'Description', singleLine: true },
+            { id: 'description', label: 'Description' },
             { id: 'numberOfParticipants', label: 'Participants' },
             {
               id: 'startAndEndYear',
@@ -662,7 +665,7 @@ const showPopulation = computed(
           description="List of datasets for this resource"
           :headers="[
             { id: 'name', label: 'Name' },
-            { id: 'description', label: 'Description', singleLine: true },
+            { id: 'description', label: 'Description' },
           ]"
           type="Datasets"
           :query="datasetQuery"


### PR DESCRIPTION
Closes #4367

What are the main changes you did:
- format the date as year

note: might be more of a model issue , would be nice to get the format from the metadata 
used to be everything was a date, catalogue model now has mix; date, year as number , year as string , maybe others 
todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
