### PR TITLE
fix: documents visible in SKIN and GENTURIS dashboards

### DIFF
--- a/apps/ern-genturis/src/views/view-contact.vue
+++ b/apps/ern-genturis/src/views/view-contact.vue
@@ -21,7 +21,7 @@
         <a href="mailto:genturis-registry@umcg.nl">genturis-registry@umcg.nl</a>
         or at the following address.
       </p>
-      <GenturisAddress :centerText="true" />
+      <Address :centerText="true" />
     </PageSection>
   </Page>
 </template>
@@ -29,4 +29,6 @@
 <script setup lang="ts">
 // @ts-ignore
 import { Page, PageHeader, PageSection } from "molgenis-viz";
+// @ts-ignore
+import Address from "../components/Address.vue";
 </script>

--- a/apps/ern-genturis/src/views/view-documents.vue
+++ b/apps/ern-genturis/src/views/view-documents.vue
@@ -17,7 +17,7 @@
     >
       <h2 id="genturis-section-documents-title">Documents</h2>
       <p>Download additional information about the GENTURIS Registry.</p>
-      <FileList table="Files" filename="name" path="path" />
+      <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>
 </template>

--- a/apps/ern-genturis/src/views/view-documents.vue
+++ b/apps/ern-genturis/src/views/view-documents.vue
@@ -3,7 +3,6 @@
     <PageHeader
       class="genturis-header"
       title="ERN Genturis Registry"
-      subtitle="Download documents"
       imageSrc="img/genturis-carousel.jpg"
       titlePositionX="center"
       titlePositionY="center"
@@ -15,7 +14,7 @@
       :verticalPadding="2"
       width="large"
     >
-      <h2 id="genturis-section-documents-title">Documents</h2>
+      <h2 id="genturis-section-documents-title">Download Documents</h2>
       <p>Download additional information about the GENTURIS Registry.</p>
       <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>

--- a/apps/ern-ithaca/src/views/view-documents.vue
+++ b/apps/ern-ithaca/src/views/view-documents.vue
@@ -10,7 +10,8 @@
       aria-labelledby="section-temp-message"
       :verticalPadding="2"
     >
-      <h2 id="section-temp-message">Documents</h2>
+      <h2 id="section-temp-message">Download Documents</h2>
+      <p>Download additional information about the ILIAD Registry.</p>
       <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>

--- a/apps/ern-ithaca/src/views/view-documents.vue
+++ b/apps/ern-ithaca/src/views/view-documents.vue
@@ -11,14 +11,12 @@
       :verticalPadding="2"
     >
       <h2 id="section-temp-message">Documents</h2>
-      <MessageBox type="warning">
-        <p>This page is under construction.</p>
-      </MessageBox>
+      <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>
 </template>
 
 <script setup lang="ts">
 // @ts-ignore
-import { Page, PageHeader, PageSection, MessageBox } from "molgenis-viz";
+import { Page, PageHeader, PageSection, FileList } from "molgenis-viz";
 </script>

--- a/apps/ern-reconnet/src/styles/index.scss
+++ b/apps/ern-reconnet/src/styles/index.scss
@@ -1,3 +1,8 @@
+.app-page,
+.app-footer {
+  font-size: 14pt;
+}
+
 .app-page {
   .page-header {
     height: 22em;
@@ -7,14 +12,26 @@
     }
   }
 
