### PR TITLE
fix: make files available in the NESTOR documents page

### DIFF
--- a/apps/nestor-public/src/pages/view-about.vue
+++ b/apps/nestor-public/src/pages/view-about.vue
@@ -12,9 +12,9 @@
       <p>
         The NESTOR Registry is a web-based platform that facilitates and
         accelerates research to improve diagnostics, treatment and the provision
-        of high-quality healthcare for patients with one of rare genetic tumour
-        risk syndromes. The NESTOR Registry is affiliated to the KWF NESTOR
-        project.
+        of high-quality healthcare for patients with one of the rare genetic
+        tumour risk syndromes. The NESTOR Registry is affiliated to the KWF
+        NESTOR project.
       </p>
       <MessageBox type="warning">
         <span>This page is under construction.</span>

--- a/apps/nestor-public/src/pages/view-documents.vue
+++ b/apps/nestor-public/src/pages/view-documents.vue
@@ -9,14 +9,12 @@
     />
     <PageSection aria-labelledby="documents-section-title">
       <h2 id="documents-section-title">Available documents</h2>
-      <MessageBox type="warning">
-        <span>This page is under construction.</span>
-      </MessageBox>
+      <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>
 </template>
 
 <script setup lang="ts">
 // @ts-expect-error
-import { Page, PageHeader, PageSection, MessageBox } from "molgenis-viz";
+import { Page, PageHeader, PageSection, FileList } from "molgenis-viz";
 </script>


### PR DESCRIPTION
### What are the main changes you did
- Up till now the documentation page of the nestor-public app, showed an "under construction" message, updated the app to show files that are in the files table
- fix a small typo on the About page (added 'the')

### How to test
- Create a schema with the ERN_DASHBOARD template
- Upload a file in the files table within that schema
- Goto "yourSchema"/nestor-public/#/documents and see that the file is shown and can be downloaded

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation