### PR TITLE
fix: update input search icon color when input is disabled

### DIFF
--- a/apps/tailwind-components/components/input/Search.vue
+++ b/apps/tailwind-components/components/input/Search.vue
@@ -55,7 +55,7 @@ function handleInput(input: string) {
           'text-valid': valid,
           'text-invalid': invalid,
           'text-disabled': disabled,
-          'text-input': !disabled && !valid && !invalid,
+          'text-input': !disabled,
           'w-[12px]': size === 'tiny',
           'w-[16px]': size === 'small',
           'w-[21px]': size === 'medium',


### PR DESCRIPTION
### What are the main changes you did

- [x] fix: icon color is now updated when input is disabled

### How to test

- Go to the input search story and disable the input

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation