### PR TITLE
feat: Add render case for auto id type

### DIFF
--- a/apps/tailwind-components/app/components/value/EMX2.vue
+++ b/apps/tailwind-components/app/components/value/EMX2.vue
@@ -113,5 +113,11 @@ defineEmits<{
     :data="data"
   />
 
+  <ValueString
+    v-else-if="metadata.columnType === 'AUTO_ID'"
+    :metadata="metadata"
+    :data="data"
+  />
+
   <template v-else> {{ metadata.columnType }} </template>
 </template>


### PR DESCRIPTION
### What are the main changes you did
- add missing type case for auto id render 
### How to test
- can be seen in petstore.pet -> order refback -> expand to see order ref back details ( order id is a auto id)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation