### PR TITLE
feat: show feedback after form action

### DIFF
--- a/apps/tailwind-components/app/components/Modal.vue
+++ b/apps/tailwind-components/app/components/Modal.vue
@@ -109,7 +109,7 @@ function hide() {
       </div>
 
       <footer
-        class="bg-modal-footer px-[30px] rounded-b-theme border-t border-divider flex-none"
+        class="bg-modal-footer px-[30px] rounded-b-theme border-t border-divider flex-none z-50"
       >
         <slot name="footer" :hide="hide" />
       </footer>

--- a/apps/tailwind-components/app/components/form/EditModal.vue
+++ b/apps/tailwind-components/app/components/form/EditModal.vue
@@ -72,7 +72,7 @@
         </NextSectionNav>
       </div>
     </div>
-    <Transition name="slide-up">
+    <TransitionSlideUp>
       <FormError
         v-show="errorMessage"
         :message="errorMessage"
@@ -80,8 +80,8 @@
         @error-prev="gotoPreviousError"
         @error-next="gotoNextError"
       />
-    </Transition>
-    <Transition name="slide-up">
+    </TransitionSlideUp>
+    <TransitionSlideUp>
       <FormError
         v-show="saveErrorMessage"
         :message="saveErrorMessage"
@@ -96,14 +96,14 @@
           >Re-authenticate</Button
         >
       </FormError>
-    </Transition>
-    <Transition name="slide-up">
+    </TransitionSlideUp>
+    <TransitionSlideUp :auto-hide="true" v-model:visible="showFormMessage">
       <FormMessage
         v-show="formMessage"
         :message="formMessage"
         class="sticky mx-4 h-[62px] bottom-0 transition-all transition-discrete"
       />
-    </Transition>
+    </TransitionSlideUp>
 
     <template #footer>
       <div class="flex justify-between items-center">
@@ -149,6 +149,7 @@ import NextSectionNav from "./NextSectionNav.vue";
 import PreviousSectionNav from "./PreviousSectionNav.vue";
 import FormRequiredInfoSection from "./RequiredInfoSection.vue";
 import DraftLabel from "../label/DraftLabel.vue";
+import TransitionSlideUp from "../transition/SlideUp.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -251,6 +252,7 @@ async function onSave(draft: boolean) {
     formMessage.value = `${isInsert.value ? "inserted" : "saved"} ${
       rowType.value
     } ${draft ? "as draft" : ""}`;
+    showFormMessage.value = true;
     emit(isInsert.value ? "update:added" : "update:updated", resp);
     if (isInsert.value) {
       await updateRowKey();
@@ -300,4 +302,7 @@ function reAuthenticate() {
     formMessage
   );
 }
+
+const showFormMessage = ref(false);
+const showSaveErrorMessage = ref(false);
 </script>

--- a/apps/tailwind-components/app/components/transition/SlideUp.vue
+++ b/apps/tailwind-components/app/components/transition/SlideUp.vue
@@ -1,0 +1,71 @@
+<script setup lang="ts">
+import { onBeforeUnmount, Transition, watch } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    autoHide?: boolean;
+    timeoutS?: number;
+  }>(),
+  {
+    autoHide: false,
+    timeoutS: 3,
+  }
+);
+
+const visible = defineModel("visible", {
+  required: false,
+});
+
+watch(visible, (newVal) => {
+  if (newVal) {
+    triggerSlide();
+  }
+});
+
+const emit = defineEmits(["closed"]);
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+const triggerSlide = () => {
+  visible.value = true;
+  if (timer !== null) {
+    clearTimeout(timer);
+  }
+  if (!props.autoHide) return;
+  timer = setTimeout(() => {
+    visible.value = false;
+    timer = null;
+    emit("closed");
+  }, props.timeoutS * 1000);
+};
+
+onBeforeUnmount(() => {
+  if (timer !== null) {
+    clearTimeout(timer);
+    timer = null;
+  }
+});
+</script>
+
+<template>
+  <Transition name="slide-up" v-show="visible">
+    <slot />
+  </Transition>
+</template>
+
+<style scoped>
+.slide-up-enter-active,
+.slide-up-leave-active {
+  transition: all 0.25s ease-out;
+}
+
+.slide-up-enter-from {
+  opacity: 0;
+  transform: translateY(62px);
+}
+
+.slide-up-leave-to {
+  opacity: 0;
+  transform: translateY(62px);
+}
+</style>

--- a/apps/tailwind-components/app/pages/transition/SlideUp.story.vue
+++ b/apps/tailwind-components/app/pages/transition/SlideUp.story.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import TransitionSlideUp from "../../components/transition/SlideUp.vue";
+import Button from "../../components/Button.vue";
+import { ref } from "vue";
+const show = ref(false);
+const showAutoHide = ref(false);
+</script>
+<template>
+  <div class="flex flex-col gap-0 pb-44">
+    <Button @click="show = !show">{{ show ? "Hide" : "Show" }}</Button>
+    <div>container</div>
+    <div
+      class="border border-1 border-theme h-80 min-w-52 flex flex-col justify-end"
+    >
+      <TransitionSlideUp>
+        <div class="bg-valid p-5 italic" v-show="show">
+          “The truth is rarely pure and never simple.”
+        </div>
+      </TransitionSlideUp>
+      <div class="z-50 bg-blue-200 h-40">other content</div>
+    </div>
+
+    <Button @click="showAutoHide = true" :disabled="showAutoHide" class="mt-5"
+      >show auto hide</Button
+    >
+    <div
+      class="border border-1 border-theme h-80 min-w-52 flex flex-col justify-end"
+    >
+      <TransitionSlideUp :auto-hide="true" v-model:visible="showAutoHide">
+        <div class="bg-valid p-5 italic" v-show="showAutoHide">
+          “I love talking about nothing. It is the only thing I know anything
+          about.”
+        </div>
+      </TransitionSlideUp>
+      <div class="z-50 bg-blue-200 h-40">other content</div>
+    </div>
+  </div>
+</template>


### PR DESCRIPTION
### What are the main changes you did
- Add SlideUp component to transition in feedback , and option to auto remove
- Slide in and keep error
- Slide in and remove draft message feedback after set time

### How to test
- set using the playground TransitionSlideUp page
- in the ui, do a draft save, notice feeback, and notice feedback is removed after 3 seconds
- in the ui create an error ( or backend error), notice the error is show and not removed until user action ( resolve form issue , close modal , .. .)
### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation