### PR TITLE
fix(forms): replaced refLabel with table label in column name (inputRef)

### DIFF
--- a/apps/tailwind-components/app/components/input/Ref.vue
+++ b/apps/tailwind-components/app/components/input/Ref.vue
@@ -51,8 +51,7 @@ const showSearch = ref<boolean>(false);
 const searchTerms: Ref<string> = ref("");
 const hasNoResults = ref<boolean>(true);
 const columnName = computed<string>(() => {
-  const label = tableMetadata.value?.label || tableMetadata.value?.id;
-  return label as string;
+  return (tableMetadata.value?.label || tableMetadata.value?.id) as string;
 });
 
 const entitiesLeftToLoad = computed<number>(() => {


### PR DESCRIPTION
### What are the main changes you did

This PR closes molgenis/molgenis-emx2#5466 by fixing the search field label in the InputRef component-

- [x] `Search in *` label: changed `columnName` (`props.refLabel.*`) to `tableMetadata?.label || tableMetadata?.id`

> [!NOTE]
> There is also an issue with the form validation. This should be fixed in molgenis/GCC#1943 as the component ref component properly emits the events

### How to test

- Go to the new UI and sign in as admin
- Go to the "patient registry demo" schema and open the Subjects table. Click the "add subject" button
- Go to section "4.2 Healthcare provider". Click the search button. The text will now show "Search in dataproviders". (Compare with emx2dev)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation
