### PR TITLE
fix(client): in molgenis-components client should cache the promises not the result

### DIFF
--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -259,7 +259,6 @@ const fetchSchemaMetaData = async (
     return schemaCache.get(currentschemaId) as Promise<ISchemaMetaData>;
   }
 
-  // Create new request and cache the Promise immediately
   const promise = axios
     .post(graphqlURL(schemaId), { query: metadataQuery })
     .then((result: AxiosResponse<{ data: { _schema: ISchemaMetaData } }>) => {
@@ -268,7 +267,7 @@ const fetchSchemaMetaData = async (
     })
     .catch((error: AxiosError) => {
       console.log(error);
-      schemaCache.delete(currentschemaId); // remove failed promises to allow retry
+      schemaCache.delete(currentschemaId);
       throw error;
     });
 


### PR DESCRIPTION
closes #5426

tricky, in molgenis schema editor many requests are made to graphql to retrieve schema.
the cache doesn't work because they all fire before result are back.
this rewrite caches the promise instead of the result, so that all users will await the same request instead of firing seperate.