### PR TITLE
fix(tw):added general input styles to the listbox component

### DIFF
--- a/apps/tailwind-components/assets/css/main.css
+++ b/apps/tailwind-components/assets/css/main.css
@@ -93,9 +93,6 @@
     --background-color-input: var(--color-white);
     --background-color-input-checked: var(--color-blue-500);
     --background-color-input-focused: var(--color-blue-800);
-    --background-color-listbox: var(--color-white);
-    --background-color-listbox-hover: var(--color-gray-100);
-    --background-color-listbox-selected: var(--color-blue-500);
     --background-color-table: var(--color-white);
     --background-color-notification: var(--color-red-700);
     --background-color-code-output: var(--color-gray-100);
@@ -148,9 +145,6 @@
     --text-color-pagination-hover: var(--color-white);
     --text-color-pagination-button: var(--color-white);
     --text-color-link: var(--color-blue-500);
-    --text-color-listbox: var(--color-black);
-    --text-color-listbox-hover: var(--color-black);
-    --text-color-listbox-selected: var(--color-blue-50);
     --text-color-button-input-toggle: var(--color-black);
     --text-color-table-column-header: var(--color-gray-600);
     --text-color-form-header: var(--color-blue-800);
@@ -183,8 +177,6 @@
     --border-color-input-hover: var(--color-blue-500);
     --border-color-input-focused: var(--color-blue-800);
     --border-color-input-inverted: var(--color-gray-600);
-    --border-color-listbox-option: var(--color-gray-100);
-    --border-color-listbox: var(--border-color-input);
 
     --border-radius-3px: 3px;
     --border-radius-50px: 50px;

--- a/apps/tailwind-components/components/input/listbox/List.vue
+++ b/apps/tailwind-components/components/input/listbox/List.vue
@@ -3,7 +3,7 @@
     role="listbox"
     ref="ul"
     :aria-expanded="isExpanded"
-    class="absolute b-0 w-full overflow-y-scroll z-10 bg-listbox border"
+    class="absolute b-0 w-full overflow-y-scroll z-10 bg-input border"
     :class="{
       hidden: !isExpanded,
       'h-44': isExpanded && hasFixedHeight,

--- a/apps/tailwind-components/components/input/listbox/ListItem.vue
+++ b/apps/tailwind-components/components/input/listbox/ListItem.vue
@@ -2,15 +2,16 @@
   <li
     ref="li"
     role="option"
-    class="flex justify-start items-center gap-3 pl-3 py-1 bg-listbox text-listbox border-t-[1px] border-t-listbox-option hover:cursor-pointer hover:bg-listbox-hover hover:text-listbox focus:bg-listbox-hover focus:text-listbox focus:ring-blue-300"
+    class="flex justify-start items-center gap-3 pl-3 py-1 bg-input border-t-[1px] hover:cursor-pointer hover:bg-input-focused focus:bg-input-focused hover:text-input-focused"
     :class="{
-      '!bg-listbox-selected !text-listbox-selected': isSelected,
+      'text-input': !isSelected,
+      'bg-input-checked text-input-checked': isSelected,
     }"
     :aria-selected="isSelected"
   >
     <BaseIcon
       name="Check"
-      class="fill-listbox-selected invisible"
+      class="fill-check invisible"
       :class="{
         '!visible': isSelected,
       }"

--- a/apps/tailwind-components/components/input/listbox/Toggle.vue
+++ b/apps/tailwind-components/components/input/listbox/Toggle.vue
@@ -6,12 +6,17 @@
     :aria-required="required"
     :aria-expanded="isExpanded"
     :aria-activedescendant="selectedElementId"
-    class="flex justify-start items-center h-10 w-full text-left pl-11 border text-button-input-toggle focus:ring-blue-300"
+    class="flex justify-start items-center h-10 w-full text-left pl-11 border rounded-input"
     :class="{
-      'bg-input': !disabled && !invalid && !valid,
-      'bg-disabled border-disabled text-disabled': disabled,
-      'border-invalid text-invalid': invalid,
-      'border-valid text-valid': valid,
+      'bg-input border-invalid text-invalid': invalid && !disabled,
+      'bg-input border-valid text-valid': valid && !disabled,
+      'bg-disabled border-disabled text-disabled cursor-not-allowed': disabled,
+      'bg-disabled border-valid text-valid cursor-not-allowed':
+        valid && disabled,
+      'bg-disabled border-invalid text-invalid cursor-not-allowed':
+        invalid && disabled,
+      'bg-input text-input hover:border-input-hover focus:border-input-focused':
+        !disabled && !invalid && !valid,
     }"
     @click="onClick()"
   >

--- a/apps/tailwind-components/pages/input/Listbox.story.vue
+++ b/apps/tailwind-components/pages/input/Listbox.story.vue
@@ -1,6 +1,6 @@
 <template>
   <h2 class="text-heading-2xl">Listbox component</h2>
-  <form class="mb-6 bg-white rounded p-4">
+  <form class="mb-6 rounded p-4 text-title">
     <legend class="mb-2 text-heading-lg">
       Configure the listbox component
     </legend>
@@ -42,7 +42,7 @@
           :showClearButton="true"
         />
       </div>
-      <div class="bg-white p-2 grow">
+      <div class="p-2 grow">
         <InputLabel for="listbox-placeholder">
           Change the default placeholder text
         </InputLabel>
@@ -50,7 +50,7 @@
       </div>
     </div>
   </form>
-  <div class="mb-6 bg-white rounded px-6 py-8">
+  <div class="mb-6 rounded px-6 py-8 text-title">
     <h3 class="text-heading-lg mb-2">Listbox example</h3>
     <InputLabel
       id="listbox-input-label"
@@ -71,18 +71,18 @@
       :placeholder="listboxPlaceholder"
       @update:model-value="(value) => (modelValue = value)"
     />
-    <output class="block w-full mt-6 bg-gray-100 py-3 px-2 pl-6">
+    <output class="block w-full mt-6 border py-3 px-2 pl-6">
       <code
         >Output {{ listboxDataType === "true" ? "Value" : "Object" }}:
         {{ modelValue }}</code
       >
     </output>
   </div>
-  <div class="mb-2 bg-white rounded p-6">
+  <div class="mb-2 rounded p-6 text-title">
     <h3 class="text-heading-lg mb-2">Input data structure</h3>
     <p>Based on the selection above, the input data is shown below.</p>
     <output
-      class="block w-full mt-6 bg-gray-100 py-3 px-2 pl-6 h-60 overflow-y-scroll shadow-inner"
+      class="block w-full mt-6 border py-3 px-2 pl-6 h-60 overflow-y-scroll shadow-inner"
     >
       <pre class="indent-[-5em]">
         {{ listboxData }}

--- a/apps/tailwind-components/tailwind.config.js
+++ b/apps/tailwind-components/tailwind.config.js
@@ -158,16 +158,13 @@ module.exports = {
         "tab": "var(--background-color-tab)",
         "tab-hover": "var(--background-color-tab-hover)",
         "tab-active": "var(--background-color-tab-active)",
-        
         "valid": "var(--color-valid-background)",
         "invalid": "var(--color-invalid-background)",
         "disabled": "var(--color-disabled-background)",
         "neutral": "var(--color-neutral-background)",
-        
         "input": "var(--background-color-input)",
-        "listbox": "var(--background-color-listbox)",
-        "listbox-hover": "var(--background-color-listbox-hover)",
-        "listbox-selected": "var(--background-color-listbox-selected)",
+        "input-focused": "var(--background-color-input-focused)",
+        "input-checked": "var(--background-color-button-primary)",
         "table": "var(--background-color-table)",
         "notification": "var(--background-color-notification)",
         "code-output": "var(--background-color-code-output)",
@@ -221,8 +218,11 @@ module.exports = {
         "link": "var(--text-color-link)",
         "table-column-header": "var(--text-color-table-column-header)",
         "form-header": "var(--text-color-form-header)",
+        
         "input": "var(--text-color-input)",
         "input-description": "var(--text-color-input-description)",
+        "input-checked": "var(--text-color-button-primary)",
+        "input-focused": "var(--text-color-button-primary)",
         
         "invalid": "var(--color-invalid-foreground)",
         "neutral": "var(--color-neutral-foreground)",
@@ -230,9 +230,6 @@ module.exports = {
         "disabled": "var(--color-disabled-foreground)",
         
         "required": "var(--text-color-required)",
-        "listbox": "var(--text-color-listbox)",
-        "listbox-hover": "var(--text-color-listbox-hover)",
-        "listbox-selected": "var(--text-color-listbox-selected)",
         "button-input-toggle": "var(--text-color-button-input-toggle)",
         "legend-error-count": "var(--text-color-legend-error-count)",
         "code-output": "var(--text-color-code-output)",
@@ -265,11 +262,10 @@ module.exports = {
         "input-hover": "var(--border-color-input-hover)",
         "input-inverted": "var(--border-color-input-inverted)",
         "input-focused": "var(--border-color-input-focused)",
-        "listbox": "var(--border-color-search-input)",
-        "listbox-option": "var(--border-color-listbox-option)",
       }),
       stroke: ({ theme }) => ({
         "input": "var(--border-color-input)",
+        "input-checked": "var(--text-color-button-primary)",
         "input-focused": "var(--border-color-input-focused)",
         "notification-text": "var(--text-color-legend-error-count)",
         "check": "var(--text-color-button-primary)",
@@ -281,8 +277,7 @@ module.exports = {
       fill: ({ theme }) => ({
         "input": "var(--background-color-input)",
         "input-focused": "var(--background-color-input-focused)",
-        "input-checked": "var(--background-color-input-checked)",
-        "listbox-selected": "var(--text-color-listbox-selected)",
+        "input-checked": "var(--background-color-button-primary)",
         "notification": "var(--background-color-notification)",
         "notification-text": "var(--text-color-legend-error-count)",
         "check": "var(--text-color-button-primary)",


### PR DESCRIPTION
### What are the main changes you did

In this PR, I replaced the listbox styles with the general input styles defined in the tailwind config. This allows the listbox styling to behave like other inputs (e.g., hover, focus, selected, etc.).

- [x] fix: replace all listbox styles with input classes
- [x] fix: remove custom styling in the story (to rely on current selected theme)

(this PR is part of molgenis/GCC#279)

### How to test

1. Go to the preview and view the listbox story
2. View the component in other themes. Make new selections, focus/hover over the component, etc. Note the styling changes and compare it to the other input elements.

### Checklist

- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation