### PR TITLE
fix: enabled email array and hyperlink array types in forms

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputEmail.vue
+++ b/apps/molgenis-components/src/components/forms/InputEmail.vue
@@ -22,6 +22,9 @@
         :placeholder="placeholder"
         :readonly="readonly"
       />
+      <template v-slot:append>
+        <slot name="append"></slot>
+      </template>
     </InputGroup>
   </FormGroup>
 </template>

--- a/apps/molgenis-components/src/components/forms/InputHyperlink.vue
+++ b/apps/molgenis-components/src/components/forms/InputHyperlink.vue
@@ -23,6 +23,9 @@
         :placeholder="placeholder"
         :readonly="readonly"
       />
+      <template v-slot:append>
+        <slot name="append"></slot>
+      </template>
     </InputGroup>
   </FormGroup>
 </template>

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -511,7 +511,7 @@ public class TypeUtils {
 
   protected static void convertRefArrayToRow(
       List<Map<String, Object>> list, Row row, Column column) {
-    if(list == null) return;
+    if (list == null) return;
     List<Reference> refs = column.getReferences();
     for (Reference ref : refs) {
       if (!ref.isOverlapping()) {


### PR DESCRIPTION
It was not possible to use EmailArray and HyperlinkArray in forms as the EmailInput and HyperlinkInput field types lacked the property to append values.
See: https://emx2.dev.molgenis.org/apps/molgenis-components/#/component/ArrayInput

### What are the main changes you did
- added missing properties to EmailInput and HyperlinkInput

### How to test
- add the [type test schema](https://emx2.dev.molgenis.org/type%20test/tables/#/) and see that the inputs now work and can be saved

### Checklist
~- [ ] updated docs in case of new feature~
~- [ ] added/updated tests~
~- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation~