### PR TITLE
fix: fixed sorting and filtering issues

### DIFF
--- a/apps/cranio-provider/src/views/provider-clp-your-center.vue
+++ b/apps/cranio-provider/src/views/provider-clp-your-center.vue
@@ -174,9 +174,13 @@ async function getPageData() {
 
 function updatePhenotypesChart() {
   patientsByPhenotypeChartData.value =
-    patientsByPhenotypeChart.value?.dataPoints?.filter((row: IChartData) => {
-      return row.dataPointPrimaryCategory === selectedAgeGroup.value;
-    });
+    patientsByPhenotypeChart.value?.dataPoints
+      ?.filter((row: IChartData) => {
+        return row.dataPointPrimaryCategory === selectedAgeGroup.value;
+      })
+      .sort((a: IChartData, b: IChartData) => {
+        return (a.dataPointOrder as number) - (b.dataPointOrder as number);
+      });
 
   const chartTicks = generateAxisTickData(
     patientsByPhenotypeChartData.value!,

--- a/apps/cranio-provider/src/views/provider-cs-all-general.vue
+++ b/apps/cranio-provider/src/views/provider-cs-all-general.vue
@@ -11,7 +11,7 @@
           class="inputs select"
           id="yearOfBirthFilter"
           v-model="selectedAgeGroup"
-          @change="updateCranioTypesChart"
+          @change="updateChartsByAgeGroup"
         >
           <option v-for="ageGroup in ageGroups" :value="ageGroup">
             {{ ageGroup }}
@@ -232,11 +232,13 @@ function updateCranioTypesChart() {
 }
 
 function updateAffectedSutureChart() {
-  affectedSutureChartData.value = affectedSutureChart.value?.dataPoints?.sort(
-    (current, next) => {
+  affectedSutureChartData.value = affectedSutureChart.value?.dataPoints
+    ?.filter((row: IChartData) => {
+      return row.dataPointPrimaryCategory === selectedAgeGroup.value;
+    })
+    .sort((current, next) => {
       return current.dataPointOrder! - next.dataPointOrder!;
-    }
-  );
+    });
 
   const affectedSutureTicks = generateAxisTickData(
     affectedSutureChartData.value!,
@@ -250,11 +252,13 @@ function updateAffectedSutureChart() {
 }
 
 function updateMultipeSuturesChart() {
-  multipleSutureChartData.value = multipleSutureChart.value?.dataPoints?.sort(
-    (current, next) => {
+  multipleSutureChartData.value = multipleSutureChart.value?.dataPoints
+    ?.filter((row: IChartData) => {
+      return row.dataPointPrimaryCategory === selectedAgeGroup.value;
+    })
+    .sort((current, next) => {
       return current.dataPointOrder! - next.dataPointOrder!;
-    }
-  );
+    });
 
   const multipleSutureTicks = generateAxisTickData(
     multipleSutureChartData.value!,
@@ -288,6 +292,12 @@ function setAgeGroupFilter() {
     "dataPointPrimaryCategory"
   );
   selectedAgeGroup.value = ageGroups.value[0];
+}
+
+function updateChartsByAgeGroup() {
+  updateCranioTypesChart();
+  updateAffectedSutureChart();
+  updateMultipeSuturesChart();
 }
 
 onMounted(() => {

--- a/apps/cranio-provider/src/views/provider-cs-all-general.vue
+++ b/apps/cranio-provider/src/views/provider-cs-all-general.vue
@@ -10,6 +10,7 @@
         <select
           class="inputs select"
           id="yearOfBirthFilter"
+          v-model="selectedAgeGroup"
           @change="updateCranioTypesChart"
         >
           <option v-for="ageGroup in ageGroups" :value="ageGroup">

--- a/apps/cranio-provider/src/views/provider-cs-center-general.vue
+++ b/apps/cranio-provider/src/views/provider-cs-center-general.vue
@@ -168,7 +168,6 @@ async function getPageData() {
 }
 
 function updateCranioTypesChart() {
-  console.log(selectedAgeGroup.value);
   cranioTypeChartData.value = cranioTypeChart.value?.dataPoints
     ?.filter((row: IChartData) => {
       return row.dataPointPrimaryCategory === selectedAgeGroup.value;

--- a/apps/cranio-provider/src/views/provider-cs-center-general.vue
+++ b/apps/cranio-provider/src/views/provider-cs-center-general.vue
@@ -7,6 +7,7 @@
         <select
           class="inputs select"
           id="yearOfBirthFilter"
+          v-model="selectedAgeGroup"
           @change="updateCranioTypesChart"
         >
           <option v-for="ageGroup in ageGroups" :value="ageGroup">
@@ -167,6 +168,7 @@ async function getPageData() {
 }
 
 function updateCranioTypesChart() {
+  console.log(selectedAgeGroup.value);
   cranioTypeChartData.value = cranioTypeChart.value?.dataPoints
     ?.filter((row: IChartData) => {
       return row.dataPointPrimaryCategory === selectedAgeGroup.value;

--- a/apps/cranio-provider/src/views/provider-cs-center-general.vue
+++ b/apps/cranio-provider/src/views/provider-cs-center-general.vue
@@ -8,7 +8,7 @@
           class="inputs select"
           id="yearOfBirthFilter"
           v-model="selectedAgeGroup"
-          @change="updateCranioTypesChart"
+          @change="updateChartsByAgeGroup"
         >
           <option v-for="ageGroup in ageGroups" :value="ageGroup">
             {{ ageGroup }}
@@ -188,11 +188,13 @@ function updateCranioTypesChart() {
 }
 
 function updateAffectedSutureChart() {
-  affectedSutureChartData.value = affectedSutureChart.value?.dataPoints?.sort(
-    (current, next) => {
+  affectedSutureChartData.value = affectedSutureChart.value?.dataPoints
+    ?.filter((row: IChartData) => {
+      return row.dataPointPrimaryCategory === selectedAgeGroup.value;
+    })
+    .sort((current, next) => {
       return current.dataPointOrder! - next.dataPointOrder!;
-    }
-  );
+    });
 
   const affectedSutureTicks = generateAxisTickData(
     affectedSutureChartData.value!,
@@ -206,11 +208,13 @@ function updateAffectedSutureChart() {
 }
 
 function updateMultipeSuturesChart() {
-  multipleSutureChartData.value = multipleSutureChart.value?.dataPoints?.sort(
-    (current, next) => {
+  multipleSutureChartData.value = multipleSutureChart.value?.dataPoints
+    ?.filter((row: IChartData) => {
+      return row.dataPointPrimaryCategory === selectedAgeGroup.value;
+    })
+    .sort((current, next) => {
       return current.dataPointOrder! - next.dataPointOrder!;
-    }
-  );
+    });
 
   const multipleSutureTicks = generateAxisTickData(
     multipleSutureChartData.value!,
@@ -228,6 +232,12 @@ function setAgeGroupFilter() {
     "dataPointPrimaryCategory"
   );
   selectedAgeGroup.value = ageGroups.value[0];
+}
+
+function updateChartsByAgeGroup() {
+  updateCranioTypesChart();
+  updateAffectedSutureChart();
+  updateMultipeSuturesChart();
 }
 
 onMounted(() => {

--- a/apps/cranio-provider/src/views/provider-cs-center-surgical.vue
+++ b/apps/cranio-provider/src/views/provider-cs-center-surgical.vue
@@ -54,7 +54,6 @@
     <h2 class="dashboard-h2">Surgical interventions by diagnosis</h2>
     <DashboardRow :columns="1">
       <DashboardChart>
-        {{ selectedDiagnosis }}
         <InputLabel id="diagnosisInput" label="Select a diagnosis" />
         <select
           id="diagnosisInput"
@@ -245,7 +244,6 @@ function updateComplicationsChart() {
 }
 
 function updateInterventionsChart() {
-  console.log(selectedDiagnosis.value);
   const filteredData = interventionsChart.value?.dataPoints?.filter(
     (row: IChartData) => {
       return row.dataPointPrimaryCategory === selectedDiagnosis.value;
@@ -277,7 +275,6 @@ function updateSurgeryAgeChart() {
   (surgeryAgeChart.value as ICharts).yAxisTicks = chartAxis.ticks;
 
   const total: number = sum(surgeryAgeChartData.value, "dataPointValue");
-  console.log(total);
   hasSurgeryAgeData.value = total > 0;
 }
 

--- a/apps/cranio-provider/src/views/provider-cs-center-surgical.vue
+++ b/apps/cranio-provider/src/views/provider-cs-center-surgical.vue
@@ -54,6 +54,7 @@
     <h2 class="dashboard-h2">Surgical interventions by diagnosis</h2>
     <DashboardRow :columns="1">
       <DashboardChart>
+        {{ selectedDiagnosis }}
         <InputLabel id="diagnosisInput" label="Select a diagnosis" />
         <select
           id="diagnosisInput"
@@ -200,11 +201,6 @@ async function getPageData() {
     "cs-provider-surgical-interventions"
   );
 
-  const ernInterventionsResponse = await getDashboardChart(
-    props.api.graphql.providers,
-    "cs-all-centers-surgical-interventions"
-  );
-
   const centerAgeResponse = await getDashboardChart(
     props.api.graphql.current,
     "cs-provider-age-at-first-surgery"
@@ -222,10 +218,6 @@ async function getPageData() {
   ] as IChartData[];
 
   interventionsChart.value = centerInterventionsResponse[0];
-  interventionsChart.value.dataPoints = [
-    ...(centerInterventionsResponse[0].dataPoints as IChartData[]),
-    ...(ernInterventionsResponse[0].dataPoints as IChartData[]),
-  ];
 
   surgeryAgeChart.value = centerAgeResponse[0];
   surgeryAgeChart.value.dataPoints = [
@@ -253,6 +245,7 @@ function updateComplicationsChart() {
 }
 
 function updateInterventionsChart() {
+  console.log(selectedDiagnosis.value);
   const filteredData = interventionsChart.value?.dataPoints?.filter(
     (row: IChartData) => {
       return row.dataPointPrimaryCategory === selectedDiagnosis.value;
@@ -284,6 +277,7 @@ function updateSurgeryAgeChart() {
   (surgeryAgeChart.value as ICharts).yAxisTicks = chartAxis.ticks;
 
   const total: number = sum(surgeryAgeChartData.value, "dataPointValue");
+  console.log(total);
   hasSurgeryAgeData.value = total > 0;
 }
 


### PR DESCRIPTION
### What are the main changes you did

- [x] fixed sorting/filtering issues in the craniosynostosis all center and provider dashboards
- [x] fixed order of CLP patients by phenotype chart

### How to test
- Navigate to the preview and sign in as admin
- Go to [craniosynostosis all centers general overview](https://preview-emx2-pr-4733.dev.molgenis.org/AT1/cranio-provider/#/cs/all-centers-general). Select a different age group (2005-2009, etc.). The chart should redraw with different values. (**NOTE**: not all values may have data as this is a test dataset.)
- Go to the [craniosynostosis you center overview](https://preview-emx2-pr-4733.dev.molgenis.org/AT1/cranio-provider/#/cs/center-general). Like the preview page, select a different age group and note the changes in the chart. (Not all charts will render as data isn't available for every category.)
- Got the [cleft lip and palate center overivew](https://preview-emx2-pr-4733.dev.molgenis.org/AT1/cranio-provider/#/clp/center). The order of the "patients by phenotype" chart should be: CL, CP, CLA, and CLAP.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation