### PR TITLE
build: autoscale previews to 0

### DIFF
--- a/helm-chart/templates/autoscale.yml
+++ b/helm-chart/templates/autoscale.yml
@@ -1,0 +1,22 @@
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: {{ include "emx2.fullname" . }}-scaler
+  namespace: default  # Replace with your namespace if different
+  labels:
+    app: {{template "emx2.name" .}}
+    chart: {{template "emx2.chart" .}}
+    release: {{.Release.Name | quote}}
+    heritage: {{.Release.Service | quote}
+spec:
+  scaleTargetRef:
+    name: {{ include "emx2.fullname" . }}
+  minReplicaCount: 0
+  maxReplicaCount: 1
+  cooldownPeriod: 5  # very short now so we can check
+  triggers:
+  - type: http
+    metadata:
+      endpoint: /  # we use the root to trigger awakening the preview
+      method: GET
+      threshold: "1"  # Scale up when at least one request is detected

--- a/helm-chart/templates/deployment.yaml
+++ b/helm-chart/templates/deployment.yaml
@@ -8,7 +8,7 @@ metadata:
     release: {{ .Release.Name | quote }}
     heritage: {{ .Release.Service | quote }}
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       {{- include "emx2.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
goal of this PR is to have previews not use resources unless accessed. therefore they should scale down rather quickly.