### PR TITLE
fix(catalogue): add 'about catalogue' to footer

### DIFF
--- a/apps/tailwind-components/components/FooterComponent.vue
+++ b/apps/tailwind-components/components/FooterComponent.vue
@@ -12,7 +12,7 @@
               href="https://data-catalogue.molgeniscloud.org/catalogue/catalogue/about"
             >
               <BaseIcon name="CaretRight" :width="16" />
-              <span>About Molgenis catalogue</span>
+              <span>About the catalogue</span>
             </a>
           </li>
           <li>

--- a/apps/tailwind-components/components/FooterComponent.vue
+++ b/apps/tailwind-components/components/FooterComponent.vue
@@ -6,14 +6,11 @@
       <div>
         <h3 class="mb-2 text-title font-bold">Created with MOLGENIS</h3>
         <ul class="list-style-none flex flex-col gap-1.5 text-link">
-          <li class="flex items-ceter">
-            <a
-              class="flex items-center hover:underline"
-              :link="`/${schema}/catalogue/all/about`"
-            >
+          <li class="flex items-center">
+            <NuxtLink to="[schema]/catalogue/catalogue/about" class="flex items-center hover:underline">
               <BaseIcon name="CaretRight" :width="16" />
               <span>About the catalogue</span>
-            </a>
+            </NuxtLink>
           </li>
           <li>
             <a

--- a/apps/tailwind-components/components/FooterComponent.vue
+++ b/apps/tailwind-components/components/FooterComponent.vue
@@ -9,10 +9,10 @@
           <li class="flex items-ceter">
             <a
               class="flex items-center hover:underline"
-              href="http://molgenis.org"
+              href="https://data-catalogue.molgeniscloud.org/catalogue/catalogue/about"
             >
               <BaseIcon name="CaretRight" :width="16" />
-              <span>About Molgenis</span>
+              <span>About the Molgenis catalogue</span>
             </a>
           </li>
           <li>

--- a/apps/tailwind-components/components/FooterComponent.vue
+++ b/apps/tailwind-components/components/FooterComponent.vue
@@ -9,7 +9,7 @@
           <li class="flex items-ceter">
             <a
               class="flex items-center hover:underline"
-              href="https://data-catalogue.molgeniscloud.org/catalogue/catalogue/about"
+              :link="`/${schema}/catalogue/all/about`"
             >
               <BaseIcon name="CaretRight" :width="16" />
               <span>About the catalogue</span>

--- a/apps/tailwind-components/components/FooterComponent.vue
+++ b/apps/tailwind-components/components/FooterComponent.vue
@@ -12,7 +12,7 @@
               href="https://data-catalogue.molgeniscloud.org/catalogue/catalogue/about"
             >
               <BaseIcon name="CaretRight" :width="16" />
-              <span>About the Molgenis catalogue</span>
+              <span>About Molgenis catalogue</span>
             </a>
           </li>
           <li>


### PR DESCRIPTION
### What are the main changes you did
Currently, the footer has 'About Molgenis', pointing to molgenis.org, and 'MOLGENIS.org', pointing to molgenis.org (new window). The first one should be 'About (the) Molgenis catalogue' and point to the about page of the catalogue at https://data-catalogue.molgeniscloud.org/catalogue/catalogue/about (?). 

### How to test
- open preview, see footer, click link