### PR TITLE
fix(tw): increased color contrast of filter well button text

### DIFF
--- a/apps/tailwind-components/assets/css/main.css
+++ b/apps/tailwind-components/assets/css/main.css
@@ -131,7 +131,7 @@
     --text-color-button-outline-hover: var(--color-blue-700);
     --text-color-button-disabled: var(--color-gray-600);
     --text-color-button-disabled-hover: var(--color-gray-600);
-    --text-color-button-filter: var(--color-blue-500);
+    --text-color-button-filter: var(--color-blue-800);
     --text-color-button-tree-node-toggle: var(--color-blue-800);
     --text-color-button-tree-node-toggle-hover: var(--color-white);
     --text-color-button-toggle-active: var(--text-color-button-secondary);


### PR DESCRIPTION
### What are the main changes you did

This PR is part of molgenis/GCC#1579

- [x] fix: adjusted text color of the filter well button to meet minimum color contrast requirements

### How to test

- In the preview, navigate to the button story in the new components gallery
- Run the WAVE browser extension. Note the contrasts errors of the filterWell button and compare with the emx2 dev demo
 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation