### PR TITLE
fix: suppress y axis scrollbar in edit mode

### DIFF
--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -29,7 +29,7 @@
   </div>
 
   <div
-    class="relative overflow-auto rounded-b-theme border border-theme border-color-theme"
+    class="relative overflow-auto overflow-y-hidden rounded-b-theme border border-theme border-color-theme"
   >
     <div class="overflow-x-auto overscroll-x-contain bg-table rounded-t-3px">
       <table ref="table" class="text-left w-full table-fixed">


### PR DESCRIPTION
### What are the main changes you did
- add class to suppress scrollbar on table container when table is shown in edit mode
- 
### How to test
- compare this preview with 
https://emx2.dev.molgenis.org/apps/tailwind-components/#/table/EMX2.story?schema=pet+store&table=Pet

toggle fullscreen mode for playground and select edit mode 

now notice the (absence) of a vertical scrollbar on the Emx2Table container 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation