### PR TITLE
fix(pyclient): parse only empty strings as NA values

### DIFF
--- a/tools/pyclient/src/molgenis_emx2_pyclient/client.py
+++ b/tools/pyclient/src/molgenis_emx2_pyclient/client.py
@@ -464,7 +464,7 @@ class Client:
         bool_columns = [c for (c, t) in dtypes.items() if t == 'boolean']
         date_columns = [c.name for c in table_meta.columns
                         if c.get('columnType') in (DATE, DATETIME) and c.name in response_columns]
-        response_data = pd.read_csv(BytesIO(response.content),  keep_default_na=True, dtype=dtypes, parse_dates=date_columns)
+        response_data = pd.read_csv(BytesIO(response.content), keep_default_na=False, na_values=[''], dtype=dtypes, parse_dates=date_columns)
 
         response_data[bool_columns] = response_data[bool_columns].replace({'true': True, 'false': False})
         response_data = response_data.astype(dtypes)


### PR DESCRIPTION
Closes #5353 

### What are the main changes you did
- Don't use pandas default NA values, but only use the empty string as an NA value

### How to test
- see reproduction steps in issue