### PR TITLE
fix: see through sticky header

### DIFF
--- a/apps/tailwind-components/app.vue
+++ b/apps/tailwind-components/app.vue
@@ -34,7 +34,7 @@ function toggleLayout () {
 
 
 <template>
-  <nav class=" text-title fixed top-0 w-[100%] z-50 p-2 flex flex-row justify-start items-center gap-2 shadow-sm">
+  <nav class=" text-title bg-navigation-sticky fixed top-0 w-[100%] z-50 p-2 flex flex-row justify-start items-center gap-2 shadow-sm">
     <div class="grow flex gap-4">
       <NuxtLink class="hover:underline" to="/">
         <img format="svg" src="~/assets/img/molgenis-logo-blue-small.svg" alt="molgenis, open source software"

--- a/apps/tailwind-components/assets/css/main.css
+++ b/apps/tailwind-components/assets/css/main.css
@@ -25,7 +25,7 @@
     --color-gray-100: #F4F4F4;
     --color-gray-200: #E2E2E2;
     --color-gray-400: #C0C0C0;
-    --color-gray-600: #6D6D6D;
+    --color-gray-600: #2C2C2C;
     --color-gray-700: #414141;
     --color-gray-800: #1E1E1E;
     --color-gray-900: #1D1D1D;
@@ -65,6 +65,7 @@
     --backgroud-color-search-button: var(--color-blue-50);
     --backgroud-color-search-button-hover: var(--color-blue-700);
     --backgroud-color-navigation: var(--color-white);
+    --backgroud-color-navigation-sticky: var(--backgroud-color-navigation);
     --backgroud-color-search-results-view-tabs: var(--color-blue-800);
     --backgroud-color-search-filter-group-toggle: var(--color-blue-800);
     --backgroud-color-app-wrapper: var(--color-black);

--- a/apps/tailwind-components/assets/css/theme/dark.css
+++ b/apps/tailwind-components/assets/css/theme/dark.css
@@ -1,5 +1,5 @@
 :root[data-theme="dark"] {
-    --backgroud-color-navigation: rgba(0, 0, 0, .2);
+    --backgroud-color-navigation: var(--color-gray-600);
     --background-image-sidebar-gradient: linear-gradient(180deg, var(--color-gray-600) -24.76%, var(--color-gray-600) 86.02%);
     --background-image-base-gradient: linear-gradient(180deg, var(--color-gray-800), var(--color-gray-800) 133.81%);
 

--- a/apps/tailwind-components/assets/css/theme/molgenis.css
+++ b/apps/tailwind-components/assets/css/theme/molgenis.css
@@ -21,6 +21,7 @@
     --backgroud-color-search-button: var(--color-blue-50);
     --backgroud-color-search-button-hover: var(--color-blue-700);
     --backgroud-color-navigation: rgba(0, 0, 0, .2);
+    --backgroud-color-navigation-sticky: var(--color-blue-800);
     --backgroud-color-search-results-view-tabs: var(--color-blue-800);
     --backgroud-color-search-filter-group-toggle: var(--color-blue-800);
     --backgroud-color-app-wrapper: var(--color-black);

--- a/apps/tailwind-components/tailwind.config.js
+++ b/apps/tailwind-components/tailwind.config.js
@@ -141,6 +141,7 @@ module.exports = {
         "search-button": "var(--backgroud-color-search-button)",
         "search-button-hover": "var(--backgroud-color-search-button-hover)",
         "navigation": "var(--backgroud-color-navigation)",
+        "navigation-sticky": "var(--backgroud-color-navigation-sticky)",
         "search-results-view-tabs": "var(--backgroud-color-search-results-view-tabs)",
         "search-filter-group-toggle": "var(--backgroud-color-search-filter-group-toggle)",
         "app-wrapper": "var(--backgroud-color-app-wrapper)",


### PR DESCRIPTION
### What are the main changes you did
- if the nav header is sticky it should be see through ( but catalogue fixed header uses see through with page gradient
-  
### How to test
- tw components header should be non see through in all themes 
- catalogue header should be see through in molgenis theme 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation