### PR TITLE
fix: getColumnByIdentifier now does a recursive check for inherited tables (similar to `getColumn()`)

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -336,10 +336,15 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
   }
 
   public Column getColumnByIdentifier(String identifier) {
-    return columns.values().stream()
-        .filter(c -> c.getIdentifier().equals(identifier))
-        .findFirst()
-        .orElse(null);
+    Column column =
+        columns.values().stream()
+            .filter(c -> c.getIdentifier().equals(identifier))
+            .findFirst()
+            .orElse(null);
+    if (column == null && getInheritedTable() != null) {
+      column = getInheritedTable().getColumnByIdentifier(identifier);
+    }
+    return column;
   }
 
   public TableMetadata add(Column... column) {

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTableMetadata.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTableMetadata.java
@@ -52,7 +52,18 @@ public class TestTableMetadata {
     c1.setTable(table);
     c2.setTable(table);
     table.setSchema(schema);
+    table.setInheritName("parent table");
 
-    assertEquals(c2, table.getColumnByIdentifier("aColName"));
+    // Parent table for inheritance validation
+    Column c3 = new Column("parent column");
+    TableMetadata parentTable = TableMetadata.table("parent table", c3);
+
+    c3.setTable(parentTable);
+    parentTable.setSchema(schema);
+    when(schema.getTableMetadata("parent table")).thenReturn(parentTable);
+
+    assertAll(
+        () -> assertEquals(c2, table.getColumnByIdentifier("aColName")),
+        () -> assertEquals(c3, table.getColumnByIdentifier("parentColumn")));
   }
 }


### PR DESCRIPTION
### What are the main changes you did
- `getColumnByIdentifier()` now checks if column identifier exists in parent tables if not present in itself (similar to `getColumn()`):

  https://github.com/molgenis/molgenis-emx2/blob/d9a618676da119865d08a255a6d8a86a12cc6883/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java#L329-L336

### How to test
- tests should succeed

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation