### PR TITLE
fix: show the catalogue logo as set via the config if no subcatalogue…

### DIFF
--- a/apps/catalogue/app/components/harmonisation/HarmonisationStatusIcon.vue
+++ b/apps/catalogue/app/components/harmonisation/HarmonisationStatusIcon.vue
@@ -53,7 +53,7 @@ const fillClass = computed(() => {
     case "available":
       return "bg-label-available text-label-available";
   }
-}); 
+});
 </script>
 <template>
   <div

--- a/apps/catalogue/app/components/harmonisation/HarmonisationTableCellAvailableIcon.vue
+++ b/apps/catalogue/app/components/harmonisation/HarmonisationTableCellAvailableIcon.vue
@@ -22,7 +22,11 @@ const statusClasses = computed(() => {
     class="absolute inset-x-0 -top-px -bottom-px justify-center items-center inline-flex group"
     :class="statusClasses"
   >
-    <BaseIcon v-if="status === 'available'" name="check" :class="statusClasses" />
+    <BaseIcon
+      v-if="status === 'available'"
+      name="check"
+      :class="statusClasses"
+    />
     <span class="sr-only">{{ status }}</span>
   </div>
 </template>

--- a/apps/catalogue/app/components/header/Catalogue.vue
+++ b/apps/catalogue/app/components/header/Catalogue.vue
@@ -20,6 +20,7 @@ const props = defineProps<{
   variableCount: number;
   collectionCount: number;
   networkCount: number;
+  logoSrc?: string;
 }>();
 
 const cohortOnly = computed(() => {
@@ -99,7 +100,7 @@ if (!cohortOnly.value) {
         <Logo
           :link="`/${catalogueRouteParam}`"
           :image="
-            catalogueRouteParam === 'all' ? undefined : catalogue?.logo?.url
+            catalogueRouteParam === 'all' ? logoSrc : catalogue?.logo?.url
           "
           :inverted="true"
         />
@@ -122,7 +123,7 @@ if (!cohortOnly.value) {
             <LogoMobile
               :link="`/${catalogueRouteParam}`"
               :image="
-                catalogueRouteParam === 'all' ? undefined : catalogue?.logo?.url
+                catalogueRouteParam === 'all' ? logoSrc : catalogue?.logo?.url
               "
             />
           </div>

--- a/apps/catalogue/app/components/layouts/DetailPage.vue
+++ b/apps/catalogue/app/components/layouts/DetailPage.vue
@@ -27,6 +27,7 @@ const bannerHtml = computed(() => {
     :variableCount="headerData.variableCount"
     :collectionCount="headerData.collectionCount"
     :networkCount="headerData.networkCount"
+    :logoSrc="headerData.logoSrc"
   />
 
   <HeaderGlobal v-else :logoSrc="headerData.logoSrc" />

--- a/apps/catalogue/app/components/layouts/LandingPage.vue
+++ b/apps/catalogue/app/components/layouts/LandingPage.vue
@@ -26,6 +26,7 @@ const bannerHtml = computed(() => {
     :variableCount="headerData.variableCount"
     :collectionCount="headerData.collectionCount"
     :networkCount="headerData.networkCount"
+    :logoSrc="headerData.logoSrc"
   />
   <HeaderGlobal v-else :logoSrc="headerData.logoSrc" />
   <Container>

--- a/apps/catalogue/app/components/layouts/SearchPage.vue
+++ b/apps/catalogue/app/components/layouts/SearchPage.vue
@@ -26,6 +26,7 @@ const bannerHtml = computed(() => {
     :variableCount="headerData.variableCount"
     :collectionCount="headerData.collectionCount"
     :networkCount="headerData.networkCount"
+    :logoSrc="headerData.logoSrc"
   />
 
   <HeaderGlobal v-else :logoSrc="headerData.logoSrc" />


### PR DESCRIPTION
### What are the main changes you did
explain what you changed and essential considerations.](fix: show the catalogue logo as set via the config if no sub catalogue logo is passed ( the /all case))

### How to test
- see issue #5569 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation