### PR TITLE
fix(upload): BOM character was not skipped when loading from classpath resulting in 'order' uknown column errors in ontologies when using profile. closes #5117

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Row.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Row.java
@@ -51,8 +51,7 @@ public class Row {
   public Row(Map<String, ?> values) {
     this();
     for (Map.Entry<String, ?> entry : values.entrySet()) {
-      // we remove BOM character that sometimes is in CSV files from Windows systems
-      this.set(entry.getKey().replace("\uFEFF", ""), entry.getValue());
+      this.set(entry.getKey(), entry.getValue());
     }
   }
 

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Row.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Row.java
@@ -51,7 +51,8 @@ public class Row {
   public Row(Map<String, ?> values) {
     this();
     for (Map.Entry<String, ?> entry : values.entrySet()) {
-      this.set(entry.getKey(), entry.getValue());
+      // we remove BOM character that sometimes is in CSV files from Windows systems
+      this.set(entry.getKey().replace("\uFEFF", ""), entry.getValue());
     }
   }
 


### PR DESCRIPTION
closes #5117 

moved the BOM skipping code so that is not only applied when loading from file but also when loading from classpath or archive

bonus, we lose dependency on depcrecated org.apache.commons.io.input.BOMInputStream