### PR TITLE
fix(admin): short password warning shows undefined

### DIFF
--- a/apps/central/src/components/admin/ManageUsers.vue
+++ b/apps/central/src/components/admin/ManageUsers.vue
@@ -170,7 +170,7 @@ export default {
           })
           .catch((error) => {
             this.alterError =
-              "Create/alter user failed: " + error.response.message;
+              "Create/alter user failed: " + error.response.errors[0].message;
           });
         this.alterLoading = false;
       }


### PR DESCRIPTION
fixes: #5057

### What are the main changes you did
- using a short password would a  display an error `Create/alter user failed: undefined`. It will now display the correct error `Create/alter user failed: Set password failed for user 'max': password too short`

### How to test
- create a user with short password in the admin interface
