### PR TITLE
Update documentation for jobs

### DIFF
--- a/docs/molgenis/use_scripts_jobs.md
+++ b/docs/molgenis/use_scripts_jobs.md
@@ -13,7 +13,7 @@ Scripts can have the following:
 * the script type
 * the script
 * outputFileExtension, optional, for returning output files. E.g. 'txt'
-* disabled, when true scripts cannot be run
+* disabled, when set to true the script will not run if a cron schedule is set
 * cron, will schedule the script to run at planned intervals
 * failureAddress, when set, will send a message to this email address, if a job fails
 


### PR DESCRIPTION
Update documentation for jobs to clarify that disabled means that scheduling the job in cron is disabled.

closes #4388 
