### PR TITLE
fix(updownload): download URLs were missing path to the schema

### DIFF
--- a/apps/updownload/src/components/Import.vue
+++ b/apps/updownload/src/components/Import.vue
@@ -63,24 +63,24 @@
           <p>Export data by downloading various file formats:</p>
           <div>
             <p>
-              Export schema as <a :href="'../api/csv'">csv</a> /
-              <a :href="'../api/json'">json</a> /
-              <a :href="'../api/yaml'">yaml</a>
+              Export schema as <a :href="`/${schema}/api/csv`">csv</a> /
+              <a :href="`/${schema}/api/json`">json</a> /
+              <a :href="`/${schema}/api/yaml`">yaml</a>
             </p>
             <p>
               Export all data as
-              <a :href="'../api/excel'">excel</a> /
-              <a :href="'../api/zip'">csv.zip</a> /
-              <a :href="'../api/ttl'">ttl</a> /
-              <a :href="'../api/jsonld'">jsonld</a>
+              <a :href="`/${schema}/api/excel`">excel</a> /
+              <a :href="`/${schema}/api/zip`">csv.zip</a> /
+              <a :href="`/${schema}/api/ttl`">ttl</a> /
+              <a :href="`/${schema}/api/jsonld`">jsonld</a>
             </p>
             <div v-if="visibleTables?.length" :key="tablesHash">
               Export specific tables:
               <ul>
                 <li v-for="table in visibleTables" :key="table.id">
                   {{ table.label }}:
-                  <a :href="'../api/csv/' + table.id">csv</a> /
-                  <a :href="'../api/excel/' + table.id">excel</a>
+                  <a :href="`/${schema}/api/csv/` + table.id">csv</a> /
+                  <a :href="`/${schema}/api/excel/` + table.id">excel</a>
                 </li>
               </ul>
             </div>


### PR DESCRIPTION
closes #5239 

n.b. I think we are now deciding that we should use absolute paths in hyperlinks to make it more robust. I think I am at peace with that now :-)

n.b. this fix is also being tested in #5231 because we found it there also.