### PR TITLE
fix(rd3): md5 added as file format in the ontology table

### DIFF
--- a/data/_ontologies/FileFormats.csv
+++ b/data/_ontologies/FileFormats.csv
@@ -578,3 +578,4 @@ GEO Matrix Series format,GEO Matrix Series format,SWO,SWO_1100126,http://www.ebi
 crai,CRAI,,,
 phenopacketJSON,"JavaScript Object Notation PhenoPacket a lightweight, text-based format to represent tree-structured data using key-value pairs.",EDAM,format:3464,http://edamontology.org/format_3464
 gVCF,"Genomic Variant Call Format (VCF) for sequence variation (indels, polymorphisms, structural variation).",EDAM,format:3016,http://edamontology.org/format_3016
+md5,MD5 Checksum,NCIT,NCIT_C171276,http://purl.obolibrary.org/obo/NCIT_C171276


### PR DESCRIPTION
### What are the main changes you did
- [x] md5 checksum is added as a file format ontology.

### How to test
- go to data > _ontologies folder
- go to FileFormats.csv
- Check if md5 is added (correctly)

### Checklist 
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation