### PR TITLE
fix(import): Unsupported array columnType found:STRING_ARRAY

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -306,6 +306,7 @@ public class TypeUtils {
   }
 
   public static ColumnType getArrayType(ColumnType columnType) {
+    if (columnType.isArray()) return columnType;
     return switch (columnType.getBaseType()) {
       case UUID -> ColumnType.UUID_ARRAY;
       case STRING -> ColumnType.STRING_ARRAY;


### PR DESCRIPTION
To reproduce:

- load Patient registry template
- see error 'Unsupported array columnType found:STRING_ARRAY'

Note, it is slightly suspicious that this error occurs, this fixes the method that is failing.

Fixes the following:

The PATIENT_REGISTRY template fails on an unknown columnType error for string array. It fails when importing the [Pedigree table](https://github.com/molgenis/molgenis-emx2/blob/master/data/_models/shared/Pedigree.csv). I’ve checked for potential issues that would throw this error (trailing whitespace, typos, missing commas, etc.), but I couldn’t find anything that would cause an error.

2025-06-11_14:21:13.863 [pool-2-thread-1] INFO  ImportTableTask - Import table Pedigree: started
2025-06-11_14:21:13.933 [pool-2-thread-1] ERROR Task - CommitTask failed: Transaction failed: Unsupported array columnType found:STRING_ARRAY

The last working version is 13.10.0. In [#5100](https://github.com/molgenis/molgenis-emx2/pull/5100), we made a few changes to the pedigree table but nothing major. This error occurs on the master branch, recent PRs, and locally. None of the recently closed PRs would impact the model. Since we use string arrays in other places, I suspect the issue is something else.