### PR TITLE
fix(directory): don't select more than 50 ontology items

### DIFF
--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -44,7 +44,8 @@
                 facetIdentifier === 'Diagnosisavailable' &&
                 filtersStore.filters['Diagnosisavailable']?.length >= 50
               "
-              >You can only select 50 items at the same time</MessageWarning
+              >You can only select 50 items at the same time, additional items
+              are ignored.</MessageWarning
             >
             <TreeComponent
               :options="displayOptions"
@@ -69,6 +70,7 @@ import TreeComponent from "./base/TreeComponent.vue";
 import { Spinner } from "../../../../molgenis-components";
 import MatchTypeRadiobutton from "./base/MatchTypeRadiobutton.vue";
 import * as _ from "lodash";
+//@ts-ignore
 import { MessageWarning } from "molgenis-components";
 
 const filtersStore = useFiltersStore();

--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -39,16 +39,13 @@
         <div v-show="selectedOntology === ontologyId" class="w-100">
           <div v-if="displayOptions.length">
             <MessageWarning
-              class="mx-3"
-              v-if="
-                facetIdentifier === 'Diagnosisavailable' &&
-                filtersStore.filters['Diagnosisavailable']?.length >= 50 &&
-                filtersStore.getFilterType('Diagnosisavailable') === 'all'
-              "
-              >You can only select 50 items at the same time, additional items
-              are ignored.</MessageWarning
+              class="mx-3 position-absolute"
+              v-if="selectionOverflow"
+              >You can only select 50 items at a time under 'Match All'. Please
+              adjust your query.</MessageWarning
             >
             <TreeComponent
+              :class="{ 'warning-padding': selectionOverflow }"
               :options="displayOptions"
               :filter="ontologyQuery"
               :facetIdentifier="facetIdentifier"
@@ -95,6 +92,14 @@ options()
   .catch((error: any) => {
     console.log(`Error resolving ontology facet options: ${error}`);
   });
