### PR TITLE
fix(updownload): enable download and upload of ontology label and description. closes #2805

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/emx2/Emx2.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/emx2/Emx2.java
@@ -229,13 +229,22 @@ public class Emx2 {
             .toList(); // NOSONAR cannot use toList because immutable
 
     List<Row> result = new ArrayList<>();
-    for (TableMetadata table : tables) {
-
+    // fix https://github.com/molgenis/molgenis-emx2/issues/2805
+    // export ontology table metadata if label or description are set
+    for (TableMetadata table :
+        schema.getTables().stream()
+            .filter(
+                t ->
+                    !t.getTableType().equals(TableType.ONTOLOGIES)
+                        || t.getDescription() != null
+                        || t.getLabel() != null)
+            .toList()) {
       Row row = new Row();
       // set null columns to ensure sensible order
       row.setString(TABLE_NAME, table.getTableName());
       row.setString(TABLE_EXTENDS, table.getInheritName());
-      row.setString(TABLE_TYPE, null);
+      row.setString(
+          TABLE_TYPE, table.getTableType().equals(TableType.ONTOLOGIES) ? "ONTOLOGIES" : null);
       row.setString(COLUMN_NAME, null);
       row.setString(COLUMN_TYPE, null);
       row.setString(KEY, null);

--- a/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/TestOntologyMetadataExport.java
+++ b/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/TestOntologyMetadataExport.java
@@ -1,0 +1,47 @@
+package org.molgenis.emx2.io;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.Database;
+import org.molgenis.emx2.Schema;
+import org.molgenis.emx2.TableType;
+import org.molgenis.emx2.datamodels.DataModels;
+import org.molgenis.emx2.sql.TestDatabaseFactory;
+
+public class TestOntologyMetadataExport {
+  static Database database;
+  static Schema schema;
+
+  @BeforeAll
+  public static void setup() {
+    database = TestDatabaseFactory.getTestDatabase();
+    schema = database.dropCreateSchema(TestOntologyMetadataExport.class.getSimpleName());
+    DataModels.Profile.PET_STORE.getImportTask(schema, false).run();
+  }
+
+  @Test
+  void testExportOntologyLabelAndDescription() throws IOException {
+    // set ontology metadata
+    schema.getMetadata().getTableMetadata("Tag").setDescription("foo").setLabel("bar");
+    // schema.migrate(schema);
+    assertEquals(TableType.ONTOLOGIES, schema.getTable("Tag").getMetadata().getTableType());
+    assertEquals("foo", schema.getTable("Tag").getMetadata().getDescription());
+    assertEquals("bar", schema.getTable("Tag").getMetadata().getLabel());
+
+    // test export import also keeps this info
+    Path tmp = Files.createTempDirectory(null);
+    Path excelFile = tmp.resolve("TestOntologyMetadataExport.xlsx");
+    MolgenisIO.toExcelFile(excelFile, schema, false);
+    schema = database.dropCreateSchema(TestOntologyMetadataExport.class.getSimpleName());
+    MolgenisIO.importFromExcelFile(excelFile, schema, false);
+
+    assertEquals(TableType.ONTOLOGIES, schema.getTable("Tag").getMetadata().getTableType());
+    assertEquals("foo", schema.getTable("Tag").getMetadata().getDescription());
+    assertEquals("bar", schema.getTable("Tag").getMetadata().getLabel());
+  }
+}

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
@@ -285,15 +285,17 @@ public class SqlColumnExecutor {
     }
     if (refSchema.getTableMetadata(column.getRefTableName()) == null) {
       TableMetadata tm =
-          getOntologyTableDefinition(column.getRefTableName(), column.getDescriptions());
+          getOntologyTableDefinition(
+              column.getRefTableName(), column.getLabels(), column.getDescriptions());
       // create the table
       refSchema.create(tm);
     }
   }
 
   public static TableMetadata getOntologyTableDefinition(
-      String name, Map<String, String> descriptions) {
+      String name, Map<String, String> labels, Map<String, String> descriptions) {
     return new TableMetadata(name)
+        .setLabels(labels)
         .setDescriptions(descriptions)
         .setTableType(TableType.ONTOLOGIES)
         .add(

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -128,7 +128,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
                       new SqlTableMetadata(
                           sm,
                           getOntologyTableDefinition(
-                              table.getTableName(), table.getDescriptions()));
+                              table.getTableName(), table.getLabels(), table.getDescriptions()));
                 } else {
                   result = new SqlTableMetadata(sm, table);
                 }


### PR DESCRIPTION
closes #2805 

To reproduce, e.g. go to pet store, use schema editor change label and description of 'Tags' ontology table and then download and upload into empty schema to see label and description are kept.

You can see that java test verifies the same.
