### PR TITLE
fix: removed code related to "id" as semantics

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/BasicIRI.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/BasicIRI.java
@@ -28,7 +28,6 @@ public class BasicIRI {
   public static final IRI SIO_DATABASE_TABLE =
       iri("http://semanticscience.org/resource/SIO_000754");
   public static final IRI SIO_FILE = iri("http://semanticscience.org/resource/SIO_000396");
-  public static final IRI SIO_IDENTIFIER = iri("http://semanticscience.org/resource/SIO_000115");
 
   /**
    * SIO:001055 = observing (definition: observing is a process of passive interaction in which one

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/generators/Emx2RdfGenerator.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/generators/Emx2RdfGenerator.java
@@ -203,10 +203,6 @@ public class Emx2RdfGenerator extends RdfGenerator implements RdfApiGenerator {
     getWriter().processTriple(subject, RDFS.DOMAIN, tableIRI(getBaseURL(), column.getTable()));
     if (column.getSemantics() != null) {
       for (String columnSemantics : column.getSemantics()) {
-        if (columnSemantics.equals("id")) {
-          // todo: need to figure out how to better handle 'id' tagging
-          columnSemantics = BasicIRI.SIO_IDENTIFIER.stringValue();
-        }
         try {
           getWriter()
               .processTriple(


### PR DESCRIPTION
### What are the main changes you did
- removed (if I'm correct) an unused functionality
  - #5039 already removed text describing this
  - could not find a shared data model that used `id` as semantic, but maybe I overlooked something?
  - `sio:SIO_000396` with correct namespace configuration would achieve exactly the same

### How to test
- Existing templates should not fail

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation