### PR TITLE
fix: run issue in system service context

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/RunMolgenisEmx2.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/RunMolgenisEmx2.java
@@ -33,13 +33,14 @@ public class RunMolgenisEmx2 {
   public static void main(String[] args) {
     logger.info("Starting MOLGENIS EMX2 Software Version=" + Version.getVersion());
 
-    Integer port = 8080;
+    Integer port;
     if (args.length >= 1) {
       try {
         port = Integer.parseInt(args[0]);
       } catch (NumberFormatException e) {
-        logger.error("Port number should be an integer, but was: " + args[0]);
-        System.exit(1);
+        logger.warn("Port number should be an integer, but was: {}", args[0]);
+        port =
+            (Integer) EnvironmentProperty.getParameter(Constants.MOLGENIS_HTTP_PORT, "8080", INT);
       }
     } else {
       port = (Integer) EnvironmentProperty.getParameter(Constants.MOLGENIS_HTTP_PORT, "8080", INT);


### PR DESCRIPTION
The default service passed params where port is expected warn and use default in case of NumberFormatException

### What are the main changes you did
- the service config passes an unexpected arg, causing the service to shutdown, this pr changes it ignore the param in case of error

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation