### PR TITLE
fix(tw): fixed color contrast in message component 

### DIFF
--- a/apps/tailwind-components/assets/css/main.css
+++ b/apps/tailwind-components/assets/css/main.css
@@ -35,6 +35,7 @@
     --color-green-200: #C7FFE2;
     --color-green-500: #72F6B2;
     --color-green-800: #349D63;
+    --color-green-900: #075F32;
     --color-orange-500: #E1B53E;
     --color-red-200: #FCECEF;
     --color-red-500: #E14F62;
@@ -143,8 +144,8 @@
     --text-color-input-description: var(--color-blue-800);
     --text-color-legend-error-count: var(--color-white);
     
-    --text-color-invalid: var(--color-red-500);
-    --text-color-valid: var(--color-green-800);
+    --text-color-invalid: var(--color-red-700);
+    --text-color-valid: var(--color-green-900);
     --text-color-disabled: var(--color-gray-600);
     --text-color-required: var(--color-red-500);
     
@@ -179,8 +180,8 @@
     --border-radius-pagination: 9999px;
     --border-radius-landing: 50px;
     
-    --border-color-invalid: var(--color-red-500);
-    --border-color-valid: var(--color-green-800);
+    --border-color-invalid: var(--color-red-700);
+    --border-color-valid: var(--color-green-900);
     --border-color-disabled: var(--color-gray-400);
 
     --outline-color-select: var(--color-gray-200);

--- a/apps/tailwind-components/assets/css/theme/molgenis.css
+++ b/apps/tailwind-components/assets/css/theme/molgenis.css
@@ -89,8 +89,8 @@
     --text-color-footer-link: var(--color-yellow-500);
     --text-color-table-column-header: var(--color-gray-600);
     
-    --text-color-invalid: var(--color-red-500);
-    --text-color-valid: var(--color-green-800);
+    --text-color-invalid: var(--color-red-700);
+    --text-color-valid: var(--color-green-900);
     --text-color-disabled: var(--color-gray-400);
     --text-color-required: var(--color-red-500);
     
@@ -123,8 +123,8 @@
     --border-radius-pagination: 9999px;
     --border-radius-landing: 50px;
     
-    --border-color-invalid: var(--color-red-500);
-    --border-color-valid: var(--color-green-800);
+    --border-color-invalid: var(--color-red-700);
+    --border-color-valid: var(--color-green-900);
     --border-color-disabled: var(--color-gray-400);
 
     --outline-color-select: var(--color-gray-200);

--- a/apps/tailwind-components/components/Message.vue
+++ b/apps/tailwind-components/components/Message.vue
@@ -4,7 +4,7 @@
     :aria-labelledby="`${id}-state-context`"
     class="p-3 font-bold flex items-center rounded-input bg-default"
     :class="{
-      'bg-invalid text-required fill-invalid': invalid,
+      'bg-invalid text-invalid fill-invalid': invalid,
       'bg-valid text-valid fill-valid': valid,
     }"
   >


### PR DESCRIPTION
### What are the main changes you did

- invalid: Changed text and border color from `red-500` to `red-700`
- success: added `green-900: #075F32` for text and border color. Used `*-900` as it is darker than 800. Contrast is now `6.86` and meets [AA threshold](https://www.w3.org/TR/WCAG22/#contrast-minimum).
- adjusted valid and invalid config in other themes

### How to test

- Navigate to the preview
- View the styles in the Message story and in the Forms
- Run the WAVE browser extension. No more contrast errors in the message story

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation