### PR TITLE
fix: only do postinstall on ci

### DIFF
--- a/apps/catalogue/package.json
+++ b/apps/catalogue/package.json
@@ -11,7 +11,7 @@
     "dev": "nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare",
+    "postinstall": "if-env CI=true && nuxt prepare || echo 'CI is not set'",
     "format": "prettier components composables gql interfaces pages plugins utils tests stores  --write --config ../.prettierrc.js --gitignore",
     "checkFormat": "prettier components composables gql interfaces pages plugins utils tests stores --check --config ../.prettierrc.js --gitignore",
     "typecheck": "nuxi typecheck"

--- a/apps/tailwind-components/package.json
+++ b/apps/tailwind-components/package.json
@@ -12,7 +12,7 @@
     "dev": "yarn generate-source-map && nuxt dev",
     "generate": "nuxt generate",
     "preview": "nuxt preview",
-    "postinstall": "nuxt prepare",
+    "postinstall": "if-env CI=true && nuxt prepare || echo 'CI is not set'",
     "format": "prettier components pages tests layouts composables --write --config ../.prettierrc.js",
     "checkFormat": "prettier components pages tests layouts composables --check --config ../.prettierrc.js",
     "test": "vitest",


### PR DESCRIPTION
### What are the main changes you did
- re-added the CI only clause for nuxt postinstall, because emx2 doesn't build in windows machines otherwise.

### How to test
- run gradlew clean run --rerun-tasks 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation