### PR TITLE
chore(docs): replaced 'data-catalogue.molgeniscloud.org' by 'molgeniscatalogue.org' in documentation

### DIFF
--- a/docs/catalogue/README.md
+++ b/docs/catalogue/README.md
@@ -1,7 +1,7 @@
 # MOLGENIS Catalogue Guide
 
 Welcome to the MOLGENIS Catalogue Guide!
-This guide explains what [the MOLGENIS Catalogue](https://data-catalogue.molgeniscloud.org/)
+This guide explains what [the MOLGENIS Catalogue](https://molgeniscatalogue.org/)
 is and how you can best use it.
 To help you get to the right information, we have distinguished three roles for users of the catalogue:
 a researcher, looking to find relevant data for their research question,

--- a/docs/catalogue/cat_data-manager.md
+++ b/docs/catalogue/cat_data-manager.md
@@ -1,6 +1,6 @@
 # Data manager
 
-The [MOLGENIS Data Catalogue](https://data-catalogue.molgeniscloud.org/) provides a
+The [MOLGENIS Data Catalogue](https://molgeniscatalogue.org/) provides a
 framework for detailed descriptions of the following:
 metadata of different types of resources, such as cohort studies and biobanks;
 definitions of the variables collected in these resources;
@@ -12,11 +12,11 @@ and multi-data source studies ([Gini et al., 2020](https://pubmed.ncbi.nlm.nih.g
 The metadata of resources consists of high-level descriptive information, such as contact details,
 contents, design, and access and usage conditions.
 The definitions of the source variables of a resource
-(e.g. a cohort study like [ALSPAC](https://data-catalogue.molgeniscloud.org/catalogue/ssr-catalogue/all/collections/ALSPAC))
+(e.g. a cohort study like [ALSPAC](https://molgeniscatalogue.org/all/collections/ALSPAC))
 can be considered its codebook or data dictionary.
 Similarly, the common data models (or 'target variables') can be considered the codebook for a network of organisations
 with access to multiple data resources
-(e.g. [LifeCycle](https://data-catalogue.molgeniscloud.org/catalogue/ssr-catalogue/LifeCycle/variables)).
+(e.g. [LifeCycle](https://molgeniscatalogue.org/LifeCycle/variables)).
 Combining these two, the variable mappings describe how source variables have been converted into target variables,
 which can be used as a basis for integrated analysis. In some projects, data may be made available via [DataSHIELD](https://www.datashield.org/).
 In these cases each resource stores the data locally in a [MOLGENIS Armadillo](../armadillo/) DataSHIELD server.
@@ -113,11 +113,11 @@ The datasets (sets of variables) that make up a resource are defined in the *Dat
 | resource\*                                | Resource that this dataset belongs to. Fill in your resource id                   | The resource id is found in the table *Resources* in the resource staging area                                                                                  |
 | name\*                                    | Unique dataset name                                                               |                                                                                                                                                                 |
 | label                                     | Dataset label                                                                     |                                                                                                                                                                 |
-| dataset type<sup id="ds1">[1](#ds1)</sup> | Type of dataset                                                                   | Find list to choose from in CatalogueOntologies [Dataset types](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/DatasetTypes)             |
+| dataset type<sup id="ds1">[1](#ds1)</sup> | Type of dataset                                                                   | Find list to choose from in CatalogueOntologies [Dataset types](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/DatasetTypes)             |
 | description                               | Dataset description                                                               |                                                                                                                                                                 |
-| unit of observation<sup>[1](#ds1)</sup>   | Defines what each record in this dataset describes                                | Find list to choose from in CatalogueOntologies [Observation targets](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/ObservationTargets) |
+| unit of observation<sup>[1](#ds1)</sup>   | Defines what each record in this dataset describes                                | Find list to choose from in CatalogueOntologies [Observation targets](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/ObservationTargets) |
 | number of rows                            | Count of the number of records in this dataset                                    |                                                                                                                                                                 |
-| keywords<sup>[1](#ds1)</sup>              | Enables grouping of datasets into topics and helps to display variables in a tree | Find list to choose from in CatalogueOntologies [Keywords](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/Keywords)                      |
+| keywords<sup>[1](#ds1)</sup>              | Enables grouping of datasets into topics and helps to display variables in a tree | Find list to choose from in CatalogueOntologies [Keywords](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/Keywords)                      |
 | since version                             | Version of the data model when this dataset was introduced                        | e.g. 1.0.0 or 2.1                                                                                                                                               |
 | until version                             | Version of the data model when this dataset was deleted                           | e.g. 2.0.0 or 2.1                                                                                                                                               |
 
@@ -130,27 +130,27 @@ to add Keywords, Observation targets or Dataset types._
 
 The variables making up the datasets specified in the *Datasets* sheet are defined in the *Variables* sheet.
 
-| Column name                             | Description                                                                        | Remarks                                                                                                                                            |
-|-----------------------------------------|------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------|
-| resource\*                              | Resource that this variable belongs to. Fill out your resource id                  | The resource id is found in the table *Resources* in the resource staging area                                                                     |
-| dataset\*                               | Dataset that contains the variable.                                                | Datasets must be predefined in the *Datasets* sheet                                                                                                |
-| name\*                                  | Variable name, unique within a dataset                                             |                                                                                                                                                    |
-| label                                   | Human readable variable label                                                      |                                                                                                                                                    |
-| format                                  | The data type of the variable                                                      | Find list to choose from in CatalogueOntologies [Formats](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/Formats)           |
-| unit<sup id="v1">[1](#v1)</sup>         | Unit in case of a continuous or integer format                                     | Find list to choose from in CatalogueOntologies [Units](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/Units)               |
-| description                             | Description of the variable                                                        |                                                                                                                                                    |
-| example values                          | Examples of values in a comma separated list                                       | Makes your data structure more insightful. E.g. 1,2,3 or TRUE,FALSE or 1.23,4.56,3.14                                                              |
-| repeat unit<sup id="v1">[1](#v1)</sup>  | In case of repeated variables, indicate the repeat period                          | Find list to choose from in CatalogueOntologies [Repeat units](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/RepeatUnits)  |
-| repeat min                              | The minimum repeat unit                                                            | E.g. 0 or 10                                                                                                                                       |
-| repeat max                              | The maximum repeat unit                                                            | E.g. 10 or 60                                                                                                                                      |
-| collection event                        | Refer to the names of collection events in a comma separated list                  | The collection events need to be predefined in the Collection events table in the resource staging area; e.g. y1, y2                               |
-| vocabularies<sup id="v1">[1](#v1)</sup> | Refer to ontologies being used                                                     | Find list to choose from in CatalogueOntologies [Vocabularies](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/Vocabularies) |
-| keywords<sup id="v1">[1](#v1)</sup>     | Enables grouping of variables into topics and helps to display variables in a tree | Find list to choose from in Catalogue [Keywords](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/Keywords)                   |
-| since version                           | Version of the data model when this variable was introduced                        | e.g. 1.0.0 or 2.1                                                                                                                                  |
-| until version                           | Version of the data model when this variable was deleted                           | e.g. 2.0.0 or 2.1                                                                                                                                  |
-| useExternaldefinition.resource          | Refer to the associated resource id                                                | When using the definitions of a harmonised variable from another CDM                                                                               |
-| useExternaldefinition.dataset           | Refer to the associated dataset name                                               | When using the definitions of a harmonised variable from another CDM                                                                               |
-| useExternaldefinition.name              | Refer to the associated variable name                                              | When using the definitions of a harmonised variable from another CDM                                                                               |
+| Column name                                     | Description                                                                        | Remarks                                                                                                                                                 |
+|-------------------------------------------------|------------------------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------|
+| resource\*                                      | Resource that this variable belongs to. Fill out your resource id                  | The resource id is found in the table *Resources* in the resource staging area                                                                          |
+| dataset\*                                       | Dataset that contains the variable.                                                | Datasets must be predefined in the *Datasets* sheet                                                                                                     |
+| name\*                                          | Variable name, unique within a dataset                                             |                                                                                                                                                         |
+| label                                           | Human readable variable label                                                      |                                                                                                                                                         |
+| format                                          | The data type of the variable                                                      | Find list to choose from in CatalogueOntologies [Formats](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/Formats)                           |
+| unit<sup id="v1">[1](#v1)</sup>                 | Unit in case of a continuous or integer format                                     | Find list to choose from in CatalogueOntologies [Units](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/Units)                               |
+| description                                     | Description of the variable                                                        |                                                                                                                                                         |
+| example values                                  | Examples of values in a comma separated list                                       | Makes your data structure more insightful. E.g. 1,2,3 or TRUE,FALSE or 1.23,4.56,3.14                                                                   |
+| repeat unit<sup id="v1">[1](#v1)</sup>          | In case of repeated variables, indicate the repeat period                          | Find list to choose from in CatalogueOntologies [Variable repeat units](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/VariableRepeatUnits) |
+| repeat min                                      | The minimum repeat unit                                                            | E.g. 0 or 10                                                                                                                                            |
+| repeat max                                      | The maximum repeat unit                                                            | E.g. 10 or 60                                                                                                                                           |
+| collection event                                | Refer to the names of collection events in a comma separated list                  | The collection events need to be predefined in the Collection events table in the resource staging area; e.g. y1, y2                                    |
+| vocabularies<sup id="v1">[1](#v1)</sup>         | Refer to ontologies being used                                                     | Find list to choose from in CatalogueOntologies [Vocabularies](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/Vocabularies)                 |
+| keywords<sup id="v1">[1](#v1)</sup>             | Enables grouping of variables into topics and helps to display variables in a tree | Find list to choose from in Catalogue [Keywords](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/Keywords)                                   |
+| since version                                   | Version of the data model when this variable was introduced                        | e.g. 1.0.0 or 2.1                                                                                                                                       |
+| until version                                   | Version of the data model when this variable was deleted                           | e.g. 2.0.0 or 2.1                                                                                                                                       |
+| useExternaldefinition.resource                  | Refer to the associated resource id                                                | When using the definitions of a harmonised variable from another CDM                                                                                    |
+| useExternaldefinition.dataset                   | Refer to the associated dataset name                                               | When using the definitions of a harmonised variable from another CDM                                                                                    |
+| useExternaldefinition.name                      | Refer to the associated variable name                                              | When using the definitions of a harmonised variable from another CDM                                                                                    |
 
 _Table 2. Description of the columns that can be filled out for Variables. \*: mandatory;
 <a id="v1">1</a>: contact [*molgenis support*](mailto:support@molgenis.org) to add Vocabularies, Keywords, Repeat units, or Units._
@@ -220,7 +220,7 @@ Harmonisation procedures at the variable level are defined in the *Variable mapp
 | target\*                                | Name of the target CDM                                                                         | e.g. LifeCycle or LongITools                                                                                                                                                                                                                        |
 | target dataset\*                        | Target dataset name.                                                                           | Map to a dataset that is defined in a CDM                                                                                                                                                                                                           |
 | target variable\*                       | Target variable name                                                                           | Map to a variable that is defined in a CDM                                                                                                                                                                                                          |
-| match\*                                 | Whether the harmonisation is partial, complete or na (non-existent)                            | Find list to choose from in CatalogueOntologies [StatusDetails](https://data-catalogue.molgeniscloud.org/CatalogueOntologies/tables/#/StatusDetails)                                                                                                |
+| match\*                                 | Whether the harmonisation is partial, complete or na (non-existent)                            | Find list to choose from in CatalogueOntologies [StatusDetails](https://molgeniscatalogue.org/CatalogueOntologies/tables/#/StatusDetails)                                                                                                |
 | repeats\*                               | In the case of a repeated target variable, comma separated list of repeats that were mapped to | e.g. 0,1,2,6,12 or NA                                                                                                                                                                                                                                |
 | description                             | Description of the harmonisation                                                               |                                                                                                                                                                                                                                                     |
 | syntax                                  | Syntax used for this harmonisation                                                             |                                                                                                                                                                                                                                                     |
@@ -233,7 +233,7 @@ for an example on how to fill this out (last line)._
 ## Upload variable metadata
 
 When you have filled out the template(s) you can start uploading variable metadata. To do this, log in to the
-[MOLGENIS catalogue](https://data-catalogue.molgeniscloud.org/apps/central/#/), where
+[MOLGENIS catalogue](https://molgeniscatalogue.org/apps/central/#/), where
 you will see a list of staging areas and other databases that are accessible to you.
 You can also reach the staging areas via the catalogue menu: click **More** and select **Upload data**.
 Click on the staging area for your resource and
@@ -244,14 +244,14 @@ errors, your variable metadata is available for viewing under **Tables**.
 If your variable metadata is correctly uploaded and ready for transfer from the staging area
 to the main catalogue, contact us at [MOLGENIS support](mailto:support@molgenis.org).
 Once the data is transferred, you can find your own harmonised variables and variable details in the
-[harmonised variable explorer](https://data-catalogue.molgeniscloud.org/catalogue/ssr-catalogue/all/variables) ([manual](cat_researcher)).
+[harmonised variable explorer](https://molgeniscatalogue.org/all/variables) ([manual](cat_researcher)).
 
 If you encounter any difficulties during this process, feel free to [contact us](mailto:support@molgenis.org).
 
 ## Request access
 
 If you do not have an account yet, you will need to set one up:
-Go to the catalogue at [data-catalogue.molgeniscloud.org](https://data-catalogue.molgeniscloud.org).
+Go to the catalogue at [molgeniscatalogue.org](https://molgeniscatalogue.org).
 Click on **More** and select **Upload data**. Click on **Sign in**. Click on **LS Login**.
 Search for and select your institution and follow the instructions.
 You can now log in using your institutional e-mail account.

--- a/docs/catalogue/cat_researcher.md
+++ b/docs/catalogue/cat_researcher.md
@@ -1,6 +1,6 @@
 # Researcher
 
-The [MOLGENIS Data Catalogue](https://data-catalogue.molgeniscloud.org/) is perfectly suited
+The [MOLGENIS Data Catalogue](https://molgeniscatalogue.org/) is perfectly suited
 to help you find the relevant data for your research question.
 Using the catalogue, you can explore a variety of resources and compose a dataset
 tailored to your research needs.


### PR DESCRIPTION
### What are the main changes you did
- the old URL was still mentioned in places in the documentation. These references have been replaced by molgeniscloud.org

### How to test
- click the changed links and see if the results are as expected
