### PR TITLE
fix(pages): script tags can now be executed if they are provided through advanced settings

### DIFF
--- a/apps/pages/src/components/ViewPage.vue
+++ b/apps/pages/src/components/ViewPage.vue
@@ -34,7 +34,6 @@ export default {
   },
   watch: {
     contents(htmlString) {
-      htmlString += "<script>alert('working!')<\/script>";
       const parser = new DOMParser();
       const doc = parser.parseFromString(htmlString, "text/html");
 


### PR DESCRIPTION

### What are the main changes you did
- explain what you changed and essential considerations.
I changed the v-html implementation to parsing the string as DOM elements, adding them to the page. For script tags I created new script tags, so they will execute once loaded. v-html uses innerHTML under the hood. That disables any execution.

### How to test
- explain here what to do to test this (or point to unit tests)

Edit a page in advanced settings and add a script tag, example <script>alert("!")</script>, this will trigger when parsed.
You can ofcourse use window.onload or such, to await execution until page has been loaded

Partially implements #4606 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
