### PR TITLE
fix(catalogue): Fix links in figure captions in docs

### DIFF
--- a/docs/catalogue/cat_data-manager.md
+++ b/docs/catalogue/cat_data-manager.md
@@ -96,13 +96,13 @@ See the section [Upload variable metadata](cat_data-manager.md#upload-variable-m
 
 *Figure 2. Tables in a cohort staging area. Note that not all tables are filled out
 via the templates, some are filled via an online form, see section
-[Fill out rich metadata](cat_resource-data-manager.md#fill-out-rich-metadata).*
+[Fill out rich metadata](cat_data-manager.md#fill-out-rich-metadata).*
 
 ![MOLGENIS tables in network staging area](../img/cat_tables-in-catalogue.png)
 
 *Figure 3. Tables in a network staging area. Note that not all tables are filled out
 via the templates, some are filled via an online form, see section
-[Fill out rich metadata](cat_resource-data-manager.md#fill-out-rich-metadata).*
+[Fill out rich metadata](cat_data-manager.md#fill-out-rich-metadata).*
 
 ### *Datasets* sheet
 


### PR DESCRIPTION
### What are the main changes you did
- Fix broken links in captions of figures in data manager page of catalogue guide