### PR TITLE
fix: twc close add modal after save

### DIFF
--- a/apps/tailwind-components/app/components/form/EditModal.vue
+++ b/apps/tailwind-components/app/components/form/EditModal.vue
@@ -249,11 +249,16 @@ async function onSave(draft: boolean) {
         `No response from server on ${isInsert.value ? "insert" : "update"}`
       );
     }
+    emit(isInsert.value ? "update:added" : "update:updated", resp);
+    if(isInsert.value && !isDraft.value) {
+      visible.value = false;
+      return;
+    }
     formMessage.value = `${isInsert.value ? "inserted" : "saved"} ${
       rowType.value
     } ${draft ? "as draft" : ""}`;
     showFormMessage.value = true;
-    emit(isInsert.value ? "update:added" : "update:updated", resp);
+    
     if (isInsert.value) {
       await updateRowKey();
     }

--- a/apps/ui/tests/e2e/crud.spec.ts
+++ b/apps/ui/tests/e2e/crud.spec.ts
@@ -46,7 +46,6 @@ test("add new row", async ({ page }) => {
   await page.getByRole("textbox", { name: "weight Required" }).click();
   await page.getByRole("textbox", { name: "weight Required" }).fill("23");
   await page.getByRole("button", { name: "Save", exact: true }).click();
-  await page.getByRole("button", { name: "Close modal", exact: true }).click();
 
   await expect(
     page.getByRole("cell", { name: "e2e", exact: true })


### PR DESCRIPTION
### What are the main changes you did
- If the mode is insert, and it's not a draft, close the modal after save ( similar to bootstrap version )

### How to test
- compare ux with current master in tailwind version and bootstrap version 
- test save (insert), modal should close 
- test draf, modal stays open 
- test edit, modal stays open ( should it close ? ) 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation