### PR TITLE
fix(cranio): hearing loss onset chart is now sorted using dataPointOrder

### DIFF
--- a/apps/cranio-provider/src/views/genetic_hearing_loss/your_center.vue
+++ b/apps/cranio-provider/src/views/genetic_hearing_loss/your_center.vue
@@ -81,6 +81,14 @@ onMounted(async () => {
   if (hearingLossOnsetChart.value) {
     hearingLossOnsetChart.value.yAxisMaxValue = onsetAxis.limit;
     hearingLossOnsetChart.value.yAxisTicks = onsetAxis.ticks;
+
+    hearingLossOnsetChart.value.dataPoints =
+      hearingLossOnsetChart.value.dataPoints?.sort((a, b) => {
+        return (
+          (a.dataPointOrder as number) - (b.dataPointOrder as number) ||
+          (a.dataPointName as string).localeCompare(b.dataPointName as string)
+        );
+      });
   }
 
   // prep genetic diagnosis gene


### PR DESCRIPTION
### What are the main changes you did

This PR closes https://github.com/molgenis/molgenis-emx2/issues/5627.

- [x] Enabled sorting of hearing loss onset chart data. `dataPointName` is now the fallback

### How to test

- Go to the [Your Center overview](https://preview-emx2-pr-5888.dev.molgenis.org/AT1/cranio-provider/#/genetic-deafness/center) in the Genetic Hearing Loss dashboard
- Scroll to the "Age at Hearing Loss Onset". Chart is now sorted in the order indicated in the [issue](https://github.com/molgenis/molgenis-emx2/issues/5627).
- Compare with beta server

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation