### PR TITLE
fix(tw): fixed file input click events

### DIFF
--- a/apps/tailwind-components/components/input/File.vue
+++ b/apps/tailwind-components/components/input/File.vue
@@ -79,10 +79,6 @@ function resetModelValue() {
   modelValue.value = null;
 }
 
-function blurFileInput() {
-  fileInputElem.value?.blur();
-}
-
 function showFileInput() {
   fileInputElem.value?.click();
 }

--- a/apps/tailwind-components/components/input/File.vue
+++ b/apps/tailwind-components/components/input/File.vue
@@ -98,7 +98,7 @@ function onInputClick(event: Event) {
 
 function onFileInput(event: Event) {
   const files = (event.target as HTMLInputElement)?.files as FileList;
-  console.log(files);
+
   if (files.length) {
     const file = files?.item(0) as File;
     modelValue.value = {

--- a/apps/tailwind-components/components/input/File.vue
+++ b/apps/tailwind-components/components/input/File.vue
@@ -9,10 +9,12 @@
       'bg-disabled cursor-not-allowed': disabled,
       'bg-input border-input': !disabled,
     }"
+    @click="onFileInputClick"
   >
     <div class="grow">
       <button
         v-if="modelValue"
+        ref="selectedFileButton"
         class="flex justify-center items-center h-10.5 px-5 text-heading-lg gap-3 tracking-widest uppercase font-display duration-default ease-in-out border rounded-input"
         :class="{
           'text-disabled bg-disabled hover:text-disabled cursor-not-allowed':
@@ -24,7 +26,6 @@
           'border-valid text-valid bg-valid hover:bg-valid hover:text-valid':
             valid,
         }"
-        @click="onFilterWellClick"
         :disabled="disabled"
       >
         <span>{{ modelValue.filename }}</span>
@@ -50,7 +51,7 @@
       </button>
       <input
         :id="`${id}-file-input`"
-        ref="fileInputElem"
+        ref="fileInput"
         class="sr-only"
         type="file"
         :disabled="disabled"
@@ -66,14 +67,33 @@
 import type { IInputProps, IFile } from "~/types/types";
 
 const modelValue = defineModel<IFile | null>();
-const fileInputElem = useTemplateRef<HTMLInputElement>("fileInputElem");
+const fileInputElem = useTemplateRef<HTMLInputElement>("fileInput");
+const selectedFileButton =
+  useTemplateRef<HTMLButtonElement>("selectedFileButton");
 
 defineProps<IInputProps>();
 
 const emit = defineEmits(["focus", "blur", "error", "update:modelValue"]);
 
+function resetModelValue() {
+  modelValue.value = null;
+}
+
 function showFileInput() {
   fileInputElem.value?.click();
+}
+
+function onFileInputClick(event: Event) {
+  const target = event.target as Node;
+  const isRefElemNode =
+    selectedFileButton.value?.contains(target) ||
+    selectedFileButton.value === target;
+
+  if (isRefElemNode) {
+    resetModelValue();
+  } else {
+    showFileInput();
+  }
 }
 
 function onChange(event: Event) {
@@ -86,9 +106,5 @@ function onChange(event: Event) {
       extension: file.type,
     };
   }
-}
-
-function onFilterWellClick() {
-  modelValue.value = null;
 }
 </script>

--- a/apps/tailwind-components/components/input/File.vue
+++ b/apps/tailwind-components/components/input/File.vue
@@ -45,7 +45,7 @@
           'hover:bg-button-primary hover:text-button-primary cursor-pointer':
             !disabled,
         }"
-        @click="showFileInput"
+        :disabled="disabled"
       >
         <span>Browse</span>
       </button>
@@ -79,6 +79,10 @@ function resetModelValue() {
   modelValue.value = null;
 }
 
+function blurFileInput() {
+  fileInputElem.value?.blur();
+}
+
 function showFileInput() {
   fileInputElem.value?.click();
 }
@@ -90,17 +94,15 @@ function onInputClick(event: Event) {
     selectedFileButton.value === target;
 
   if (isRefElemNode) {
-    console.log(target, 'resetting modelValue')
     resetModelValue();
   } else {
-    console.log(target,"opening file chooser")
     showFileInput();
   }
 }
 
 function onFileInput(event: Event) {
   const files = (event.target as HTMLInputElement)?.files as FileList;
-  console.log(files)
+  console.log(files);
   if (files.length) {
     const file = files?.item(0) as File;
     modelValue.value = {

--- a/apps/tailwind-components/components/input/File.vue
+++ b/apps/tailwind-components/components/input/File.vue
@@ -9,7 +9,7 @@
       'bg-disabled cursor-not-allowed': disabled,
       'bg-input border-input': !disabled,
     }"
-    @click="onFileInputClick"
+    @click="onInputClick"
   >
     <div class="grow">
       <button
@@ -55,7 +55,7 @@
         class="sr-only"
         type="file"
         :disabled="disabled"
-        @change="onChange"
+        @input="onFileInput"
         @focus="$emit('focus')"
         @blur="$emit('blur')"
       />
@@ -83,23 +83,26 @@ function showFileInput() {
   fileInputElem.value?.click();
 }
 
-function onFileInputClick(event: Event) {
+function onInputClick(event: Event) {
   const target = event.target as Node;
   const isRefElemNode =
     selectedFileButton.value?.contains(target) ||
     selectedFileButton.value === target;
 
   if (isRefElemNode) {
+    console.log(target, 'resetting modelValue')
     resetModelValue();
   } else {
+    console.log(target,"opening file chooser")
     showFileInput();
   }
 }
 
-function onChange(event: Event) {
-  const files = (event.target as HTMLInputElement)?.files;
-  if (files) {
-    const file = files.item(0) as File;
+function onFileInput(event: Event) {
+  const files = (event.target as HTMLInputElement)?.files as FileList;
+  console.log(files)
+  if (files.length) {
+    const file = files?.item(0) as File;
     modelValue.value = {
       filename: file.name,
       size: file.size,

--- a/apps/tailwind-components/pages/input/File.story.vue
+++ b/apps/tailwind-components/pages/input/File.story.vue
@@ -25,5 +25,5 @@
 
 <script setup lang="ts">
 import type { columnValueObject } from "../../../metadata-utils/src/types";
-const file = ref<columnValueObject>();
+const file = ref<columnValueObject | null>();
 </script>


### PR DESCRIPTION
### What are the main changes you did

- [x] fix: adjusted click event so that the file input opens when focused or if the input is clicked anywhere in the component (except for the button to remove the file)

### How to test

- Navigate to the preview
- In the tw component gallery, go to the file input story.
- Click anywhere in the input component to open the file menu (new functionality)
- Select a file. Click anywhere in the component (except the file button) to reopen the file selector
- Click the file button to remove the file (file selector should not open)

#### Checks

I have confirmed that this component works in the following browsers.

- [x] Firefox (macOS)
- [x] Chrome (macOS)
- [x] Safari (macOS)


### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation