### PR TITLE
fix: added default mimetype when downloading files

### DIFF
--- a/apps/molgenis-components/src/components/tables/cellTypes/FileDisplay.vue
+++ b/apps/molgenis-components/src/components/tables/cellTypes/FileDisplay.vue
@@ -1,9 +1,5 @@
 <template>
-  <a
-    v-if="data.id"
-    :href="data.url"
-    :target="data.extension.toLowerCase() == 'html' ? '_blank' : null"
-  >
+  <a v-if="data.id" :href="data.url" target="_blank">
     {{ data?.filename ? data.filename : metadata.name + "." + data.extension }}
     ({{ fileSize }})
   </a>

--- a/apps/molgenis-components/src/components/tables/cellTypes/FileDisplay.vue
+++ b/apps/molgenis-components/src/components/tables/cellTypes/FileDisplay.vue
@@ -1,5 +1,9 @@
 <template>
-  <a v-if="data.id" :href="data.url">
+  <a
+    v-if="data.id"
+    :href="data.url"
+    :target="data.extension.toLowerCase() == 'html' ? '_blank' : null"
+  >
     {{ data?.filename ? data.filename : metadata.name + "." + data.extension }}
     ({{ fileSize }})
   </a>

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FileApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FileApi.java
@@ -66,6 +66,9 @@ public class FileApi {
     ctx.header(
         "Content-Disposition",
         "attachment; filename=" + (fileName != null ? fileName : columnName + "." + extension));
+    if (mimetype == null) {
+      mimetype = "application/octet-stream";
+    }
     ctx.contentType(mimetype);
     try (OutputStream out = ctx.outputStream()) {
       out.write(contents); // autoclosing

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FileApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/FileApi.java
@@ -11,11 +11,14 @@ import java.util.List;
 import org.molgenis.emx2.*;
 
 public class FileApi {
+
+  private static final String DEFAULT_MIME_TYPE = "application/octet-stream";
+
   public static void create(Javalin app) {
-    app.get("/{schema}/api/file/{table}/{column}/{id}", FileApi::getFile);
+    app.get("/{schema}/api/file/{table}/{column}/{id}", FileApi::serveFile);
   }
 
-  public static void getFile(Context ctx) {
+  public static void serveFile(Context ctx) {
     String tableName = ctx.pathParam("table");
     String columnName = ctx.pathParam("column");
     String id = ctx.pathParam("id");
@@ -62,7 +65,7 @@ public class FileApi {
     ctx.header(
         "Content-Disposition",
         "inline; filename=" + (fileName != null ? fileName : columnName + "." + extension));
-    ctx.contentType(mimetype != null ? mimetype : "application/octet-stream");
+    ctx.contentType(mimetype != null ? mimetype : DEFAULT_MIME_TYPE);
     ctx.result(contents);
   }
 }


### PR DESCRIPTION
Fixes #4833 where files with certain extensions cannot be download

### What are the main changes you did
- Added default mimetype for files downloaded via file api

### How to test
See issue [4833](https://github.com/molgenis/molgenis-emx2/issues/4833)


### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation