### PR TITLE
fix(forms): List.isEmpty on "list" error when a ref_array is null

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -511,7 +511,7 @@ public class TypeUtils {
 
   protected static void convertRefArrayToRow(
       List<Map<String, Object>> list, Row row, Column column) {
-
+    if(list == null) return;
     List<Reference> refs = column.getReferences();
     for (Reference ref : refs) {
       if (!ref.isOverlapping()) {


### PR DESCRIPTION
This is a lucky guess to fixing #4673 