### PR TITLE
fix: connected value showcase to charts table

### DIFF
--- a/apps/cranio-provider/package.json
+++ b/apps/cranio-provider/package.json
@@ -15,13 +15,14 @@
     "graphql-request": "5.2.0",
     "molgenis-components": "*",
     "molgenis-viz": "*",
-    "vue":"3.5.13",
+    "vue": "3.5.13",
     "vue-router": "4.4.3"
   },
   "devDependencies": {
     "@vitejs/plugin-vue": "4.6.2",
     "prettier": "2.8.8",
-    "vite": "5.4.12"
+    "vite": "5.4.12",
+    "vitest": "1.6.1"
   },
   "browserslist": [
     "> 1%",

--- a/apps/cranio-provider/src/utils/index.ts
+++ b/apps/cranio-provider/src/utils/index.ts
@@ -76,6 +76,13 @@ export function uniqueValues(data: any, key: string): string[] {
   return Array.from(new Set(values)).sort() as string[];
 }
 
+export function uniqueAgeGroups(data: any, key: string): string[] {
+  const values = uniqueValues(data, key);
+  return values.sort((a: string, b: string) => {
+    return b.charCodeAt(0) - a.charCodeAt(0);
+  });
+}
+
 /**
  * @name ernCenterPalette
  * @description color palette for charts that show ERN and center comparisons

--- a/apps/cranio-provider/src/utils/parseChartTitle.ts
+++ b/apps/cranio-provider/src/utils/parseChartTitle.ts
@@ -1,0 +1,14 @@
+/**
+ * @name parseChartTitle
+ * @param string string containing a value to replace
+ * @param value value to subsititute
+ * @param pattern search pattern
+ * @returns string
+ */
+export function parseChartTitle(
+  string: string,
+  value: string | number,
+  pattern: string = "${value}"
+) {
+  return string.replace(pattern, `${value}`);
+}

--- a/apps/cranio-provider/src/views/provider-cs-all-general.vue
+++ b/apps/cranio-provider/src/views/provider-cs-all-general.vue
@@ -144,7 +144,7 @@ import ProviderDashboard from "../components/ProviderDashboard.vue";
 import { generateAxisTickData } from "../utils/generateAxisTicks";
 import { getDashboardChart } from "../utils/getDashboardData";
 import { generateColorPalette } from "../utils/generateColorPalette";
-import { uniqueValues } from "../utils";
+import { uniqueValues, uniqueAgeGroups } from "../utils";
 
 import type { ICharts, IChartData } from "../types/schema";
 import type { IKeyValuePair } from "../types";
@@ -282,7 +282,7 @@ function updatePatientsByCountryChart() {
 }
 
 function setAgeGroupFilter() {
-  ageGroups.value = uniqueValues(
+  ageGroups.value = uniqueAgeGroups(
     cranioTypeChart.value?.dataPoints,
     "dataPointPrimaryCategory"
   );

--- a/apps/cranio-provider/src/views/provider-cs-center-general.vue
+++ b/apps/cranio-provider/src/views/provider-cs-center-general.vue
@@ -113,7 +113,7 @@ import {
 import { generateAxisTickData } from "../utils/generateAxisTicks";
 import { getDashboardChart } from "../utils/getDashboardData";
 import { generateColorPalette } from "../utils/generateColorPalette";
-import { uniqueValues } from "../utils";
+import { uniqueValues, uniqueAgeGroups } from "../utils";
 
 import type { ICharts, IChartData } from "../types/schema";
 import type { IKeyValuePair } from "../types/index";
@@ -222,7 +222,7 @@ function updateMultipeSuturesChart() {
 }
 
 function setAgeGroupFilter() {
-  ageGroups.value = uniqueValues(
+  ageGroups.value = uniqueAgeGroups(
     cranioTypeChart.value?.dataPoints,
     "dataPointPrimaryCategory"
   );

--- a/apps/cranio-provider/tests/parseChartTitle.test.ts
+++ b/apps/cranio-provider/tests/parseChartTitle.test.ts
@@ -1,0 +1,11 @@
+import { describe, expect, test } from "vitest";
+import { parseChartTitle } from "../src/utils/parseChartTitle";
+
+describe("parseChartTitle", () => {
+  test("text is correctly replaces", () => {
+    const currentTitle = "The current selected value is ${value}.";
+    const dataValue = 123;
+    const updatedTitle = parseChartTitle(currentTitle, dataValue, "${value}");
+    expect(updatedTitle).toBe("The current selected value is 123.");
+  });
+});


### PR DESCRIPTION
### What are the main changes you did

- [x] retrieved chart configuration for the patient count titles (total and subtotals)
- [x] Enabled expression like feature for changing the title in the database
- [x] Connected the value showcase to the title
- [x] Added unit test
- [x] Fixed sorting of age group filters so that "All patients" is always first

### How to test

1. Navigate to the preview and login as admin
2. Go to the demo schema: `AT1`
3. On the home page, view the value showcase component (e.g., "_n_ patients submitted")
4. In the Charts table, edit the chart titles for this component. Use the pattern "${value}" to indicate where the value should be placed in the string. E.g., `The current value is ${value}.` 
5. To confirm the sorting, view both "General overview" pages in the Craniosynostosis dashboard. Click the filter that says "Filter data by year of birth". The order should be "All patients" followed by year ranges in order.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation