### PR TITLE
fix: truncate form chapter headings and show on hover

### DIFF
--- a/apps/tailwind-components/components/form/Legend.vue
+++ b/apps/tailwind-components/components/form/Legend.vue
@@ -1,39 +1,32 @@
 <template>
   <nav class="pt-4 pb-8" v-if="sections.length > 1">
     <h3 class="text-disabled p-4 ml-4">Jump to</h3>
-    <ul class="list-none space-y-3">
+    <ul class="list-none">
       <li
         v-for="section in sections"
-        class="group/chapter flex justify-start items-center gap-1 cursor-pointer [&_div]:border [&_div]:border-red-500"
+        class="py-2 pr-4 relative group/chapter cursor-pointer flex items-center gap-2 justify-start h-full"
       >
         <div
-          class="h-[24px] w-1 group-hover/chapter:bg-button-primary"
+          class="absolute left-0 top-0 h-full w-1 group-hover/chapter:bg-button-primary transition-translate duration-100 ease-in-out origin-left -translate-full group-hover/chapter:translate-0"
           :class="{ 'bg-button-primary': section.isActive }"
         />
-        <div class="pl-4">
-          <a
-            class="relative w-10/12 inline-flex items-center truncate"
-            href="#"
-            :aria-current="section.isActive"
-            @click.prevent="emit('goToSection', section.id)"
-          >
-            <span
-              class="text-title-contrast capitalize truncate"
-              :class="{ 'font-bold': section.isActive }"
-            >
-              {{ section.label }}
-            </span>
-          </a>
-          <div class="w-1/12 inline-flex items-center justify-center">
-            <div
-              class="inline-flex h-6 w-6 shrink-0 grow-0 items-center justify-center rounded-full bg-notification text-legend-error-count"
-            >
-              {{ (section.errorCount ?? 0) > 9 ? "9+" : section.errorCount }}
-              <span class="sr-only">
-                {{ section.errorCount === 1 ? "error" : "errors" }}
-              </span>
-            </div>
-          </div>
+        <a
+          class="pl-7 truncate hover:overflow-visible bg-form-legend"
+          href="#"
+          :aria-current="section.isActive"
+          @click.prevent="emit('goToSection', section.id)"
+        >
+          <span class="text-title-contrast capitalize">
+            {{ section.label }}
+          </span>
+          <span v-if="(section.errorCount ?? 0) > 0" class="sr-only">
+            {{ section.errorCount === 1 ? "error" : "errors" }}
+          </span>
+        </a>
+        <div
+          class="inline-flex h-6 w-6 shrink-0 grow-0 items-center justify-center rounded-full bg-notification text-legend-error-count"
+        >
+          {{ (section.errorCount ?? 0) > 9 ? "9+" : section.errorCount }}
         </div>
       </li>
     </ul>

--- a/apps/tailwind-components/components/form/Legend.vue
+++ b/apps/tailwind-components/components/form/Legend.vue
@@ -4,34 +4,37 @@
     <ul class="list-none space-y-3">
       <li
         v-for="section in sections"
-        class="group/chapter flex items-center cursor-pointer"
+        class="group/chapter flex justify-start items-center gap-1 cursor-pointer [&_div]:border [&_div]:border-red-500"
       >
         <div
           class="h-[24px] w-1 group-hover/chapter:bg-button-primary"
           :class="{ 'bg-button-primary': section.isActive }"
         />
-        <a
-          class="pl-7 flex items-center"
-          href="#"
-          :aria-current="section.isActive"
-          @click.prevent="emit('goToSection', section.id)"
-        >
-          <span
-            class="text-title-contrast capitalize"
-            :class="{ 'font-bold': section.isActive }"
+        <div class="pl-4">
+          <a
+            class="relative w-10/12 inline-flex items-center truncate"
+            href="#"
+            :aria-current="section.isActive"
+            @click.prevent="emit('goToSection', section.id)"
           >
-            {{ section.label }}
-          </span>
-          <span
-            v-if="(section.errorCount ?? 0) > 0"
-            class="ml-2 flex h-6 w-6 shrink-0 grow-0 items-center justify-center rounded-full bg-notification text-legend-error-count"
-          >
-            {{ (section.errorCount ?? 0) > 9 ? "9+" : section.errorCount }}
-            <span class="sr-only">{{
-              section.errorCount === 1 ? "error" : "errors"
-            }}</span>
-          </span>
-        </a>
+            <span
+              class="text-title-contrast capitalize truncate"
+              :class="{ 'font-bold': section.isActive }"
+            >
+              {{ section.label }}
+            </span>
+          </a>
+          <div class="w-1/12 inline-flex items-center justify-center">
+            <div
+              class="inline-flex h-6 w-6 shrink-0 grow-0 items-center justify-center rounded-full bg-notification text-legend-error-count"
+            >
+              {{ (section.errorCount ?? 0) > 9 ? "9+" : section.errorCount }}
+              <span class="sr-only">
+                {{ section.errorCount === 1 ? "error" : "errors" }}
+              </span>
+            </div>
+          </div>
+        </div>
       </li>
     </ul>
   </nav>


### PR DESCRIPTION
### What are the main changes you did

- [x] fix: chapter title is truncated by default and shown on hover
- [x] fix: adjusted list item border transitions to get it closer to the designs
- [x] fix: moved error count into link so that it is available for screen readers
- [x] minor refactoring to the component

> [!NOTE]
> By default, if a section has an error and the title is truncated, the error message will also shifted when the title is hovered. Is this the behaviour that we want? Originally, I allowed the text to flow onto the error badge, but it was odd when it was partially covered by one letter and it was difficult to read.  

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
