### PR TITLE
fix: isRequired field filledin check for boolean type column

### DIFF
--- a/apps/tailwind-components/app/composables/useForm.ts
+++ b/apps/tailwind-components/app/composables/useForm.ts
@@ -135,9 +135,17 @@ export default function useForm(
   /** return required and empty, visible fields across all sections */
   const emptyRequiredFields = computed(() => {
     return (
-      requiredFields.value?.filter(
-        (column: IColumn) => !formValues.value[column.id]
-      ) || []
+      requiredFields.value?.filter((column: IColumn) => {
+        if (column.columnType === "BOOL") {
+          //boolean required fields are considered filled when they are either true or false
+          return (
+            formValues.value[column.id] === undefined ||
+            formValues.value[column.id] === null
+          );
+        } else {
+          return !formValues.value[column.id];
+        }
+      }) || []
     );
   });
 

--- a/apps/tailwind-components/tests/vitest/composables/useForm.spec.ts
+++ b/apps/tailwind-components/tests/vitest/composables/useForm.spec.ts
@@ -40,6 +40,12 @@ describe("useForm", () => {
         label: "columns 5",
         required: true,
       },
+      {
+        columnType: "BOOL",
+        id: "col6",
+        label: "columns 6",
+        required: true,
+      },
     ],
   });
 
@@ -59,11 +65,20 @@ describe("useForm", () => {
         label: "columns 4",
         required: true,
       },
+      {
+        columnType: "BOOL",
+        id: "col6",
+        label: "columns 6",
+        required: true,
+      },
     ]);
   });
 
   test("should return a list of empty required fields", () => {
-    const formValues = ref<Record<string, columnValue>>({});
+    const formValues = ref<Record<string, columnValue>>({
+      // non empty required bool field
+      col6: false,
+    });
     const { emptyRequiredFields } = useForm(tableMetadata, formValues);
     expect(emptyRequiredFields.value).toEqual([
       {
@@ -82,7 +97,10 @@ describe("useForm", () => {
   });
 
   test("should go to the next required field", () => {
-    const formValues = ref<Record<string, columnValue>>({});
+    const formValues = ref<Record<string, columnValue>>({
+      // non empty required bool field
+      col6: false,
+    });
     const { gotoNextRequiredField, lastScrollTo } = useForm(
       tableMetadata,
       formValues
@@ -94,7 +112,10 @@ describe("useForm", () => {
   });
 
   test("should go to the previous required field", () => {
-    const formValues = ref<Record<string, columnValue>>({});
+    const formValues = ref<Record<string, columnValue>>({
+      // non empty required bool field
+      col6: false,
+    });
     const { gotoPreviousRequiredField, lastScrollTo } = useForm(
       tableMetadata,
       formValues
@@ -106,12 +127,15 @@ describe("useForm", () => {
   });
 
   test("setting a value on required field should update the message", () => {
-    const formValues = ref<Record<string, columnValue>>({});
+    const formValues = ref<Record<string, columnValue>>({
+      // non empty required bool field
+      col6: false,
+    });
     const { requiredMessage, emptyRequiredFields } = useForm(
       tableMetadata,
       formValues
     );
-    expect(requiredMessage.value).toBe("2/2 required fields left");
+    expect(requiredMessage.value).toBe("2/3 required fields left");
 
     // setting a value removes the field from the required list
     formValues.value["col2"] = "some value";
@@ -123,7 +147,7 @@ describe("useForm", () => {
         required: true,
       },
     ]);
-    expect(requiredMessage.value).toBe("1/2 required field left");
+    expect(requiredMessage.value).toBe("1/3 required field left");
   });
 
   test("setting an error should update the message", () => {


### PR DESCRIPTION
Fix issue where required boolean field with a value of false were counted as not being filled in

### What are the main changes you did
- when checking if a required field has a value set, if the field type is of type boolean either value true or false are counted as set ( i.e. although false is falsy the value has still been set

### How to test
- go to form with required boolean field ( or create one by setting a bool field to required ), fill out the field testing true, false en no value. setting the value to false should remove the field form the empty required field count ( so should setting the value to true,  clearing the value should include the field in the empty required fields count ) 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation