### PR TITLE
fix(molgenis-components): multiple auto-id fields in chapters

### DIFF
--- a/apps/molgenis-components/src/components/forms/RowEdit.vue
+++ b/apps/molgenis-components/src/components/forms/RowEdit.vue
@@ -120,9 +120,7 @@ export default {
   },
   methods: {
     showColumn(column: IColumn) {
-      if (column.columnType === AUTO_ID) {
-        return this.pkey;
-      } else if (column.refLinkId) {
+      if (column.refLinkId) {
         return this.internalValues[column.refLinkId];
       } else {
         const isColumnVisible = this.visibleColumns


### PR DESCRIPTION
fixes: #4027

Have auto-id fields respect the pages it should not be displayed.

Review comments: Notice that the 'showColumn' was returning a pkey for auto-id and the function needed to return a boolean.

how to test:
- Add an auto-id field to Pet in pet store.
- Make sure only one auto-id field is visible in all chapters.
