### PR TITLE
fix(emx2): update search trigger after column drop

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -971,7 +971,7 @@ public class SqlQuery extends QueryBean {
             join =
                 join.leftJoin(
                         DSL.select(refbackSelection)
-                            .from(column.getRefTable().getJooqTable())
+                            .from(tableWithInheritanceJoin(column.getRefTable()))
                             .groupBy(
                                 refBack.getReferences().stream()
                                     .map(ref -> field(name("_refback_" + ref.getRefTo())))

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
@@ -335,6 +335,7 @@ class SqlTableMetadata extends TableMetadata {
     DSLContext jooq = ((SqlDatabase) db).getJooq();
     SqlColumnExecutor.executeRemoveColumn(jooq, tm.getColumn(columnName));
     tm.columns.remove(columnName);
+    SqlTableMetadataExecutor.updateSearchIndexTriggerFunction(jooq, tm, tableName);
     return tm;
   }
 

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRefBack.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRefBack.java
@@ -280,7 +280,9 @@ public class TestRefBack {
                 .setRefTable("treatmentxyz")
                 .setRefBack("partOfSubject"));
     schema.getTable("subject").insert(row("id", "s1"));
-    schema.getTable("treatmentxyz").insert(row("id", "t1"));
+    schema.getTable("treatmentxyz").insert(row("id", "t1", "partOfSubject", "s1"));
+    List<Row> subjects = schema.query("subject").retrieveRows();
+    assertEquals("t1", subjects.get(0).getString("treatxyz"));
   }
 
   @Test


### PR DESCRIPTION
Fixes #2842 

### What are the main changes you did
- Update the search trigger after a column is dropped.
- Not sure if this is the correct place to do it.

### How to test
- See issue: https://github.com/molgenis/molgenis-emx2/issues/2842

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation