### PR TITLE
chore(staging-migrator): fix staging migrator dtype warning

### DIFF
--- a/tools/staging_migrator/requirements.txt
+++ b/tools/staging_migrator/requirements.txt
@@ -1,3 +1,3 @@
-molgenis-emx2-pyclient>=11.57.0
+molgenis-emx2-pyclient>=11.61.2
 requests>=2.32.3
 pandas>=2.2.2

--- a/tools/staging_migrator/src/molgenis_emx2_staging_migrator/migrator.py
+++ b/tools/staging_migrator/src/molgenis_emx2_staging_migrator/migrator.py
@@ -271,7 +271,7 @@ class StagingMigrator(Client):
             raw_df = pd.read_csv(BytesIO(archive.read(f"{table.name}.csv")), nrows=1)
 
         columns = raw_df.columns
-        dtypes = {c: t for (c, t) in convert_dtypes(table).items() if c in columns}
+        dtypes = {c: convert_dtypes(table).get(c, "string") for c in columns}
 
         bool_columns = [c for (c, t) in dtypes.items() if t == 'boolean']
         date_columns = [c.name for c in table.columns


### PR DESCRIPTION
### What are the main changes you did
Prevented the occurrence of a _pandas_ warning about data types when loading in a CSV table, specifically the _Variables_ table in the data catalogue.
After this fix the data type `string` is automatically assigned to any column for which a data type could not be deduced.

### How to test
- execute _publish\_resources.py_ in directory _dev_ with a catalogue schema as target.