+
+let selectionOverflow = computed(() => {
+  return (
+    facetIdentifier === "Diagnosisavailable" &&
+    filtersStore.filters["Diagnosisavailable"]?.length >= 50 &&
+    filtersStore.getFilterType("Diagnosisavailable") === "all"
+  );
+});
 
 let displayOptions = computed(() => {
   if (!resolvedOptions.value) return [];
@@ -174,5 +179,9 @@ function setSelectedOntology(ontologyId: string) {
 
 .ontology-search {
   width: 100%;
+}
+
+.warning-padding{
+  padding-top:4rem;
 }
 </style>

--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -38,7 +38,14 @@
       >
         <div v-show="selectedOntology === ontologyId" class="w-100">
           <div v-if="displayOptions.length">
-            <MessageWarning class="mx-3" v-if="facetIdentifier === 'Diagnosisavailable' && filtersStore.filters['Diagnosisavailable']?.length >=50">You can only select 50 items at the same time</MessageWarning>
+            <MessageWarning
+              class="mx-3"
+              v-if="
+                facetIdentifier === 'Diagnosisavailable' &&
+                filtersStore.filters['Diagnosisavailable']?.length >= 50
+              "
+              >You can only select 50 items at the same time</MessageWarning
+            >
             <TreeComponent
               :options="displayOptions"
               :filter="ontologyQuery"

--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -42,7 +42,8 @@
               class="mx-3"
               v-if="
                 facetIdentifier === 'Diagnosisavailable' &&
-                filtersStore.filters['Diagnosisavailable']?.length >= 50
+                filtersStore.filters['Diagnosisavailable']?.length >= 50 &&
+                filtersStore.getFilterType('Diagnosisavailable') === 'all'
               "
               >You can only select 50 items at the same time, additional items
               are ignored.</MessageWarning

--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -38,6 +38,7 @@
       >
         <div v-show="selectedOntology === ontologyId" class="w-100">
           <div v-if="displayOptions.length">
+            <MessageWarning class="mx-3" v-if="facetIdentifier === 'Diagnosisavailable' && filtersStore.filters['Diagnosisavailable']?.length >=50">Please don't select more than 50 items in this filter</MessageWarning>
             <TreeComponent
               :options="displayOptions"
               :filter="ontologyQuery"
@@ -61,6 +62,7 @@ import TreeComponent from "./base/TreeComponent.vue";
 import { Spinner } from "../../../../molgenis-components";
 import MatchTypeRadiobutton from "./base/MatchTypeRadiobutton.vue";
 import * as _ from "lodash";
+import { MessageWarning } from "molgenis-components";
 
 const filtersStore = useFiltersStore();
 

--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -38,7 +38,7 @@
       >
         <div v-show="selectedOntology === ontologyId" class="w-100">
           <div v-if="displayOptions.length">
-            <MessageWarning class="mx-3" v-if="facetIdentifier === 'Diagnosisavailable' && filtersStore.filters['Diagnosisavailable']?.length >=50">Please don't select more than 50 items in this filter</MessageWarning>
+            <MessageWarning class="mx-3" v-if="facetIdentifier === 'Diagnosisavailable' && filtersStore.filters['Diagnosisavailable']?.length >=50">You can only select 50 items at the same time</MessageWarning>
             <TreeComponent
               :options="displayOptions"
               :filter="ontologyQuery"

--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -181,7 +181,7 @@ function setSelectedOntology(ontologyId: string) {
   width: 100%;
 }
 
-.warning-padding{
-  padding-top:4rem;
+.warning-padding {
+  padding-top: 4rem;
 }
 </style>

--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -229,7 +229,10 @@ export const useFiltersStore = defineStore("filtersStore", () => {
     const limit = 50;
     let ontologySet = value;
     const slotsRemaining = limit - diagnosisavailableCount;
-    if (filterName === "Diagnosisavailable") {
+    if (
+      filterName === "Diagnosisavailable" &&
+      getFilterType("Diagnosisavailable") === "all"
+    ) {
       ontologySet = ontologySet.slice(0, slotsRemaining);
     }
 

--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -359,6 +359,17 @@ export const useFiltersStore = defineStore("filtersStore", () => {
   }
 
   function updateFilterType(filterName: string, value: any, fromBookmark: any) {
+    if (
+      filterName === "Diagnosisavailable" &&
+      value === "all" &&
+      (filterType.value[filterName] === "any" || filterType.value[filterName] === undefined) &&
+      filters.value["Diagnosisavailable"].length>50
+    ) {
+      filters.value["Diagnosisavailable"] = filters.value[
+        "Diagnosisavailable"
+      ].slice(0, 50);
+    }
+
     bookmarkTriggeredFilter.value = fromBookmark;
 
     if (value === "" || value === undefined || value.length === 0) {

--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -225,10 +225,10 @@ export const useFiltersStore = defineStore("filtersStore", () => {
   function addOntologyOptions(filterName: string, value: IOntologyItem[]) {
     /// Temporary fix for issue #906
     const diagnosisavailableCount = filters.value.Diagnosisavailable?.length
-      ? filters.value.Diagnosisavailable?.length
+      ? filters.value.Diagnosisavailable.length
       : 0;
     const limit = 50;
-    var ontologySet = value;
+    let ontologySet = value;
     const slotsRemaining = limit - diagnosisavailableCount;
     if (filterName === "Diagnosisavailable") {
       ontologySet = ontologySet.slice(0, slotsRemaining);
@@ -239,7 +239,7 @@ export const useFiltersStore = defineStore("filtersStore", () => {
       const existingValues = filters.value[filterName].map(
         (option: IOntologyItem) => option.name
       );
-      var filterOptionsToAdd = ontologySet.filter(
+      const filterOptionsToAdd = ontologySet.filter(
         (newValue: IOntologyItem) => !existingValues.includes(newValue.name)
       );
       filters.value[filterName] =

--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -362,8 +362,9 @@ export const useFiltersStore = defineStore("filtersStore", () => {
     if (
       filterName === "Diagnosisavailable" &&
       value === "all" &&
-      (filterType.value[filterName] === "any" || filterType.value[filterName] === undefined) &&
-      filters.value["Diagnosisavailable"].length>50
+      (filterType.value[filterName] === "any" ||
+        filterType.value[filterName] === undefined) &&
+      filters.value["Diagnosisavailable"].length > 50
     ) {
       filters.value["Diagnosisavailable"] = filters.value[
         "Diagnosisavailable"

--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -223,14 +223,16 @@ export const useFiltersStore = defineStore("filtersStore", () => {
   }
 
   function addOntologyOptions(filterName: string, value: IOntologyItem[]) {
-    /// Temporary fix for issue #906 
-    const DiagnosisavailableCount = filters.value.Diagnosisavailable?.length?filters.value.Diagnosisavailable?.length:0;
+    /// Temporary fix for issue #906
+    const diagnosisavailableCount = filters.value.Diagnosisavailable?.length
+      ? filters.value.Diagnosisavailable?.length
+      : 0;
     const limit = 50;
     var ontologySet = value;
-    const slotsRemaining = limit - DiagnosisavailableCount
-    if(filterName === "Diagnosisavailable"){
+    const slotsRemaining = limit - diagnosisavailableCount;
+    if (filterName === "Diagnosisavailable") {
       ontologySet = ontologySet.slice(0, slotsRemaining);
-    }  
+    }
     ///
 
     if (filters.value[filterName]) {

--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -223,17 +223,27 @@ export const useFiltersStore = defineStore("filtersStore", () => {
   }
 
   function addOntologyOptions(filterName: string, value: IOntologyItem[]) {
+    /// Temporary fix for issue #906 
+    const DiagnosisavailableCount = filters.value.Diagnosisavailable?.length?filters.value.Diagnosisavailable?.length:0;
+    const limit = 50;
+    var ontologySet = value;
+    const slotsRemaining = limit - DiagnosisavailableCount
+    if(filterName === "Diagnosisavailable"){
+      ontologySet = ontologySet.slice(0, slotsRemaining);
+    }  
+    ///
+
     if (filters.value[filterName]) {
       const existingValues = filters.value[filterName].map(
         (option: IOntologyItem) => option.name
       );
-      const filterOptionsToAdd = value.filter(
+      var filterOptionsToAdd = ontologySet.filter(
         (newValue: IOntologyItem) => !existingValues.includes(newValue.name)
       );
       filters.value[filterName] =
         filters.value[filterName].concat(filterOptionsToAdd);
     } else {
-      filters.value[filterName] = value;
+      filters.value[filterName] = ontologySet;
     }
   }
 

--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -361,10 +361,9 @@ export const useFiltersStore = defineStore("filtersStore", () => {
   function updateFilterType(filterName: string, value: any, fromBookmark: any) {
     if (
       filterName === "Diagnosisavailable" &&
-      value === "all" &&
       (filterType.value[filterName] === "any" ||
         filterType.value[filterName] === undefined) &&
-      filters.value["Diagnosisavailable"].length > 50
+      filters.value["Diagnosisavailable"]?.length > 50
     ) {
       filters.value["Diagnosisavailable"] = filters.value[
         "Diagnosisavailable"

--- a/apps/directory/src/stores/filtersStore.ts
+++ b/apps/directory/src/stores/filtersStore.ts
@@ -223,7 +223,6 @@ export const useFiltersStore = defineStore("filtersStore", () => {
   }
 
   function addOntologyOptions(filterName: string, value: IOntologyItem[]) {
-    /// Temporary fix for issue #906
     const diagnosisavailableCount = filters.value.Diagnosisavailable?.length
       ? filters.value.Diagnosisavailable.length
       : 0;
@@ -233,7 +232,6 @@ export const useFiltersStore = defineStore("filtersStore", () => {
     if (filterName === "Diagnosisavailable") {
       ontologySet = ontologySet.slice(0, slotsRemaining);
     }
-    ///
 
     if (filters.value[filterName]) {
       const existingValues = filters.value[filterName].map(


### PR DESCRIPTION
fixes: [#906](https://github.com/molgenis/GCC/issues/906)

### What are the main changes you did
- selecting "Diagnosis available" is limited to 50 items
- having 50 selected items shows a warning box to limit your selections
<img width="905" alt="Scherm­afbeelding 2025-01-21 om 13 47 47" src="https://github.com/user-attachments/assets/42d13aa0-ad8c-4114-a82d-c705cea01cb7" />

### Todo
- [x] Limit selected items on switching any/all filter

### How to test
- select a root "Diagnosis available" filter, notice that only the first 50 are selected and a info box is shown 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation