### PR TITLE
implemented correct content negotiation

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
@@ -60,8 +60,8 @@ public class RDFApi {
 
   private static final Comparator<MediaType> MEDIA_TYPE_COMPARATOR =
       Comparator.comparing((MediaType mediaType) -> mediaType.type().equals("*"))
-        .thenComparing(mediaType -> mediaType.subtype().equals("*"))
-        .thenComparing(
+          .thenComparing(mediaType -> mediaType.subtype().equals("*"))
+          .thenComparing(
               mediaType -> {
                 try {
                   return Double.parseDouble(mediaType.parameters().get("q").getFirst());

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/RDFApi.java
@@ -59,8 +59,10 @@ public class RDFApi {
   }
 
   private static final Comparator<MediaType> MEDIA_TYPE_COMPARATOR =
-      Comparator.comparing(
-              (MediaType mediaType) -> {
+      Comparator.comparing((MediaType mediaType) -> mediaType.type().equals("*"))
+        .thenComparing(mediaType -> mediaType.subtype().equals("*"))
+        .thenComparing(
+              mediaType -> {
                 try {
                   return Double.parseDouble(mediaType.parameters().get("q").getFirst());
                 } catch (NoSuchElementException e) {
@@ -69,9 +71,7 @@ public class RDFApi {
               },
               Comparator.reverseOrder())
           .thenComparing( // RDF-specific
-              mediaType -> mediaType.subtype().contains("turtle"), Comparator.reverseOrder())
-          .thenComparing(mediaType -> mediaType.subtype().equals("*"))
-          .thenComparing(mediaType -> mediaType.type().equals("*"));
+              mediaType -> mediaType.subtype().contains("turtle"), Comparator.reverseOrder());
 
   public static void create(Javalin app, MolgenisSessionManager sm) {
     // ideally, we estimate/calculate the content length and inform the client using

--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/WebApiSmokeTests.java
@@ -1001,7 +1001,9 @@ public class WebApiSmokeTests {
     final String defaultContentType = "text/turtle";
     final String jsonldContentType = "application/ld+json";
     final String ttlContentType = "text/turtle";
+    final String ntriplesContentType = "application/n-triples";
     final String defaultContentTypeWithCharset = "text/turtle; charset=utf-8"; // charset is ignored
+    final String multipleContentTypes = "text/turtle; q=0.5, application/n-triples";
 
     // skip 'all schemas' test because data is way to big (i.e.
     // get("http://localhost:PORT/api/rdf");)
@@ -1066,6 +1068,10 @@ public class WebApiSmokeTests {
     rdfApiRequest(200, ACCEPT_YAML).head(urlPrefix + "/api/rdf?shacls");
     rdfApiContentTypeRequest(200, defaultContentType, ACCEPT_YAML)
         .head(urlPrefix + "/api/rdf?shacls");
+
+    // Validate multi-content type negotiation
+    rdfApiContentTypeRequest(200, multipleContentTypes, ntriplesContentType)
+        .head(urlPrefix + "/pet store/api/rdf");
   }
 
   @Test

--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/WebApiSmokeTests.java
@@ -1001,9 +1001,7 @@ public class WebApiSmokeTests {
     final String defaultContentType = "text/turtle";
     final String jsonldContentType = "application/ld+json";
     final String ttlContentType = "text/turtle";
-    final String ntriplesContentType = "application/n-triples";
     final String defaultContentTypeWithCharset = "text/turtle; charset=utf-8"; // charset is ignored
-    final String multipleContentTypes = "text/turtle; q=0.5, application/n-triples";
 
     // skip 'all schemas' test because data is way to big (i.e.
     // get("http://localhost:PORT/api/rdf");)
@@ -1070,7 +1068,10 @@ public class WebApiSmokeTests {
         .head(urlPrefix + "/api/rdf?shacls");
 
     // Validate multi-content type negotiation
-    rdfApiContentTypeRequest(200, multipleContentTypes, ntriplesContentType)
+    rdfApiContentTypeRequest(
+            200, "text/turtle; q=0.5, application/n-triples", "application/n-triples")
+        .head(urlPrefix + "/pet store/api/rdf");
+    rdfApiContentTypeRequest(200, "application/trig; q=0.5, text/*", "application/trig")
         .head(urlPrefix + "/pet store/api/rdf");
   }
 


### PR DESCRIPTION
### What are the main changes you did
- Fixes content negotiation according to [rfc7231](https://datatracker.ietf.org/doc/html/rfc7231#section-5.3.2).
  - Note: Only includes wildcard & quality factor comparison (with turtle taking priority if multiple are equal). Any additional specificity is ignored (such as `text/plain` vs `text/plain;format=flowed`).

### How to test
- Tests should succeed.

### TODO
- [ ] Add more test covering additional scenario's.
- [ ] Error handling in case of failing content negotiation.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation