### PR TITLE
fix: when filename is absent add it as id.extension

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Row.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Row.java
@@ -231,9 +231,12 @@ public class Row {
     } else {
       String id = UUID.randomUUID().toString().replace("-", "");
       this.values.put(name, id);
-      this.values.put(
-          name + "_filename",
-          !value.getFileName().isEmpty() ? value.getFileName() : id + "." + value.getExtension());
+      String filename = value.getFileName();
+      if (filename != null && !filename.isEmpty()) {
+        this.values.put(name + "_filename", filename);
+      } else {
+        this.values.put(name + "_filename", id + "." + value.getExtension());
+      }
       this.values.put(name + "_extension", value.getExtension());
       this.values.put(name + "_mimetype", value.getMimeType());
       this.values.put(name + "_size", value.getSize());


### PR DESCRIPTION
Fixes https://github.com/molgenis/GCC/issues/1211

### What are the main changes you did
- When setting a binary with an absent filename set it to id.extension

### How to test
- Hard to test in my browser, I can't upload a file without a filename

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation