### PR TITLE
fix(upload): enabled use of `mg_delete` column for uploading CSV table files

### DIFF
--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
@@ -133,10 +133,14 @@ public class CsvApi {
   }
 
   private static void tableUpdate(Context ctx) {
-    int count = MolgenisWebservice.getTableByIdOrName(ctx).save(getRowList(ctx));
+    Table table = MolgenisWebservice.getTableByIdOrName(ctx);
+    TableStoreForCsvInMemory tableStore = new TableStoreForCsvInMemory();
+    tableStore.setCsvString(table.getName(), ctx.body());
+    Task task = new ImportTableTask(tableStore, table, false);
+    task.run();
     ctx.status(200);
     ctx.contentType(ACCEPT_CSV);
-    ctx.result(String.valueOf(count));
+    ctx.result(String.valueOf(task.getProgress()));
   }
 
   private static Iterable<Row> getRowList(Context ctx) {


### PR DESCRIPTION
### What are the main changes you did
The API handling CSV files for specific tables used the `SqlTable`'s `save` method which does not account for deletions.
The application of this class is replaced by the `ImportTableTask`, which is also used by the general CSV API which does account for the `mg_delete_column`.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation