### PR TITLE
fix: row edit and delete modals no longer close on mouseout

### DIFF
--- a/apps/tailwind-components/components/Modal.vue
+++ b/apps/tailwind-components/components/Modal.vue
@@ -62,17 +62,18 @@ function hide() {
 </script>
 
 <template>
-  <section
+  <div
     v-show="visible"
     role="dialog"
     :aria-labelledby="title"
+    :aria-modal="true"
     ref="dialog"
-    class="fixed min-h-lvh w-full top-0 left-0 flex z-20 overscroll-behavior: contain"
+    class="fixed min-h-lvh w-full top-0 left-0 flex z-30 overscroll-contain"
   >
-    <a
+    <div
       id="backdrop"
       @click="visible = false"
-      class="w-full h-full absolute left-0 bg-black/60 overscroll-behavior: contain"
+      class="w-full h-full absolute left-0 bg-black/60 overscroll-contain"
       tabindex="-1"
     />
 
@@ -112,5 +113,5 @@ function hide() {
         <slot name="footer" :hide="hide" />
       </footer>
     </div>
-  </section>
+  </div>
 </template>

--- a/apps/tailwind-components/components/Modal.vue
+++ b/apps/tailwind-components/components/Modal.vue
@@ -63,7 +63,7 @@ function hide() {
 
 <template>
   <div
-    v-show="visible"
+    v-if="visible"
     role="dialog"
     :aria-labelledby="title"
     :aria-modal="true"

--- a/apps/tailwind-components/components/form/AddModal.vue
+++ b/apps/tailwind-components/components/form/AddModal.vue
@@ -1,14 +1,16 @@
 <template>
-  <slot :setVisible="setVisible">
-    <Button
-      class="m-10"
-      type="primary"
-      size="small"
-      icon="plus"
-      @click="visible = true"
-      >Add {{ rowType }}</Button
-    >
-  </slot>
+  <template v-if="showButton">
+    <slot :setVisible="setVisible">
+      <Button
+        class="m-10"
+        type="primary"
+        size="small"
+        icon="plus"
+        @click="visible = true"
+        >Add {{ rowType }}</Button
+      >
+    </slot>
+  </template>
   <Modal v-model:visible="visible" max-width="max-w-9/10">
     <template #header>
       <header class="pt-[36px] px-8 overflow-y-auto border-b border-divider">
@@ -115,8 +117,11 @@ const props = withDefaults(
     metadata: ITableMetaData;
     schemaId: string;
     constantValues?: IRow;
+    showButton?: boolean;
   }>(),
-  {}
+  {
+    showButton: true,
+  }
 );
 
 const emit = defineEmits(["update:added", "update:cancelled"]);

--- a/apps/tailwind-components/components/form/DeleteModal.vue
+++ b/apps/tailwind-components/components/form/DeleteModal.vue
@@ -11,8 +11,11 @@ const props = withDefaults(
     schemaId: string;
     metadata: ITableMetaData;
     formValues: Record<columnId, columnValue>;
+    showButton?: boolean;
   }>(),
-  {}
+  {
+    showButton: true,
+  }
 );
 
 const emit = defineEmits(["update:deleted", "update:cancelled"]);
@@ -64,16 +67,18 @@ async function onDeleteConfirm() {
 </script>
 
 <template>
-  <slot :setVisible="setVisible">
-    <Button
-      class="m-10"
-      type="primary"
-      size="small"
-      icon="plus"
-      @click="visible = true"
-      >Delete {{ rowType }}</Button
-    >
-  </slot>
+  <template v-if="showButton">
+    <slot :setVisible="setVisible">
+      <Button
+        class="m-10"
+        type="primary"
+        size="small"
+        icon="plus"
+        @click="visible = true"
+        >Delete {{ rowType }}</Button
+      >
+    </slot>
+  </template>
   <Modal v-model:visible="visible" max-width="max-w-9/10">
     <template #header>
       <header class="pt-[36px] px-8 overflow-y-auto border-b border-divider">

--- a/apps/tailwind-components/components/form/EditModal.vue
+++ b/apps/tailwind-components/components/form/EditModal.vue
@@ -97,7 +97,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, ref, toRaw, watchEffect } from "vue";
+import { computed, ref, toRaw } from "vue";
 import useForm from "../../composables/useForm";
 import useSections from "../../composables/useSections";
 import type { ITableMetaData } from "../../../metadata-utils/src";

--- a/apps/tailwind-components/components/form/EditModal.vue
+++ b/apps/tailwind-components/components/form/EditModal.vue
@@ -1,14 +1,16 @@
 <template>
-  <slot :setVisible="setVisible">
-    <Button
-      class="m-10"
-      type="primary"
-      size="small"
-      icon="plus"
-      @click="visible = true"
-      >Update {{ rowType }}</Button
-    >
-  </slot>
+  <template v-if="showButton">
+    <slot :setVisible="setVisible">
+      <Button
+        class="m-10"
+        type="primary"
+        size="small"
+        icon="plus"
+        @click="visible = true"
+        >Update {{ rowType }}</Button
+      >
+    </slot>
+  </template>
   <Modal v-model:visible="visible" max-width="max-w-9/10">
     <template #header>
       <header class="pt-[36px] px-8 overflow-y-auto border-b border-divider">
@@ -109,8 +111,11 @@ const props = withDefaults(
     schemaId: string;
     metadata: ITableMetaData;
     formValues: Record<columnId, columnValue>;
+    showButton?: boolean;
   }>(),
-  {}
+  {
+    showButton: true,
+  }
 );
 
 const emit = defineEmits(["update:updated", "update:cancelled"]);

--- a/apps/tailwind-components/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/components/table/TableEMX2.vue
@@ -99,6 +99,9 @@
                   size="small"
                   label="delete"
                   @click="onShowDeleteModal(row)"
+                  :aria-controls="`table-emx2-${schemaId}-${tableId}-modal-delete`"
+                  aria-haspopup="dialog"
+                  :aria-expanded="showDeleteModal"
                 />
                 <Button
                   :icon-only="true"
@@ -107,6 +110,9 @@
                   size="small"
                   label="edit"
                   @click="onShowEditModal(row)"
+                  :aria-controls="`table-emx2-${schemaId}-${tableId}-modal-edit`"
+                  aria-haspopup="dialog"
+                  :aria-expanded="showEditModal"
                 />
               </div>
             </TableCellEMX2>
@@ -124,6 +130,7 @@
   />
 
   <TableModalRef
+    :id="`table-emx2-${schemaId}-${tableId}-modal-ref`"
     v-if="showModal && refTableRow && refTableColumn"
     v-model:visible="showModal"
     :metadata="refTableColumn"
@@ -134,7 +141,9 @@
   />
 
   <DeleteModal
+    :id="`table-emx2-${schemaId}-${tableId}-modal-delete`"
     v-if="data?.tableMetadata && rowDataForModal"
+    :showButton="false"
     :schemaId="props.schemaId"
     :metadata="data.tableMetadata"
     :formValues="rowDataForModal"
@@ -146,7 +155,9 @@
   />
 
   <EditModal
+    :id="`table-emx2-${schemaId}-${tableId}-modal-edit`"
     v-if="data?.tableMetadata && rowDataForModal"
+    :showButton="false"
     :schemaId="props.schemaId"
     :metadata="data.tableMetadata"
     :formValues="rowDataForModal"

--- a/apps/tailwind-components/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/components/table/TableEMX2.vue
@@ -92,40 +92,22 @@
                 v-if="isEditable && index === 0"
                 class="flex items-center gap-1 flex-none invisible group-hover:visible h-4 py-6 px-4 absolute right-7 bg-hover"
               >
-                <DeleteModal
-                  v-if="data?.tableMetadata"
-                  :schemaId="props.schemaId"
-                  :metadata="data.tableMetadata"
-                  :formValues="row"
-                  v-slot="{ setVisible }"
-                  @update:deleted="afterRowDeleted"
-                >
-                  <Button
-                    :icon-only="true"
-                    type="inline"
-                    icon="trash"
-                    size="small"
-                    label="delete"
-                    @click="setVisible"
-                  />
-                </DeleteModal>
-                <EditModal
-                  v-if="data?.tableMetadata"
-                  :schemaId="props.schemaId"
-                  :metadata="data.tableMetadata"
-                  :formValues="row"
-                  v-slot="{ setVisible }"
-                  @update:updated="afterRowUpdated"
-                >
-                  <Button
-                    :icon-only="true"
-                    type="inline"
-                    icon="edit"
-                    size="small"
-                    label="edit"
-                    @click="setVisible"
-                  />
-                </EditModal>
+                <Button
+                  :icon-only="true"
+                  type="inline"
+                  icon="trash"
+                  size="small"
+                  label="delete"
+                  @click="onShowDeleteModal(row)"
+                />
+                <Button
+                  :icon-only="true"
+                  type="inline"
+                  icon="edit"
+                  size="small"
+                  label="edit"
+                  @click="onShowEditModal(row)"
+                />
               </div>
             </TableCellEMX2>
           </tr>
@@ -146,9 +128,33 @@
     v-model:visible="showModal"
     :metadata="refTableColumn"
     :row="refTableRow"
-    :schema="props.schemaId"
+    :schema="schemaId"
     :sourceTableId="refSourceTableId"
     :showDataOwner="false"
+  />
+
+  <DeleteModal
+    v-if="data?.tableMetadata && rowDataForModal"
+    :schemaId="props.schemaId"
+    :metadata="data.tableMetadata"
+    :formValues="rowDataForModal"
+    v-model:visible="showDeleteModal"
+    @update:deleted="
+      afterRowDeleted;
+      showDeleteModal = false;
+    "
+  />
+
+  <EditModal
+    v-if="data?.tableMetadata && rowDataForModal"
+    :schemaId="props.schemaId"
+    :metadata="data.tableMetadata"
+    :formValues="rowDataForModal"
+    v-model:visible="showEditModal"
+    @update:updated="
+      afterRowUpdated;
+      showEditModal = false;
+    "
   />
 </template>
 
@@ -158,6 +164,7 @@ import type {
   IRow,
   IColumn,
   IRefColumn,
+  columnValue,
 } from "../../../metadata-utils/src/types";
 import type {
   ITableSettings,
@@ -172,6 +179,10 @@ import AddModal from "../form/AddModal.vue";
 import EditModal from "../form/EditModal.vue";
 import DeleteModal from "../form/DeleteModal.vue";
 import TableModalRef from "./modal/TableModalRef.vue";
+
+const showDeleteModal = ref<boolean>(false);
+const showEditModal = ref<boolean>(false);
+const rowDataForModal = ref();
 
 const props = withDefaults(
   defineProps<{
@@ -302,6 +313,16 @@ function handleCellClick(
       : (column as IRefColumn); // todo other types of column
 
   showModal.value = true;
+}
+
+function onShowDeleteModal(row: Record<string, columnValue>) {
+  rowDataForModal.value = row;
+  showDeleteModal.value = true;
+}
+
+function onShowEditModal(row: Record<string, columnValue>) {
+  rowDataForModal.value = row;
+  showEditModal.value = true;
 }
 
 function afterRowAdded() {


### PR DESCRIPTION
### What are the main changes you did

This PR introduces a fix in the row delete/edit modal components where if the mouse was hovered on a different window, display, or program, the modal would close. This was caused by a conflict in the row hover actions and the fact that the modals were rendered in each row. Central modals should be used instead as it is more efficient rather than generating modals and modal content for each row.

- [x] Refactored edit/delete modal (there are now two row-level modals for the table component)

This PR is part of molgenis/GCC#1579

> [!NOTE]
> There's still an issue with buttons and semantics. In the next PR, we will likely reposition the buttons so that they are placed in the first cell in each row. Currently, the buttons are not accessible and do not correspond to the primary key(s). I attempted to fix this in this PR, but it was decided to move this in the next PR to keep this one relatively small.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation