### PR TITLE
chore: reset the database for the dev server every 3 weeks

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -451,7 +451,7 @@ jobs:
             bash ci/create_or_update_k8s-azure.sh "emx2" latest true
 
       - run:
-          name: Message slack about a new molgenis-emx2-pyclient version
+          name: Message slack about a database cleanup
           command: |
             curl -d "token=${SLACK_TOKEN}" \
             -d "cleaned database at https://emx2.dev.molgenis.org/" \


### PR DESCRIPTION
### What are the main changes you did
- trigger every week via cron in circleci ( cron has no syntax for every 3 weeks ) 
- add job that each week: if the third week, reset emx2 ( dev server ) namespace to latest ( current ) version using delete = true option to reset the db

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation