### PR TITLE
fix(catalogue): in variable list second column, when label is null then show description

### DIFF
--- a/apps/catalogue/components/VariableCard.vue
+++ b/apps/catalogue/components/VariableCard.vue
@@ -51,7 +51,7 @@ const repeats = computed(() =>
       </div>
       <div class="hidden md:flex md:basis-3/5">
         <p class="text-body-base">
-          {{ variable?.label }}
+          {{ variable?.label || variable?.description }}
         </p>
       </div>
       <div class="hidden basis-1/5 xl:flex xl:justify-end">


### PR DESCRIPTION
closes https://github.com/molgenis/GCC/issues/1372