### PR TITLE
chore(pyclient): updated GraphQL metadata query to be in line with current metadata model

### DIFF
--- a/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/graphql_queries.py
@@ -167,8 +167,6 @@ def list_schema_meta():
                     value
                 }
                 id
-                schemaName
-                schemaId
                 inheritName
                 inheritId
                 descriptions {


### PR DESCRIPTION
### What are the main changes you did
In https://github.com/molgenis/molgenis-emx2/pull/4586 the attributes `schemaName` and `schemaId` were removed from the MolgenisTableType in the GraphqlSchemaFieldFactory. 
These attributes were still present in the GraphQL query for retrieving a schema's metadata.
Posting this query to the latest versions of EMX2 causes errors as these attributes cannot be found.

This PR fixes this issue and makes the query in line with the schemas built by the backend.

### How to test
- grab the raw query from the method `list_schema_meta` in graphq_queries.py and paste it in [the Graphql playground on the catalogue-demo schema on the test server](https://emx2.dev.molgenis.org/catalogue-demo/graphql-playground/)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation