### PR TITLE
chore: use semantic name for constants

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/Migrations.java
@@ -4,7 +4,7 @@ import static org.jooq.impl.DSL.*;
 import static org.jooq.impl.SQLDataType.VARCHAR;
 import static org.molgenis.emx2.Constants.MG_TABLECLASS;
 import static org.molgenis.emx2.sql.MetadataUtils.*;
-import static org.molgenis.emx2.sql.SqlDatabase.TEN_SECONDS;
+import static org.molgenis.emx2.sql.SqlDatabase.MAX_EXECUTION_TIME_IN_SECONDS;
 import static org.molgenis.emx2.sql.SqlTableMetadataExecutor.MG_TABLECLASS_UPDATE;
 import static org.molgenis.emx2.sql.SqlTableMetadataExecutor.updateSearchIndexTriggerFunction;
 
@@ -23,7 +23,7 @@ import org.slf4j.LoggerFactory;
 public class Migrations {
   // version the current software needs to work
   private static final int SOFTWARE_DATABASE_VERSION = 23;
-  public static final int THREE_MINUTES = 180;
+  public static final int MAX_EXECUTION_TIME_FOR_LONG_JOBS_IN_SECONDS = 180;
   private static Logger logger = LoggerFactory.getLogger(Migrations.class);
 
   public static synchronized void initOrMigrate(SqlDatabase db) {
@@ -217,14 +217,14 @@ public class Migrations {
   static void executeMigrationFile(Database db, String sqlFile, String message) {
     DSLContext jooq = ((SqlDatabase) db).getJooq();
     try {
-      jooq.settings().setQueryTimeout(THREE_MINUTES);
+      jooq.settings().setQueryTimeout(MAX_EXECUTION_TIME_FOR_LONG_JOBS_IN_SECONDS);
       String sql = new String(Migrations.class.getResourceAsStream(sqlFile).readAllBytes());
       jooq.execute(sql);
       logger.debug(message + "(file = " + sqlFile);
     } catch (IOException e) {
       throw new MolgenisException("Execute migration failed", e);
     } finally {
-      jooq.settings().setQueryTimeout(TEN_SECONDS);
+      jooq.settings().setQueryTimeout(MAX_EXECUTION_TIME_IN_SECONDS);
     }
   }
 

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -32,9 +32,9 @@ public class SqlDatabase extends HasSettings<Database> implements Database {
   public static final String ANONYMOUS = "anonymous";
   public static final String USER = "user";
   public static final String WITH = "with {} = {} ";
-  public static final int TEN_SECONDS = 10;
+  public static final int MAX_EXECUTION_TIME_IN_SECONDS = 10;
   private static final Settings DEFAULT_JOOQ_SETTINGS =
-      new Settings().withQueryTimeout(TEN_SECONDS);
+      new Settings().withQueryTimeout(MAX_EXECUTION_TIME_IN_SECONDS);
   private static final Random random = new SecureRandom();
 
   // shared between all instances
@@ -739,7 +739,7 @@ public class SqlDatabase extends HasSettings<Database> implements Database {
         connectionProvider.setActiveUser(user);
       }
     } else {
-      final Settings settings = new Settings().withQueryTimeout(TEN_SECONDS);
+      final Settings settings = new Settings().withQueryTimeout(MAX_EXECUTION_TIME_IN_SECONDS);
       SqlUserAwareConnectionProvider adminProvider = new SqlUserAwareConnectionProvider(source);
       adminProvider.setActiveUser(ADMIN_USER);
       DSLContext adminJooq = DSL.using(adminProvider, SQLDialect.POSTGRES, settings);


### PR DESCRIPTION
### What are the main changes you did
- Renamed constants to have a semantic name, which though longer, would make it easier to find.

### How to test
- If it compiles it is otherwise equal to the current main branch, so no additional tests are needed

### Checklist
None of these tasks were relevant:

- [X] updated docs in case of new feature 
- [X] added/updated tests
- [X] added/updated testplan to include a test for this fix, including ref to bug using # notation