### PR TITLE
fix(rdf): various minor changes

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/ColumnTypeRdfMapper.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/ColumnTypeRdfMapper.java
@@ -281,13 +281,7 @@ public class ColumnTypeRdfMapper {
     abstract Set<Value> retrieveValues(final String baseURL, final Row row, final Column column);
 
     boolean isEmpty(final Row row, final Column column) {
-      if (column.isReference() && column.getReferences().size() > 1) {
-        // check composite keys to be empty
-        return column.getReferences().stream()
-            .anyMatch(ref -> row.getString(ref.getName()) == null);
-      } else {
-        return row.getString(column.getName()) == null;
-      }
+      return row.getString(column.getName()) == null;
     }
 
     private static Set<Value> retrieveReferenceValues(

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/ColumnTypeRdfMapper.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/ColumnTypeRdfMapper.java
@@ -132,12 +132,6 @@ public class ColumnTypeRdfMapper {
         return basicRetrievalString(row.getStringArrayPreserveDelimiter(column), Values::literal);
       }
     },
-    TEXT(CoreDatatype.XSD.STRING) {
-      @Override
-      Set<Value> retrieveValues(String baseURL, Row row, Column column) {
-        return basicRetrievalString(row.getStringArrayPreserveDelimiter(column), Values::literal);
-      }
-    },
     INT(CoreDatatype.XSD.INT) {
       @Override
       Set<Value> retrieveValues(String baseURL, Row row, Column column) {

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -179,11 +179,11 @@ public class RDFService {
 
       if (logger.isDebugEnabled()) {
         logger.debug(
-                "Tables to show: "
-                        + tables.stream()
-                        .map(
-                                i -> i.getMetadata().getSchemaName() + "." + i.getMetadata().getTableName())
-                        .toList());
+            "Tables to show: "
+                + tables.stream()
+                    .map(
+                        i -> i.getMetadata().getSchemaName() + "." + i.getMetadata().getTableName())
+                    .toList());
         logger.debug("Namespaces per schema: " + namespaces.toString());
       }
 

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -174,17 +174,19 @@ public class RDFService {
         allTables.addAll(schema.getTablesSorted());
       }
 
+      // Tables to include in output.
+      final Set<Table> tables = table != null ? tablesToDescribe(allTables, table) : allTables;
+
       if (logger.isDebugEnabled()) {
         logger.debug(
-            "All tables to show: "
-                + allTables.stream()
-                    .map(
-                        i -> i.getMetadata().getSchemaName() + "." + i.getMetadata().getTableName())
-                    .toList());
+                "Tables to show: "
+                        + tables.stream()
+                        .map(
+                                i -> i.getMetadata().getSchemaName() + "." + i.getMetadata().getTableName())
+                        .toList());
         logger.debug("Namespaces per schema: " + namespaces.toString());
       }
 
-      final Set<Table> tables = table != null ? tablesToDescribe(allTables, table) : allTables;
       for (final Table tableToDescribe : tables) {
         // for full-schema retrieval, don't print the (huge and mostly unused) ontologies
         // of course references to ontologies are still included and are fully retrievable

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -575,18 +575,6 @@ public class RDFService {
     }
   }
 
-  private static Table getSubclassTableForRowBasedOnMgTableclass(Table table, Row row) {
-    if (row.getString(MG_TABLECLASS) != null) {
-      table =
-          table
-              .getSchema()
-              .getDatabase()
-              .getSchema(row.getSchemaName())
-              .getTable(row.getTableName());
-    }
-    return table;
-  }
-
   private String getLabelForRow(final Row row, final TableMetadata metadata) {
     List<String> primaryKeyValues = new ArrayList<>();
     for (Column column : metadata.getPrimaryKeyColumns()) {


### PR DESCRIPTION
### What are the main changes you did
- removed an unused `RdfColumnType`
- removed check for `REFERENCE` that gets overridden anyway due to a `REFERENCE`-specific implementation (see `isEmpty()`):
  - https://github.com/molgenis/molgenis-emx2/blob/cb19bed6e94be5e64bff152c19cf3205095d9475/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/ColumnTypeRdfMapper.java#L210-L226
- fixed debug log message
- removed some `rowId` specific code to select a sub-table.
  - Before any rowId filtering is done, if a table filter is present all tables that are (grand)children of this table are already included in the output generation process. This is because if retrieving a parent table with several different grandchildren, they should be included in the RDF output. Any `rowId` filter added later on will only functionally need to filter out the rows in these tables.
  - Existing tests should already cover this:
    - The test schema:
  https://github.com/molgenis/molgenis-emx2/blob/cb19bed6e94be5e64bff152c19cf3205095d9475/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java#L216-L243
    - The triples to validate on:
  https://github.com/molgenis/molgenis-emx2/blob/cb19bed6e94be5e64bff152c19cf3205095d9475/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java#L1503-L1514
    - The test (specifically, L785-787):
  https://github.com/molgenis/molgenis-emx2/blob/cb19bed6e94be5e64bff152c19cf3205095d9475/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java#L777-L792


### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation