### PR TITLE
chore: update to java 21

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ orbs:
 definitions:
   build_config: &build_config
     docker:
-    - image: molgenis/ci-build:1.2.4
+    - image: molgenis/ci-build:1.3.3
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -30,7 +30,7 @@ definitions:
       TERM: dumb
   test_config: &test_config
     docker:
-    - image: molgenis/ci-build:1.2.4
+    - image: molgenis/ci-build:1.3.3
     - image: postgres:15-alpine
       environment:
         POSTGRES_USER: postgres
@@ -44,7 +44,7 @@ definitions:
       TERM: dumb
   release_config: &release_config
     docker:
-      - image: molgenis/ci-build:1.2.4
+      - image: molgenis/ci-build:1.3.3
       - image: postgres:15-alpine
         environment:
           POSTGRES_USER: postgres

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,13 @@
-FROM eclipse-temurin:21.0.6_7-jdk-noble
+FROM ubuntu:24.10
+
+RUN apt update && apt -y upgrade
+RUN apt update && apt -y install python3 python3-pip python3-venv openjdk-21-jre-headless
+RUN pip3 install setuptools --break-system-packages
+
 ARG JAR_FILE
 COPY ${JAR_FILE} app.jar
 EXPOSE 8080
-RUN apt-get update && apt-get install python3 python3-venv -y
+RUN useradd -m molgenis
+
+USER molgenis
 ENTRYPOINT ["java","-jar","app.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM eclipse-temurin:17.0.11_9-jdk-jammy
+FROM eclipse-temurin:21.0.6_7-jdk-noble
 ARG JAR_FILE
 COPY ${JAR_FILE} app.jar
 EXPOSE 8080

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -36,11 +36,11 @@ steps:
     sudo update-alternatives --display java
   displayName: list available java versions (for debug purposes)
 - script: |
-    export JAVA_HOME=/usr/lib/jvm/temurin-17-jdk-amd64/
+    export JAVA_HOME=/usr/lib/jvm/temurin-21-jdk-amd64/
     ./gradlew -version
     ./gradlew test jacocoMergedReport
   # sonarqube -Dsonar.login=$(SONAR_TOKEN) -Dsonar.organization=molgenis -Dsonar.host.url=https://sonarcloud.io -Dorg.ajoberstar.grgit.auth.username=$(GITHUB_TOKEN) -Dorg.ajoberstar.grgit.auth.password
-  displayName: run test, ensure we are using java 17 JAVA_HOME
+  displayName: run test, ensure we are using java 21 JAVA_HOME
 
   env:
     MOLGENIS_POSTGRES_USER: molgenis

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInDatabase.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/TaskServiceInDatabase.java
@@ -288,7 +288,7 @@ f.close()
                     "script",
                     demoScript,
                     "dependencies",
-                    "numpy==1.23.4", // it has a dependency :-)
+                    "numpy==2.2.4", // it has a dependency :-)
                     "type",
                     "python",
                     "outputFileExtension",

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
@@ -22,7 +22,7 @@ public class TestScriptTask {
     ScriptTask r1 =
         new ScriptTask("hello")
             .type(PYTHON)
-            .dependencies("numpy==1.23.4")
+            .dependencies("numpy==2.2.4")
             // example with some characters that need escaping
             .parameters("\"netherlands & world\"")
             .script(

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 
 ext {
     javaMainClass = "org.molgenis.emx2.RunMolgenisEmx2"
-    javaVersion = JavaVersion.VERSION_17
+    javaVersion = JavaVersion.VERSION_21
 }
 
 allprojects {

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ plugins {
     id 'maven-publish'
     id 'com.github.johnrengelman.shadow' version '8.1.1'
     id 'application'
-    id 'com.palantir.docker' version '0.35.0'
+    id 'com.palantir.docker' version '0.36.0'
 }
 
 ext {

--- a/ci-build-images/Dockerfile
+++ b/ci-build-images/Dockerfile
@@ -3,7 +3,7 @@
 # docker buildx build -t molgenis/ci-build:1.2.2 --platform linux/amd64 .
 # docker push molgenis/ci-build:1.2.2
 
-FROM gradle:jdk17-jammy
+FROM gradle:jdk21-noble
 
 RUN apt-get update && apt-get install python3 python3-venv -y
 RUN apt-get install python3 python3-venv python3-pip -y

--- a/docs/install.md
+++ b/docs/install.md
@@ -39,7 +39,7 @@ N.B.
 
 ## Using java and your own postgresql
 
-* Install java (we use java 17)
+* Install java (we use java 21)
 * Download a molgenis-emx2-version-all.jar from [releases](https://github.com/molgenis/molgenis-emx2/releases).
 * Download and install [Postgresql](https://www.postgresql.org/download/) (we use 13)
 * Create postgresql database with name 'molgenis' and with superadmin user/pass 'molgenis'. On Linux/Mac commandline:

--- a/docs/molgenis/run_java.md
+++ b/docs/molgenis/run_java.md
@@ -13,7 +13,7 @@ Steps:
     create user molgenis with login nosuperuser inherit createrole encrypted password 'molgenis';
     grant all privileges on database molgenis to molgenis;
     ```
-* Install java (we use adopt [OpenJDK 17](https://adoptium.net/))
+* Install java (we use adopt [OpenJDK 21](https://adoptium.net/))
 * Optionally, if you want to use [scripts](use_scripts_jobs.md) then also install python3
 * Download molgenis-emx2-version-all.jar from [releases](https://github.com/molgenis/molgenis-emx2/releases).
 * Start molgenis-emx2 using command below (will run on 8080)

--- a/docs/molgenis/run_systemd.md
+++ b/docs/molgenis/run_systemd.md
@@ -5,7 +5,7 @@ We support Redhat and Ubuntu based installations.
 
 ## Java 
 
-MOLGENIS EMX2 runs on java > 17
+MOLGENIS EMX2 runs on java > 21
 <!-- tabs:start -->
 
 #### **Ubuntu (apt)**


### PR DESCRIPTION
motivation: so we can do some dependency updates that seem to block on that (e.g. jooq)

todo:
- [ ] docs
- [ ] if we require java 21, does this make it a breaking change?