### PR TITLE
fix: use correct mime-type when windows doesn't recognize it

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/StaticFileMapper.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/StaticFileMapper.java
@@ -4,6 +4,7 @@ import com.google.common.io.ByteStreams;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import java.io.InputStream;
+import java.net.URLConnection;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
@@ -89,10 +90,12 @@ public class StaticFileMapper {
         return;
       }
       if (mimeType == null) {
-        mimeType = Files.probeContentType(Path.of(path));
-        if (mimeType.equals("text/plain") && path.endsWith(".js")) {
-          mimeType = "text/javascript";
+        mimeType = URLConnection.guessContentTypeFromName(path);
+
+        if (mimeType == null) {
+          mimeType = Files.probeContentType(Path.of(path));
         }
+
         if (mimeType == null) {
           mimeType = "application/octet-stream";
         }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/StaticFileMapper.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/StaticFileMapper.java
@@ -90,6 +90,9 @@ public class StaticFileMapper {
       }
       if (mimeType == null) {
         mimeType = Files.probeContentType(Path.of(path));
+        if (mimeType.equals("text/plain") && path.endsWith(".js")) {
+          mimeType = "text/javascript";
+        }
         if (mimeType == null) {
           mimeType = "application/octet-stream";
         }


### PR DESCRIPTION
Currently running EMX2 on windows return a white webpage because of incorrect mime type of js files.

### What are the main changes you did
- Hardcode the mime type of js files because you can't assume it is correctly set in the windows registry.

### How to test
- Run the application on windows
- go to localhost:8080
- the application should load 

- it should make no difference on unix machines
