### PR TITLE
fix(dashboards): added missing download attribute in file component

### DIFF
--- a/apps/molgenis-viz/src/components/display/FileList.vue
+++ b/apps/molgenis-viz/src/components/display/FileList.vue
@@ -54,7 +54,7 @@
       <p class="file-element file-size">
         {{ (file[fileColumn].size / Math.pow(1024, 2)).toFixed(2) }} MB
       </p>
-      <a class="file-element file-url" :href="file[fileColumn].url">
+      <a class="file-element file-url" :href="file[fileColumn].url" download>
         <span class="visually-hidden">
           Download {{ file[fileColumn].filename }}
         </span>


### PR DESCRIPTION
### What are the main changes you did

The ERN dashboards have a page where project members can download documents. There is an issue where documents are opened in the a new tab and not automatically downloaded.

- [x] `FileList` component: added missing `download` attribute

### How to test

- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation