### PR TITLE
feat(catalogue): add option to set catalogue theme at runtime

### DIFF
--- a/apps/catalogue/app/app.vue
+++ b/apps/catalogue/app/app.vue
@@ -1,13 +1,13 @@
 <script setup lang="ts">
-import { useRuntimeConfig, useRoute, useCookie, useHead } from "#app";
-import { useGtag, useDatasetStore } from "#imports";
+import { useRuntimeConfig, useCookie, useHead } from "#app";
+import { useGtag, useDatasetStore, useTheme } from "#imports";
 import { computed, ref } from "vue";
 import BottomModal from "../app/components/BottomModal.vue";
 import Button from "../../tailwind-components/app/components/Button.vue";
 import BackgroundGradient from "../../tailwind-components/app/components/BackgroundGradient.vue";
 
 const config = useRuntimeConfig();
-const route = useRoute();
+const theme = await useTheme();
 const { initialize } = useGtag();
 
 const datasetStore = useDatasetStore();
@@ -54,10 +54,7 @@ const faviconHref = config.public.emx2Theme
   ? `/_nuxt-styles/img/${config.public.emx2Theme}.ico`
   : "/_nuxt-styles/img/molgenis.ico";
 useHead({
-  htmlAttrs: {
-    "data-theme":
-      (route.query.theme as string) || config.public.emx2Theme || "",
-  },
+  htmlAttrs: { "data-theme": theme },
   link: [{ rel: "icon", href: faviconHref }],
   titleTemplate: (titleChunk) => {
     if (titleChunk && config.public.siteTitle) {

--- a/apps/catalogue/app/composables/useTheme.ts
+++ b/apps/catalogue/app/composables/useTheme.ts
@@ -1,0 +1,31 @@
+import { useRuntimeConfig, useRoute, useAsyncData, useState } from "#app";
+
+export async function useTheme() {
+  const config = useRuntimeConfig();
+  const route = useRoute();
+
+  const theme = useState("theme", () => "molgenis");
+
+  const { data } = await useAsyncData(
+    "theme",
+    () =>
+      $fetch(`/${config.public.schema}/graphql`, {
+        method: "POST",
+        body: {
+          query: `{_settings (keys: ["CATALOGUE_THEME"]){ key, value }}`,
+        },
+      }),
+    {
+      transform: (data) => {
+        const themeValue = data.data._settings.find(
+          (s: { key: string }) => s.key === "CATALOGUE_THEME"
+        );
+        return themeValue?.value ?? config.public.emx2Theme ?? "molgenis";
+      },
+    }
+  );
+
+  theme.value = data.value;
+
+  return (route.query.theme as string) ?? theme.value;
+}

--- a/apps/catalogue/app/error.vue
+++ b/apps/catalogue/app/error.vue
@@ -1,21 +1,19 @@
 <script setup lang="ts">
-import { useRuntimeConfig, useRoute, useHead, useRouter } from "#app";
+import { useRuntimeConfig, useHead, useRouter } from "#app";
+import { useTheme } from "./composables/useTheme";
 
 defineProps(["error"]);
 
 const config = useRuntimeConfig();
-const route = useRoute();
 const router = useRouter();
+const theme = await useTheme();
 
 const faviconHref = config.public.emx2Theme
   ? `/_nuxt-styles/img/${config.public.emx2Theme}.ico`
   : "/_nuxt-styles/img/molgenis.ico";
 
 useHead({
-  htmlAttrs: {
-    "data-theme":
-      (route.query.theme as string) || config.public.emx2Theme || "",
-  },
+  htmlAttrs: { "data-theme": theme },
   link: [{ rel: "icon", href: faviconHref }],
   titleTemplate: (titleChunk) => {
     return titleChunk

--- a/docs/catalogue/cat_admin.md
+++ b/docs/catalogue/cat_admin.md
@@ -146,6 +146,19 @@ String containing html to be rendered on the all ( default subcatalogue) page
 #### default
 None, no additional content is shown    
 
+## Theme Configuration
+
+You can configure the application theme either **at deploy time** or **at runtime**.
+
+- 🏗️ Deploy Time: Set the NUXT_PUBLIC_EMX2_THEME environment variable to the theme value.
+- ⚙️ Run Time: Create or update the CATALOGUE_THEME settings to the theme value.
+
+If neither value is provided, the default theme **molgenis** will be used.
+
+#### debug theme 
+
+For debugging or development purposes, you can override the active theme by adding a query parameter to the URL:, ```?theme=my-theme```
+
 ## Favicon
 
 A themed favicon is set by placing a [theme].ico file in the public/img folder.


### PR DESCRIPTION
### What are the main changes you did
You can configure the application theme either **at deploy time** or **at runtime**.

- 🏗️ Deploy Time: Set the NUXT_PUBLIC_EMX2_THEME environment variable to the theme value.
- ⚙️ Run Time: Create or update the CATALOGUE_THEME settings to the theme value.

If neither value is provided, the default theme **molgenis** will be used.

For debugging or development purposes, you can override the active theme by adding a query parameter to the URL:, ```?theme=my-theme```


### How to test
- try out different ways of setting the theme 
- compare page load times between pr version and current version

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation