### PR TITLE
fix: always add mg_draft to table output

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/emx2/Emx2Tables.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/emx2/Emx2Tables.java
@@ -37,14 +37,12 @@ public class Emx2Tables {
                         || isFileType(c, metadata)
                         || store instanceof TableAndFileStore)
             .map(Column::getName)
-            .filter(name -> !name.startsWith("mg_") || includeSystemColumns)
+            .filter(
+                name -> name.equals(MG_DRAFT) || !name.startsWith("mg_") || includeSystemColumns)
             .toList();
 
     Query query = table.query();
-    // exclude drafts when system columns are not included
-    if (!includeSystemColumns) {
-      query.where(f(MG_DRAFT, Operator.NOT_EQUALS, true));
-    }
+
     if (table.getMetadata().getColumnNames().contains(MG_TABLECLASS)) {
       query.where(
           f(MG_TABLECLASS, Operator.EQUALS, table.getSchema().getName() + "." + table.getName()));

--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForCsvInMemory.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForCsvInMemory.java
@@ -10,7 +10,7 @@ import org.molgenis.emx2.io.readers.CsvTableWriter;
 
 public class TableStoreForCsvInMemory implements TableStore {
   private final Map<String, String> store;
-  private Character separator;
+  private final Character separator;
 
   public TableStoreForCsvInMemory() {
     this(',');
@@ -30,7 +30,7 @@ public class TableStoreForCsvInMemory implements TableStore {
       String existing = "";
       if (store.containsKey(name)) existing = store.get(name);
       // make sure first row has all columnNames
-      Iterator iterator = rows.iterator();
+      Iterator<Row> iterator = rows.iterator();
       if (iterator.hasNext()) {
         Row row = rows.iterator().next();
         for (String columnName : columnNames) {
@@ -46,7 +46,7 @@ public class TableStoreForCsvInMemory implements TableStore {
         writer.write(columnNames.stream().collect(Collectors.joining("" + separator)));
       }
       bufferedWriter.close();
-      store.put(name, existing + writer.toString());
+      store.put(name, existing + writer);
     } catch (IOException ioe) {
       throw new MolgenisException("export failed", ioe);
     }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
@@ -1,5 +1,6 @@
 package org.molgenis.emx2.web;
 
+import static org.molgenis.emx2.Constants.MG_DRAFT;
 import static org.molgenis.emx2.graphql.GraphqlTableFieldFactory.convertMapToFilterArray;
 import static org.molgenis.emx2.io.emx2.Emx2.getHeaders;
 import static org.molgenis.emx2.web.Constants.ACCEPT_CSV;
@@ -112,7 +113,7 @@ public class CsvApi {
     boolean includeSystem = includeSystemColumns(ctx);
     return table.getMetadata().getDownloadColumnNames().stream()
         .map(Column::getName)
-        .filter(name -> !name.startsWith("mg_") || includeSystem)
+        .filter(name -> name.equals(MG_DRAFT) || !name.startsWith("mg_") || includeSystem)
         .toList();
   }
 

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -1045,7 +1045,6 @@ public class WebApiSmokeTests {
     assertTrue(
         response.getBody().asString().contains("name,category,photoUrls,status,tags,weight"));
     assertTrue(response.getBody().asString().contains("pooky,cat,,available,,9.4"));
-    assertFalse(response.getBody().asString().contains("mg_"));
   }
 
   @Test
@@ -1058,7 +1057,7 @@ public class WebApiSmokeTests {
   public void downloadExcelTable() throws IOException {
     Response response = downloadPet("/pet store/api/excel/Pet");
     List<String> rows = TestUtils.readExcelSheet(response.getBody().asInputStream());
-    assertEquals("name,category,photoUrls,status,tags,weight,orders", rows.get(0));
+    assertEquals("name,category,photoUrls,status,tags,weight,orders,mg_draft", rows.get(0));
     assertEquals(
         "pooky,cat,,available,,9.4,ORDER:6fe7a528-2e97-48cc-91e6-a94c689b4919", rows.get(1));
   }

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -1059,7 +1059,7 @@ public class WebApiSmokeTests {
     List<String> rows = TestUtils.readExcelSheet(response.getBody().asInputStream());
     assertEquals("name,category,photoUrls,status,tags,weight,orders,mg_draft", rows.get(0));
     assertEquals(
-        "pooky,cat,,available,,9.4,ORDER:6fe7a528-2e97-48cc-91e6-a94c689b4919", rows.get(1));
+        "pooky,cat,,available,,9.4,ORDER:6fe7a528-2e97-48cc-91e6-a94c689b4919,", rows.get(1));
   }
 
   @Test


### PR DESCRIPTION
Fixes #1682 

### What are the main changes you did
- Always add the mg_draft column when outputting tables via download api's

### How to test
- go to: https://preview-emx2-pr-4948.dev.molgenis.org/
- create a draft record with validation errors
- download the table or schema via the excel zip or csv api.
- upload the data via the up/download app 
- see the draft records in the table explorer

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation