### PR TITLE
fix: SKIN private files filter

### DIFF
--- a/apps/ern-skin/src/components/PrivateFiles.vue
+++ b/apps/ern-skin/src/components/PrivateFiles.vue
@@ -9,7 +9,7 @@
   <p v-if="user !== 'anonymous' && user">
     <FileList
       table="Files"
-      filter='(filter: { tags: { equals: "private" } })'
+      filter='filter: { tags: { equals: "private" } }'
       labelsColumn="name"
       fileColumn="file"
     />


### PR DESCRIPTION
### What are the main changes you did
- Forgot to adjust the filter string in apps/ern-skin/src/components/PrivateFiles.vue in PR #5721, this PR fixes this

### How to test
- Go to https://emx2.dev.molgenis.org and **SIGN IN**
- Click on schema PR-5734
- Click on general documents and see that an error is shown: 
```
Unable to retrieve files: Syntax Error: Expected Name, found "(".
```
- Go to https://preview-emx2-pr-5734.dev.molgenis.org/ and **SIGN IN**
- Click on PR-DEMO schema
- Click on General Documents => see that Doc2 is shown and no error is shown

