### PR TITLE
fix(tw): refactor breadcrumbs component

### DIFF
--- a/apps/tailwind-components/components/BreadCrumbs.vue
+++ b/apps/tailwind-components/components/BreadCrumbs.vue
@@ -42,12 +42,9 @@ withDefaults(
         >
           <BaseIcon name="caret-right" :width="12" />
         </span>
+      </li>
+      <li v-if="current && !Object.keys(crumbs).includes(current)">
         <a
-          v-if="
-            current &&
-            !Object.keys(crumbs).includes(current) &&
-            !(index < Object.keys(crumbs).length - 1)
-          "
           href=""
           class="text-breadcrumb hover:underline"
           aria-current="page"

--- a/apps/tailwind-components/components/BreadCrumbs.vue
+++ b/apps/tailwind-components/components/BreadCrumbs.vue
@@ -24,13 +24,26 @@ withDefaults(
       <BaseIcon name="star" />
     </a> -->
   </div>
-  <nav
-    class="items-center hidden gap-3 tracking-widest xl:flex font-display text-heading-lg"
-    :class="{ 'justify-center': align === 'center' }"
-  >
-    <ol>
-      <li v-for="(url, label, index) in crumbs" :key="label">
-        <NuxtLink :to="url" class="text-breadcrumb hover:underline">
+  <nav aria-label="breadcrumb">
+    <ol
+      class="items-center hidden gap-3 tracking-widest xl:flex font-display text-heading-lg"
+      :class="{ 'justify-center': align === 'center' }"
+    >
+      <li
+        v-for="(url, label, index) in crumbs"
+        :key="label"
+        class="flex justify-center items-center gap-3"
+      >
+        <a
+          href=""
+          class="text-breadcrumb"
+          v-if="current"
+          aria-current="page"
+          @click.prevent
+        >
+          {{ current }}
+        </a>
+        <NuxtLink v-else :to="url" class="text-breadcrumb hover:underline">
           {{ label }}
         </NuxtLink>
         <span
@@ -39,34 +52,7 @@ withDefaults(
         >
           <BaseIcon name="caret-right" :width="12" />
         </span>
-        <template v-if="current">
-          <BaseIcon
-            v-if="Object.keys(crumbs).length > 0"
-            name="caret-right"
-            :width="12"
-            class="text-breadcrumb-arrow"
-          /><a class="text-breadcrumb"> {{ current }}</a>
-        </template>
       </li>
     </ol>
-    <!-- <template v-for="(url, label, index) in crumbs" :key="label">
-      <NuxtLink :to="url" class="text-breadcrumb hover:underline">{{
-        label
-      }}</NuxtLink>
-      <span
-        v-if="index < Object.keys(crumbs).length - 1"
-        class="text-breadcrumb-arrow"
-      >
-        <BaseIcon name="caret-right" :width="12" />
-      </span>
-    </template>
-    <template v-if="current">
-      <BaseIcon
-        v-if="Object.keys(crumbs).length > 0"
-        name="caret-right"
-        :width="12"
-        class="text-breadcrumb-arrow"
-      /><a class="text-breadcrumb"> {{ current }}</a>
-    </template> -->
   </nav>
 </template>

--- a/apps/tailwind-components/components/BreadCrumbs.vue
+++ b/apps/tailwind-components/components/BreadCrumbs.vue
@@ -14,17 +14,16 @@ withDefaults(
 </script>
 
 <template>
-  <div class="flex justify-between xl:hidden text-menu">
-    <NuxtLink :to="Object.values(crumbs).slice(-1)[0]">
-      <span class="sr-only">Go up one level</span>
-      <BaseIcon name="arrow-left" />
-    </NuxtLink>
-    <!-- <a href="#">
-      <span class="sr-only">Favorite</span>
-      <BaseIcon name="star" />
-    </a> -->
-  </div>
   <nav aria-label="breadcrumb">
+    <ol class="flex justify-between xl:hidden text-menu">
+      <li>
+        <NuxtLink :to="Object.values(crumbs).slice(-1)[0]">
+          <span class="sr-only">Go back one page</span>
+          <BaseIcon name="arrow-left" />
+        </NuxtLink>
+      </li>
+    </ol>
+
     <ol
       class="items-center hidden gap-3 tracking-widest xl:flex font-display text-heading-lg"
       :class="{ 'justify-center': align === 'center' }"
@@ -34,24 +33,28 @@ withDefaults(
         :key="label"
         class="flex justify-center items-center gap-3"
       >
-        <a
-          href=""
+        <NuxtLink :to="url" class="text-breadcrumb hover:underline">
+          {{ label }}
+        </NuxtLink>
+        <span
           class="text-breadcrumb"
-          v-if="current"
+          v-if="index < Object.keys(crumbs).length - 1 || current"
+        >
+          <BaseIcon name="caret-right" :width="12" />
+        </span>
+        <a
+          v-if="
+            current &&
+            !Object.keys(crumbs).includes(current) &&
+            !(index < Object.keys(crumbs).length - 1)
+          "
+          href=""
+          class="text-breadcrumb hover:underline"
           aria-current="page"
           @click.prevent
         >
           {{ current }}
         </a>
-        <NuxtLink v-else :to="url" class="text-breadcrumb hover:underline">
-          {{ label }}
-        </NuxtLink>
-        <span
-          v-if="index < Object.keys(crumbs).length - 1"
-          class="text-breadcrumb-arrow"
-        >
-          <BaseIcon name="caret-right" :width="12" />
-        </span>
       </li>
     </ol>
   </nav>

--- a/apps/tailwind-components/components/BreadCrumbs.vue
+++ b/apps/tailwind-components/components/BreadCrumbs.vue
@@ -28,7 +28,28 @@ withDefaults(
     class="items-center hidden gap-3 tracking-widest xl:flex font-display text-heading-lg"
     :class="{ 'justify-center': align === 'center' }"
   >
-    <template v-for="(url, label, index) in crumbs" :key="label">
+    <ol>
+      <li v-for="(url, label, index) in crumbs" :key="label">
+        <NuxtLink :to="url" class="text-breadcrumb hover:underline">
+          {{ label }}
+        </NuxtLink>
+        <span
+          v-if="index < Object.keys(crumbs).length - 1"
+          class="text-breadcrumb-arrow"
+        >
+          <BaseIcon name="caret-right" :width="12" />
+        </span>
+        <template v-if="current">
+          <BaseIcon
+            v-if="Object.keys(crumbs).length > 0"
+            name="caret-right"
+            :width="12"
+            class="text-breadcrumb-arrow"
+          /><a class="text-breadcrumb"> {{ current }}</a>
+        </template>
+      </li>
+    </ol>
+    <!-- <template v-for="(url, label, index) in crumbs" :key="label">
       <NuxtLink :to="url" class="text-breadcrumb hover:underline">{{
         label
       }}</NuxtLink>
@@ -46,6 +67,6 @@ withDefaults(
         :width="12"
         class="text-breadcrumb-arrow"
       /><a class="text-breadcrumb"> {{ current }}</a>
-    </template>
+    </template> -->
   </nav>
 </template>

--- a/apps/tailwind-components/pages/BreadCrumbs.story.vue
+++ b/apps/tailwind-components/pages/BreadCrumbs.story.vue
@@ -1,6 +1,5 @@
 <template>
   <p class="pb-3">Default breadcrumbs, with 3 items</p>
-  {{ crumbs }}
   <div>
     <BreadCrumbs :crumbs="crumbs" />
   </div>

--- a/apps/tailwind-components/pages/BreadCrumbs.story.vue
+++ b/apps/tailwind-components/pages/BreadCrumbs.story.vue
@@ -25,4 +25,5 @@ const crumbs = ref<Crumbs>({});
 crumbs.value["item 1"] = route.path;
 crumbs.value["item 2"] = route.path;
 crumbs.value["item 3"] = route.path;
+crumbs.value["item 4"] = route.path;
 </script>

--- a/apps/tailwind-components/pages/BreadCrumbs.story.vue
+++ b/apps/tailwind-components/pages/BreadCrumbs.story.vue
@@ -1,5 +1,6 @@
 <template>
   <p class="pb-3">Default breadcrumbs, with 3 items</p>
+  {{ crumbs }}
   <div>
     <BreadCrumbs :crumbs="crumbs" />
   </div>
@@ -25,5 +26,4 @@ const crumbs = ref<Crumbs>({});
 crumbs.value["item 1"] = route.path;
 crumbs.value["item 2"] = route.path;
 crumbs.value["item 3"] = route.path;
-crumbs.value["item 4"] = route.path;
 </script>


### PR DESCRIPTION
What are the main changes you did:
- Refactored breadcrumbs component to ensure good semantic HTML practices. This includes: using `nav` and `ol` elements, removing templates, adding aria properties where necessary, removing duplicate code (i.e., multiple svg calls, etc.) 
- Simplified `v-if` statements
- `current` page property is now rendered in a separate `li` element

how to test:
- Navigate to the breadcrumbs story: https://preview-emx2-pr-4407.dev.molgenis.org/apps/tailwind-components/#/BreadCrumbs.story
- View examples and resize the browser to view the alternate layouts

todo:
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
