### PR TITLE
feat: add input email to tw

### DIFF
--- a/apps/tailwind-components/components/input/Email.vue
+++ b/apps/tailwind-components/components/input/Email.vue
@@ -1,6 +1,7 @@
 <template>
   <InputString
     ref="inputString"
+    type="email"
     :id="id"
     :label="label"
     :placeholder="placeholder"

--- a/apps/tailwind-components/components/input/Email.vue
+++ b/apps/tailwind-components/components/input/Email.vue
@@ -1,0 +1,61 @@
+<template>
+  <InputString
+    ref="inputString"
+    :id="id"
+    :label="label"
+    :placeholder="placeholder"
+    :valid="valid"
+    :hasError="hasError"
+    :required="required"
+    :disabled="disabled"
+    :value="modelValue"
+    @update:modelValue="validateInput"
+    @focus="$emit('focus')"
+    @blur="$emit('blur')"
+  />
+</template>
+
+<script setup lang="ts">
+import type { InputString } from "#build/components";
+
+const EMAIL_REGEX =
+  /^(([^<>()\\[\]\\.,;:\s@"]+(\.[^<>()\\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$|^$/;
+
+const inputString = ref<InstanceType<typeof InputString>>();
+
+withDefaults(
+  defineProps<{
+    id: string;
+    modelValue?: string;
+    label?: string;
+    placeholder?: string;
+    disabled?: boolean;
+    required?: boolean;
+    hasError?: boolean;
+    valid?: boolean;
+  }>(),
+  {
+    disabled: false,
+    required: false,
+    hasError: false,
+  }
+);
+
+const emit = defineEmits(["update:modelValue", "error", "focus", "blur"]);
+
+defineExpose({ validate });
+
+function validateInput(value: string) {
+  emit("update:modelValue", value);
+  validate(value);
+}
+
+function validate(value: string) {
+  const stringErrors = inputString.value?.validate(value) || [];
+  if (EMAIL_REGEX.test(value)) {
+    emit("error", stringErrors);
+  } else {
+    emit("error", [{ message: "Invalid email" }, ...stringErrors]);
+  }
+}
+</script>

--- a/apps/tailwind-components/pages/input/Email.story.vue
+++ b/apps/tailwind-components/pages/input/Email.story.vue
@@ -1,22 +1,22 @@
 <template>
-  <h2>Hyperlink component</h2>
+  <h2>Email component</h2>
   <p>
-    The <code>Hyperlink Component</code> enables you to use the String component
-    with the added validation of the input being a hyperlink.
+    The <code>Email Component</code> enables you to use the String component
+    with the added validation of the input being a email.
   </p>
 
   <div
     class="grid grid-cols-2 gap-6 my-5 [&>div]:bg-white [&>div]:p-4 [&_h3]:font-semibold [&_h3]:my-2"
   >
     <div>
-      <h3>Input Hyperlink: (model value: {{ demoValue }})</h3>
-      <InputLabel for="input-hyperlink">
+      <h3>Input email: (model value: {{ demoValue }})</h3>
+      <InputLabel for="input-email">
         {{ label }}
       </InputLabel>
-      <InputHyperlink
-        id="input-hyperlink"
+      <InputEmail
+        id="input-email"
         v-model="demoValue"
-        ref="input-hyperlink"
+        ref="input-email"
         :placeholder="placeholder"
         :hasError="error.length > 0"
         @error="handleError"
@@ -29,8 +29,8 @@
 <script setup lang="ts">
 import type { IFieldError } from "../../../metadata-utils/src/types";
 
-const label = "Input a hyperlink";
-const placeholder = "https://example.com";
+const label = "Input an email address";
+const placeholder = "example@molgenis.net";
 const demoValue = ref("");
 const error = ref<IFieldError[]>([]);
 

--- a/apps/tailwind-components/tests/components/form/inputEmail.spec.ts
+++ b/apps/tailwind-components/tests/components/form/inputEmail.spec.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "@playwright/test";
+import playwrightConfig from "../../../playwright.config";
+const route = playwrightConfig?.use?.baseURL?.startsWith("http://localhost")
+  ? ""
+  : "/apps/tailwind-components/#/";
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(`${route}input/Email.story`);
+  await page
+    .getByRole("textbox", { name: "Input an email address" })
+    .click({ delay: 500 });
+});
+
+test("the inputEmail", async ({ page }) => {
+  await expect(page.getByText("Error:")).not.toContainText(
+    "Error: Invalid email"
+  );
+  await page.fill("#input-email", "blaat");
+  await expect(page.getByText("Error: Invalid email")).toContainText(
+    "Error: Invalid email"
+  );
+  await page.getByPlaceholder("example@molgenis.net").clear();
+  await page.fill("#input-email", "test@molgenis.net");
+  await expect(page.getByText("Error:")).not.toContainText(
+    "Error: Invalid email"
+  );
+});


### PR DESCRIPTION
### What are the main changes you did
- Added input email to en tailwind components.
- Note: this uses the regex currently used in the old version of the forms. This does not yet use the more lenient version that was requested.
