### PR TITLE
fix: 4790 Catalogue documentation link is broken

### DIFF
--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -26,7 +26,7 @@ spec:
     http:
       paths:
       - path: /[^\/]+/catalogue/
-        pathType: Prefix
+        pathType: ImplementationSpecific
         backend:
           service:
             name: ssr-catalogue


### PR DESCRIPTION
only allow for a single section /[schema-name]/catalogue to match the proxy path pointing to the node server (instead of allowing /foo/bar/catalogue to match )

Closes #4790 

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation