### PR TITLE
fix(tw): added missing classes to tree input

### DIFF
--- a/apps/tailwind-components/components/input/CheckboxIcon.vue
+++ b/apps/tailwind-components/components/input/CheckboxIcon.vue
@@ -40,7 +40,7 @@
     <path
       v-if="indeterminate"
       d="M5,10 L 15,10"
-      class="stroke-input-checked"
+      class="stroke-check"
       stroke-width="2"
       stroke-linecap="round"
       stroke-linejoin="round"

--- a/apps/tailwind-components/components/input/Listbox.vue
+++ b/apps/tailwind-components/components/input/Listbox.vue
@@ -16,7 +16,7 @@
     </InputListboxToggle>
     <InputListboxList
       :id="`listbox-${id}-options`"
-      :isExpanded="isExpanded"
+      :isExpanded="!disabled && isExpanded"
       :hasFixedHeight="listboxOptions.length > 5"
       @keydown.prevent="onListboxKeyDown"
     >

--- a/apps/tailwind-components/components/input/Tree.vue
+++ b/apps/tailwind-components/components/input/Tree.vue
@@ -242,34 +242,21 @@ const rootNodes = computed(() => {
 </script>
 
 <template>
-  <button
-    v-if="!showOptionsSearch"
-    class="flex items-center ml-6"
-    @click="toggleSearch"
-  >
-    <BaseIcon
-      name="search"
-      :class="`text-search-filter-expand${inverted ? '-mobile' : ''}`"
-      :width="18"
+  <ButtonText icon="Search" @click="toggleSearch">
+    <span>Search for options</span>
+  </ButtonText>
+  <div v-if="showOptionsSearch">
+    <input
+      :value="optionsSearch"
+      @input="(event) => handleSearchInput((event.target as HTMLInputElement).value)"
+      type="search"
+      class="w-full pr-4 font-sans text-black text-gray-300 outline-none rounded-search-input h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input search-input-mobile border"
+      placeholder="Type to search in options..."
     />
-    <span
-      class="ml-2 text-body-sm hover:underline"
-      :class="`text-search-filter-expand${inverted ? '-mobile' : ''}`"
-    >
-      Search for options
+    <span v-if="rootNodes.filter((node) => node.visible).length === 0">
+      no results found
     </span>
-  </button>
-  <input
-    v-else
-    :value="optionsSearch"
-    @input="(event) => handleSearchInput((event.target as HTMLInputElement).value)"
-    type="search"
-    class="w-full pr-4 font-sans text-black text-gray-300 outline-none rounded-search-input h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input search-input-mobile border"
-    placeholder="Type to search in options..."
-  />
-  <span v-if="rootNodes.filter((node) => node.visible).length === 0"
-    >no results found</span
-  >
+  </div>
   <TreeNode
     :nodes="rootNodes"
     :inverted="inverted"

--- a/apps/tailwind-components/components/input/TreeNode.vue
+++ b/apps/tailwind-components/components/input/TreeNode.vue
@@ -43,11 +43,12 @@ function toggleExpand(name: string) {
           v-if="node.children?.length"
           @click.stop="toggleExpand(node.name)"
           class="-left-[11px] top-0 rounded-full hover:cursor-pointer h-6 w-6 flex items-center justify-center absolute z-20"
-          :class="[
-            inverted
-              ? 'text-search-filter-group-toggle-inverted hover:bg-search-filter-group-toggle-inverted'
-              : 'text-search-filter-group-toggle hover:bg-search-filter-group-toggle',
-          ]"
+          :class="{
+            'text-search-filter-group-toggle-inverted hover:bg-search-filter-group-toggle-inverted':
+              inverted,
+            'text-search-filter-group-toggle hover:bg-search-filter-group-toggle focus:bg-search-filter-group-toggle':
+              !inverted,
+          }"
           :aria-expanded="node.expanded"
           :aria-controls="node.name"
         >
@@ -91,16 +92,12 @@ function toggleExpand(name: string) {
             v-if="node.selectable"
             :indeterminate="node.selected === 'intermediate'"
             :checked="node.selected === 'selected'"
-            class="w-[20px] ml-[-6px]"
+            class="ml-[-6px]"
             :class="{
               '[&>rect]:stroke-gray-400': inverted,
             }"
           />
-          <span
-            :class="{ 'w-[calc(100%-20px)]': node.selectable }"
-            class="block text-body-sm leading-normal"
-            >{{ node.name }}</span
-          >
+          <span class="block text-body-sm leading-normal">{{ node.name }}</span>
         </InputLabel>
         <div class="inline-flex items-center whitespace-nowrap">
           <div class="inline-block pl-1">


### PR DESCRIPTION
### What are the main changes you did

- [x] Fixed issue in the listbox component where the list would still open when the disabled was true
- [x] Tree Input
    - [x] Fixed width issue in tree component checkbox icon
    - [x] Fixed issue where "Show search" would disappear when clicked
    - [x] Integrated ButtonText component to resolved text issues in different themes
    - [x] initial refactoring of the search input and error messages
    - [x] Fixed styling in the checkbox icon when indeterminate is true

This PR is part of molgenis/GCC#279

> [!NOTE]
> There is still an issue with the styling of the expand group button icon. In the light theme, the text color does not change. In a future PR, this will be fixed (likely after the input style and button refactoring)

### How to test
- Navigate to the preview
- View the InputListbox component story. Select the "disabled" state and click the listbox component. It should no longer open.
- View the InputTree story. The right border of the check should be trimmed. The horizontal line in the checkbox should be visible when one node in a group is selected.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation