### PR TITLE
fix(updownload): excel decimal parsing

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -158,17 +158,30 @@ public class TypeUtils {
   }
 
   public static Double toDecimal(Object v) {
-    if (v == null) return null;
-    if (v instanceof String string) {
-      if ("".equals(string)) {
+    switch (v) {
+      case null -> {
         return null;
-      } else {
-        return Double.parseDouble(string);
+      }
+      case String string -> {
+        if (string.isBlank()) {
+          return null;
+        } else {
+          return Double.parseDouble(string);
+        }
+      }
+      case BigDecimal bigDecimal -> {
+        return bigDecimal.doubleValue();
+      }
+      case Integer integer -> {
+        return Double.valueOf(integer);
+      }
+      case Long decimal -> {
+        return Double.valueOf(decimal);
+      }
+      default -> {
+        return (Double) v;
       }
     }
-    if (v instanceof BigDecimal bigDecimal) return bigDecimal.doubleValue();
-    if (v instanceof Integer integer) return Double.valueOf(integer);
-    return (Double) v;
   }
 
   public static Double[] toDecimalArray(Object v) {

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -88,6 +89,20 @@ class TestTypeUtils {
     assertThrows(MolgenisException.class, () -> TypeUtils.toBool(onePointZero));
     assertThrows(MolgenisException.class, () -> TypeUtils.toBool(five));
     assertThrows(MolgenisException.class, () -> TypeUtils.toBool(minusOne));
+  }
+
+  @Test
+  void testToDecimal() {
+    assertNull(TypeUtils.toDecimal(null));
+    assertNull(TypeUtils.toDecimal(""));
+    assertNull(TypeUtils.toDecimal("\n"));
+
+    assertEquals(15, TypeUtils.toDecimal("15.0"));
+    assertEquals(-15, TypeUtils.toDecimal("-15.0"));
+    assertEquals(15, TypeUtils.toDecimal(new BigDecimal(15)));
+    assertEquals(15, TypeUtils.toDecimal(15));
+    assertEquals(15, (double) 15);
+    assertEquals(15, TypeUtils.toDecimal(15L));
   }
 
   @Test


### PR DESCRIPTION
Fixes: #5621

### What are the main changes you did
Fixed an issue with importing data via excel. When a value like '15' is provided for a column of type `Decimal`, it gets picked up as a `Long` which breaks the import. This PR adds support for converting `Long` values into `Decimal`.

Also did some cleaning up in `org.molgenis.emx2.TestTypeUtils` and fixed a test that wat testing the same thing twice.

### How to test
**Unit test**
`org.molgenis.emx2.TestTypeUtils#testToDecimal`

**UI**
1. Create a new schema using PET_STORE template
2. Download the data from the Order table in Excel
3. Adjust the value in the price column to an integer (for example 14.99 to 15).
4. Save as Excel and upload the data 

### Checklist
- [x] updated docs in case of new feature
- [x] added/updated tests
- [x] added/updated testplan to include a test for this fix, including ref to bug using # notation