-  .message-box {
-    display: flex;
-    align-items: center;
+  .page-section {
+    padding-top: 1em;
 
-    .message-text {
-      p {
-        margin-bottom: 0;
+    .page-section-content {
+      h2 {
+        padding: 12px 0;
+        margin-bottom: 0.15em;
       }
+    }
+  }
+}
+
+.message-box {
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+
+  .message-text {
+    p {
+      margin-bottom: 0;
     }
   }
 }

--- a/apps/ern-reconnet/src/views/documents-page.vue
+++ b/apps/ern-reconnet/src/views/documents-page.vue
@@ -6,7 +6,8 @@
       imageSrc="img/ern-reconnet-header.jpg"
     />
     <PageSection aria-labelledby="welcome-title">
-      <h2 id="welcome-title">ERN ReCONNET registry Documents</h2>
+      <h2 id="welcome-title">Download Documents</h2>
+      <p>Download additional information about the ReCONNECT Registry.</p>
       <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>

--- a/apps/ern-reconnet/src/views/documents-page.vue
+++ b/apps/ern-reconnet/src/views/documents-page.vue
@@ -7,14 +7,12 @@
     />
     <PageSection aria-labelledby="welcome-title">
       <h2 id="welcome-title">ERN ReCONNET registry Documents</h2>
-      <MessageBox>
-        <p>This page is under construction.</p>
-      </MessageBox>
+      <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>
 </template>
 
 <script setup lang="ts">
 // @ts-ignore
-import { Page, PageHeader, PageSection, MessageBox } from "molgenis-viz";
+import { Page, PageHeader, PageSection, FileList } from "molgenis-viz";
 </script>

--- a/apps/ern-skin/src/views/view-documents.vue
+++ b/apps/ern-skin/src/views/view-documents.vue
@@ -3,6 +3,7 @@
     <CustomPageHeader
       class="erras-header"
       title="ERN-Skin Registry"
+      subtitle="Download Documents"
       imageSrc="img/erras-header.jpg"
       height="xlarge"
       title-position-x="center"
@@ -13,7 +14,7 @@
       aria-labelledby="section-documents-title"
       :verticalPadding="2"
     >
-      <h2 id="section-documents-title">Download Documents</h2>
+      <h2 id="section-documents-title"></h2>
       <p>Download additional information about the ERRAS Registry.</p>
       <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>

--- a/apps/ern-skin/src/views/view-documents.vue
+++ b/apps/ern-skin/src/views/view-documents.vue
@@ -16,15 +16,13 @@
     >
       <h2 id="section-documents-title">Documents</h2>
       <p>Download additional information about the ERRAS Registry.</p>
-      <MessageBox class="page-warning" type="warning">
-        <p>This page is under construction.</p>
-      </MessageBox>
+      <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>
 </template>
 
 <script setup lang="ts">
 // @ts-ignore
-import { Page, PageSection, MessageBox } from "molgenis-viz";
+import { Page, PageSection, FileList } from "molgenis-viz";
 import CustomPageHeader from "../components/CustomPageHeader.vue";
 </script>

--- a/apps/ern-skin/src/views/view-documents.vue
+++ b/apps/ern-skin/src/views/view-documents.vue
@@ -3,7 +3,6 @@
     <CustomPageHeader
       class="erras-header"
       title="ERN-Skin Registry"
-      subtitle="Download Documents"
       imageSrc="img/erras-header.jpg"
       height="xlarge"
       title-position-x="center"
@@ -14,7 +13,7 @@
       aria-labelledby="section-documents-title"
       :verticalPadding="2"
     >
-      <h2 id="section-documents-title">Documents</h2>
+      <h2 id="section-documents-title">Download Documents</h2>
       <p>Download additional information about the ERRAS Registry.</p>
       <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>


### PR DESCRIPTION
### What are the main changes you did
- replace "under construction warning" in documents overview in SKIN dashboard by and actual select files statement
- solve the error in documents overview in GENTURIS dashboard by adjusting the column names.
- fix missing address on GENTURIS contact page

### How to test
- Goto preview server, login and create a schema using ERN_DASHBOARD template
- goto schemaName/tables and create records in the files table
- goto schemaName/ern-genturis => click documents tile => see that the uploaded documents are shown
- goto schemaName/ern-skin => click at the bottom of the page the Documents link and see that no longer an "under construction warning" is shown, but the files that were added to the files table.
- goto schemaName/ern-genturis/#/contact and see that the UMCG address is shown (was currently missing)

### Checklist
- [nvt] updated docs in case of new feature
- [nvt] added/updated tests
- [nvt] added/updated testplan to include a test for this fix, including ref to bug using # notation