### PR TITLE
fix(forms): if key is of type integer, correctly resolve the key in Edit modal

### DIFF
--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -7,7 +7,7 @@ import type {
   ITableMetaData,
 } from "../../../metadata-utils/src/types";
 import type { IRow } from "../Interfaces/IRow";
-import { deepClone } from "../components/utils";
+import { deepClone, getKeyValue } from "../components/utils";
 import type { aggFunction } from "./IClient";
 import type { IClient, INewClient } from "./IClient";
 import type { IQueryMetaData } from "./IQueryMetaData";
@@ -380,23 +380,5 @@ async function convertRowToPrimaryKey(
       },
       Promise.resolve({})
     );
-  }
-
-  async function getKeyValue(
-    cellValue: any,
-    column: IColumn,
-    schemaId: string
-  ) {
-    if (typeof cellValue === "string") {
-      return cellValue;
-    } else {
-      if (column.refTableId) {
-        return await convertRowToPrimaryKey(
-          cellValue,
-          column.refTableId,
-          schemaId
-        );
-      }
-    }
   }
 }

--- a/apps/molgenis-components/src/components/utils.test.ts
+++ b/apps/molgenis-components/src/components/utils.test.ts
@@ -45,7 +45,7 @@ describe("isRefType", () => {
 });
 
 describe("getKeyValue", () => {
-  test("it should return the value if of type number", async () => {
+  test("it should return the value if the cellValue is of type number", async () => {
     const column = {
       columnType: "INT" as CellValueType,
       id: "someId",

--- a/apps/molgenis-components/src/components/utils.test.ts
+++ b/apps/molgenis-components/src/components/utils.test.ts
@@ -8,8 +8,10 @@ import {
   flattenObject,
   isNumericKey,
   isRefType,
+  getKeyValue,
 } from "./utils";
 import { contactsMetadata, resourcesMetadata } from "./mockDatasets";
+import { CellValueType } from "metadata-utils/src/types";
 
 vi.mock("../client/client", () => {
   // For use with convertRowToPrimaryKey
@@ -35,6 +37,23 @@ describe("isRefType", () => {
     assert.isTrue(isRefType("REFBACK"));
     assert.isTrue(isRefType("ONTOLOGY"));
     assert.isTrue(isRefType("ONTOLOGY_ARRAY"));
+  });
+
+  test("it should return false for other types", () => {
+    assert.isFalse(isRefType("SOME_OTHER_TYPE"));
+  });
+});
+
+describe("getKeyValue", () => {
+  test("it should return the value if of type number", async () => {
+    const column = {
+      columnType: "INT" as CellValueType,
+      id: "someId",
+      label: "someId",
+    };
+    const actualValue = await getKeyValue(1, column);
+
+    assert.deepEqual(actualValue, 1);
   });
 
   test("it should return false for other types", () => {

--- a/apps/molgenis-components/src/components/utils.ts
+++ b/apps/molgenis-components/src/components/utils.ts
@@ -75,8 +75,12 @@ export async function convertRowToPrimaryKey(
   }
 }
 
-async function getKeyValue(cellValue: any, column: IColumn, schemaId?: string) {
-  if (typeof cellValue === "string") {
+export async function getKeyValue(
+  cellValue: any,
+  column: IColumn,
+  schemaId?: string
+) {
+  if (typeof cellValue === "string" || typeof cellValue === "number") {
     return cellValue;
   } else {
     if (column.refTableId) {
@@ -85,6 +89,8 @@ async function getKeyValue(cellValue: any, column: IColumn, schemaId?: string) {
         column.refTableId,
         schemaId
       );
+    } else {
+      throw new Error("Unexpected key type");
     }
   }
 }


### PR DESCRIPTION
Fixes #5204

### What are the main changes you did
- Added test if key = number in utils getKey (from row)

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation