### PR TITLE
fix(forms-tw): validate client side before saving form

### DIFF
--- a/apps/tailwind-components/components/form/AddModal.vue
+++ b/apps/tailwind-components/components/form/AddModal.vue
@@ -54,6 +54,7 @@
       >
         <FormFields
           v-if="visible"
+          ref="formFields"
           :schemaId="schemaId"
           :metadata="metadata"
           :sections="sections"
@@ -111,6 +112,7 @@ import type {
 import useSections from "../../composables/useSections";
 import useForm from "../../composables/useForm";
 import { errorToMessage } from "../../utils/errorToMessage";
+import FormFields from "./Fields.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -125,6 +127,7 @@ const props = withDefaults(
 );
 
 const emit = defineEmits(["update:added", "update:cancelled"]);
+const formFields = ref<InstanceType<typeof FormFields>>();
 
 const visible = defineModel("visible", {
   type: Boolean,
@@ -163,6 +166,10 @@ async function onSaveDraft() {
 }
 
 async function onSave() {
+  const isValid = formFields.value?.validate();
+  if (!isValid) {
+    return;
+  }
   const resp = await insertInto(props.schemaId, props.metadata.id).catch(
     (err) => {
       console.error("Error saving data", err);

--- a/apps/tailwind-components/components/form/EditModal.vue
+++ b/apps/tailwind-components/components/form/EditModal.vue
@@ -53,6 +53,7 @@
         class="col-span-3 px-4 py-50px overflow-y-auto"
       >
         <FormFields
+          ref="formFields"
           :schemaId="schemaId"
           :metadata="metadata"
           :sections="sections"
@@ -105,6 +106,7 @@ import useSections from "../../composables/useSections";
 import type { ITableMetaData } from "../../../metadata-utils/src";
 import type { columnId, columnValue } from "../../../metadata-utils/src/types";
 import { errorToMessage } from "../../utils/errorToMessage";
+import FormFields from "./Fields.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -128,6 +130,8 @@ const visible = defineModel("visible", {
   type: Boolean,
   default: false,
 });
+
+const formFields = ref<InstanceType<typeof FormFields>>();
 
 const updateErrorMessage = ref<string>("");
 
@@ -161,6 +165,10 @@ async function onUpdateDraft() {
 }
 
 async function onUpdate() {
+  const isValid = formFields.value?.validate();
+  if (!isValid) {
+    return;
+  }
   const resp = await updateInto(props.schemaId, props.metadata.id).catch(
     (err) => {
       console.error("Error saving data", err);

--- a/apps/tailwind-components/components/form/Fields.vue
+++ b/apps/tailwind-components/components/form/Fields.vue
@@ -35,6 +35,17 @@ const errors = defineModel<Record<columnId, string>>("errors", {
   required: true,
 });
 
+function validate() {
+  props.metadata.columns.forEach((column) => {
+    if (visibleMap[column.id]) {
+      validateColumn(column);
+    }
+  });
+  return Object.keys(errors.value).length === 0;
+}
+
+defineExpose({ validate });
+
 const emit = defineEmits(["error", "update:activeChapterId"]);
 
 function validateColumn(column: IColumn) {

--- a/apps/tailwind-components/tests/e2e/components/form/addModal.spec.ts
+++ b/apps/tailwind-components/tests/e2e/components/form/addModal.spec.ts
@@ -28,3 +28,13 @@ test("should show the add modal", async ({ page }) => {
   ).toBeVisible();
   await expect(page.getByText("name Required the name")).toBeVisible();
 });
+
+test("should validate form before saving", async ({ page }) => {
+  await page.getByRole("button", { name: "Add Pet" }).click();
+  await expect(
+    page.getByRole("textbox", { name: "name Required" })
+  ).toBeEmpty();
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(page.getByText("2 fields require attention")).toBeVisible();
+  await expect(page.getByText("errorname is required")).toBeVisible();
+});

--- a/apps/tailwind-components/tests/e2e/components/form/editModal.spec.ts
+++ b/apps/tailwind-components/tests/e2e/components/form/editModal.spec.ts
@@ -1,5 +1,4 @@
 import { test, expect } from "@playwright/test";
-
 import playwrightConfig from "../../../../playwright.config";
 
 const route = playwrightConfig?.use?.baseURL?.startsWith("http://localhost")
@@ -8,13 +7,15 @@ const route = playwrightConfig?.use?.baseURL?.startsWith("http://localhost")
 
 test.beforeEach(async ({ page }) => {
   await page.goto(
-    `${route}form/EditModal.story?schema=pet+store&table=Pet&rowIndex=1`
+    `${route}form/EditModal.story?schema=pet+store&table=Pet&rowIndex=3`,
+    { waitUntil: "networkidle" }
   );
-  await expect(page.getByText("Update Pet").first()).toBeVisible();
+  await expect(page.getByText("Update Pet")).toBeVisible();
 });
 
 test("should show the edit modal", async ({ page }) => {
-  await page.getByRole("button", { name: "Update Pet" }).first().click();
+  await expect(page.getByText("Update Pet")).toBeVisible();
+  await page.getByRole("button", { name: "Update Pet" }).click();
   await expect(page.getByRole("link", { name: "_top" })).toBeVisible();
   await expect(
     page.getByRole("listitem").filter({ hasText: "details" })
@@ -29,4 +30,19 @@ test("should show the edit modal", async ({ page }) => {
     page.getByRole("button", { name: "Save", exact: true })
   ).toBeVisible();
   await expect(page.getByText("name Required the name")).toBeVisible();
+});
+
+test("should validate form before updating", async ({ page }) => {
+  await expect(page.getByText("Update Pet")).toBeVisible();
+  await page.getByRole("button", { name: "Update Pet" }).click();
+
+  await page.getByRole("textbox", { name: "name Required" }).click();
+  await page.getByRole("textbox", { name: "name Required" }).fill("");
+
+  await page.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(
+    page.getByText("1 field requires attention before you can save this cohort")
+  ).toBeVisible();
+  await page.getByRole("button", { name: "go to next error" }).click();
+  await expect(page.getByText("name is required")).toBeVisible();
 });


### PR DESCRIPTION
### What are the main changes you did
- (re)validate client side before save 

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation