### PR TITLE
fix: set clearing caches to use separate db connection

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -699,14 +699,9 @@ public class SqlDatabase extends HasSettings<Database> implements Database {
     this.schemaCache.clear();
     this.schemaNames.clear();
     this.schemaInfos.clear();
-    // elevate privileges for loading settings
-    String user = this.connectionProvider.getActiveUser();
-    try {
-      this.connectionProvider.setActiveUser(ADMIN_USER);
-      this.setSettingsWithoutReload(MetadataUtils.loadDatabaseSettings(getJooq()));
-    } finally {
-      this.connectionProvider.setActiveUser(user);
-    }
+
+    getJooqAsAdmin(
+        adminJooq -> this.setSettingsWithoutReload(MetadataUtils.loadDatabaseSettings(adminJooq)));
   }
 
   public DSLContext getJooq() {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -589,17 +589,7 @@ public class SqlDatabase extends HasSettings<Database> implements Database {
 
   @Override
   public String getActiveUser() {
-    String user = jooq.fetchOne("SELECT CURRENT_USER").get(0, String.class);
-    if (user.equals(postgresUser)) {
-      return ADMIN_USER;
-    } else if (user.contains(MG_USER_PREFIX)) {
-      String userName = user.substring(MG_USER_PREFIX.length());
-      if (!userName.isEmpty()) {
-        return userName;
-      }
-    }
-    // user is either valid MG_USER_* or postgresUser, otherwise error state
-    throw new MolgenisException("Unexpected user found as activeUser " + user);
+    return connectionProvider.getActiveUser();
   }
 
   @Override

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -192,7 +192,7 @@ public class WebApiSmokeTests {
     // Propagate any failures to fail the test
     if (!failures.isEmpty()) {
       for (Throwable t : failures) {
-        t.printStackTrace(); // optional: helpful for debugging
+        t.printStackTrace();
       }
       fail("One or more threads failed. Total failures: " + failures.size());
     }

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -119,7 +119,7 @@ public class WebApiSmokeTests {
   }
 
   @Test
-  public void testLoginMultithreaded() throws InterruptedException {
+  void testLoginMultithreaded() throws InterruptedException {
     String testUser = "test@test.com";
     String password = "somepass";
 
@@ -130,7 +130,7 @@ public class WebApiSmokeTests {
             + password
             + "\\\") { message }}\"}";
 
-    final String signinQuery =
+    String signinQuery =
         "{\"query\":\"mutation{signin(email:\\\""
             + testUser
             + "\\\",password:\\\""
@@ -139,8 +139,7 @@ public class WebApiSmokeTests {
 
     String sessionQuery = "{ \"query\": \"{ _session { email } } \"}";
 
-    String createUserResult =
-        given().sessionId(SESSION_ID).body(createUserQuery).post("/api/graphql").asString();
+    given().sessionId(SESSION_ID).body(createUserQuery).post("/api/graphql").asString();
 
     int threadCount = 10;
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -142,7 +142,7 @@ public class WebApiSmokeTests {
     String createUserResult =
         given().sessionId(SESSION_ID).body(createUserQuery).post("/api/graphql").asString();
 
-    int threadCount = 50;
+    int threadCount = 10;
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);
     CountDownLatch readyLatch = new CountDownLatch(threadCount);
     CountDownLatch startLatch = new CountDownLatch(1);

--- a/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org.molgenis.emx2.web/WebApiSmokeTests.java
@@ -30,6 +30,10 @@ import java.io.OutputStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.*;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.*;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.Order;
@@ -112,6 +116,86 @@ public class WebApiSmokeTests {
     db.dropSchemaIfExists(PET_STORE_SCHEMA);
     db.dropSchemaIfExists("pet store yaml");
     db.dropSchemaIfExists("pet store json");
+  }
+
+  @Test
+  public void testLoginMultithreaded() throws InterruptedException {
+    String testUser = "test@test.com";
+    String password = "somepass";
+
+    String createUserQuery =
+        "{ \"query\": \"mutation { signup(email: \\\""
+            + testUser
+            + "\\\", password: \\\""
+            + password
+            + "\\\") { message }}\"}";
+
+    final String signinQuery =
+        "{\"query\":\"mutation{signin(email:\\\""
+            + testUser
+            + "\\\",password:\\\""
+            + password
+            + "\\\"){message}}\"}";
+
+    String sessionQuery = "{ \"query\": \"{ _session { email } } \"}";
+
+    String createUserResult =
+        given().sessionId(SESSION_ID).body(createUserQuery).post("/api/graphql").asString();
+
+    int threadCount = 50;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch readyLatch = new CountDownLatch(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+    // To collect any failures
+    ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(
+          () -> {
+            try {
+              readyLatch.countDown();
+              startLatch.await();
+
+              String result =
+                  RestAssured.given()
+                      .sessionId(SESSION_ID)
+                      .body(signinQuery)
+                      .post("/api/graphql")
+                      .asString();
+
+              assertTrue(
+                  result.contains("Signed in"),
+                  "Login failed in thread: " + Thread.currentThread().getName());
+
+              String sessionResult =
+                  given().sessionId(SESSION_ID).body(sessionQuery).post("/api/graphql").asString();
+
+              assertTrue(
+                  sessionResult.contains(testUser),
+                  "Session check failed in thread: " + Thread.currentThread().getName());
+
+            } catch (Throwable t) {
+              failures.add(t); // catch all errors
+            } finally {
+              doneLatch.countDown();
+            }
+          });
+    }
+
+    readyLatch.await();
+    startLatch.countDown();
+    doneLatch.await();
+    executor.shutdown();
+
+    // Propagate any failures to fail the test
+    if (!failures.isEmpty()) {
+      for (Throwable t : failures) {
+        t.printStackTrace(); // optional: helpful for debugging
+      }
+      fail("One or more threads failed. Total failures: " + failures.size());
+    }
   }
 
   @Test


### PR DESCRIPTION
### What are the main changes you did
- When clearing caches use jooqAsAdmin instead of reusing the current connection. Elevating the admin rights on the current connection gives issues.
- Added a unit test with 10 threads to login simultaneously and check which user is logged in by querying the session
- Delegated getActiveUser to connectionProvider, as some test failed because there was no active user on the connection. I don't understand why this logic existed in the first place? Why parse the postgress user, instead of using the user on the connectionProvider?

### How to test
- Try the added unit test without the changes to clearCache and see it fail in some cases

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation