### PR TITLE
feat(data): boolean data coded as integer 0 and 1 are cast to boolean upon importing

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -134,6 +134,17 @@ public class TypeUtils {
 
   public static Boolean toBool(Object v) {
     if (v == null) return null; // NOSONAR
+    try {
+      int value = Integer.parseInt(toString(v));
+      if (value == 1) {
+        return true;
+      }
+      if (value == 0) {
+        return false;
+      }
+    } catch (NumberFormatException ignored) {
+
+    }
     if (v instanceof String) {
       String value = toString(v);
       if (value == null) {

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -134,26 +134,15 @@ public class TypeUtils {
 
   public static Boolean toBool(Object v) {
     if (v == null) return null; // NOSONAR
-    try {
-      int value = Integer.parseInt(toString(v));
-      if (value == 1) {
-        return true;
-      }
-      if (value == 0) {
-        return false;
-      }
-    } catch (NumberFormatException ignored) {
-
-    }
     if (v instanceof String) {
       String value = toString(v);
       if (value == null) {
         return null; // NOSONAR
       }
-      if ("true".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value)) {
+      if ("true".equalsIgnoreCase(value) || "yes".equalsIgnoreCase(value) || value.equals("1")) {
         return true;
       }
-      if ("false".equalsIgnoreCase(value) || "no".equalsIgnoreCase(value)) {
+      if ("false".equalsIgnoreCase(value) || "no".equalsIgnoreCase(value) || value.equals("0")) {
         return false;
       }
     }

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
@@ -80,6 +80,7 @@ public class TestTypeUtils {
     String onePointZero = "1.0";
     String five = "5";
     String minusOne = "-1";
+    assertNull(TypeUtils.toBool(null));
     assertEquals(false, TypeUtils.toBool(falseString));
     assertEquals(true, TypeUtils.toBool(trueString));
     assertEquals(false, TypeUtils.toBool(zero));

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
@@ -72,6 +72,20 @@ public class TestTypeUtils {
   }
 
   @Test
+  void testToBool() {
+    String zero = "0";
+    String one = "1";
+    String onePointZero = "1.0";
+    String five = "5";
+    String minusOne = "-1";
+    assertEquals(false, TypeUtils.toBool(zero));
+    assertEquals(true, TypeUtils.toBool(one));
+    assertThrows(MolgenisException.class, () -> TypeUtils.toBool(onePointZero));
+    assertThrows(MolgenisException.class, () -> TypeUtils.toBool(five));
+    assertThrows(MolgenisException.class, () -> TypeUtils.toBool(minusOne));
+  }
+
+  @Test
   void testToJsonb() throws JsonProcessingException {
     // object
     String objectString = "{\"key\":\"value\"}";

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
@@ -73,11 +73,15 @@ public class TestTypeUtils {
 
   @Test
   void testToBool() {
+    String falseString = "False";
+    String trueString = "True";
     String zero = "0";
     String one = "1";
     String onePointZero = "1.0";
     String five = "5";
     String minusOne = "-1";
+    assertEquals(false, TypeUtils.toBool(falseString));
+    assertEquals(true, TypeUtils.toBool(trueString));
     assertEquals(false, TypeUtils.toBool(zero));
     assertEquals(true, TypeUtils.toBool(one));
     assertThrows(MolgenisException.class, () -> TypeUtils.toBool(onePointZero));


### PR DESCRIPTION
### What are the main changes you did
Added a check for values in a boolean type column if the value can be cast to integer. In that case checks whether the value is either 0 (_false_) or 1 (_true_) and will raise an error otherwise.

### How to test
- created a unit test in TestTypeUtils.java

### Checklist
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] ~added/updated testplan to include a test for this fix, including ref to bug using # notation~