### PR TITLE
fix(tw): added missing v-else-if

### DIFF
--- a/apps/tailwind-components/components/value/List.vue
+++ b/apps/tailwind-components/components/value/List.vue
@@ -24,7 +24,7 @@ const elementType = computed(() => props.metadata.columnType.split("_")[0]);
       :data="listElement as string"
     />
     <ValueString
-      v-if="elementType === 'TEXT'"
+      v-else-if="elementType === 'TEXT'"
       :metadata="metadata"
       :data="listElement as string"
     />


### PR DESCRIPTION
### What are the main changes you did

- [x] added missing v-else-if in table cell list component

### How to test

- On the preview, go to the [Pedigree table in the RD3 schema](https://preview-emx2-pr-5377.dev.molgenis.org/apps/ui/rd3/Pedigree)
- The column family IDs should not show the column types (e.g., `STRING`) as it does in the [pedigree table in the current release](https://emx2.dev.molgenis.org/apps/ui/rd3/Pedigree)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation