### PR TITLE
chore(docs): updated docs to use `yarn dev` instead of `yarn serve`

### DIFF
--- a/docs/molgenis/dev_apps.md
+++ b/docs/molgenis/dev_apps.md
@@ -100,11 +100,11 @@ In the apps folder, there are several core frontend applications (e.g., settings
 docker-compose up
 ```
 
-The `/api` and `/graphql` paths are proxied as defined in the dev-proxy.config.js. In order to preview individual apps, use yarn serve. For example, to preview the app `apps/schema`, run the following command.
+The `/api` and `/graphql` paths are proxied as defined in the dev-proxy.config.js. In order to preview individual apps, use `yarn dev`. For example, to preview the app `apps/schema`, run the following command.
 
 ```bash
 cd apps/schema
-yarn serve
+yarn dev
 ```
 
 ## Deploying your application

--- a/docs/molgenis/dev_quickstart.md
+++ b/docs/molgenis/dev_quickstart.md
@@ -71,7 +71,7 @@ Requires postgresql, gradle and [yarn 1.x](https://yarnpkg.com/)
 
 * Build the app workspace as a whole (once)
   ```console
-  cd apps
+  cd molgenis-emx2/apps
   yarn install
   ```
 * Start molgenis 'headless' (i.e. without apps) using gradle (restart on java changes)
@@ -82,8 +82,8 @@ Requires postgresql, gradle and [yarn 1.x](https://yarnpkg.com/)
   You can verify that it's running by looking at http://localhost:8080
 * Serve only the app you want to look at
   ```console
-  cd <yourapp>
-  yarn serve
+  cd molgenis-emx2/apps/<yourapp>
+  yarn dev
   ```
   Typically the app is then served at http://localhost:9090 (look at the console to see actual port number)
 


### PR DESCRIPTION
### What are the main changes you did
- see title

### How to test
- NA

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation