### PR TITLE
Updated path comparison for zip extraction in ScriptTask to take symlinks into account

### DIFF
--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
@@ -188,10 +188,8 @@ public class ScriptTask extends Task {
           ZipEntry entry;
           while ((entry = zis.getNextEntry()) != null) {
             File newFile = new File(tempDir.toFile(), entry.getName());
-            if (!newFile.getCanonicalPath().startsWith(tempDir.toFile().getAbsolutePath())) {
-              throw new MolgenisException(
-                  "ZIP archive contains files with illegal path: " + entry.getName());
-            }
+            checkForZipSlip(tempDir, newFile);
+
             if (entry.isDirectory()) {
               newFile.mkdirs();
             } else {
@@ -227,6 +225,17 @@ public class ScriptTask extends Task {
         + " && "
         + runScriptCommand
         + escapedParameters;
+  }
+
+  /**
+   * Checks if the extracted file does not attempt a zip-slip attack. Based on a security post by <a
+   * href="https://security.snyk.io/research/zip-slip-vulnerability">Snyk</a>.
+   */
+  private static void checkForZipSlip(Path tempDir, File newFile) throws IOException {
+    if (!newFile.getCanonicalPath().startsWith(tempDir.toFile().getCanonicalPath())) {
+      throw new MolgenisException(
+          "ZIP archive contains files with illegal path: " + newFile.getCanonicalPath());
+    }
   }
 
   private void sendFailureMail() {


### PR DESCRIPTION


### What are the main changes you did
Compare two canonical paths instead of an absolute and canonical path.
The difference between the two is as follows:
- Absolute is the complete path that a file is placed on the file path.
- Canonical is the complete path **but** things like sym links have been resolved, which is **not** the case for absolute.

`TestScriptTask#testPythonExtraFiles` fails on my machine because the temporary script files are placed in the `/tmp/`. However, that directory is symlinked to `/private/tmp/`. This results in the canonical path being different because `/tmp/` is transformed into `/private/tmp/`

### How to test
- Run `TestScriptTask#testPythonExtraFiles`

### Checklist
- [x] updated docs in case of new feature
- [x] added/updated tests
- [x] added/updated testplan to include a test for this fix, including ref to bug using # notation