### PR TITLE
fix(upload): clean up arrays when uploading a csv

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableReader.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableReader.java
@@ -3,6 +3,8 @@ package org.molgenis.emx2.io.readers;
 import java.io.*;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Row;
 import org.simpleflatmapper.csv.CsvParser;
@@ -34,7 +36,7 @@ public class CsvTableReader {
       String secondLine = bufferedReader.readLine();
 
       // if file is empty we return empty iterator
-      if (firstLine == null || firstLine.trim().equals("") || secondLine == null) {
+      if (firstLine == null || firstLine.trim().isEmpty() || secondLine == null) {
         return Collections.emptyList();
       }
       char separator = ',';
@@ -49,6 +51,8 @@ public class CsvTableReader {
       if (firstLine.contains(";")) {
         separator = ';';
       }
+
+      final String sep = String.valueOf(separator);
 
       // push back in
       bufferedReader.reset();
@@ -89,7 +93,25 @@ public class CsvTableReader {
                 next = (HashMap<String, Object>) it.next();
                 isEmpty = next.values().stream().allMatch(Objects::isNull);
               }
-              return new Row(next);
+
+              Map<String, Object> cleaned =
+                  next.entrySet().stream()
+                      .collect(
+                          Collectors.toMap(
+                              Map.Entry::getKey,
+                              e -> {
+                                Object v = e.getValue();
+                                if (v instanceof String s && s.contains(sep)) {
+                                  // normalize list-like fields
+                                  return Arrays.stream(s.split(Pattern.quote(sep)))
+                                      .map(String::trim)
+                                      .filter(str -> !str.isEmpty())
+                                      .toList();
+                                }
+                                return v;
+                              }));
+
+              return new Row(cleaned);
             }
 
             @Override


### PR DESCRIPTION
Closes #5267 

### What are the main changes you did
- When parsing csv check for array type and use split(sep) to parse the array

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation