### PR TITLE
fix: JSON_ARRAY String containing multiple items now split correctly into a JSONB[]

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -287,7 +287,14 @@ public class TypeUtils {
     for (char c : jsonbArray.toCharArray()) {
       switch (c) {
         case '{' -> depth++;
-        case '}' -> depth--;
+        case '}' -> {
+          if (depth > 0) {
+            depth--;
+          } else {
+            throw new MolgenisException(
+                "Invalid JSON_ARRAY: Negative depth at position: " + currentPos);
+          }
+        }
         case ',' -> {
           if (depth == 0) {
             subStrings.add(jsonbArray.substring(lastSplitPos, currentPos));
@@ -297,6 +304,11 @@ public class TypeUtils {
       }
       currentPos++;
     }
+
+    if (depth != 0)
+      throw new MolgenisException(
+          "Invalid JSON_ARRAY: Number of opening/closing parenthesis does not match.");
+
     subStrings.add(jsonbArray.substring(lastSplitPos, currentPos));
 
     return subStrings;

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
@@ -70,4 +70,21 @@ public class TestTypeUtils {
         TypeUtils.toDateTime("2023-02-24T12:08:23.46378"),
         LocalDateTime.of(2023, 02, 24, 12, 8, 23, 463780000));
   }
+
+  @Test
+  public void testJsonbArrayFromStringWithMultipleItems() {
+    List<JSONB> expected = List.of(JSONB.valueOf("{\"c\":3}"), JSONB.valueOf("{\"d\":4,\"e\":5}"));
+    List<JSONB> actual =
+        Arrays.stream(TypeUtils.toJsonbArray("{\"c\":3},{\"d\":4,\"e\":5}")).toList();
+
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testJsonbArrayFromStringWithOneItem() {
+    List<JSONB> expected = List.of(JSONB.valueOf("{\"d\":4,\"e\":5}"));
+    List<JSONB> actual = Arrays.stream(TypeUtils.toJsonbArray("{\"d\":4,\"e\":5}")).toList();
+
+    assertEquals(expected, actual);
+  }
 }


### PR DESCRIPTION
What are the main changes you did:
- Added custom logics to extract multiple JSON array's from a single String by checking for "top level comma's" (any comma's inside `{` and `}` are ignored).

how to test:
- Check if written tests are good enough and whether they succeed.

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
