### PR TITLE
fix(central): Include the default app when building the schema list

### DIFF
--- a/apps/molgenis-components/src/components/layout/Molgenis.vue
+++ b/apps/molgenis-components/src/components/layout/Molgenis.vue
@@ -140,12 +140,13 @@ export default {
       };
       //all databases
       if (this.session?.schemas) {
+        const appName = this.menu[0]?.href || "tables";
         this.session.schemas
           .sort((a: string, b: string) =>
             a.localeCompare(b, undefined, { sensitivity: "base" })
           )
           .forEach((schema: string) => {
-            result[schema] = "../../" + schema; // all paths are of form /:schema/:app
+            result[schema] = "../../" + schema + "/" + appName; // all paths are of form /:schema/:app/tables
           });
       }
       return result;

--- a/apps/molgenis-components/src/components/layout/Molgenis.vue
+++ b/apps/molgenis-components/src/components/layout/Molgenis.vue
@@ -140,13 +140,12 @@ export default {
       };
       //all databases
       if (this.session?.schemas) {
-        const appName = this.menu[0]?.href || "tables";
         this.session.schemas
           .sort((a: string, b: string) =>
             a.localeCompare(b, undefined, { sensitivity: "base" })
           )
           .forEach((schema: string) => {
-            result[schema] = "../../" + schema + "/" + appName; // all paths are of form /:schema/:app/tables
+            result[schema] = "../../" + schema + "/_index";
           });
       }
       return result;

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisWebservice.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisWebservice.java
@@ -119,6 +119,7 @@ public class MolgenisWebservice {
 
     app.get("/{schema}", MolgenisWebservice::redirectSchemaToFirstMenuItem);
     app.get("/{schema}/", MolgenisWebservice::redirectSchemaToFirstMenuItem);
+    app.get("/{schema}/_index", MolgenisWebservice::redirectSchemaToFirstMenuItem);
 
     // greedy proxy stuff, always put last!
     StaticFileMapper.create(app);


### PR DESCRIPTION
### What are the main changes you did
- add route to dynamic schema index page

If a server is setup in a way where the empty path '/' result another service this can have unintended results when the webui used the empty path to direct the request to the 'default' app ( via setting > first menu item > tables app ). This pr add a named path '_index' to the router to allow the frontend to explicitly send the request to the emx2 backend, even if a default service is configured via a proxy.

alternative solution could be to just always link to the tables app when selecting a schema form the breadcrumb schema select dropdown, or make this configurable ( per database , per schema would mean that each schema needs to be queried ahead of time for the setting, in that case the solution as implemented in this pr would be better ) 

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation