### PR TITLE
fix: `column.getReferences()` returning incorrect column names for `ColumnType.REFBACK`

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -63,7 +63,7 @@ public class SqlQuery extends QueryBean {
 
   /** Create alias that is short enough for postgresql to not complain */
   public String alias(String label) {
-    if (!label.contains("-")) {
+    if (!label.contains(SUBSELECT_SEPARATOR)) {
       // we only need aliases for subquery tables
       return label;
     }
@@ -154,7 +154,7 @@ public class SqlQuery extends QueryBean {
     List<Field<?>> fields = new ArrayList<>();
     for (SelectColumn select : selection.getSubselect()) {
       Column column = getColumnByName(table, select.getColumn());
-      String columnAlias = prefix.equals("") ? column.getName() : prefix + "-" + column.getName();
+      String columnAlias = prefix.equals("") ? column.getName() : prefix + SUBSELECT_SEPARATOR + column.getName();
       if (column.isFile()) {
         // check what they want to get, contents, mimetype, size, filename and/or extension
         if (select.getSubselect().isEmpty() || select.has("id")) {
@@ -181,7 +181,7 @@ public class SqlQuery extends QueryBean {
         fields.addAll(
             rowSelectFields(
                 column.getRefTable(),
-                tableAlias + "-" + column.getName(),
+                tableAlias + SUBSELECT_SEPARATOR + column.getName(),
                 columnAlias,
                 selection.getSubselect(column.getName())));
       } else if (column.isRefback()) {
@@ -312,7 +312,7 @@ public class SqlQuery extends QueryBean {
       Filter filters,
       String[] searchTerms) {
     checkHasViewPermission(table);
-    String subAlias = tableAlias + (parentColumn != null ? "-" + parentColumn.getName() : "");
+    String subAlias = tableAlias + (parentColumn != null ? SUBSELECT_SEPARATOR + parentColumn.getName() : "");
     Collection<Field<?>> selection = jsonSubselectFields(table, subAlias, select);
     return jsonField(
         table, parentColumn, tableAlias, select, filters, searchTerms, subAlias, selection);
@@ -690,7 +690,7 @@ public class SqlQuery extends QueryBean {
       SelectColumn select,
       Filter filters,
       String[] searchTerms) {
-    String subAlias = tableAlias + (column != null ? "-" + column.getName() : "");
+    String subAlias = tableAlias + (column != null ? SUBSELECT_SEPARATOR + column.getName() : "");
     List<Field<?>> fields = new ArrayList<>();
     for (SelectColumn field : select.getSubselect()) {
       if (COUNT_FIELD.equals(field.getColumn())) {
@@ -749,7 +749,7 @@ public class SqlQuery extends QueryBean {
       Filter filter,
       String[] searchTerms) {
     DSLContext jooq = table.getJooq();
-    String subAlias = tableAlias + (column != null ? "-" + column.getName() : "");
+    String subAlias = tableAlias + (column != null ? SUBSELECT_SEPARATOR + column.getName() : "");
 
     if (groupBy.getSubselect(COUNT_FIELD) == null && groupBy.getSubselect(SUM_FIELD) == null) {
       throw new MolgenisException("COUNt or SUM is required when using group by");
@@ -928,7 +928,7 @@ public class SqlQuery extends QueryBean {
         } else {
           Column column = getColumnByName(table, filter.getColumn());
           if (column.isReference() && !filter.getSubfilters().isEmpty()) {
-            String subAlias = tableAlias + "-" + column.getName();
+            String subAlias = tableAlias + SUBSELECT_SEPARATOR + column.getName();
             if (!aliasList.contains(subAlias)) {
               // to ensure only join once
               aliasList.add(subAlias);
@@ -955,7 +955,7 @@ public class SqlQuery extends QueryBean {
         // then do same as above
         Column column = getColumnByName(table, select.getColumn());
         if (column.isReference()) {
-          String subAlias = tableAlias + "-" + column.getName();
+          String subAlias = tableAlias + SUBSELECT_SEPARATOR + column.getName();
           // only join if subselection extists
           if (!aliasList.contains(subAlias) && !select.getSubselect().isEmpty()) {
             aliasList.add(subAlias);
@@ -1109,7 +1109,7 @@ public class SqlQuery extends QueryBean {
           if (column.isReference()) {
             conditions.add(
                 whereConditionsFilter(
-                    column.getRefTable(), tableAlias + "-" + column.getName(), subfilter));
+                    column.getRefTable(), tableAlias + SUBSELECT_SEPARATOR + column.getName(), subfilter));
           } else if (column.isFile()) {
             Filter sub = filters.getSubfilter("id");
             if (sub != null && EQUALS.equals(sub.getOperator())) {

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Column.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Column.java
@@ -441,7 +441,6 @@ public class Column extends HasLabelsDescriptionsAndSettings<Column> implements 
 
   /** will return self in case of single, and multiple in case of composite key wrapper */
   public List<Reference> getReferences() {
-
     // no ref
     if (getRefTableName() == null) {
       throw new MolgenisException(
@@ -460,6 +459,13 @@ public class Column extends HasLabelsDescriptionsAndSettings<Column> implements 
               + getRefTableName()
               + " fails because that table has no primary key");
     }
+
+    // Defines separator to be used.
+    // Default is COMPOSITE_REF_SEPARATOR, though REFBACK requires use of a subselect so to ensure
+    // function returns valid column name for a basic REFBACK to a composite key, overrides default
+    // behavior.
+    String separator =
+        (getColumnType().isRefback() ? SUBSELECT_SEPARATOR : COMPOSITE_REF_SEPARATOR);
 
     // create the refs
     Column refLink = getRefLinkColumn();
@@ -484,7 +490,7 @@ public class Column extends HasLabelsDescriptionsAndSettings<Column> implements 
           if (name == null) {
             name = getName();
             if (pkeys.size() > 1) {
-              name += COMPOSITE_REF_SEPARATOR + ref.getName();
+              name += separator + ref.getName();
             }
           }
           refColumns.add(
@@ -511,7 +517,7 @@ public class Column extends HasLabelsDescriptionsAndSettings<Column> implements 
         // create the ref
         String name = getName();
         if (pkeys.size() > 1) {
-          name += COMPOSITE_REF_SEPARATOR + keyPart.getName();
+          name += separator + keyPart.getName();
         }
         refColumns.add(
             new Reference(

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Constants.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Constants.java
@@ -10,6 +10,7 @@ public class Constants {
   public static final String MG_USER_PREFIX = "MG_USER_";
 
   public static final String COMPOSITE_REF_SEPARATOR = ".";
+  public static final String SUBSELECT_SEPARATOR = "-";
   public static final String REF_LINK = "refLink";
   public static final String REF_LABEL = "refLabel";
   public static final String REF_LABEL_DEFAULT = "refLabelDefault";

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestColumn.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestColumn.java
@@ -1,7 +1,10 @@
 package org.molgenis.emx2;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 public class TestColumn {
@@ -48,5 +51,31 @@ public class TestColumn {
                 () ->
                     new Column(
                         "a234567890123456789012345678901234567890123456789012345678901234")));
+  }
+
+  @Test
+  void testUsedSeparator() {
+    Column pk1 = new Column("id1").setType(ColumnType.STRING);
+    Column pk2 = new Column("id2").setType(ColumnType.STRING);
+    List<Column> primaryKeys = List.of(pk1, pk2);
+
+    TableMetadata tableMetadata = mock(TableMetadata.class);
+    when(tableMetadata.getPrimaryKeyColumns()).thenReturn(primaryKeys);
+
+    Column column = mock(Column.class);
+    when(column.getReferences()).thenCallRealMethod();
+    when(column.getRefTableName()).thenReturn("MyRefTable");
+    when(column.getRefTable()).thenReturn(tableMetadata);
+    when(column.getRefLinkColumn()).thenReturn(null);
+    when(column.getName()).thenReturn("MyColname");
+
+    when(column.getColumnType()).thenReturn(ColumnType.REF);
+    List<String> actualRefs = column.getReferences().stream().map(Reference::getName).toList();
+    when(column.getColumnType()).thenReturn(ColumnType.REFBACK);
+    List<String> actualRefbacks = column.getReferences().stream().map(Reference::getName).toList();
+
+    assertAll(
+        () -> assertEquals(List.of("MyColname.id1", "MyColname.id2"), actualRefs),
+        () -> assertEquals(List.of("MyColname-id1", "MyColname-id2"), actualRefbacks));
   }
 }

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestColumn.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestColumn.java
@@ -54,7 +54,7 @@ public class TestColumn {
   }
 
   @Test
-  void testUsedSeparator() {
+  void testCompositeKeySeparator() {
     Column pk1 = new Column("id1").setType(ColumnType.STRING);
     Column pk2 = new Column("id2").setType(ColumnType.STRING);
     List<Column> primaryKeys = List.of(pk1, pk2);


### PR DESCRIPTION
### What are the main changes you did
- Fixes #4564 by checking on the ColumnType to define what separator to use.

### How to test
- Evaluate if indeed this method is the preferred way to fix the issue (instead of f.e. changing the output of a REFBACK Query).
- All tests succeed.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation