### PR TITLE
fix(upload): when uploading a csv with empty values at auto_id column skip validation

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/ImportTableTask.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/ImportTableTask.java
@@ -142,7 +142,7 @@ public class ImportTableTask extends Task {
                   .map(Field::getName)
                   .collect(Collectors.joining(","));
           task.addSubTask("Found duplicate Key (" + keyFields + ")=(" + keyValue + ")").setError();
-        } else if (!keyValue.isEmpty()) {
+        } else if (!keyValue.isEmpty() && !keyValue.equals("null")) {
           keys.add(keyValue);
         }
         task.setProgress(++index);


### PR DESCRIPTION
Closes #5350 

when uploading a csv with empty values at auto_id column skip validation

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation