### PR TITLE
fix(catalogue-app): improved alt text for logos

### DIFF
--- a/apps/catalogue/components/content/ContentBlockCatalogues.vue
+++ b/apps/catalogue/components/content/ContentBlockCatalogues.vue
@@ -33,7 +33,7 @@ const props = defineProps<{
                   v-if="catalogue?.logo?.url"
                   :src="catalogue?.logo?.url"
                   class="h-full object-contain"
-                  alt="Catalogue Logo"
+                  :alt="catalogue?.name"
                 />
               </div>
             </NuxtLink>

--- a/apps/catalogue/components/content/ContentBlockCatalogues.vue
+++ b/apps/catalogue/components/content/ContentBlockCatalogues.vue
@@ -33,7 +33,7 @@ const props = defineProps<{
                   v-if="catalogue?.logo?.url"
                   :src="catalogue?.logo?.url"
                   class="h-full object-contain"
-                  :alt="catalogue?.name"
+                  :alt="catalogue.name"
                 />
               </div>
             </NuxtLink>


### PR DESCRIPTION
### What are the main changes you did

This is a follow-up PR to molgenis/molgenis-emx2#5150. I noticed that alt text for the logo was not descriptive enough (see [Using alt attributes on img elements](https://www.w3.org/WAI/WCAG22/Techniques/html/H37)). For the catalogue, this should be the name of the catalogue. Given this is a required field, it will accurately describe the image.

- [x] Passed `catalogue.name` into the `alt` attribute

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation