### PR TITLE
fix(emx2): check if a user exists in user_metadata

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlDatabase.java
@@ -493,10 +493,8 @@ public class SqlDatabase extends HasSettings<Database> implements Database {
   }
 
   @Override
-  public boolean hasUser(String user) {
-    return !jooq.fetch(
-            "SELECT rolname FROM pg_catalog.pg_roles WHERE rolname = {0}", MG_USER_PREFIX + user)
-        .isEmpty();
+  public boolean hasUser(String username) {
+    return jooq.fetchExists(DSL.selectOne().from(USERS_METADATA).where(USER_NAME.eq(username)));
   }
 
   @Override


### PR DESCRIPTION
### What are the main changes you did
- When checking if a user exist use user_metadata, instead of check if the user role exists

This should give the same result but when removing the 'molgenis' database you can have lingering roles. This can cause strange behaviour when restarting emx2.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation