### PR TITLE
fix(directory): withdrawn collections should be invisible in network

### DIFF
--- a/apps/directory/src/views/NetworkReport.vue
+++ b/apps/directory/src/views/NetworkReport.vue
@@ -129,7 +129,6 @@ import ContactInformation from "../components/report-components/ContactInformati
 import ReportDescription from "../components/report-components/ReportDescription.vue";
 import ReportDetailsList from "../components/report-components/ReportDetailsList.vue";
 import ReportTitle from "../components/report-components/ReportTitle.vue";
-import useErrorHandler from "../composables/errorHandler";
 import {
   getCollectionDetails,
   mapAlsoKnownIn,
@@ -174,6 +173,9 @@ function filterCollections(collections: Record<string, any>[]) {
     collections
       ?.filter((collection: Record<string, any>) => {
         return !collection.parent_collection;
+      })
+      .filter((collection: Record<string, any>) => {
+        return !collection.withdrawn;
       })
       .map((collection: Record<string, any>) =>
         getCollectionDetails(collection)


### PR DESCRIPTION
fix(directory): withdrawn collections should be invisible in network details page

Closes #4035

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation