### PR TITLE
fix(catalogue): update styles for catalogue, use theme vars

### DIFF
--- a/apps/catalogue/components/SideNavigation.vue
+++ b/apps/catalogue/components/SideNavigation.vue
@@ -17,7 +17,7 @@ function setSideMenuStyle(hash: string) {
 
 <template>
   <nav
-    class="text-body-base bg-white rounded-t-3px rounded-b-50px px-12 py-16 shadow-primary"
+    class="text-body-base bg-white rounded-t-3px rounded-b-50px px-12 py-16 shadow-primary mb-18"
   >
     <div v-if="title || image" class="mb-6 font-display text-heading-4xl">
       <NuxtLink

--- a/apps/catalogue/components/content/ContentBlockCatalogues.vue
+++ b/apps/catalogue/components/content/ContentBlockCatalogues.vue
@@ -46,7 +46,7 @@ const props = defineProps<{
               >
             </NuxtLink>
           </TableCell>
-          <TableCell class="hidden sm:table-cell">
+          <TableCell class="hidden sm:table-cell text-title-contrast">
             <NuxtLink :to="`/${catalogue.id}`">
               {{ catalogue?.name }}
             </NuxtLink>

--- a/apps/catalogue/nuxt.config.ts
+++ b/apps/catalogue/nuxt.config.ts
@@ -4,6 +4,7 @@ import { defineNuxtConfig } from "nuxt/config";
 export default defineNuxtConfig({
   extends: ["../tailwind-components"],
   devtools: { enabled: true },
+  ignore: ['.gradle/**', '.git/**', 'node_modules/**', 'dist/**', 'coverage/**'],
   modules: ["@nuxt/image", "@nuxt/test-utils/module", "nuxt-gtag", "@pinia/nuxt"],
   tailwindcss: {
     cssPath: "../tailwind-components/assets/css/main.css",

--- a/apps/tailwind-components/assets/css/theme/molgenis.css
+++ b/apps/tailwind-components/assets/css/theme/molgenis.css
@@ -99,6 +99,7 @@
   --text-color-pagination-button: var(--color-white);
   --text-color-pagination-button-hover: var(--color-blue-800);
   --text-color-link: var(--color-yellow-500);
+  --text-color-link-inverted: var(--color-blue-500);
   --text-color-table-column-header: var(--color-gray-600);
 
   --text-color-invalid: var(--color-red-700);

--- a/apps/tailwind-components/assets/css/theme/umcg.css
+++ b/apps/tailwind-components/assets/css/theme/umcg.css
@@ -61,7 +61,7 @@
   --text-color-breadcrumb-arrow: var(--color-umcg-mid-blue);
   --text-color-breadcrumb: var(--color-umcg-mid-blue);
   --text-color-title: var(--color-umcg-dark-blue);
-  --text-color-title-contrast: var(--color-umcg-dark-blue);
+  --text-color-title-contrast: var(--color-gray-900);
   --text-color-sub-title-contrast: var(--color-umcg-dark-blue);
   --text-color-search-button: var(--color-umcg-light-blue);
   --text-color-search-button-hover: var(--color-umcg-light-blue);
@@ -88,6 +88,8 @@
   --text-color-pagination-input: var(--color-umcg-dark-blue);
   --text-color-pagination-hover: var(--color-white);
   --text-color-link: var(--color-umcg-mid-blue);
+  --text-color-link-inverted: var(--color-blue-500);
+  --text-color-table-row: var(--color-gray-900);
 
   --border-color-button-primary: var(--color-orange-500);
   --border-color-button-primary-hover: var(--color-orange-500);

--- a/apps/tailwind-components/components/TableCell.vue
+++ b/apps/tailwind-components/components/TableCell.vue
@@ -8,7 +8,7 @@ defineProps({
 
 <template>
   <td
-    class="py-2.5 px-2.5 border-b border-gray-200 first:text-link first:font-bold first:pl-0 last:pr-0 sm:first:pl-2.5 sm:last:pr-2.5"
+    class="py-2.5 px-2.5 border-b border-gray-200 text-table-row first:font-bold first:text-link-inverted first:pl-0 last:pr-0 sm:first:pl-2.5 sm:last:pr-2.5"
   >
     <div :class="{ 'whitespace-nowrap': allowLineBreak }"><slot></slot></div>
   </td>

--- a/apps/tailwind-components/components/content/ContentBlock.vue
+++ b/apps/tailwind-components/components/content/ContentBlock.vue
@@ -7,7 +7,7 @@ defineProps<{
 
 <template>
   <section
-    class="bg-content py-18 lg:px-12.5 px-5 text-title xl:rounded-3px last:rounded-b-50px last:mb-18 shadow-primary xl:border-b-0 border-b-[1px] overflow-hidden"
+    class="bg-content py-18 lg:px-12.5 px-5 text-title-contrast xl:rounded-3px last:rounded-b-50px last:mb-18 shadow-primary xl:border-b-0 border-b-[1px] overflow-hidden"
   >
     <h2 class="mb-5 uppercase text-heading-4xl font-display" v-if="title">
       {{ title }}

--- a/apps/tailwind-components/tailwind.config.js
+++ b/apps/tailwind-components/tailwind.config.js
@@ -263,6 +263,7 @@ module.exports = {
         "pagination-button": "var(--text-color-pagination-button)",
         "pagination-button-hover": "var(--text-color-pagination-button-hover)",
         link: "var(--text-color-link)",
+        "link-inverted": "var(--text-color-link-inverted)",
         "table-column-header": "var(--text-color-table-column-header)",
         "table-row": "var(--text-color-table-row)",
         "form-header": "var(--text-color-form-header)",


### PR DESCRIPTION
### What are the main changes you did
- The tailwind components now use theme vars instead of hard coded values for the content components
- This pr updates the usage in the catalogue contest and add missing theme vars ( used to be hard coded )

### How to test
- check styling for data-catalogue ( molgenis ) and umcgresearchcatalogue ( umcg) , compare preview with prod ( acc has the version with issues )
- note: add `?theme=[name-of-the-theme]` to the url to test , for example ?theme=umcg

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation