### PR TITLE
fix(Ref): reduce time between click to open form, and form showing by reducing options loaded for Refs

### DIFF
--- a/apps/tailwind-components/app/components/input/Ref.vue
+++ b/apps/tailwind-components/app/components/input/Ref.vue
@@ -10,7 +10,7 @@ import type {
 import { type IInputProps, type IValueLabel } from "../../../types/types";
 import logger from "../../utils/logger";
 import fetchTableMetadata from "../../composables/fetchTableMetadata";
-import { ref, type Ref, computed, watch, onMounted } from "vue";
+import { ref, type Ref, computed, watch, onMounted, nextTick } from "vue";
 import fetchTableData from "../../composables/fetchTableData";
 import InputCheckboxGroup from "./CheckboxGroup.vue";
 import InputRadioGroup from "./RadioGroup.vue";
@@ -192,7 +192,7 @@ async function select(label: string) {
   if (!props.isArray) {
     selectionMap.value = {};
   }
-  selectionMap.value[label] = extractPrimaryKey(optionMap.value[label]);
+  selectionMap.value[label] = await extractPrimaryKey(optionMap.value[label]);
   if (searchTerms.value) toggleSearch();
   emitValue();
 }
@@ -200,11 +200,13 @@ async function select(label: string) {
 function emitValue() {
   emit(
     "update:modelValue",
-    props.isArray ? Object.values(selectionMap.value) : optionMap.value[label]
+    props.isArray
+      ? Object.values(selectionMap.value)
+      : Object.values(selectionMap.value)[0]
   );
 }
 
-async function extractPrimaryKey(row: columnValueObject) {
+async function extractPrimaryKey(row: recordValue) {
   return await fetchRowPrimaryKey(row, props.refTableId, props.refSchemaId);
 }
 


### PR DESCRIPTION
before: catalogue-demo.Resources form takes 4sec before it is rendered.
after: catalogue-demo.Resources form is near instant

note:
- [x] fixed that limit should be included in fetchTableData
- [x] retrieval of records for the selected values (needed for labels) are reduced by lower expandLevel
- [x] fixed extractPrimaryKey to use the more advanced rowkey code we use elsewhere for nested primary keys

discussion:
- I speculate that slowness was because of reactivity of visible expressions and re-rendering, because this all should have been 'lazy'
- we would love to somehow move the label calculations to server 
- the expandLevel might now be too low for wild labels that include stuff from relationship

There seems some more room improvement to show the EditModal before the form is fully loaded, possibly with a loading spinner.