### PR TITLE
fix(catalogue): fix 4366

### DIFF
--- a/apps/nuxt3-ssr/components/header/Catalogue.vue
+++ b/apps/nuxt3-ssr/components/header/Catalogue.vue
@@ -19,7 +19,11 @@ const catalogueRouteParam = route.params.catalogue as string;
 
 const menu: { label: string; link: string }[] = [];
 
-if (route.params.resourceType) {
+// the variable route does not set the resourceType param, therefore check the route name
+if (
+  route.params.resourceType ||
+  route.name === "schema-ssr-catalogue-catalogue-variables"
+) {
   menu.push({
     label: "overview",
     link: `/${route.params.schema}/ssr-catalogue/${catalogueRouteParam}`,


### PR DESCRIPTION
'overview' check expected resourceType not set in variable route Closes #4366

What are the main changes you did:
- add check for variable route 

how to test:
- compare variable route menu with resource route menu , should now both have the overview link 

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
