### PR TITLE
fix: added admin username check to isAdmin

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/User.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/User.java
@@ -87,6 +87,6 @@ public class User extends HasSettings<User> {
   }
 
   public boolean isAdmin() {
-    return isAdmin;
+    return username.equals("admin") || isAdmin;
   }
 }


### PR DESCRIPTION
### What are the main changes you did
Fixes the issue where a clean jar throws an exception because it doesn't recognize the admin user yet.
This is due to the migration to the isAdmin field.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation