### PR TITLE
fix: import metadata-utils interface correctly

### DIFF
--- a/apps/molgenis-components/src/components/layout/Molgenis.vue
+++ b/apps/molgenis-components/src/components/layout/Molgenis.vue
@@ -56,16 +56,15 @@
 </template>
 
 <script setup lang="ts">
-import MolgenisMenu from "./MolgenisMenu.vue";
-import MolgenisSession from "../account/MolgenisSession.vue";
-import MolgenisFooter from "./MolgenisFooter.vue";
-import Breadcrumb from "./Breadcrumb.vue";
-import CookieWall from "./CookieWall.vue";
+import { ISetting } from "metadata-utils";
+import { computed, onMounted, ref, watch } from "vue";
 import Client from "../../client/client";
 import { MenuItem } from "../../Interfaces/MenuItem";
-import { computed, ref, unref, watch } from "vue";
-import { onMounted } from "vue";
-import { ISetting } from "metadata-utils/src";
+import MolgenisSession from "../account/MolgenisSession.vue";
+import Breadcrumb from "./Breadcrumb.vue";
+import CookieWall from "./CookieWall.vue";
+import MolgenisFooter from "./MolgenisFooter.vue";
+import MolgenisMenu from "./MolgenisMenu.vue";
 
 const defaultSchemaMenuItems: MenuItem[] = [
   {


### PR DESCRIPTION
### What are the main changes you did
- molgenis components was not able to run due to a faulty interface import.

### How to test
- run yarn dev on the molgenis-components app

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation