### PR TITLE
fix: input line height consistency

### DIFF
--- a/apps/tailwind-components/app/components/input/File.vue
+++ b/apps/tailwind-components/app/components/input/File.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex items-center border rounded-input px-2 h-[56px]"
+    class="flex items-center border rounded-input px-2 h-input"
     :class="{
       'cursor-pointer duration-default ease-in-out hover:border-input-hover focus-within:border-input-focused':
         !disabled && !invalid,

--- a/apps/tailwind-components/app/components/input/Listbox.vue
+++ b/apps/tailwind-components/app/components/input/Listbox.vue
@@ -62,7 +62,7 @@
             listboxOptions[0] &&
             listboxOptions[0].value === null
           "
-          class="flex justify-center items-center h-[56px] pl-3 py-1 bg-input border-b-[1px] last:border-b-0"
+          class="flex justify-center items-center h-input pl-3 py-1 bg-input border-b-[1px] last:border-b-0"
         >
           <TextNoResultsMessage />
         </li>

--- a/apps/tailwind-components/app/components/input/Ontology.vue
+++ b/apps/tailwind-components/app/components/input/Ontology.vue
@@ -461,7 +461,7 @@ onMounted(() => {
     >
       <div
         v-show="displayAsSelect"
-        class="flex items-center justify-between gap-2 px-2 h-[56px]"
+        class="flex items-center justify-between gap-2 px-2 h-input"
         @click.stop="toggleSelect"
       >
         <div class="flex flex-wrap items-center gap-2">

--- a/apps/tailwind-components/app/components/input/Ref.vue
+++ b/apps/tailwind-components/app/components/input/Ref.vue
@@ -311,7 +311,7 @@ onMounted(() => {
     >
       <div
         v-show="displayAsSelect"
-        class="flex items-center justify-between gap-2 px-2 h-[56px]"
+        class="flex items-center justify-between gap-2 px-2 h-input"
         @click.stop.self="toggleSelect"
       >
         <div class="flex flex-wrap items-center gap-2">

--- a/apps/tailwind-components/app/components/input/String.vue
+++ b/apps/tailwind-components/app/components/input/String.vue
@@ -20,7 +20,7 @@ const emit = defineEmits(["focus", "blur"]);
     :type="type || 'text'"
     :placeholder="placeholder"
     :disabled="disabled"
-    class="w-full h-[56px] pr-4 pl-3 border outline-none rounded-input"
+    class="w-full h-input pr-4 pl-3 border outline-none rounded-input"
     :class="{
       'bg-input border-valid text-valid': valid && !disabled,
       'bg-input border-invalid text-invalid': invalid && !disabled,

--- a/apps/tailwind-components/app/components/input/listbox/ListItem.vue
+++ b/apps/tailwind-components/app/components/input/listbox/ListItem.vue
@@ -2,7 +2,7 @@
   <li
     ref="li"
     role="option"
-    class="flex justify-start items-center gap-3 h-[56px] pl-3 py-1 bg-input border-b-[1px] last:border-b-0 hover:cursor-pointer hover:bg-input-focused focus:bg-input-focused hover:text-input-focused focus:text-input-focused"
+    class="flex justify-start items-center gap-3 h-input pl-3 py-1 bg-input border-b-[1px] last:border-b-0 hover:cursor-pointer hover:bg-input-focused focus:bg-input-focused hover:text-input-focused focus:text-input-focused"
     :class="{
       'text-input': !isSelected,
       'bg-input-checked text-input-checked': isSelected,


### PR DESCRIPTION
### What are the main changes you did
- set input line height (these use div as custom input override) equal to other input types 

### How to test
- compare custom input line height ( ontology as select , file selector ) to native input ( string , number )  line height  
### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation