### PR TITLE
fix: add newsletter link to GENTURIS documents page

### DIFF
--- a/apps/ern-genturis/src/views/view-documents.vue
+++ b/apps/ern-genturis/src/views/view-documents.vue
@@ -2,7 +2,8 @@
   <Page id="page-documents">
     <PageHeader
       class="genturis-header"
-      title="ERN Genturis Registry"
+      title="ERN GENTURIS registry"
+      subtitle="Registry for Genetic Tumour Risk Syndromes"
       imageSrc="img/genturis-carousel.jpg"
       titlePositionX="center"
       titlePositionY="center"
@@ -14,8 +15,19 @@
       :verticalPadding="2"
       width="large"
     >
-      <h2 id="genturis-section-documents-title">Download Documents</h2>
-      <p>Download additional information about the GENTURIS Registry.</p>
+      <h2 id="genturis-section-documents-title">Documents</h2>
+      <p>
+        The latest newsletter can be found
+        <a
+          href="https://www.genturis.eu/l=eng/news-and-events-1/newsletter.html"
+          target="_blank"
+          >here</a
+        >
+      </p>
+      <p>
+        More information about the GENTURIS registry can be found in the
+        following documents:
+      </p>
       <FileList table="Files" labelsColumn="name" fileColumn="file" />
     </PageSection>
   </Page>


### PR DESCRIPTION
### What are the main changes you did
- Currently the ERN GENTURIS newsletter is available as PDF under documents on genturis-registry.eu. This means it needs to be updated every now and then. This PR adds a link to the newsletters page, so people have always access to the latest newsletter and data managers don't need to think of updating the document anymore (with the changes of outdated newsletters).

### How to test
- Go to the preview
- Create a schema using ERN_DASHBOARD template.
- Go to previewURL/YOURSCHEMA/ern-genturis/#/documents
- Compare with https://genturis-registry.eu/menu/main/app-ern-genturis/documents AND/OR https://demo-erngenturis.molgenis.net/GENTURIS/ern-genturis/#/documents