### PR TITLE
fix(reports): return multiple reports as json

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/JsonApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/JsonApi.java
@@ -25,7 +25,7 @@ public class JsonApi {
     Schema schema = getSchema(ctx);
     String reports = ctx.queryParam("id");
     Map<String, ?> parameters = getReportParameters(ctx);
-    Map<String, Object> jsonResponse = new HashMap<>();
+    Map<String, Object> jsonResponse = new LinkedHashMap<>();
     for (String reportId : reports.split(",")) {
       jsonResponse.put(reportId, getReportById(reportId, schema, parameters));
     }

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/JsonApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/JsonApi.java
@@ -1,6 +1,6 @@
 package org.molgenis.emx2.web;
 
-import static org.molgenis.emx2.settings.ReportUtils.getReportAsJson;
+import static org.molgenis.emx2.settings.ReportUtils.getReportById;
 import static org.molgenis.emx2.web.MolgenisWebservice.getSchema;
 import static org.molgenis.emx2.web.ZipApi.getReportParameters;
 
@@ -27,7 +27,7 @@ public class JsonApi {
     Map<String, ?> parameters = getReportParameters(ctx);
     Map<String, Object> jsonResponse = new HashMap<>();
     for (String reportId : reports.split(",")) {
-      jsonResponse.put(reportId, getReportAsJson(reportId, schema, parameters));
+      jsonResponse.put(reportId, getReportById(reportId, schema, parameters));
     }
     if (jsonResponse.size() == 1) {
       ctx.json(jsonResponse.values().iterator().next());


### PR DESCRIPTION
Fixes #4930

### What are the main changes you did
- Added functionality to fetch reports as objects in back-end

### How to test
fetch multiple reports via json api:
- https://preview-emx2-pr-4968.dev.molgenis.org/pet%20store/api/reports/json?id=report1,report3
see the difference from master:
- https://emx2.dev.molgenis.org/pet%20store2/api/reports/json?id=report1,report3


### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation