### PR TITLE
chore(staging-migrator): corrected mismatch between table ids and table file names

### DIFF
--- a/data/scripts/catalogue/publish/delete_resource.py
+++ b/data/scripts/catalogue/publish/delete_resource.py
@@ -23,7 +23,7 @@ LOG_LEVEL = "INFO"
 def delete_resource(args: list):
 
     # Set up the logger
-    logging.basicConfig(level=LOG_LEVEL)
+    logging.basicConfig(level=LOG_LEVEL, stream=sys.stdout)
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 

--- a/data/scripts/catalogue/publish/publish_resources.py
+++ b/data/scripts/catalogue/publish/publish_resources.py
@@ -25,7 +25,7 @@ log = logging.getLogger('publisher')
 def main(args):
 
     # Set up the logger
-    logging.basicConfig(level=LOG_LEVEL)
+    logging.basicConfig(level=LOG_LEVEL, stream=sys.stdout)
     logging.getLogger("requests").setLevel(logging.WARNING)
     logging.getLogger("urllib3").setLevel(logging.WARNING)
 

--- a/tools/staging_migrator/src/molgenis_emx2_staging_migrator/migrator.py
+++ b/tools/staging_migrator/src/molgenis_emx2_staging_migrator/migrator.py
@@ -212,11 +212,13 @@ class StagingMigrator(Client):
                 if '_files/' in file_name:
                     upload_archive.writestr(file_name, BytesIO(source_archive.read(file_name)).getvalue())
                     continue
-                elif (table_name := Path(file_name).stem) not in [*tables_to_sync.keys(), *self.extra_tables]:
+
+                table_id = "".join(word.capitalize() for word in Path(file_name).stem.split(' '))
+                if table_id not in [*tables_to_sync.keys(), *self.extra_tables]:
                     continue
 
                 _table = source_archive.read(file_name)
-                if consent_val := has_statement_of_consent(table_name, self.get_schema_metadata(self.staging_area)):
+                if consent_val := has_statement_of_consent(table_id, self.get_schema_metadata(self.staging_area)):
                     _table = process_statement(table=_table, consent_val=consent_val)
                 upload_archive.writestr(file_name, BytesIO(_table).getvalue())
 


### PR DESCRIPTION
### What are the main changes you did
Corrected an oversight in the staging migrator tool where a check for table ids in a list of table file names failed due to differences between table ids and table names for table names with spaces.

### Issue replication

1. On localhost or test server clone the schemas _testCohort_ and _testCatalogue_  from the data catalogue production server.
2. Create a task in the server's \_SYSTEM\_ environment from the _publish\_resources.py_ script located in data/scripts/catalogue/publish , with dependency `molgenis_emx2_staging_migrator>=11.54.8`. Change the `CATALOGUE` parameter in the script to `testCatalogue`
3. Run this script with `testCohort` as script parameter
4. See that tables with spaces in their name (e.g. Collection events, Subpopulation counts) were not correctly migrated

### How to test
1. Modify the _publish\_resources.py_ script located in tools/staging_migrator/dev by changing the `CATALOGUE` parameter in the script to `testCatalogue`
2. Create an admin token on the server and store the server URL and this token as environment variables `MG_URL` AND `MG_TOKEN`, respectively.
3. Run the script with commandline argument `testCohort`
4. See that _Collection events_ and _Subpopulation counts_ have now been correctly migrated.


### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation