### PR TITLE
fix: don't allow deleting the user 'user'

### DIFF
--- a/apps/central/src/components/admin/ManageUsers.vue
+++ b/apps/central/src/components/admin/ManageUsers.vue
@@ -21,7 +21,11 @@
     <TableSimple class="bg-white" :rows="users" :columns="['email', 'enabled']">
       <template v-slot:rowheader="row">
         <template
-          v-if="row.row.email !== 'admin' && row.row.email !== 'anonymous'"
+          v-if="
+            row.row.email !== 'admin' &&
+            row.row.email !== 'anonymous' &&
+            row.row.email !== 'user'
+          "
         >
           <IconDanger
             icon="trash"

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -502,8 +502,9 @@ public class SqlDatabase extends HasSettings<Database> implements Database {
   @Override
   public void removeUser(String user) {
     long start = System.currentTimeMillis();
-    if (user.equals("admin")) throw new MolgenisException("You cant remove admin");
-    if (user.equals("anonymous")) throw new MolgenisException("You cant remove anonymous");
+    if (user.equals("admin")) throw new MolgenisException("You can't remove admin");
+    if (user.equals("anonymous")) throw new MolgenisException("You can't remove anonymous");
+    if(user.equals("user")) throw new MolgenisException("You can't remove user");
 
     if (!hasUser(user))
       throw new MolgenisException(

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -504,7 +504,7 @@ public class SqlDatabase extends HasSettings<Database> implements Database {
     long start = System.currentTimeMillis();
     if (user.equals("admin")) throw new MolgenisException("You can't remove admin");
     if (user.equals("anonymous")) throw new MolgenisException("You can't remove anonymous");
-    if(user.equals("user")) throw new MolgenisException("You can't remove user");
+    if (user.equals("user")) throw new MolgenisException("You can't remove user");
 
     if (!hasUser(user))
       throw new MolgenisException(

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestUsersAndPermissions.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestUsersAndPermissions.java
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.*;
 
 public class TestUsersAndPermissions {
+  public static final String ADMIN = "admin";
+  public static final String ANONYMOUS = "anonymous";
+  public static final String USER = "user";
   static Database database;
   private static final String TEST_ENABLE_USERS = "TestEnableUser";
   private static final String TEST_INITIALLY_ENABLE_USERS = "TestInitiallyEnableUser";
@@ -105,7 +108,7 @@ public class TestUsersAndPermissions {
   @Test
   public void testDisableAdmin() {
     try {
-      database.setEnabledUser("admin", false);
+      database.setEnabledUser(ADMIN, false);
       fail("should have failed");
     } catch (Exception e) {
       // ok
@@ -115,7 +118,7 @@ public class TestUsersAndPermissions {
   @Test
   public void testDisableAnonymous() {
     try {
-      database.setEnabledUser("anonymous", false);
+      database.setEnabledUser(ANONYMOUS, false);
       fail("should have failed");
     } catch (Exception e) {
       // ok
@@ -125,7 +128,7 @@ public class TestUsersAndPermissions {
   @Test
   public void testRemoveAdmin() {
     try {
-      database.removeUser("admin");
+      database.removeUser(ADMIN);
       fail("should have failed");
     } catch (Exception e) {
       // ok
@@ -135,7 +138,17 @@ public class TestUsersAndPermissions {
   @Test
   public void testRemoveAnonymous() {
     try {
-      database.removeUser("anonymous");
+      database.removeUser(ANONYMOUS);
+      fail("should have failed");
+    } catch (Exception e) {
+      // ok
+    }
+  }
+
+  @Test
+  public void testRemoveUser() {
+    try {
+      database.removeUser(USER);
       fail("should have failed");
     } catch (Exception e) {
       // ok


### PR DESCRIPTION
### What are the main changes you did
- fixes #4575 
 
### How to test
- log in as admin
- Go to the admin settings
- Confirm that the user 'user' no longer has a delete and edit button (like admin and anonymous)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation