### PR TITLE
fix: collaboration filter on direct link/refresh

### DIFF
--- a/apps/directory/src/functions/bookmarkMapper.ts
+++ b/apps/directory/src/functions/bookmarkMapper.ts
@@ -5,6 +5,7 @@ import router from "../router";
 import { ILabelValuePair, useCheckoutStore } from "../stores/checkoutStore";
 import { useCollectionStore } from "../stores/collectionStore";
 import { useFiltersStore } from "../stores/filtersStore";
+import { filter } from "lodash";
 
 let bookmarkApplied = false;
 
@@ -79,6 +80,9 @@ export async function applyBookmark(watchedQuery: LocationQuery) {
           break;
         case "search":
           filtersStore.updateFilter(filterName, filtersToAdd, true);
+          break;
+        case "Collaborationtype":
+          filtersStore.updateFilter(filterName, filtersToAdd === "true", true);
           break;
         default:
           const filterOptions = await filtersStore.facetDetails[


### PR DESCRIPTION
### What are the main changes you did
- fixes #5331 

### How to test
- go to directory app
- select collaboration available filter
- refresh of copy the link to a new tab
- filter should now be applied after reload

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation