### PR TITLE
fix(emx2): update search trigger after column drop

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
@@ -335,6 +335,7 @@ class SqlTableMetadata extends TableMetadata {
     DSLContext jooq = ((SqlDatabase) db).getJooq();
     SqlColumnExecutor.executeRemoveColumn(jooq, tm.getColumn(columnName));
     tm.columns.remove(columnName);
+    SqlTableMetadataExecutor.updateSearchIndexTriggerFunction(jooq, tm, tableName);
     return tm;
   }
 


### PR DESCRIPTION
Fixes #2842

Where new items cannot be inserted after a column is dropped. This seems to be related to the search trigger.

### What are the main changes you did
- update search trigger after column drop
- Not sure if this is the right place to do it

### How to test
See issue:
https://github.com/molgenis/molgenis-emx2/issues/2842

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation