### PR TITLE
chore: update performance test for local usage

### DIFF
--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/PerformanceTest.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/PerformanceTest.java
@@ -10,6 +10,11 @@ import io.restassured.RestAssured;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
 import org.junit.jupiter.api.*;
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.Privileges;
@@ -26,21 +31,147 @@ import org.slf4j.LoggerFactory;
 public class PerformanceTest {
 
   static final Logger logger = LoggerFactory.getLogger(PerformanceTest.class);
+  /// private static final String BASE_URL = "https://emx2.dev.molgenis.org/";
   private static final String BASE_URL = "http://localhost";
+
   private static final String SCHEMA_NAME = "catalogue-demo";
-  private static final int PORT = 8082;
+  //  private static final int PORT = 80;
+  private static final int PORT = 8080;
   private static Database database;
+  private static final int NUMBER_OF_REQUESTS = 100000;
+
+  private static final int THREAD_COUNT = 10;
 
   @BeforeAll
   public static void before() throws Exception {
 
-    database = TestDatabaseFactory.getTestDatabase();
-    RunMolgenisEmx2.main(new String[] {String.valueOf(PORT)});
+    if (BASE_URL.startsWith("http://localhot")) {
+      database = TestDatabaseFactory.getTestDatabase();
+      RunMolgenisEmx2.main(new String[] {String.valueOf(PORT)});
+    }
 
-    // set default rest assured settings
+    //    RestAssured.port = PORT;
+    RestAssured.baseURI = BASE_URL;
     RestAssured.port = PORT;
-    RestAssured.baseURI = "http://localhost";
 
+    // createDemoData();
+  }
+
+  @AfterAll
+  public static void after() {
+    if (database != null) {
+      database.dropSchemaIfExists(SCHEMA_NAME);
+    }
+  }
+
+  @Test
+  @Disabled("Disabled for CI, run manually to test performance")
+  void testPerformanceSequential() {
+
+    List<Integer> responseTimes = new ArrayList<>();
+
+    for (int i = 1; i <= NUMBER_OF_REQUESTS; i++) {
+      long t1 = new Date().getTime();
+      String resp = doDemoRequest();
+      long t2 = new Date().getTime();
+      assertTrue(resp.contains("Contacts"), "Response does not contain expected data: " + resp);
+      logger.info("Response time: {} ms, ms, request: {}", t2 - t1, i);
+      responseTimes.add((int) (t2 - t1));
+    }
+
+    long mean = responseTimes.stream().mapToInt(Integer::intValue).sum() / responseTimes.size();
+    logger.info("Mean response time: {} ms for {} requests", mean, NUMBER_OF_REQUESTS);
+
+    long max = responseTimes.stream().mapToInt(Integer::intValue).max().orElse(0);
+
+    logger.info("Max response time: {} ms for {} requests", max, NUMBER_OF_REQUESTS);
+
+    long variance =
+        responseTimes.stream()
+                .mapToInt(Integer::intValue)
+                .map(i -> i - (int) mean)
+                .map(i -> i * i)
+                .sum()
+            / responseTimes.size();
+
+    long stdDev = (long) Math.sqrt(variance);
+    logger.info(
+        "Standard deviation of response times: {} ms for  {}  requests",
+        stdDev,
+        NUMBER_OF_REQUESTS);
+
+    assertTrue(
+        mean < 3000,
+        "Request took too long: " + mean + " ms (sd: " + stdDev + "ms, max: " + max + "ms)");
+  }
+
+  @Test
+  @Disabled
+  void testPerformanceMultiThreaded() throws InterruptedException {
+    ExecutorService executor = Executors.newFixedThreadPool(THREAD_COUNT);
+    List<Future<Integer>> futures = new ArrayList<>();
+
+    for (int i = 1; i <= NUMBER_OF_REQUESTS; i++) {
+      final int requestNumber = i;
+      futures.add(
+          executor.submit(
+              () -> {
+                long t1 = System.currentTimeMillis();
+                String resp = doDemoRequest();
+                long t2 = System.currentTimeMillis();
+
+                if (!resp.contains("Contacts")) {
+                  throw new AssertionError("Response does not contain expected data: " + resp);
+                }
+
+                logger.info("Response time: {} ms, request: {}", t2 - t1, requestNumber);
+                return (int) (t2 - t1);
+              }));
+    }
+
+    executor.shutdown();
+    executor.awaitTermination(5, TimeUnit.MINUTES);
+
+    List<Integer> responseTimes =
+        futures.stream()
+            .map(
+                future -> {
+                  try {
+                    return future.get();
+                  } catch (Exception e) {
+                    throw new RuntimeException("Error getting response time", e);
+                  }
+                })
+            .collect(Collectors.toList());
+
+    analyzeAndAssert(responseTimes);
+  }
+
+  private void analyzeAndAssert(List<Integer> responseTimes) {
+    long mean = responseTimes.stream().mapToInt(Integer::intValue).sum() / responseTimes.size();
+    long max = responseTimes.stream().mapToInt(Integer::intValue).max().orElse(0);
+    long variance =
+        responseTimes.stream().mapToInt(i -> i - (int) mean).map(i -> i * i).sum()
+            / responseTimes.size();
+    long stdDev = (long) Math.sqrt(variance);
+
+    logger.info("Mean response time: {} ms for {} requests", mean, responseTimes.size());
+    logger.info("Max response time: {} ms for {} requests", max, responseTimes.size());
+    logger.info("Standard deviation: {} ms", stdDev);
+
+    assertTrue(
+        mean < 3000,
+        "Request took too long: " + mean + " ms (sd: " + stdDev + "ms, max: " + max + "ms)");
+  }
+
+  private String doDemoRequest() {
+    return RestAssured.given()
+        .body("{\"query\":\"{Contacts{lastName}}\"}")
+        .post("/" + SCHEMA_NAME + "/graphql")
+        .asString();
+  }
+
+  private static void createDemoData() {
     // create an admin session to work with
     String adminPass =
         (String)
@@ -61,60 +192,5 @@ public class PerformanceTest {
     DataModels.Profile.DATA_CATALOGUE.getImportTask(schema, true).run();
 
     schema.addMember(ANONYMOUS, Privileges.VIEWER.toString());
-  }
-
-  @AfterAll
-  public static void after() {
-    // Always clean up database to avoid instability due to side effects.
-    database.dropSchemaIfExists(SCHEMA_NAME);
-  }
-
-  //  @Disabled("Disabled for CI, run manually to test performance")
-  @Test
-  void testPerformance() {
-    RestAssured.baseURI = BASE_URL + ":" + PORT;
-
-    List<Integer> responseTimes = new ArrayList<>();
-
-    int numRequests = 1000;
-
-    for (int i = 1; i <= numRequests; i++) {
-      long t1 = new Date().getTime();
-      String resp = doDemoRequest();
-      long t2 = new Date().getTime();
-      assertTrue(resp.contains("Contacts"), "Response does not contain expected data: " + resp);
-      logger.info("Response time: {} ms, ms, request: {}", t2 - t1, i);
-      responseTimes.add((int) (t2 - t1));
-    }
-
-    long mean = responseTimes.stream().mapToInt(Integer::intValue).sum() / responseTimes.size();
-    logger.info("Mean response time: {} ms for {} requests", mean, numRequests);
-
-    long max = responseTimes.stream().mapToInt(Integer::intValue).max().orElse(0);
-
-    logger.info("Max response time: {} ms for {} requests", max, numRequests);
-
-    long variance =
-        responseTimes.stream()
-                .mapToInt(Integer::intValue)
-                .map(i -> i - (int) mean)
-                .map(i -> i * i)
-                .sum()
-            / responseTimes.size();
-
-    long stdDev = (long) Math.sqrt(variance);
-    logger.info(
-        "Standard deviation of response times: {} ms for  {}  requests", stdDev, numRequests);
-
-    assertTrue(
-        mean < 3000,
-        "Request took too long: " + mean + " ms (sd: " + stdDev + "ms, max: " + max + "ms)");
-  }
-
-  private String doDemoRequest() {
-    return RestAssured.given()
-        .body("{\"query\":\"{Contacts{lastName}}\"}")
-        .post("/" + SCHEMA_NAME + "/graphql")
-        .asString();
   }
 }


### PR DESCRIPTION
add multiThreaded test , disable and comment out lines for local usage

the test is not meant to be run during preview/release ci but rather from a developer system to test the performance of a local or remote emx2 with regard to anonymous session memory usage and response times when using the gql endpoint

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation