### PR TITLE
fix: int input sets error when emptied

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputInt.vue
+++ b/apps/molgenis-components/src/components/forms/InputInt.vue
@@ -14,9 +14,7 @@
         :readonly="readonly"
         :required="required"
         :class="{ 'is-invalid': errorMessage }"
-        @update:modelValue="
-          $emit('update:modelValue', $event === NaN ? null : parseInt($event))
-        "
+        @update:modelValue="$emit('update:modelValue', $event)"
       />
       <template v-slot:append>
         <slot name="append" />


### PR DESCRIPTION
### What are the main changes you did
- fix: #5070 

### How to test
- create an int column in a table
- go to the form input
- enter a number into the int input
- delete the input using backspace
- see 'invalid input' message (or not after the fix).

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation