### PR TITLE
fix(graphql): concurrent GraphQL queries do not clash

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSession.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/MolgenisSession.java
@@ -6,8 +6,8 @@ import static org.molgenis.emx2.web.util.EnvHelpers.getEnvLong;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 import graphql.GraphQL;
-import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.MolgenisException;
@@ -29,7 +29,7 @@ public class MolgenisSession {
           .build();
   private final GraphqlApiFactory graphqlApiFactory;
   private final Database database;
-  private final Map<String, GraphQL> graphqlPerSchema = new LinkedHashMap<>();
+  private final Map<String, GraphQL> graphqlPerSchema = new ConcurrentHashMap<>();
   private GraphQL graphqlForDatabase;
 
   public MolgenisSession(Database database, GraphqlApiFactory graphqlApiFactory) {

--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/MolgenisSessionTest.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/MolgenisSessionTest.java
@@ -51,7 +51,7 @@ class MolgenisSessionTest {
   }
 
   @Test
-  void concurrentAccess() throws InterruptedException {
+  void concurrentGetGraphQL() throws InterruptedException {
     Database database = mock(Database.class);
 
     // Mock the database to return a schema when requested

--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/MolgenisSessionTest.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/MolgenisSessionTest.java
@@ -68,7 +68,7 @@ class MolgenisSessionTest {
     when(database.isAnonymous()).thenReturn(false);
 
     // Create two threads for getting the GraphQL for the schema
-    int threadCount = 2;
+    int threadCount = 10;
     ExecutorService executor = Executors.newFixedThreadPool(threadCount);
     CountDownLatch readyLatch = new CountDownLatch(threadCount);
     CountDownLatch startLatch = new CountDownLatch(1);
@@ -86,7 +86,7 @@ class MolgenisSessionTest {
             } catch (ConcurrentModificationException cme) {
               failures.add(cme);
             } catch (InterruptedException ignore) {
-
+              // The latches require interruptions to be caught
             } finally {
               doneLatch.countDown();
             }

--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/MolgenisSessionTest.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/MolgenisSessionTest.java
@@ -6,6 +6,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import graphql.GraphQL;
+import java.util.ConcurrentModificationException;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.Schema;
@@ -43,5 +48,56 @@ class MolgenisSessionTest {
     GraphQL anonymousGraphqlAfterClear = molgenisSession.getGraphqlForSchema("testSchema");
     assertNotNull(anonymousGraphqlAfterClear, "Anonymous GraphQL schema should not be null");
     assertEquals(anonymousGraphql, anonymousGraphqlAfterClear);
+  }
+
+  @Test
+  void concurrentAccess() throws InterruptedException {
+    Database database = mock(Database.class);
+
+    // Mock the database to return a schema when requested
+    Schema schema = mock(Schema.class);
+    SchemaMetadata metaData = mock(SchemaMetadata.class);
+    when(metaData.getName()).thenReturn("testSchema");
+    when(schema.getMetadata()).thenReturn(metaData);
+    when(database.getSchema("testSchema")).thenReturn(schema);
+    GraphqlApiFactory graphQlApiFactory = mock(GraphqlApiFactory.class);
+    // Mock the GraphqlApiFactory to return a GraphQL instance
+    GraphQL mockGraphQL = mock(GraphQL.class);
+    when(graphQlApiFactory.createGraphqlForSchema(any(), any())).thenReturn(mockGraphQL);
+    MolgenisSession molgenisSession = new MolgenisSession(database, graphQlApiFactory);
+    when(database.isAnonymous()).thenReturn(false);
+
+    // Create two threads for getting the GraphQL for the schema
+    int threadCount = 2;
+    ExecutorService executor = Executors.newFixedThreadPool(threadCount);
+    CountDownLatch readyLatch = new CountDownLatch(threadCount);
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+    ConcurrentLinkedQueue<Throwable> failures = new ConcurrentLinkedQueue<>();
+
+    for (int i = 0; i < threadCount; i++) {
+      executor.submit(
+          () -> {
+            try {
+              readyLatch.countDown();
+              startLatch.await();
+              molgenisSession.getGraphqlForSchema("testSchema");
+            } catch (ConcurrentModificationException cme) {
+              failures.add(cme);
+            } catch (InterruptedException ignore) {
+
+            } finally {
+              doneLatch.countDown();
+            }
+          });
+    }
+
+    readyLatch.await();
+    startLatch.countDown();
+    doneLatch.await();
+    executor.shutdown();
+
+    assertEquals(0, failures.size());
   }
 }


### PR DESCRIPTION
### What are the main changes you did
- changed the `graphqlPerSchema` attribute of class `MolgenisSession` from `LinkedHashMap` to `ConcurrentHashMap` to prevent `ConcurrentModificationException`

### How to test
- wrote a new test to verify this behaviour

### Checklist
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation