### PR TITLE
fix(tw): added blur and focus emits to input groups

### DIFF
--- a/apps/tailwind-components/components/input/CheckboxGroup.vue
+++ b/apps/tailwind-components/components/input/CheckboxGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <InputGroupContainer
     :id="`${id}-checkbox-group`"
     :aria-describedby="describedBy"
     class="border-l-4 border-transparent"
@@ -7,6 +7,8 @@
       'border-l-invalid': invalid,
       'border-l-valid': valid,
     }"
+    @focus="emit('focus')"
+    @blur="emit('blur')"
   >
     <div class="flex flex-row" v-for="option in options">
       <InputLabel
@@ -53,7 +55,7 @@
     >
       Clear
     </ButtonText>
-  </div>
+  </InputGroupContainer>
 </template>
 
 <script lang="ts" setup>

--- a/apps/tailwind-components/components/input/InputGroupContainer.vue
+++ b/apps/tailwind-components/components/input/InputGroupContainer.vue
@@ -1,0 +1,21 @@
+<template>
+  <div ref="inputGroup">
+    <slot></slot>
+  </div>
+</template>
+
+<script lang="ts" setup>
+import { useFocusWithin } from "@vueuse/core";
+const inputGroupElem = useTemplateRef<HTMLDivElement>("inputGroup");
+const { focused } = useFocusWithin(inputGroupElem);
+
+const emit = defineEmits(["focus", "blur"]);
+
+watch(focused, (focused) => {
+  if (focused) {
+    emit("focus");
+  } else {
+    emit("blur");
+  }
+});
+</script>

--- a/apps/tailwind-components/components/input/RadioGroup.vue
+++ b/apps/tailwind-components/components/input/RadioGroup.vue
@@ -1,5 +1,5 @@
 <template>
-  <div
+  <InputGroupContainer
     :id="`${id}-radio-group`"
     :aria-describedby="describedBy"
     class="flex gap-1 border-l-4 border-transparent"
@@ -9,6 +9,8 @@
       'border-l-invalid': invalid,
       'border-l-valid': valid,
     }"
+    @focus="emit('focus')"
+    @blur="emit('blur')"
   >
     <div v-for="option in options" class="flex flex-row">
       <InputLabel
@@ -57,7 +59,7 @@
     >
       Clear
     </ButtonText>
-  </div>
+  </InputGroupContainer>
 </template>
 
 <script lang="ts" setup>

--- a/apps/tailwind-components/pages/input/CheckboxGroup.story.vue
+++ b/apps/tailwind-components/pages/input/CheckboxGroup.story.vue
@@ -1,47 +1,56 @@
-<script setup lang="ts">
-const groupSelection = ref<string[]>(["tomatoes", "basil"]);
-</script>
-
 <template>
   <InputTestContainer show-state v-slot="{ invalid, valid, disabled }">
-    <fieldset>
-      <legend class="text-title">
-        Which toppings would you like on your pizza? You may select more than
-        one.
-      </legend>
-      <InputCheckboxGroup
-        id="example-4"
-        v-model="groupSelection"
-        :valid="valid"
-        :invalid="invalid"
-        :disabled="disabled"
-        :options="[
-          {
-            value: 'tomatoes',
-            label: 'Roma tomatoes',
-          },
-          {
-            value: 'pepperoni',
-            label: 'Pepperoni',
-          },
-          {
-            value: 'mozzerella',
-            label: 'Fresh mozzerella',
-          },
-          {
-            value: 'chillies',
-            label: 'Chillies',
-          },
-          {
-            value: 'basil',
-            label: 'Fresh basil',
-          },
-        ]"
-        :showClearButton="true"
-      />
-    </fieldset>
+    <form>
+      <fieldset>
+        <legend id="checkbox-input-group-title" class="text-title">
+          Which toppings would you like on your pizza? You may select more than
+          one.
+        </legend>
+        <InputCheckboxGroup
+          id="checkbox-input-group"
+          described-by="checkbox-input-group-title"
+          v-model="selection"
+          :valid="valid"
+          :invalid="invalid"
+          :disabled="disabled"
+          :options="[
+            {
+              value: 'tomatoes',
+              label: 'Roma tomatoes',
+            },
+            {
+              value: 'pepperoni',
+              label: 'Pepperoni',
+            },
+            {
+              value: 'mozzerella',
+              label: 'Fresh mozzerella',
+            },
+            {
+              value: 'chillies',
+              label: 'Chillies',
+            },
+            {
+              value: 'basil',
+              label: 'Fresh basil',
+            },
+          ]"
+          :showClearButton="true"
+          @focus="inputState = 'focused'"
+          @blur="inputState = 'blurred'"
+        />
+      </fieldset>
+    </form>
   </InputTestContainer>
-  <output>
-    <span>Selection: {{ groupSelection }}</span>
-  </output>
+  <div>
+    <ul class="text-title">
+      <li>Selection: {{ selection }}</li>
+      <li>Input Group State: {{ inputState }}</li>
+    </ul>
+  </div>
 </template>
+
+<script setup lang="ts">
+const selection = ref<string[]>(["tomatoes", "basil"]);
+const inputState = ref<string>("inactive");
+</script>

--- a/apps/tailwind-components/pages/input/RadioGroup.story.vue
+++ b/apps/tailwind-components/pages/input/RadioGroup.story.vue
@@ -2,12 +2,13 @@
   <InputTestContainer show-state v-slot="{ invalid, valid, disabled }">
     <form>
       <fieldset>
-        <legend class="text-title">
+        <legend id="radio-input-group-title" class="text-title">
           Select the patient's group allocation. If unknown, please leave blank.
         </legend>
         <InputRadioGroup
           id="radio-input-group"
-          v-model="example"
+          described-by="radio-input-group-title"
+          v-model="selection"
           :options="[
             { value: 'control', label: 'Healthy control' },
             {
@@ -20,15 +21,21 @@
           :invalid="invalid"
           :valid="valid"
           :disabled="disabled"
+          @focus="inputState = 'focused'"
+          @blur="inputState = 'blurred'"
         />
       </fieldset>
     </form>
-    <output>
-      <span>Selection: {{ example }}</span>
-    </output>
   </InputTestContainer>
+  <div>
+    <ul class="text-title">
+      <li>Selection: {{ selection }}</li>
+      <li>Input Group State: {{ inputState }}</li>
+    </ul>
+  </div>
 </template>
 
 <script lang="ts" setup>
-const example = ref<string>("intervention");
+const selection = ref<string>("intervention");
+const inputState = ref<string>("inactive");
 </script>


### PR DESCRIPTION
### What are the main changes you did

This PR adds focus and blur events to input groups. In the previous version, events are trigger at the input level (i.e., checkbox, radio) which caused validation to occur when a user tabbed between input elements. Instead, these events should be triggered when the group no longer has focus. Now, the components will trigger a focus when their is an active element within the component and blur when there is no longer an active element within the group. 

- [x] fix: added container to handle focus and blur
- [x] feat: updated stories and added input state to output section

This PR is part of molgenis/GCC#279

### How to test

- Navigate to the preview
- Go to the Forms story and select the following schema: `patient registry demo` and table `Subject`. In section 2 "Personal Information", select one of the radio checkbox group inputs (e.g., sex at birth, country of birth, etc). Clear the default value and move to another input. Error will be thrown as it is a required field.
- View the input group stories: tab through the group and view the input state change listed in the output section

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation