### PR TITLE
feat(RDF): RDF rowId is now part of path instead of query

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/IriGenerator.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/IriGenerator.java
@@ -72,7 +72,7 @@ public class IriGenerator {
             + API_RDF
             + "/"
             + escaper.escape(table.getIdentifier())
-            + "?"
+            + "/"
             + primaryKey.getEncodedValue());
   }
 

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/PrimaryKey.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/PrimaryKey.java
@@ -3,9 +3,9 @@ package org.molgenis.emx2.rdf;
 import static org.molgenis.emx2.FilterBean.and;
 import static org.molgenis.emx2.FilterBean.f;
 import static org.molgenis.emx2.Operator.EQUALS;
+import static org.molgenis.emx2.rdf.IriGenerator.escaper;
 
 import java.net.URLDecoder;
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import org.molgenis.emx2.Filter;
@@ -52,8 +52,8 @@ class PrimaryKey {
       // Sort the list to have a stable order
       var sortedMap = new TreeMap<>(this.keys);
       for (var pair : sortedMap.entrySet()) {
-        var name = URLEncoder.encode(pair.getKey(), StandardCharsets.UTF_8.toString());
-        var value = URLEncoder.encode(pair.getValue(), StandardCharsets.UTF_8.toString());
+        var name = escaper.escape(pair.getKey());
+        var value = escaper.escape(pair.getValue());
         encodedPairs.add(name + NAME_VALUE_SEPARATOR + value);
       }
       return String.join(KEY_PARTS_SEPARATOR, encodedPairs);

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/ColumnTypeRdfMapperTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/ColumnTypeRdfMapperTest.java
@@ -499,17 +499,17 @@ class ColumnTypeRdfMapperTest {
         // RELATIONSHIP
         () ->
             assertEquals(
-                Set.of(Values.iri(RDF_API_URL_PREFIX + REF_TABLE + "?id=1")),
+                Set.of(Values.iri(RDF_API_URL_PREFIX + REF_TABLE + "/id=1")),
                 retrieveValues(ColumnType.REF.name())),
         () ->
             assertEquals(
                 Set.of(
-                    Values.iri(RDF_API_URL_PREFIX + REF_TABLE + "?id=2"),
-                    Values.iri(RDF_API_URL_PREFIX + REF_TABLE + "?id=3")),
+                    Values.iri(RDF_API_URL_PREFIX + REF_TABLE + "/id=2"),
+                    Values.iri(RDF_API_URL_PREFIX + REF_TABLE + "/id=3")),
                 retrieveValues(ColumnType.REF_ARRAY.name())),
         () ->
             assertEquals(
-                Set.of(Values.iri(RDF_API_URL_PREFIX + REFBACK_TABLE + "?id=1")),
+                Set.of(Values.iri(RDF_API_URL_PREFIX + REFBACK_TABLE + "/id=1")),
                 retrieveValues(ColumnType.REFBACK.name())),
         // LAYOUT and other constants -> should return empty sets as they should be excluded
         () -> assertEquals(Set.of(), retrieveValues(ColumnType.HEADING.name())),
@@ -529,7 +529,7 @@ class ColumnTypeRdfMapperTest {
             assertEquals(
                 Set.of(
                     Values.iri("http://example.com/bb"),
-                    Values.iri(RDF_API_URL_PREFIX + ONT_TABLE_URL + "?name=c%2Bc")),
+                    Values.iri(RDF_API_URL_PREFIX + ONT_TABLE_URL + "/name=c%2Bc")),
                 retrieveValues(ColumnType.ONTOLOGY_ARRAY.name())),
         () ->
             assertEquals(
@@ -552,32 +552,32 @@ class ColumnTypeRdfMapperTest {
         // Composite reference / refback
         () ->
             assertEquals(
-                Set.of(Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REF_TABLE + "?idi=1&ids=a")),
+                Set.of(Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REF_TABLE + "/idi=1&ids=a")),
                 retrieveValues(COLUMN_COMPOSITE_REF)),
         () ->
             assertEquals(
                 Set.of(
-                    Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REF_TABLE + "?idi=2&ids=b"),
-                    Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REF_TABLE + "?idi=3&ids=c")),
+                    Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REF_TABLE + "/idi=2&ids=b"),
+                    Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REF_TABLE + "/idi=3&ids=c")),
                 retrieveValues(COLUMN_COMPOSITE_REF_ARRAY)),
         () ->
             assertEquals(
                 Set.of(
-                    Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REFBACK_TABLE + "?id1=a&id2=b"),
-                    Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REFBACK_TABLE + "?id1=c&id2=d")),
+                    Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REFBACK_TABLE + "/id1=a&id2=b"),
+                    Values.iri(RDF_API_URL_PREFIX + COMPOSITE_REFBACK_TABLE + "/id1=c&id2=d")),
                 actualRefback),
         // Overriding default behaviour
         // ontology as reference (key=1 instead of ontologyTermURI)
         () ->
             assertEquals(
-                Set.of(Values.iri(RDF_API_URL_PREFIX + ONT_TABLE_URL + "?name=aa")),
+                Set.of(Values.iri(RDF_API_URL_PREFIX + ONT_TABLE_URL + "/name=aa")),
                 retrieveValuesCustom(
                     ColumnType.ONTOLOGY.name(), ColumnTypeRdfMapper.RdfColumnType.REFERENCE)),
         () ->
             assertEquals(
                 Set.of(
-                    Values.iri(RDF_API_URL_PREFIX + ONT_TABLE_URL + "?name=bb"),
-                    Values.iri(RDF_API_URL_PREFIX + ONT_TABLE_URL + "?name=c%2Bc")),
+                    Values.iri(RDF_API_URL_PREFIX + ONT_TABLE_URL + "/name=bb"),
+                    Values.iri(RDF_API_URL_PREFIX + ONT_TABLE_URL + "/name=c%2Bc")),
                 retrieveValuesCustom(
                     ColumnType.ONTOLOGY_ARRAY.name(), ColumnTypeRdfMapper.RdfColumnType.REFERENCE)),
         // email as regular string

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/IriGeneratorTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/IriGeneratorTest.java
@@ -22,7 +22,7 @@ class IriGeneratorTest {
   private static final String TABLE_ID = "MyTable";
   private static final String COLUMN_NAME = "my Column";
   private static final String COLUMN_ID = "myColumn";
-  private static final String ENCODED_PRIMARYKEY = "last+name=van+de+achternaam";
+  private static final String ENCODED_PRIMARYKEY = "lastName=van%20de%20achternaam";
 
   @Test
   void testIRIGenerator() {
@@ -61,7 +61,7 @@ class IriGeneratorTest {
                 columnIRI(baseURL, column).toString()),
         () ->
             assertEquals(
-                "http://example.com/my%20Schema/api/rdf/MyTable?last+name=van+de+achternaam",
+                "http://example.com/my%20Schema/api/rdf/MyTable/lastName=van%20de%20achternaam",
                 rowIRI(baseURL, table, primaryKey).toString()));
   }
 }

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/PrimaryKeyTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/PrimaryKeyTest.java
@@ -16,7 +16,7 @@ public class PrimaryKeyTest {
   static final Map.Entry<String, String> LAST_KEY = Map.entry("last", "value");
   // Linked Map to enforce order
   static final Map<String, String> KEYS_MAP = new LinkedHashMap<>();
-  static final String ENCODED_KEY = "complex+pair=me%2C+myself+%26+I&last=value";
+  static final String ENCODED_KEY = "complexPair=me%2C%20myself%20%26%20I&last=value";
 
   static {
     KEYS_MAP.put(LAST_KEY.getKey(), LAST_KEY.getValue());

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/PrimaryKeyTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/PrimaryKeyTest.java
@@ -16,7 +16,7 @@ public class PrimaryKeyTest {
   static final Map.Entry<String, String> LAST_KEY = Map.entry("last", "value");
   // Linked Map to enforce order
   static final Map<String, String> KEYS_MAP = new LinkedHashMap<>();
-  static final String ENCODED_KEY = "complexPair=me%2C%20myself%20%26%20I&last=value";
+  static final String ENCODED_KEY = "complex%20pair=me%2C%20myself%20%26%20I&last=value";
 
   static {
     KEYS_MAP.put(LAST_KEY.getKey(), LAST_KEY.getValue());

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/RDFTest.java
@@ -589,7 +589,7 @@ public class RDFTest {
     Set<Value> endpointIris =
         handler
             .resources
-            .get(Values.iri(getApi(petStore_nr1) + "Pet?" + POOKY_ROWID))
+            .get(Values.iri(getApi(petStore_nr1) + "Pet/" + POOKY_ROWID))
             .get(Values.iri(DCAT.ENDPOINT_URL.stringValue()));
     assertAll(
         () -> assertEquals(1, endpointIris.size()),
@@ -720,7 +720,7 @@ public class RDFTest {
     var subject =
         Values.iri(
             getApi(ontologyTest)
-                + "Diseases?name=C00-C14+Malignant+neoplasms+of+lip%2C+oral+cavity+and+pharynx");
+                + "Diseases/name=C00-C14%20Malignant%20neoplasms%20of%20lip%2C%20oral%20cavity%20and%20pharynx");
 
     var parents = handler.resources.get(subject).get(RDFS.SUBCLASSOF);
     assertEquals(
@@ -737,23 +737,23 @@ public class RDFTest {
             Values.iri("https://icd.who.int/browse10/2019/en#/U07"),
             Values.iri(
                 getApi(ontologyTest)
-                    + "Diseases?name=C00-C14+Malignant+neoplasms+of+lip%2C+oral+cavity+and+pharynx"));
+                    + "Diseases/name=C00-C14%20Malignant%20neoplasms%20of%20lip%2C%20oral%20cavity%20and%20pharynx"));
     Set<Value> expectedNonSemantic =
         Set.of(
-            Values.iri(getApi(ontologyTest) + "Diseases?name=U07"),
+            Values.iri(getApi(ontologyTest) + "Diseases/name=U07"),
             Values.iri(
                 getApi(ontologyTest)
-                    + "Diseases?name=C00-C14+Malignant+neoplasms+of+lip%2C+oral+cavity+and+pharynx"));
+                    + "Diseases/name=C00-C14%20Malignant%20neoplasms%20of%20lip%2C%20oral%20cavity%20and%20pharynx"));
 
     Set<Value> actualSemantic =
         handler
             .resources
-            .get(Values.iri(getApi(ontologyTest) + "Patients?name=bob"))
+            .get(Values.iri(getApi(ontologyTest) + "Patients/name=bob"))
             .get(Values.iri("http://purl.obolibrary.org/obo/NCIT_C2991"));
     Set<Value> actualNonSemantic =
         handler
             .resources
-            .get(Values.iri(getApi(ontologyTest) + "Patients?name=bob"))
+            .get(Values.iri(getApi(ontologyTest) + "Patients/name=bob"))
             .get(Values.iri(getApi(ontologyTest) + "Patients/column/diseases"));
 
     assertEquals(expectedSemantic, actualSemantic);
@@ -770,23 +770,23 @@ public class RDFTest {
             Values.iri("https://icd.who.int/browse10/2019/en#/U07"),
             Values.iri(
                 getApi(ontologyTest)
-                    + "Diseases?name=C00-C14+Malignant+neoplasms+of+lip%2C+oral+cavity+and+pharynx"));
+                    + "Diseases/name=C00-C14%20Malignant%20neoplasms%20of%20lip%2C%20oral%20cavity%20and%20pharynx"));
     Set<Value> expectedNonSemantic =
         Set.of(
-            Values.iri(getApi(ontologyTest) + "Diseases?name=U07"),
+            Values.iri(getApi(ontologyTest) + "Diseases/name=U07"),
             Values.iri(
                 getApi(ontologyTest)
-                    + "Diseases?name=C00-C14+Malignant+neoplasms+of+lip%2C+oral+cavity+and+pharynx"));
+                    + "Diseases/name=C00-C14%20Malignant%20neoplasms%20of%20lip%2C%20oral%20cavity%20and%20pharynx"));
 
     Set<Value> actualSemantic =
         handler
             .resources
-            .get(Values.iri(getApi(ontologyCrossSchemaTest) + "Patients?name=pim"))
+            .get(Values.iri(getApi(ontologyCrossSchemaTest) + "Patients/name=pim"))
             .get(Values.iri("http://purl.obolibrary.org/obo/NCIT_C2991"));
     Set<Value> actualNonSemantic =
         handler
             .resources
-            .get(Values.iri(getApi(ontologyCrossSchemaTest) + "Patients?name=pim"))
+            .get(Values.iri(getApi(ontologyCrossSchemaTest) + "Patients/name=pim"))
             .get(Values.iri(getApi(ontologyCrossSchemaTest) + "Patients/column/diseases"));
 
     assertEquals(expectedSemantic, actualSemantic);
@@ -1491,7 +1491,7 @@ example,http://example.com/
     Set<Value> files =
         handler
             .resources
-            .get(Values.iri(getApi(fileTest) + "MyFiles?id=1"))
+            .get(Values.iri(getApi(fileTest) + "MyFiles/id=1"))
             .get(Values.iri(getApi(fileTest) + "MyFiles/column/file"));
 
     IRI fileIRI = (IRI) files.stream().findFirst().get();
@@ -1518,9 +1518,9 @@ example,http://example.com/
     Set<Value> refBacks =
         handler
             .resources
-            .get(Values.iri(getApi(refBackTest) + "TableRefBack?id=a"))
+            .get(Values.iri(getApi(refBackTest) + "TableRefBack/id=a"))
             .get(Values.iri(getApi(refBackTest) + "TableRefBack/column/backlink"));
-    assertEquals(Set.of(Values.iri(getApi(refBackTest) + "TableRef?id=1")), refBacks);
+    assertEquals(Set.of(Values.iri(getApi(refBackTest) + "TableRef/id=1")), refBacks);
   }
 
   @Test
@@ -1539,7 +1539,7 @@ example,http://example.com/
     var handler = new InMemoryRDFHandler() {};
     getAndParseRDF(Selection.of(semanticTest, "valid"), handler);
     Set<IRI> actualPredicates =
-        handler.resources.get(Values.iri(getApi(semanticTest) + "Valid?id=1")).keySet();
+        handler.resources.get(Values.iri(getApi(semanticTest) + "Valid/id=1")).keySet();
     assertTrue(actualPredicates.containsAll(expectedPredicates));
 
     assertThrows(
@@ -1647,39 +1647,39 @@ example,http://example.com/
   private enum ValidationTriple {
     // Inheritance testing
     INHER_ID1(
-        getApi(tableInherTest) + "Root?id=1",
+        getApi(tableInherTest) + "Root/id=1",
         getApi(tableInherTest) + "Root/column/rootColumn",
         Values.literal("id1 data")),
     INHER_ID2(
-        getApi(tableInherTest) + "Root?id=2",
+        getApi(tableInherTest) + "Root/id=2",
         getApi(tableInherTest) + "Child/column/childColumn",
         Values.literal("id2 data")),
     INHER_ID3(
-        getApi(tableInherTest) + "Root?id=3",
+        getApi(tableInherTest) + "Root/id=3",
         getApi(tableInherTest) + "GrandchildTypeA/column/grandchildColumn",
         Values.literal("id3 data")),
     INHER_ID4(
-        getApi(tableInherTest) + "Root?id=4",
+        getApi(tableInherTest) + "Root/id=4",
         getApi(tableInherTest) + "GrandchildTypeB/column/grandchildColumn",
         Values.literal("id4 data")),
     INHER_ID4_GRANDPARENT_FIELD(
-        getApi(tableInherTest) + "Root?id=4",
+        getApi(tableInherTest) + "Root/id=4",
         getApi(tableInherTest) + "Root/column/rootColumn",
         Values.literal("id4 data for rootColumn")),
     INHER_ID4_PARENT_FIELD(
-        getApi(tableInherTest) + "Root?id=4",
+        getApi(tableInherTest) + "Root/id=4",
         getApi(tableInherTest) + "Child/column/childColumn",
         Values.literal("id4 data for childColumn")),
     INHER_ID5(
-        getApi(tableInherTest) + "Root?id=5",
+        getApi(tableInherTest) + "Root/id=5",
         getApi(tableInherExtTest) + "ExternalChild/column/externalChildColumn",
         Values.literal("id5 data")),
     INHER_ID6(
-        getApi(tableInherTest) + "Root?id=6",
+        getApi(tableInherTest) + "Root/id=6",
         getApi(tableInherExtTest) + "ExternalGrandchild/column/externalGrandchildColumn",
         Values.literal("id6 data")),
     INHER_UNRELATED(
-        getApi(tableInherExtTest) + "ExternalUnrelated?id=a",
+        getApi(tableInherExtTest) + "ExternalUnrelated/id=a",
         getApi(tableInherExtTest) + "ExternalUnrelated/column/externalUnrelatedColumn",
         Values.literal("unrelated data")),
 
@@ -1739,13 +1739,13 @@ example,http://example.com/
   }
 
   enum ValidationSubjects {
-    COMP_ROOT1_FIRST("Root1?r1.c1a=c1a_first&r1.c1b.gc1a=gc1a_first&r1.c1b.gc1b=gc1b_first"),
+    COMP_ROOT1_FIRST("Root1/r1.c1a=c1a_first&r1.c1b.gc1a=gc1a_first&r1.c1b.gc1b=gc1b_first"),
     COMP_ROOT2_FIRST(
-        "Root2?r2a=r2a_first&r2b.c1a=c1a_second&r2b.c1b.gc1a=gc1a_first&r2b.c1b.gc1b=gc1b_first"),
-    COMP_CHILD1_FIRST("Child1?c1a=c1a_first&c1b.gc1a=gc1a_first&c1b.gc1b=gc1b_first"),
-    COMP_CHILD1_SECOND("Child1?c1a=c1a_second&c1b.gc1a=gc1a_first&c1b.gc1b=gc1b_first"),
-    COMP_GRANDCHILD1_FIRST("Grandchild1?gc1a=gc1a_first&gc1b=gc1b_first"),
-    COMP_GRANDCHILD1_SECOND("Grandchild1?gc1a=gc1a_second&gc1b=gc1b_second");
+        "Root2/r2a=r2a_first&r2b.c1a=c1a_second&r2b.c1b.gc1a=gc1a_first&r2b.c1b.gc1b=gc1b_first"),
+    COMP_CHILD1_FIRST("Child1/c1a=c1a_first&c1b.gc1a=gc1a_first&c1b.gc1b=gc1b_first"),
+    COMP_CHILD1_SECOND("Child1/c1a=c1a_second&c1b.gc1a=gc1a_first&c1b.gc1b=gc1b_first"),
+    COMP_GRANDCHILD1_FIRST("Grandchild1/gc1a=gc1a_first&gc1b=gc1b_first"),
+    COMP_GRANDCHILD1_SECOND("Grandchild1/gc1a=gc1a_second&gc1b=gc1b_second");
 
     Value value;
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
@@ -53,9 +53,8 @@ public class RDFApi {
     app.head("{schema}" + apiLocation, (ctx) -> rdfHead(ctx, format));
     app.get("{schema}" + apiLocation + "/{table}", (ctx) -> rdfForTable(ctx, format));
     app.head("{schema}" + apiLocation + "/{table}", (ctx) -> rdfHead(ctx, format));
-    // TODO: Enable once rowIRI uses '/' instead of '?'
-    //    app.get("{schema}" + apiLocation + "/{table}/{row}", (ctx) -> rdfForRow(ctx, format));
-    //    app.head("{schema}" + apiLocation + "/{table}/{row}", (ctx) -> rdfHead(ctx, format));
+        app.get("{schema}" + apiLocation + "/{table}/{row}", (ctx) -> rdfForRow(ctx, format));
+        app.head("{schema}" + apiLocation + "/{table}/{row}", (ctx) -> rdfHead(ctx, format));
     app.get(
         "{schema}" + apiLocation + "/{table}/column/{column}", (ctx) -> rdfForColumn(ctx, format));
     app.head("{schema}" + apiLocation + "/{table}/column/{column}", (ctx) -> rdfHead(ctx, format));
@@ -110,15 +109,8 @@ public class RDFApi {
   }
 
   private static void rdfForTable(Context ctx, RDFFormat format) throws IOException {
-    // TODO: remove once rowIRI uses '/' instead of '?'
-    String rowId = null;
-    if (ctx.queryString() != null && !ctx.queryString().isBlank()) {
-      rowId = ctx.queryString();
-    }
-    // end TODO
-
     Table table = getTableByIdOrName(ctx);
-    runService(ctx, format, table, rowId, null, table.getSchema());
+    runService(ctx, format, table, null, null, table.getSchema());
   }
 
   private static void rdfForColumn(Context ctx, RDFFormat format) throws IOException {

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
@@ -53,8 +53,8 @@ public class RDFApi {
     app.head("{schema}" + apiLocation, (ctx) -> rdfHead(ctx, format));
     app.get("{schema}" + apiLocation + "/{table}", (ctx) -> rdfForTable(ctx, format));
     app.head("{schema}" + apiLocation + "/{table}", (ctx) -> rdfHead(ctx, format));
-        app.get("{schema}" + apiLocation + "/{table}/{row}", (ctx) -> rdfForRow(ctx, format));
-        app.head("{schema}" + apiLocation + "/{table}/{row}", (ctx) -> rdfHead(ctx, format));
+    app.get("{schema}" + apiLocation + "/{table}/{row}", (ctx) -> rdfForRow(ctx, format));
+    app.head("{schema}" + apiLocation + "/{table}/{row}", (ctx) -> rdfHead(ctx, format));
     app.get(
         "{schema}" + apiLocation + "/{table}/column/{column}", (ctx) -> rdfForColumn(ctx, format));
     app.head("{schema}" + apiLocation + "/{table}/column/{column}", (ctx) -> rdfHead(ctx, format));

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
@@ -1,7 +1,6 @@
 package org.molgenis.emx2;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.molgenis.emx2.utils.TypeUtils.convertToCamelCase;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -125,14 +124,5 @@ public class TestTypeUtils {
         () -> assertThrows(MolgenisException.class, () -> TypeUtils.toJsonb(trailingData)),
         // invalid: Java type int
         () -> assertThrows(ClassCastException.class, () -> TypeUtils.toJsonb(invalidJavaType)));
-  }
-
-  @Test
-  void testCamelCase() {
-    assertAll(
-        () -> assertEquals("aName", convertToCamelCase("a name")),
-        () -> assertEquals("aNaMe", convertToCamelCase("a naMe")),
-        () -> assertEquals("aNaMe", convertToCamelCase("A NaMe")),
-        () -> assertEquals("aNaMe", convertToCamelCase("a na me")));
   }
 }

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
@@ -1,6 +1,7 @@
 package org.molgenis.emx2;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.molgenis.emx2.utils.TypeUtils.convertToCamelCase;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -124,5 +125,14 @@ public class TestTypeUtils {
         () -> assertThrows(MolgenisException.class, () -> TypeUtils.toJsonb(trailingData)),
         // invalid: Java type int
         () -> assertThrows(ClassCastException.class, () -> TypeUtils.toJsonb(invalidJavaType)));
+  }
+
+  @Test
+  void testCamelCase() {
+    assertAll(
+        () -> assertEquals("aName", convertToCamelCase("a name")),
+        () -> assertEquals("aNaMe", convertToCamelCase("a naMe")),
+        () -> assertEquals("aNaMe", convertToCamelCase("A NaMe")),
+        () -> assertEquals("aNaMe", convertToCamelCase("a na me")));
   }
 }

--- a/data/_demodata/applications/datacatalogue/Container.csv
+++ b/data/_demodata/applications/datacatalogue/Container.csv
@@ -1,2 +1,2 @@
 id,title,membershipResource,hasMemberRelation,contains.name,contains.network
-Example_FDP_catalog_container,Example FAIR Data Point catalog container,http://localhost:8080/catalogue/api/rdf/Endpoint?id=Example_FAIR_Data_Point,https://w3id.org/fdp/fdp-o#metadataCatalog,"LifeCycle,ATHLETE","LifeCycle,ATHLETE"
+Example_FDP_catalog_container,Example FAIR Data Point catalog container,http://localhost:8080/catalogue/api/rdf/Endpoint/id=Example_FAIR_Data_Point,https://w3id.org/fdp/fdp-o#metadataCatalog,"LifeCycle,ATHLETE","LifeCycle,ATHLETE"

--- a/data/_demodata/shared-examples/Container.csv
+++ b/data/_demodata/shared-examples/Container.csv
@@ -1,3 +1,3 @@
 id,title,membershipResource,hasMemberRelation,containsCatalogs,containsDatasets,containsDistributions
 Example_FDP_catalog_container,Example FAIR Data Point catalog container,https://www.MyMOLGENISServer.org/myFDPschema/api/rdf,https://w3id.org/fdp/fdp-o#metadataCatalog,"catalogId01,catalogId02,minCatId03,minFileCatId04,mixedCatId05,catWithoutDatasetsId06",,
-Example_FDP_dataset_container,Example FAIR Data Point dataset container,https://www.MyMOLGENISServer.org/myFDPschema/api/rdf/Catalog?id=catalogId01,http://purl.org/dc/terms/hasPart,,"datasetId01,datasetId02,datasetId03,minDatId04,oneFileId05,filesetId06,dataAndFilesId07,allOtherDistrId08",
+Example_FDP_dataset_container,Example FAIR Data Point dataset container,https://www.MyMOLGENISServer.org/myFDPschema/api/rdf/Catalog/id=catalogId01,http://purl.org/dc/terms/hasPart,,"datasetId01,datasetId02,datasetId03,minDatId04,oneFileId05,filesetId06,dataAndFilesId07,allOtherDistrId08",


### PR DESCRIPTION
### What are the main changes you did
- rowId is now part of path instead of query
- ensure character escaping adheres to this

### How to test
- explain here what to do to test this (or point to unit tests)

### Notes
- The column name in a KeyPair still needs to be converted to pascalCase, but this will be a separate PR.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation