### PR TITLE
fix(tasks): also send failure mails when failing jobs are scheduled

### DIFF
--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
@@ -260,11 +260,14 @@ public class ScriptTask extends Task {
   }
 
   private String getJobUrl() {
-    return this.serverUrl.toExternalForm()
-        + "/"
-        + Constants.SYSTEM_SCHEMA
-        + "/tasks/#/jobs?id="
-        + this.getId();
+    if (serverUrl != null) {
+      return this.serverUrl.toExternalForm()
+          + "/"
+          + Constants.SYSTEM_SCHEMA
+          + "/tasks/#/jobs?id="
+          + this.getId();
+    }
+    return null;
   }
 
   public ScriptTask setServerUrl(URL url) {

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskService.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskService.java
@@ -1,6 +1,5 @@
 package org.molgenis.emx2.tasks;
 
-import java.net.URL;
 import java.util.Collection;
 import java.util.List;
 import java.util.Set;
@@ -11,8 +10,6 @@ public interface TaskService {
   String submit(Task task);
 
   String submitTaskFromName(String name, String parameters);
-
-  String submitTaskFromName(String name, String parameters, URL host);
 
   Set<String> getJobIds();
 

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInDatabase.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInDatabase.java
@@ -23,10 +23,12 @@ import org.molgenis.emx2.sql.SqlDatabase;
 public class TaskServiceInDatabase extends TaskServiceInMemory {
   private SqlDatabase database;
   private String systemSchemaName;
+  private URL hostUrl;
 
-  public TaskServiceInDatabase(String systemSchemaName) {
+  public TaskServiceInDatabase(String systemSchemaName, URL hostUrl) {
     this.database = new SqlDatabase(false);
     this.systemSchemaName = systemSchemaName;
+    this.hostUrl = hostUrl;
     this.init();
   }
 
@@ -90,7 +92,7 @@ public class TaskServiceInDatabase extends TaskServiceInMemory {
   }
 
   @Override
-  public String submitTaskFromName(String scriptName, String parameters, URL url) {
+  public String submitTaskFromName(String scriptName, String parameters) {
     StringBuilder result = new StringBuilder();
     String defaultUser = database.getActiveUser();
     database.tx(
@@ -99,7 +101,7 @@ public class TaskServiceInDatabase extends TaskServiceInMemory {
           Schema systemSchema = db.getSchema(this.systemSchemaName);
 
           ScriptTask scriptTask = retrieveTaskFromDatabase(systemSchema, scriptName);
-          scriptTask.setServerUrl(url);
+          scriptTask.setServerUrl(hostUrl);
           String user =
               scriptTask.getCronUserName() == null ? defaultUser : scriptTask.getCronUserName();
 
@@ -116,11 +118,6 @@ public class TaskServiceInDatabase extends TaskServiceInMemory {
                       .submitUser(user)));
         });
     return result.toString();
-  }
-
-  @Override
-  public String submitTaskFromName(final String scriptName, final String parameters) {
-    return submitTaskFromName(scriptName, parameters, null);
   }
 
   private ScriptTask retrieveTaskFromDatabase(Schema systemSchema, String scriptName) {

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInMemory.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInMemory.java
@@ -2,7 +2,6 @@ package org.molgenis.emx2.tasks;
 
 import static org.molgenis.emx2.tasks.TaskStatus.RUNNING;
 
-import java.net.URL;
 import java.util.*;
 import java.util.concurrent.*;
 import org.molgenis.emx2.MolgenisException;
@@ -46,11 +45,6 @@ public class TaskServiceInMemory implements TaskService {
 
   @Override
   public String submitTaskFromName(String name, String parameters) {
-    throw new UnsupportedOperationException("Not supported when using in memory task service");
-  }
-
-  @Override
-  public String submitTaskFromName(String name, String parameters, URL url) {
     throw new UnsupportedOperationException("Not supported when using in memory task service");
   }
 

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestTaskServiceDatabaseBacked.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestTaskServiceDatabaseBacked.java
@@ -23,7 +23,7 @@ public class TestTaskServiceDatabaseBacked {
     // we don't use 'ADMIN' schema
     Schema testSchema =
         database.dropCreateSchema(TestTaskServiceDatabaseBacked.class.getSimpleName());
-    TaskServiceInDatabase taskService = new TaskServiceInDatabase(testSchema.getName());
+    TaskServiceInDatabase taskService = new TaskServiceInDatabase(testSchema.getName(), null);
     DummyTask dummyTask = new DummyTask();
     String id = taskService.submit(dummyTask);
 

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestTaskServiceScheduler.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestTaskServiceScheduler.java
@@ -26,7 +26,7 @@ public class TestTaskServiceScheduler {
   @Test
   @Disabled
   public void testTaskServiceScheduler() throws InterruptedException, SchedulerException {
-    TaskServiceInDatabase service = new TaskServiceInDatabase(SCHEMA_NAME);
+    TaskServiceInDatabase service = new TaskServiceInDatabase(SCHEMA_NAME, null);
     TaskServiceScheduler scheduler = new TaskServiceScheduler(service);
 
     Row scriptRow = row("name", "test", "script", "print('hello');", "cron", "0/1 * * * * ?");
@@ -72,7 +72,7 @@ public class TestTaskServiceScheduler {
 
   @Test
   public void testCronPersistence() {
-    TaskServiceInDatabase service = new TaskServiceInDatabase(SCHEMA_NAME);
+    TaskServiceInDatabase service = new TaskServiceInDatabase(SCHEMA_NAME, null);
     TaskServiceScheduler scheduler = new TaskServiceScheduler(service);
 
     // not there from before
@@ -87,7 +87,7 @@ public class TestTaskServiceScheduler {
 
     // destroy and recreate see if task comes back
     scheduler.shutdown();
-    service = new TaskServiceInDatabase(SCHEMA_NAME);
+    service = new TaskServiceInDatabase(SCHEMA_NAME, null);
 
     // make sure only 'test' is in the scheduled tasks, not other scripts
     scheduler = new TaskServiceScheduler(service);

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisWebservice.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisWebservice.java
@@ -12,8 +12,10 @@ import io.javalin.http.Context;
 import io.swagger.util.Yaml;
 import io.swagger.v3.oas.models.OpenAPI;
 import java.io.IOException;
+import java.net.URL;
 import java.util.*;
 import org.molgenis.emx2.*;
+import org.molgenis.emx2.utils.URIUtils;
 import org.molgenis.emx2.web.controllers.OIDCController;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,6 +33,7 @@ public class MolgenisWebservice {
   private static final String USER_AGENT_ALLOW = "User-agent: *\nAllow: /";
   public static MolgenisSessionManager sessionManager;
   public static OIDCController oidcController;
+  static URL hostUrl;
 
   private MolgenisWebservice() {
     // hide constructor
@@ -50,6 +53,12 @@ public class MolgenisWebservice {
                       handler -> handler.setSessionHandler(sessionManager.getSessionHandler()));
                 })
             .start(port);
+
+    try {
+      hostUrl = new URL(URIUtils.extractHost(app.jettyServer().server().getURI()));
+    } catch (Exception ignored) {
+      // should we handle this?
+    }
 
     MessageApi.create(app);
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/TaskApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/TaskApi.java
@@ -12,7 +12,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
 import java.io.IOException;
-import java.net.MalformedURLException;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import org.molgenis.emx2.*;
@@ -23,10 +22,11 @@ import org.molgenis.emx2.tasks.*;
 public class TaskApi {
 
   // todo, make jobs private to the user?
-  public static TaskService taskService = new TaskServiceInDatabase(SYSTEM_SCHEMA, hostUrl);
+  public static final TaskService taskService = new TaskServiceInDatabase(SYSTEM_SCHEMA, hostUrl);
   // to schedule jobs, see MolgenisSessionManager how we keep this in sync with Database using a
   // TableListener
-  public static TaskServiceScheduler taskSchedulerService = new TaskServiceScheduler(taskService);
+  public static final TaskServiceScheduler taskSchedulerService =
+      new TaskServiceScheduler(taskService);
 
   public static void create(Javalin app) {
     app.get("/api/tasks", TaskApi::listTasks);
@@ -71,7 +71,7 @@ public class TaskApi {
     ctx.json(new ObjectMapper().writeValueAsString(taskSchedulerService.scheduledTaskNames()));
   }
 
-  private static void postScript(Context ctx) throws MalformedURLException {
+  private static void postScript(Context ctx) {
     MolgenisSession session = sessionManager.getSession(ctx.req());
     String user = session.getSessionUser();
     if (!"admin".equals(user)) {

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/TaskApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/TaskApi.java
@@ -3,8 +3,8 @@ package org.molgenis.emx2.web;
 import static org.molgenis.emx2.Constants.SYSTEM_SCHEMA;
 import static org.molgenis.emx2.FilterBean.f;
 import static org.molgenis.emx2.SelectColumn.s;
-import static org.molgenis.emx2.utils.URIUtils.extractHost;
 import static org.molgenis.emx2.web.FileApi.addFileColumnToResponse;
+import static org.molgenis.emx2.web.MolgenisWebservice.hostUrl;
 import static org.molgenis.emx2.web.MolgenisWebservice.sessionManager;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -13,7 +13,6 @@ import io.javalin.Javalin;
 import io.javalin.http.Context;
 import java.io.IOException;
 import java.net.MalformedURLException;
-import java.net.URL;
 import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import org.molgenis.emx2.*;
@@ -24,7 +23,7 @@ import org.molgenis.emx2.tasks.*;
 public class TaskApi {
 
   // todo, make jobs private to the user?
-  public static TaskService taskService = new TaskServiceInDatabase(SYSTEM_SCHEMA);
+  public static TaskService taskService = new TaskServiceInDatabase(SYSTEM_SCHEMA, hostUrl);
   // to schedule jobs, see MolgenisSessionManager how we keep this in sync with Database using a
   // TableListener
   public static TaskServiceScheduler taskSchedulerService = new TaskServiceScheduler(taskService);
@@ -81,8 +80,7 @@ public class TaskApi {
     String name = URLDecoder.decode(ctx.pathParam("name"), StandardCharsets.UTF_8);
     String parameters = ctx.body();
 
-    URL host = new URL(extractHost(ctx.url()));
-    String id = taskService.submitTaskFromName(name, parameters, host);
+    String id = taskService.submitTaskFromName(name, parameters);
     ctx.json(new TaskReference(id));
   }
 


### PR DESCRIPTION
Fixes #4542 

### What are the main changes you did
- Fixed sending failure mails when failing jobs are scheduled
- By storing the host url in WebService and passing it the TaskService

### How to test
- Can only be tested on prod/acc server
- 
### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation