### PR TITLE
fix(tw): broken references in field component

### DIFF
--- a/apps/tailwind-components/components/Message.vue
+++ b/apps/tailwind-components/components/Message.vue
@@ -9,16 +9,14 @@
       'bg-neutral text-neutral': !valid && !invalid,
     }"
   >
+    <span :id="`${id}-state-context`" class="sr-only">
+      {{ invalid ? "error" : valid ? "success" : "information" }}
+    </span>
     <template v-if="invalid">
-      <span :id="`${id}-state-context`" class="sr-only">error</span>
       <BaseIcon name="exclamation" />
     </template>
     <template v-else-if="valid">
-      <span :id="`${id}-state-context`" class="sr-only">success</span>
       <BaseIcon name="check" />
-    </template>
-    <template v-else>
-      <span :id="`${id}-state-context`" class="sr-only">information</span>
     </template>
     <slot></slot>
   </div>

--- a/apps/tailwind-components/components/Message.vue
+++ b/apps/tailwind-components/components/Message.vue
@@ -1,6 +1,5 @@
 <template>
   <div
-    role="alertdialog"
     :aria-labelledby="`${id}-state-context`"
     class="p-3 font-bold flex items-center rounded-input"
     :class="{

--- a/apps/tailwind-components/components/form/Field.vue
+++ b/apps/tailwind-components/components/form/Field.vue
@@ -33,13 +33,11 @@ const emit = defineEmits(["focus", "blur"]);
         </span>
       </label>
     </template>
-    <p
-      :id="`${id}-input-description`"
-      v-if="description"
-      class="text-input-description text-body-sm"
-    >
-      {{ description }}
-    </p>
+    <div :id="`${id}-input-description`">
+      <p v-if="description" class="text-input-description text-body-sm">
+        {{ description }}
+      </p>
+    </div>
     <Input
       v-model="modelValue"
       :id="id"
@@ -47,19 +45,21 @@ const emit = defineEmits(["focus", "blur"]);
       :valid="valid"
       :invalid="invalid"
       :disabled="disabled"
-      :describedBy="`${id}-description ${id}-input-error`"
+      :describedBy="`${id}-input-description ${id}-input-error`"
       :placeholder="placeholder"
       :options="options"
-      :refSchemaId="refSchemaId as string"
-      :refTableId="refTableId as string"
-      :refLabel="refLabel as string"
+      :refSchemaId="(refSchemaId as string)"
+      :refTableId="(refTableId as string)"
+      :refLabel="(refLabel as string)"
       :trueLabel="trueLabel"
       :falseLabel="falseLabel"
       @blur="emit('blur')"
       @focus="emit('focus')"
     />
-    <Message v-if="errorMessage" invalid id="`${id}-input-error`">{{
-      errorMessage
-    }}</Message>
+    <div :id="`${id}-input-error`">
+      <Message :id="id" invalid v-if="errorMessage">
+        {{ errorMessage }}
+      </Message>
+    </div>
   </div>
 </template>


### PR DESCRIPTION
### What are the main changes you did

The purpose of this PR is to fix the broken aria references in the field component. This component controls the input and the corresponding text elements (label, description, errors, etc.). The text elements are displayed correctly, but the references are broken as text elements are dynamically shown/hidden. If an element is hidden, then it cannot be linked to the input element.

- [x] fix: change element ID of the description to `*-input-description`. (Previously, the ID did not match the ID in the `described by` attribute)
- [x] fix: error message container is displayed by default only the message is displayed dynamically
- [x] fix: message context is displayed by default. Only the text is changed
- [x] removed role in message component (I do not think it needs to be defined in the component as it depends on the context.)
- [x] minor ts fixes to prevent linting issues. When using `* as <type>`, the linting will break. Wrapping it in parentheses will prevent this.

This PR is part of molgenis/GCC#279

### How to test

- Go to the preview
- View the Forms story and run the WAVE extension. There should be no more broken reference serrors on the input elements
- View the Message story and run the WAVE extension. No more reference errors should be thrown.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation