### PR TITLE
fix(forms): fixed validation for period type

### DIFF
--- a/apps/molgenis-components/src/components/forms/formUtils/formUtils.ts
+++ b/apps/molgenis-components/src/components/forms/formUtils/formUtils.ts
@@ -98,7 +98,7 @@ export function getColumnError(
   if (type === "HYPERLINK_ARRAY" && containsInvalidHyperlink(value)) {
     return "Invalid hyperlink";
   }
-  if (type === "PERIOD" && !isInvalidPeriod(value)) {
+  if (type === "PERIOD" && isInvalidPeriod(value)) {
     return "Invalid Period: should start with a P and should contain at least a Y(year), M(month) or D(day): e.g. 'P1Y3M14D'";
   }
   if (type === "PERIOD_ARRAY" && containsInvalidPeriod(value)) {


### PR DESCRIPTION
### What are the main changes you did

This PR closes molgenis/molgenis-emx2#5454

- [x] fixed validation for in the period input type: the issue was that there was an extra `!` that would throw an error when the value was valid. This prevented the form from saving.

```diff
- if (type === "period" && !isInvalidPeriod(value)) // throws an error if the value is valid
+ if (type === "period" && isInvalidPeriod(value)) // throws an error if the value is invalid
```

### How to test

- In the preview, go to the type test schema and open the form.
- Enter a period value (e.g., `P1Y3M14D`). Error should not be thrown.
- Compare with master

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation