### PR TITLE
fix: use separate domains for emx2-app and catalogue

### DIFF
--- a/helm-chart/templates/ingress.yaml
+++ b/helm-chart/templates/ingress.yaml
@@ -24,34 +24,20 @@ spec:
     - host: {{ index .Values.ingress.hosts 1 | quote }}
       http:
         paths:
-            - path: /apps
-              pathType: Prefix
-              backend:
-                service:
-                  name: {{ $fullName }}
-                  port:
-                    number: 8080
-            - path: /api
-              pathType: Prefix
-              backend:
-                service:
-                  name: {{ $fullName }}
-                  port:
-                    number: 8080
-            - path: /[^/]+/(aggregates|central|cranio-provider|cranio-public|directory|ern-genturis|ern-ithaca|ern-reconnect|ern-skin|gportal|graphql-playground|helloworld|imdhub-public|molgenis-components|molgenis-viz|nestor-public|pages|projectmanager|reports|schema|settings|tables|tailwind-components|tasks|ui|updownload|docs|graphql|api|index|sitemap\.xml|theme\.css)
-              pathType: ImplementationSpecific
-              backend:
-                service:
-                  name: {{ $fullName }}
-                  port:
-                    number: 8080
-            - path: /
-              pathType: Prefix
-              backend:
-                service:
-                  name: ssr-catalogue
-                  port:
-                    number: 3000
+          - path: /.+/(graphql|sitemap\.xml|docs)
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: {{ $fullName }}
+                port:
+                  number: 8080
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: ssr-catalogue
+                port:
+                  number: 3000
     - host: {{ index .Values.ingress.hosts 0 | quote }}
       http:
         paths:


### PR DESCRIPTION
DO NOT MERGE, might not be needed 


### What are the main changes you did
- for some reason the preview deploys result in a valid catalogue deployment 
 https://preview-catalogue-pr-[PR_NUMBER].dev.molgenis.org while the dev now has a broken deployment
https://catalogue.dev.molgenis.org/ both should now work by splitting on domain mijn ( only the vm's use the path splitting)

but i'm not sure where the preview / dev proxy is passed/updated

note; the preview for this pr now show the same error as the dev server so i guess the ingress.yml is the one used in the preview, maybe the dev server just needs a config reload 


note2: o i spoke to soon , it's up now at https://preview-catalogue-pr-5354.dev.molgenis.org/ ( this pr ) 

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation