### PR TITLE
fix: default values are not properly set in database

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
@@ -510,7 +510,7 @@ public class SqlColumnExecutor {
   }
 
   public static void executeSetDefaultValue(DSLContext jooq, Column newColumn) {
-    if (newColumn.getDefaultValue() != null && newColumn.isReference()) {
+    if (newColumn.getDefaultValue() != null && !newColumn.isReference()) {
       // we can't do this for references yet
       Object defaultValue = newColumn.getDefaultValue();
       if (newColumn.getDefaultValue().startsWith("=")) {


### PR DESCRIPTION
Fixes: #5455 

### What are the main changes you did
- The columnExecutor never applies the default value to the actual column in the table

### How to test
https://preview-emx2-pr-5479.dev.molgenis.org/apps/central/#/
- upload the molgenis.csv from the corresponding issue #5455 
- see the default value when entering a new record

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation