### PR TITLE
fix(forms-tw): don't use magic imports for inputs

### DIFF
--- a/apps/tailwind-components/app/components/input/Boolean.vue
+++ b/apps/tailwind-components/app/components/input/Boolean.vue
@@ -14,9 +14,11 @@
   />
 </template>
 
-<script lang="ts" setup>
+<script setup lang="ts">
 import { ref } from "vue";
 import type { IInputProps, IRadioOptionsData } from "../../../types/types";
+import InputRadioGroup from "./RadioGroup.vue";
+
 const props = withDefaults(
   defineProps<
     IInputProps & {

--- a/apps/tailwind-components/app/components/input/Int.vue
+++ b/apps/tailwind-components/app/components/input/Int.vue
@@ -16,12 +16,13 @@
 </template>
 
 <script setup lang="ts">
-import type { IInputProps } from "../../../types/types";
 import constants from "../../../../molgenis-components/src/components/constants";
 import {
   flipSign,
   isNumericKey,
 } from "../../../../molgenis-components/src/components/utils";
+import type { IInputProps } from "../../../types/types";
+import InputString from "./String.vue";
 
 const modelValue = defineModel<string | number | undefined>({ required: true });
 

--- a/apps/tailwind-components/app/components/input/Long.vue
+++ b/apps/tailwind-components/app/components/input/Long.vue
@@ -24,6 +24,7 @@ import {
   isNumericKey,
 } from "../../../../molgenis-components/src/components/utils";
 import type { IInputProps } from "../../../types/types";
+import InputString from "./String.vue";
 
 const modelValue = defineModel<string | undefined>("modelValue", {
   required: true,

--- a/apps/tailwind-components/app/components/input/Ontology.vue
+++ b/apps/tailwind-components/app/components/input/Ontology.vue
@@ -1,25 +1,27 @@
 <script setup lang="ts">
+import { fetchGraphql } from "#imports";
+import {
+  computed,
+  defineEmits,
+  defineModel,
+  defineProps,
+  nextTick,
+  onMounted,
+  ref,
+  useTemplateRef,
+  watch,
+  withDefaults,
+  type Ref,
+} from "vue";
 import type { IInputProps, ITreeNodeState } from "../../../types/types";
 import TreeNode from "../../components/input/TreeNode.vue";
-import {
-  onMounted,
-  onBeforeUnmount,
-  ref,
-  watch,
-  type Ref,
-  computed,
-  useTemplateRef,
-  nextTick,
-} from "vue";
-import { fetchGraphql } from "#imports";
 import BaseIcon from "../BaseIcon.vue";
-import InputSearch from "./Search.vue";
-import InputGroupContainer from "../input/InputGroupContainer.vue";
-import ButtonFilterWellContainer from "../button/FilterWellContainer.vue";
 import Button from "../Button.vue";
-import TextNoResultsMessage from "../text/NoResultsMessage.vue";
+import ButtonFilterWellContainer from "../button/FilterWellContainer.vue";
 import ButtonText from "../button/Text.vue";
-import { defineEmits, defineModel, defineProps, withDefaults } from "vue";
+import InputGroupContainer from "../input/InputGroupContainer.vue";
+import TextNoResultsMessage from "../text/NoResultsMessage.vue";
+import InputSearch from "./Search.vue";
 
 const props = withDefaults(
   defineProps<

--- a/apps/tailwind-components/app/components/input/Radio.vue
+++ b/apps/tailwind-components/app/components/input/Radio.vue
@@ -12,7 +12,10 @@
 <script lang="ts" setup>
 import type { columnValue } from "../../../../metadata-utils/src/types";
 import { type IInputProps } from "../../../types/types";
+
 defineProps<IInputProps>();
+
 const modelValue = defineModel<columnValue>();
+
 const emit = defineEmits(["focus", "update:modelValue"]);
 </script>


### PR DESCRIPTION
### What are the main changes you did
- Fixes and issues for the 'Int', 'Long', and 'Bool' inputs, where they work in dev mode, but not in the final build. In the full build only their header would show, and not their input field. 

### How to test
- Build and run emx2
- Go to the tw-ui
- Go to the pet store
- Go to the order table
- Login
- Click the 'Add Order' button
- See that the 'quantity' and 'completed' input can be filled.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation