### PR TITLE
fix(tailwind-components): active form legend selection

### DIFF
--- a/apps/tailwind-components/app/components/form/Fields.vue
+++ b/apps/tailwind-components/app/components/form/Fields.vue
@@ -49,54 +49,50 @@ const isRequired = (value: string | boolean): boolean =>
 </script>
 
 <template>
-  <div ref="container">
-    <template v-for="column in columns" :key="column.id">
-      <div
-        v-if="
-          column.columnType === 'HEADING' || column.columnType === 'SECTION'
+  <template v-for="column in columns" :key="column.id">
+    <div
+      v-if="column.columnType === 'HEADING' || column.columnType === 'SECTION'"
+      :id="`${column.id}-form-field`"
+      v-intersection-observer="onIntersectionObserver"
+    >
+      <h2
+        class="first:pt-0 pt-10 font-display md:text-heading-5xl text-heading-5xl text-form-header pb-8"
+        :class="
+          column.columnType === 'HEADING'
+            ? 'md:text-heading-4xl text-heading-4xl'
+            : 'md:text-heading-5xl text-heading-5xl'
         "
-        :id="`${column.id}-form-field`"
-        v-intersection-observer="[onIntersectionObserver, { root: container }]"
+        v-if="column.id != 'mg_top_of_form'"
       >
-        <h2
-          class="first:pt-0 pt-10 font-display md:text-heading-5xl text-heading-5xl text-form-header pb-8"
-          :class="
-            column.columnType === 'HEADING'
-              ? 'md:text-heading-4xl text-heading-4xl'
-              : 'md:text-heading-5xl text-heading-5xl'
-          "
-          v-if="column.id != 'mg_top_of_form'"
-        >
-          {{ column.label }}
-        </h2>
-      </div>
-      <FormField
-        class="pb-8"
-        v-else-if="!Object.keys(constantValues || {}).includes(column.id)"
-        v-intersection-observer="[onIntersectionObserver, { root: container }]"
-        v-model="modelValue[column.id]"
-        :id="`${column.id}-form-field`"
-        :type="column.columnType"
-        :label="column.formLabel ?? column.label"
-        :description="column.description"
-        :disabled="
-          Boolean(
-            column.readonly === 'true' ||
-              (rowKey && Object.keys(rowKey).length && column.key === 1) ||
-              column.columnType === 'AUTO_ID'
-          )
-        "
-        :rowKey="rowKey"
-        :required="isRequired(column.required ?? false)"
-        :error-message="errorMap[column.id]"
-        :ref-schema-id="column.refSchemaId"
-        :ref-table-id="column.refTableId"
-        :ref-label="column.refLabel || column.refLabelDefault"
-        :ref-back-id="column.refBackId"
-        :invalid="(errorMap[column.id] || '').length > 0"
-        @update:modelValue="emit('update', column)"
-        @blur="emit('blur', column)"
-      />
-    </template>
-  </div>
+        {{ column.label }}
+      </h2>
+    </div>
+    <FormField
+      class="pb-8"
+      v-else-if="!Object.keys(constantValues || {}).includes(column.id)"
+      v-intersection-observer="onIntersectionObserver"
+      v-model="modelValue[column.id]"
+      :id="`${column.id}-form-field`"
+      :type="column.columnType"
+      :label="column.formLabel ?? column.label"
+      :description="column.description"
+      :disabled="
+        Boolean(
+          column.readonly === 'true' ||
+            (rowKey && Object.keys(rowKey).length && column.key === 1) ||
+            column.columnType === 'AUTO_ID'
+        )
+      "
+      :rowKey="rowKey"
+      :required="isRequired(column.required ?? false)"
+      :error-message="errorMap[column.id]"
+      :ref-schema-id="column.refSchemaId"
+      :ref-table-id="column.refTableId"
+      :ref-label="column.refLabel || column.refLabelDefault"
+      :ref-back-id="column.refBackId"
+      :invalid="(errorMap[column.id] || '').length > 0"
+      @update:modelValue="emit('update', column)"
+      @blur="emit('blur', column)"
+    />
+  </template>
 </template>


### PR DESCRIPTION

### What are the main changes you did
- fix the dom by removing unneeded wrapper div.
this extra div broke the IntersectionObserver.isVisible as all fields we visible on this div, while the scrollbar was placed on the parent div


### How to test

The bug:
- in the old situation ( dev server ), open the beta ui, go to the subject table(  apps/ui/patient%20registry%20demo/Subject ), sigin in , and open the add dialog, for the field 'Type of disease group' select the third option (dna). As a result of this selection lots of fields become visible, and a whole list of legend headers become active, this should not happen as most of these fields are not visible in the viewport ( scroll area )

The expected situation:
- In the new situation ( the pr preview ), take the same steps, only no the active headers should remain the same, as expected.  

note only the wrapper div is removed, the rest in indentation ( because of the div removal) 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation