### PR TITLE
fix(directory): partial selected state stays partialy selected

### DIFF
--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -41,9 +41,10 @@
             <MessageWarning
               class="mx-3 position-absolute"
               v-if="selectionOverflow"
-              >You can only select 50 items at a time under 'Match All'. Please
-              adjust your query.</MessageWarning
             >
+              You can only select 50 items at a time under 'Match All'. Please
+              adjust your query.
+            </MessageWarning>
             <TreeComponent
               :class="{ 'warning-padding': selectionOverflow }"
               :options="displayOptions"

--- a/apps/directory/src/components/filters/OntologyFilter.vue
+++ b/apps/directory/src/components/filters/OntologyFilter.vue
@@ -82,9 +82,9 @@ const { facetIdentifier, ontologyIdentifiers, options, showMatchTypeSelector } =
     showMatchTypeSelector: boolean;
   }>();
 
-let ontologyQuery = ref("");
-let resolvedOptions = ref<Record<string, any> | undefined>(undefined);
-let selectedOntology = ref(ontologyIdentifiers[0]);
+const ontologyQuery = ref("");
+const resolvedOptions = ref<Record<string, any> | undefined>(undefined);
+const selectedOntology = ref(ontologyIdentifiers[0]);
 
 options()
   .then((response: any) => {
@@ -94,7 +94,7 @@ options()
     console.log(`Error resolving ontology facet options: ${error}`);
   });
 
-let selectionOverflow = computed(() => {
+const selectionOverflow = computed(() => {
   return (
     facetIdentifier === "Diagnosisavailable" &&
     filtersStore.filters["Diagnosisavailable"]?.length >= 50 &&
@@ -102,7 +102,7 @@ let selectionOverflow = computed(() => {
   );
 });
 
-let displayOptions = computed(() => {
+const displayOptions = computed(() => {
   if (!resolvedOptions.value) return [];
   if (!ontologyQuery.value) {
     return resolvedOptions.value[selectedOntology.value] || [];

--- a/apps/directory/src/components/filters/base/TreeBranchComponent.vue
+++ b/apps/directory/src/components/filters/base/TreeBranchComponent.vue
@@ -106,7 +106,6 @@ watch(filter, (newFilter: string) => {
 
 function selectOption(checked: boolean, option: Record<string, any>) {
   filtersStore.updateOntologyFilter(facetIdentifier.value, option, checked);
-  // emit("indeterminate-update", checked || isIndeterminate.value);
 }
 
 function handleChildIndeterminateUpdate(newStatus: boolean) {
@@ -114,7 +113,7 @@ function handleChildIndeterminateUpdate(newStatus: boolean) {
 }
 
 function signalParentOurIndeterminateStatus() {
-  emit("indeterminate-update", isIndeterminate);
+  emit("indeterminate-update", isIndeterminate.value);
 }
 </script>
 <style scoped>

--- a/apps/directory/src/components/filters/base/TreeBranchComponent.vue
+++ b/apps/directory/src/components/filters/base/TreeBranchComponent.vue
@@ -11,7 +11,7 @@
         :ref="`${option.name}-checkbox`"
         class="mr-1"
         :checked="selected"
-        :indeterminate.prop="isIndeterminate"
+        :indeterminate.prop="isIndeterminate && !selected"
       />
       <label>
         <span class="code">{{ option.code }}</span> {{ option.label }}
@@ -94,7 +94,7 @@ const isIndeterminate = computed<boolean>(() => {
 
   return (
     selectedChildren.value.length > 0 &&
-    selectedChildren.value.length < option.value.children.length
+    selectedChildren.value.length <= option.value.children.length
   );
 });
 

--- a/apps/directory/src/components/filters/base/TreeBranchComponent.vue
+++ b/apps/directory/src/components/filters/base/TreeBranchComponent.vue
@@ -1,7 +1,7 @@
 <template>
   <ul>
     <li @click="open = !open" :class="option.children ? 'clickable' : ''">
-      <!-- because Vue3 does not allow me, for some odd reason, to toggle a class or spans with font awesome icons, we have to do it like this. -->
+      <!-- because Vue3 does not allow me, for some odd reason, to toggle a class or spans with font awesome icons, we have to do it like  -->
       <span class="toggle-icon">
         {{ option.children ? (open ? "&#9660;" : "&#9650;") : "" }}
       </span>
@@ -34,115 +34,95 @@
   </ul>
 </template>
 
-<script lang="ts">
-import { defineAsyncComponent } from "vue";
+<script setup lang="ts">
+import { computed, defineAsyncComponent, ref, toRefs, watch } from "vue";
 import { useFiltersStore } from "../../../stores/filtersStore";
 
 /** need to lazy load because it gets too large quickly. Over 9000! */
 const TreeComponent = defineAsyncComponent(() => import("./TreeComponent.vue"));
-export default {
-  setup() {
-    const filtersStore = useFiltersStore();
-    return { filtersStore };
-  },
-  emits: ["indeterminate-update"],
-  props: {
-    facetIdentifier: {
-      type: String,
-      required: true,
-    },
-    option: {
-      type: Object,
-      required: true,
-    },
-    parentSelected: {
-      type: Boolean,
-      required: false,
-      default: () => false,
-    },
-    filter: {
-      type: String,
-      required: false,
-      default: () => "",
-    },
-  },
-  name: "TreeBranchComponent",
-  components: {
-    TreeComponent,
-  },
-  data() {
-    return {
-      open: !!this.filter,
-      childIsIndeterminate: false,
-      selectedChildren: [],
-    };
-  },
-  watch: {
-    indeterminateState(status) {
-      this.signalParentOurIndeterminateStatus(status);
-    },
-    filter(newFilter) {
-      this.open = !!newFilter;
-    },
-  },
-  computed: {
-    currentFilterSelection() {
-      if (!this.filtersStore) return [];
-      return this.filtersStore.getFilterValue(this.facetIdentifier) || [];
-    },
-    selected() {
-      if (this.parentSelected) {
-        return true;
-      } else if (!this.currentFilterSelection?.length) {
-        return false;
-      } else {
-        return this.currentFilterSelection.some(
-          (selectedValue: Record<string, any>) =>
-            selectedValue.name === this.option.name
-        );
-      }
-    },
-    numberOfChildrenInSelection() {
-      if (!this.option.children) {
-        return 0;
-      }
 
-      const childNames = this.option.children.map(
-        (childOption: Record<string, any>) => childOption.name
-      );
-      const selectedChildren = this.currentFilterSelection.filter(
-        (selectedOption: Record<string, any>) =>
-          childNames.includes(selectedOption.name)
-      );
-      return selectedChildren.length;
-    },
-    indeterminateState() {
-      if (this.parentSelected) return false;
-      if (this.childIsIndeterminate) return true;
-      if (!this.option.children) return false;
+const filtersStore = useFiltersStore();
+const emit = defineEmits(["indeterminate-update"]);
 
-      return (
-        this.numberOfChildrenInSelection !== this.option.children.length &&
-        this.numberOfChildrenInSelection > 0
-      );
-    },
-  },
+const props = withDefaults(
+  defineProps<{
+    facetIdentifier: string;
+    option: Record<string, any>;
+    parentSelected?: boolean;
+    filter?: string;
+  }>(),
+  { parentSelected: false, filter: "" }
+);
 
-  methods: {
-    selectOption(checked: boolean, option: Record<string, any>) {
-      /** if it is checked we add */
-      this.filtersStore.updateOntologyFilter(
-        this.facetIdentifier,
-        option,
-        checked
-      );
-    },
-    signalParentOurIndeterminateStatus(status: boolean) {
-      this.childIsIndeterminate = status;
-      this.$emit("indeterminate-update", status);
-    },
-  },
-};
+const { option, filter, parentSelected, facetIdentifier } = toRefs(props);
+
+const open = ref<boolean>(!!filter.value);
+const childIsIndeterminate = ref<boolean>(false);
+
+const currentFilterSelection = computed<any[]>(() => {
+  return filtersStore.getFilterValue(facetIdentifier.value) || [];
+});
+
+const selected = computed(() => {
+  if (parentSelected.value) {
+    return true;
+  } else if (!currentFilterSelection.value?.length) {
+    return false;
+  } else {
+    return currentFilterSelection.value.some(
+      (selectedValue: Record<string, any>) =>
+        selectedValue.name === option.value.name
+    );
+  }
+});
+
+const numberOfChildrenInSelection = computed(() => {
+  if (!option.value.children) {
+    return 0;
+  }
+
+  return selectedChildren.value.length;
+});
+
+const selectedChildren = computed(() => {
+  const childNames = option.value.children.map(
+    (childOption: Record<string, any>) => childOption.name
+  );
+  return currentFilterSelection.value.filter(
+    (selectedOption: Record<string, any>) =>
+      childNames.includes(selectedOption.name)
+  );
+});
+
+const indeterminateState = computed(() => {
+  if (parentSelected.value) return false;
+  if (childIsIndeterminate.value) return true;
+  if (!option.value.children) return false;
+
+  return (
+    numberOfChildrenInSelection.value !== option.value.children.length &&
+    numberOfChildrenInSelection.value > 0
+  );
+});
+
+watch(indeterminateState, (status: boolean) => {
+  signalParentOurIndeterminateStatus(status);
+});
+
+watch(filter, (newFilter: string) => {
+  open.value = !!newFilter;
+});
+
+function selectOption(checked: boolean, option: Record<string, any>) {
+  /** if it is checked we add */
+  filtersStore.updateOntologyFilter(facetIdentifier.value, option, checked);
+  signalParentOurIndeterminateStatus(checked);
+}
+
+function signalParentOurIndeterminateStatus(status: boolean) {
+  childIsIndeterminate.value = status;
+  emit("indeterminate-update", status);
+}
 </script>
 <style scoped>
 li {

--- a/apps/directory/src/components/filters/base/TreeBranchComponent.vue
+++ b/apps/directory/src/components/filters/base/TreeBranchComponent.vue
@@ -116,6 +116,7 @@ function signalParentOurIndeterminateStatus() {
   emit("indeterminate-update", isIndeterminate.value);
 }
 </script>
+
 <style scoped>
 li {
   margin-right: 1rem;

--- a/apps/directory/src/components/filters/base/TreeComponent.vue
+++ b/apps/directory/src/components/filters/base/TreeComponent.vue
@@ -80,7 +80,7 @@ function getTopPaginatedOptions() {
   }
 }
 
-function signalParentOurIndeterminateStatus(status: any) {
+function signalParentOurIndeterminateStatus(status: boolean) {
   emit("indeterminate-update", status);
 }
 


### PR DESCRIPTION
### What are the main changes you did
- fix: #3344 
- known issue: when setting filters through bookmarks (e.g. refreshing) doesn't correctly update the parent of a parent. 

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation