### PR TITLE
fix: default ERN_DASHBOARD menu

### DIFF
--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DashboardLoader.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DashboardLoader.java
@@ -27,7 +27,7 @@ public class DashboardLoader extends ImportDataModelTask {
         .getMetadata()
         .setSetting(
             "menu",
-            "[{'label': 'Demo', 'href': './molgenis-viz/', 'key': 'mwlu8b', 'submenu': [], 'role': 'Viewer'}, {'label': 'Tables', 'href': 'tables', 'role': 'Viewer', 'key': '3ywoaq', 'submenu': []}, {'label': 'Schema', 'href': 'schema', 'role': 'Manager', 'key': 'd0y34a', 'submenu': []}, {'label': 'Up/Download', 'href': 'updownload', 'role': 'Editor', 'key': 'r2mc15', 'submenu': []}, {'label': 'Graphql', 'href': 'graphql-playground', 'role': 'Viewer', 'key': 're5u4i', 'submenu': []}, {'label': 'Settings', 'href': 'settings', 'role': 'Manager', 'key': 'v1zouk', 'submenu': []}, {'label': 'Help', 'href': 'docs', 'role': 'Viewer', 'key': 'dikoff', 'submenu': []}]");
+            "[{\"label\": \"Demo\", \"href\": \"./molgenis-viz/\", \"key\": \"mwlu8b\", \"submenu\": [], \"role\": \"Viewer\"}, {\"label\": \"Tables\", \"href\": \"tables\", \"role\": \"Viewer\", \"key\": \"3ywoaq\", \"submenu\": []}, {\"label\": \"Schema\", \"href\": \"schema\", \"role\": \"Manager\", \"key\": \"d0y34a\", \"submenu\": []}, {\"label\": \"Up/Download\", \"href\": \"updownload\", \"role\": \"Editor\", \"key\": \"r2mc15\", \"submenu\": []}, {\"label\": \"Graphql\", \"href\": \"graphql-playground\", \"role\": \"Viewer\", \"key\": \"re5u4i\", \"submenu\": []}, {\"label\": \"Settings\", \"href\": \"settings\", \"role\": \"Manager\", \"key\": \"v1zouk\", \"submenu\": []}, {\"label\": \"Help\", \"href\": \"docs\", \"role\": \"Viewer\", \"key\": \"dikoff\", \"submenu\": []}]");
     this.complete();
   }
 }


### PR DESCRIPTION
### What are the main changes you did
- The default menu when using the ERN_DASHBOARD template was not correctly generated. Using double quotes in stead of single quotes fixed it.

### How to test
- Create a schema using the ERN_DASHBOARD template
- Click on the schema name and see that you get redirected to a dashboard in stead of staying on apps/central what happens without this fix.