### PR TITLE
fix: select all collections/services when biobank has none

### DIFF
--- a/apps/directory/src/components/checkout-components/CollectionSelector.vue
+++ b/apps/directory/src/components/checkout-components/CollectionSelector.vue
@@ -85,7 +85,6 @@ const collections = computed(() =>
 );
 
 function handleCollectionStatus(event: any) {
-  console.log(event);
   const { checked } = event.target;
   if (checked) {
     checkoutStore.addCollectionsToSelection(

--- a/apps/directory/src/components/partial-views/ApplicationHeaderPartialView.vue
+++ b/apps/directory/src/components/partial-views/ApplicationHeaderPartialView.vue
@@ -178,10 +178,11 @@ export default {
     selectAllServices() {
       const allSelections = this.biobanksStore.biobankCards.map((biobank) => ({
         biobank: { id: biobank.id, name: biobank.name },
-        services: biobank.services.map((service) => ({
-          label: service.name,
-          value: service.id,
-        })),
+        services:
+          biobank.services?.map((service) => ({
+            label: service.name,
+            value: service.id,
+          })) || [],
       }));
       allSelections.forEach((item) => {
         this.checkoutStore.addServicesToSelection(
@@ -194,10 +195,11 @@ export default {
     selectAllCollections() {
       const allSelections = this.biobanksStore.biobankCards.map((biobank) => ({
         biobank: { id: biobank.id, name: biobank.name },
-        collections: biobank.collections.map((collection) => ({
-          label: collection.name,
-          value: collection.id,
-        })),
+        collections:
+          biobank.collections?.map((collection) => ({
+            label: collection.name,
+            value: collection.id,
+          })) || [],
       }));
       allSelections.forEach((item) => {
         this.checkoutStore.addCollectionsToSelection(


### PR DESCRIPTION
### What are the main changes you did
- fixes a crash when pressing select all collections/services when there is a biobank that has none.
- closes #4699 

### How to test
- see ticket (can also test on demo set, since biobank 3 has no collections)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation