### PR TITLE
fix: 5706 form crud flow

### DIFF
--- a/apps/tailwind-components/app/components/form/DeleteModal.vue
+++ b/apps/tailwind-components/app/components/form/DeleteModal.vue
@@ -42,10 +42,6 @@ const session = await useSession();
 const formMessage = ref<string>("");
 const showReAuthenticateButton = ref<boolean>(false);
 
-function setVisible() {
-  visible.value = true;
-}
-
 const rowType = computed(() => props.metadata.id);
 const isDraft = ref(false);
 
@@ -90,7 +86,7 @@ function reAuthenticate() {
 
 <template>
   <template v-if="showButton">
-    <slot :setVisible="setVisible">
+    <slot>
       <Button
         class="m-10"
         type="primary"

--- a/apps/tailwind-components/app/components/form/EditModal.vue
+++ b/apps/tailwind-components/app/components/form/EditModal.vue
@@ -1,6 +1,6 @@
 <template>
   <template v-if="showButton">
-    <slot :setVisible="setVisible">
+    <slot>
       <Button
         class="m-10"
         type="primary"
@@ -149,28 +149,24 @@ const props = withDefaults(
   }
 );
 
+type FormType = ComponentPublicInstance<InstanceType<typeof Form>>;
+const form = useTemplateRef<FormType>("edit-modal-form");
+
+const saving = ref(false);
+const isInsert = ref(props.isInsert);
+const formValues = ref<Record<string, columnValue>>(initFormValues());
+
 const emit = defineEmits([
   "update:added",
   "update:updated",
   "update:cancelled",
 ]);
 
-const visible = defineModel("visible", {
-  type: Boolean,
-  default: false,
-});
+const visible = defineModel<boolean>("visible");
 
-const form = useTemplateRef<FormType>("edit-modal-form");
-
-type FormType = ComponentPublicInstance<InstanceType<typeof Form>>;
-
-const saving = ref(false);
 const savingDraft = computed(
   () => saving.value && formValues.value["mg_draft"] === true
 );
-
-const isInsert = ref(props.isInsert);
-const formValues = ref<Record<string, columnValue>>(initFormValues());
 
 watch(formValues.value, () => {
   formMessage.value = "";
@@ -183,10 +179,6 @@ const showReAuthenticateButton = ref<boolean>(false);
 
 const rowType = computed(() => props.metadata.id);
 const isDraft = computed(() => formValues.value["mg_draft"] === true || false);
-
-function setVisible() {
-  visible.value = true;
-}
 
 function initFormValues() {
   const values =
@@ -227,9 +219,6 @@ const errorMessage = computed(() => {
 
 function onCancel() {
   visible.value = false;
-  saveErrorMessage.value = "";
-  formMessage.value = "";
-  formValues.value = initFormValues();
   emit("update:cancelled");
 }
 

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -9,18 +9,14 @@
     />
 
     <div class="flex gap-[10px]">
-      <EditModal
+      <Button
         v-if="props.isEditable && data?.tableMetadata"
-        :metadata="data.tableMetadata"
-        :schemaId="props.schemaId"
-        :isInsert="true"
-        v-slot="{ setVisible }"
-        @update:added="afterRowAdded"
+        type="primary"
+        icon="add-circle"
+        @click="onAddRowClicked"
       >
-        <Button type="primary" icon="add-circle" @click="setVisible">
-          Add {{ tableId }}
-        </Button>
-      </EditModal>
+        Add {{ tableId }}
+      </Button>
 
       <TableControlColumns
         :columns="columns"
@@ -174,14 +170,26 @@
   />
 
   <EditModal
-    v-if="data?.tableMetadata && rowDataForModal"
+    v-if="data?.tableMetadata && showEditModal"
+    :key="`edit-modal-${useId()}`"
     :showButton="false"
-    :schemaId="props.schemaId"
+    :schemaId="schemaId"
     :metadata="data.tableMetadata"
     :formValues="rowDataForModal"
     :isInsert="false"
     v-model:visible="showEditModal"
-    @update:updated="afterRowUpdated"
+    @update:cancelled="afterClose"
+  />
+
+  <EditModal
+    v-if="data?.tableMetadata && showAddModal"
+    :key="`add-modal-${useId()}`"
+    :showButton="false"
+    :schemaId="schemaId"
+    :metadata="data.tableMetadata"
+    :isInsert="true"
+    v-model:visible="showAddModal"
+    @update:cancelled="afterClose"
   />
 </template>
 
@@ -229,8 +237,9 @@ const props = withDefaults(
   }
 );
 
-const showDeleteModal = ref<boolean>(false);
+const showAddModal = ref<boolean>(false);
 const showEditModal = ref<boolean>(false);
+const showDeleteModal = ref<boolean>(false);
 const rowDataForModal = ref();
 const showModal = ref(false);
 const refTableRow = ref<IRow>();
@@ -376,17 +385,25 @@ function onShowEditModal(row: Record<string, columnValue>) {
   showEditModal.value = true;
 }
 
-function afterRowAdded() {
+function onAddRowClicked() {
+  showAddModal.value = true;
+}
+
+async function afterRowAdded() {
   // todo reset filters and search, goto page with added item, flash row with add item
-  refresh();
+  await refresh();
 }
 
-function afterRowUpdated() {
-  refresh();
+async function afterRowUpdated() {
+  await refresh();
 }
 
-function afterRowDeleted() {
+async function afterClose() {
+  await refresh();
+}
+
+async function afterRowDeleted() {
   // maybe notify user, and do more stuff
-  refresh();
+  await refresh();
 }
 </script>


### PR DESCRIPTION
Refactor the tableEmx2 form management. Instead of reusing a single component, create a new modal on each crud action. This solved several state management issued where form state ( data , editMode, isDirty, ... ) was not as expected ( out of sync ). This also simplifies the programming model by removing the need to do cleanup and initializing.

Closes #5706

### What are the main changes you did
- instead of reusing a single component for add / edit[row1, .. n], create and destroy a modal when the action button is clicked ( and remove it when the modal is closed)
- remove broken ( and now longer needed reset/sync code )
### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation