### PR TITLE
fix: add boolean null state

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputBoolean.vue
+++ b/apps/molgenis-components/src/components/forms/InputBoolean.vue
@@ -13,7 +13,7 @@
     v-else
     v-bind="$props"
     :id="id"
-    :modelValue="modelValue ? 'Yes' : 'No'"
+    :modelValue="insertValue(modelValue)"
     :options="['Yes', 'No']"
     :isClearable="isClearable"
     @update:modelValue="$emit('update:modelValue', returnValue($event))"
@@ -33,6 +33,15 @@ export default {
     isClearable: { type: Boolean, default: true },
   },
   methods: {
+    insertValue(value) {
+      if (value === true) {
+        return "Yes";
+      }
+      if (value === false) {
+        return "No";
+      }
+      return null;
+    },
     returnValue(value) {
       if (value === "Yes") {
         return true;


### PR DESCRIPTION
fixes: #4580

### What are the main changes you did
- a boolean input had a broken state. It will now start unselected until a user choses a state for it.

### How to test
- have a boolean field, see that the boolean is unselected when creating a new record.
