### PR TITLE
fix(schema): raise error when schema template does not exist upon schema creation

### DIFF
--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataModels.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataModels.java
@@ -86,7 +86,7 @@ public class DataModels {
     } else if (Regular.hasRegular(template)) {
       task = Regular.valueOf(template).getImportTask(schema, includeDemoData);
     } else {
-      throw new MolgenisException("Invalid template '" + template + "'.");
+      throw new MolgenisException("Cannot create schema from template '" + template + "'. Template does not exist.");
     }
     return task.setDescription("Loading data model: " + template + " onto " + schema.getName());
   }

--- a/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataModels.java
+++ b/backend/molgenis-emx2-datamodels/src/main/java/org/molgenis/emx2/datamodels/DataModels.java
@@ -1,6 +1,7 @@
 package org.molgenis.emx2.datamodels;
 
 import java.util.Arrays;
+import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Schema;
 import org.molgenis.emx2.io.ImportDataModelTask;
 import org.molgenis.emx2.io.ImportProfileTask;
@@ -57,6 +58,10 @@ public class DataModels {
         ((schema, includeDemoData) ->
             new BiobankDirectoryLoader(schema, includeDemoData).setStaging(true)));
 
+    public static boolean hasRegular(String nameOther) {
+      return Arrays.stream(values()).anyMatch(regular -> regular.name().equals(nameOther));
+    }
+
     @FunctionalInterface
     private interface TaskFactory {
       ImportDataModelTask createTask(Schema schema, boolean includeDemoData);
@@ -78,8 +83,10 @@ public class DataModels {
     if (Profile.hasProfile(template)) {
       Profile profile = Profile.valueOf(template);
       task = profile.getImportTask(schema, includeDemoData);
-    } else {
+    } else if (Regular.hasRegular(template)) {
       task = Regular.valueOf(template).getImportTask(schema, includeDemoData);
+    } else {
+      throw new MolgenisException("Invalid template '" + template + "'.");
     }
     return task.setDescription("Loading data model: " + template + " onto " + schema.getName());
   }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlDatabaseFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlDatabaseFieldFactory.java
@@ -99,13 +99,18 @@ public class GraphqlDatabaseFieldFactory {
 
               Schema schema = database.createSchema(name, description);
               if (template != null) {
-                Task task = DataModels.getImportTask(schema, template, includeDemoData);
-                if (parentTaskId != null) {
-                  Task parentTask = taskService.getTask(parentTaskId);
-                  task.setParentTask(parentTask);
+                try {
+                  Task task = DataModels.getImportTask(schema, template, includeDemoData);
+                  if (parentTaskId != null) {
+                    Task parentTask = taskService.getTask(parentTaskId);
+                    task.setParentTask(parentTask);
+                  }
+                  String id = taskService.submit(task);
+                  result.setTaskId(id);
+                } catch (MolgenisException e) {
+                  database.dropSchema(name);
+                  throw e;
                 }
-                String id = taskService.submit(task);
-                result.setTaskId(id);
               } else {
                 database.getListener().onSchemaChange();
               }


### PR DESCRIPTION
Fixes #5588 
### What are the main changes you did
- added check if template is not in 'Regular' list
- added catching of exception if template does not exist

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation