### PR TITLE
chore: removed dependency already defined in parent `build.gradle`

### DIFF
--- a/backend/molgenis-emx2-webapi/build.gradle
+++ b/backend/molgenis-emx2-webapi/build.gradle
@@ -11,7 +11,6 @@ dependencies {
     implementation project(':backend:molgenis-emx2-tasks')
     implementation project(':backend:molgenis-emx2-email')
     implementation project(':backend:molgenis-emx2-analytics')
-    implementation 'org.eclipse.rdf4j:rdf4j-rio-api:5.0.1'
     implementation 'io.swagger.parser.v3:swagger-parser:2.1.22'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.squareup.okhttp3:okhttp-brotli:4.11.0'

--- a/backend/molgenis-emx2-webapi/build.gradle
+++ b/backend/molgenis-emx2-webapi/build.gradle
@@ -11,7 +11,7 @@ dependencies {
     implementation project(':backend:molgenis-emx2-tasks')
     implementation project(':backend:molgenis-emx2-email')
     implementation project(':backend:molgenis-emx2-analytics')
-    implementation 'org.eclipse.rdf4j:rdf4j-rio-api:4.3.12'
+    implementation 'org.eclipse.rdf4j:rdf4j-rio-api:5.0.1'
     implementation 'io.swagger.parser.v3:swagger-parser:2.1.22'
     implementation 'com.squareup.okhttp3:okhttp:4.11.0'
     implementation 'com.squareup.okhttp3:okhttp-brotli:4.11.0'


### PR DESCRIPTION
### What are the main changes you did
- see title
  - this change should in practice not change anything as according to `./gradlew dependencies` the webapi already uses 5.0.1

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation