### PR TITLE
fix(RDF): column range was literal instead of IRI

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/RDFService.java
@@ -346,7 +346,7 @@ public class RDFService {
         builder.add(subject, RDF.TYPE, OWL.OBJECTPROPERTY);
       } else {
         builder.add(subject, RDF.TYPE, OWL.DATATYPEPROPERTY);
-        builder.add(subject, RDFS.RANGE, getCoreDataType(column));
+        builder.add(subject, RDFS.RANGE, getCoreDataType(column).getIri());
       }
     }
     builder.add(subject, RDFS.LABEL, column.getName());


### PR DESCRIPTION
### What are the main changes you did
Minor fixes to RDF API so that equality check works as expected:
- column description range was literal instead of IRI
  - Adding the following does not fail pre-fix (maybe due to how InMemoryRDFHandler processes the data?):  
    ```
    assertTrue(
            handler.resources.values().stream().map(i -> i.get(RDFS.RANGE)).findFirst().get().stream()
                .findFirst()
                .get()
                .isIRI());
    ```

### How to test
Use `curl http://localhost:8080/pet%20store/api/rdf/Pet/column/name` and see the difference.

On master (`cadb470d4328054a2ebd50ee8a217db3be8e6034`):
```
<http://localhost:8080/pet%20store/api/rdf/Pet/column/name> a owl:DatatypeProperty;
  rdfs:range "http://www.w3.org/2001/XMLSchema#string";
```

On PR (`d3312abb4aafded47bf31f3e2447e1e2c0c0979f`):
```
<http://localhost:8080/pet%20store/api/rdf/Pet/column/name> a owl:DatatypeProperty;
  rdfs:range xsd:string;
```

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation