### PR TITLE
fix: Excel API exception handling. 

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
@@ -116,7 +116,19 @@ public class TableStoreForXlsxFile implements TableStore {
       // write a contents row
       org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(rowNum);
       for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
-        excelRow.createCell(entry.getValue()).setCellValue(row.getString(entry.getKey()));
+        try {
+          excelRow.createCell(entry.getValue()).setCellValue(row.getString(entry.getKey()));
+        } catch (IllegalArgumentException e) {
+          throw new MolgenisException(
+              "Error writing table "
+                  + name
+                  + ", column "
+                  + entry.getKey()
+                  + ", row "
+                  + rowNum
+                  + ": "
+                  + e.getMessage());
+        }
       }
       rowNum++;
     }

--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
@@ -120,11 +120,11 @@ public class TableStoreForXlsxFile implements TableStore {
           excelRow.createCell(entry.getValue()).setCellValue(row.getString(entry.getKey()));
         } catch (IllegalArgumentException e) {
           throw new MolgenisException(
-              "Error writing table "
+              "Error writing table '"
                   + name
-                  + ", column "
+                  + "', column '"
                   + entry.getKey()
-                  + ", row "
+                  + "', at row "
                   + rowNum
                   + ": "
                   + e.getMessage());

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ExcelApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ExcelApi.java
@@ -100,11 +100,11 @@ public class ExcelApi {
     Table table = MolgenisWebservice.getTableByIdOrName(ctx);
     Path tempDir = Files.createTempDirectory(MolgenisWebservice.TEMPFILES_DELETE_ON_EXIT);
     tempDir.toFile().deleteOnExit();
+    Path excelFile = tempDir.resolve("download.xlsx");
+    TableStore excelStore = new TableStoreForXlsxFile(excelFile);
+    excelStore.writeTable(
+        table.getName(), getDownloadColumns(ctx, table), getDownloadRows(ctx, table));
     try (OutputStream outputStream = ctx.res().getOutputStream()) {
-      Path excelFile = tempDir.resolve("download.xlsx");
-      TableStore excelStore = new TableStoreForXlsxFile(excelFile);
-      excelStore.writeTable(
-          table.getName(), getDownloadColumns(ctx, table), getDownloadRows(ctx, table));
       ctx.contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
       ctx.header(
           "Content-Disposition",
@@ -122,10 +122,10 @@ public class ExcelApi {
   static void getExcelReport(Context ctx) throws IOException {
     Path tempDir = Files.createTempDirectory(MolgenisWebservice.TEMPFILES_DELETE_ON_EXIT);
     tempDir.toFile().deleteOnExit();
+    Path excelFile = tempDir.resolve("download.xlsx");
+    TableStore excelStore = new TableStoreForXlsxFile(excelFile);
+    generateReportsToStore(ctx, excelStore);
     try (OutputStream outputStream = ctx.res().getOutputStream()) {
-      Path excelFile = tempDir.resolve("download.xlsx");
-      TableStore excelStore = new TableStoreForXlsxFile(excelFile);
-      generateReportsToStore(ctx, excelStore);
       ctx.contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
       ctx.header("Content-Disposition", "attachment; filename=report.xlsx");
       outputStream.write(Files.readAllBytes(excelFile));

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ExcelApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ExcelApi.java
@@ -75,14 +75,15 @@ public class ExcelApi {
     boolean includeSystemColumns = includeSystemColumns(ctx);
     Path tempDir = Files.createTempDirectory(MolgenisWebservice.TEMPFILES_DELETE_ON_EXIT);
     tempDir.toFile().deleteOnExit();
-    try (OutputStream outputStream = ctx.res().getOutputStream()) {
-      Path excelFile = tempDir.resolve("download.xlsx");
-      if (ctx.queryParam("emx1") != null) {
-        MolgenisIO.toEmx1ExcelFile(excelFile, schema);
-      } else {
-        MolgenisIO.toExcelFile(excelFile, schema, includeSystemColumns);
-      }
 
+    Path excelFile = tempDir.resolve("download.xlsx");
+    if (ctx.queryParam("emx1") != null) {
+      MolgenisIO.toEmx1ExcelFile(excelFile, schema);
+    } else {
+      MolgenisIO.toExcelFile(excelFile, schema, includeSystemColumns);
+    }
+
+    try (OutputStream outputStream = ctx.outputStream()) {
       ctx.contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
       ctx.header(
           "Content-Disposition",


### PR DESCRIPTION
### What are the main changes you did
- Changed the excel api code so that error messages in the excel api are properly handled.
- Added a more explicit error message in the XlsTableStore when writing values to excel cells.

### How to test
- Go to the preview server and try to download the catalogue schema using the xls api
- See the error message.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation