### PR TITLE
feat: allow boolean default without =

### DIFF
--- a/apps/molgenis-components/src/components/forms/RowEdit.vue
+++ b/apps/molgenis-components/src/components/forms/RowEdit.vue
@@ -246,9 +246,9 @@ export default {
 };
 
 function getBooleanDefaultValue(value: any): boolean | undefined {
-  if (value === "true" || value === "TRUE" || value === true) {
+  if (value === "TRUE" || value === "true" || value === true) {
     return true;
-  } else if (value === "false" || value === "FALSE" || value === false) {
+  } else if (value === "FALSE" || value === "false" || value === false) {
     return false;
   } else {
     return undefined;


### PR DESCRIPTION
### What are the main changes you did
- implements #5455
- Added a special case for boolean default values, where you no longer need to add an '=' in front. So possible options are now:
  - false
  - FALSE
  - =false // or other js expression
  -  true
  - TRUE
  - =true // or other js expression
- If anything else is entered, the value will be ignored.

### How to test
- Add a boolean column to a table with the default value set for each of the above cases
- Go to the table
- Add a new row
- See that all values or defaulted.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation