### PR TITLE
build(gradle): make getGitHash() resilient to restricted environments

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,16 +123,24 @@ tasks.register('dockerClean', Delete) {
 }
 
 String getGitHash() {
-    // git hash
-    def command = Runtime.getRuntime().exec("git rev-parse --short HEAD")
-    def result = command.waitFor()
-    if (result != 0) {
-        throw new IOException("Command 'getGitHash()' exited with " + result)
+    try {
+        // Use ProcessBuilder to properly inherit environment and handle git command
+        def process = new ProcessBuilder('git', 'rev-parse', '--short', 'HEAD')
+            .directory(rootProject.projectDir)
+            .redirectErrorStream(true)
+            .start()
+        process.waitFor()
+
+        if (process.exitValue() == 0) {
+            return process.inputStream.text.trim()
+        } else {
+            logger.warn("Git command failed, using 'unknown' as hash")
+            return "unknown"
+        }
+    } catch (Exception e) {
+        logger.warn("Failed to get git hash: ${e.message}, using 'unknown' as hash")
+        return "unknown"
     }
-
-    String gitCommitHash = command.inputStream.text.trim()
-
-    return gitCommitHash
 }
 
 application {


### PR DESCRIPTION
## Summary
### Goal
Enable Gradle compatibility with VS Code.

### Issue
I'm checking out using VSCode as IDE. When opening the project with VSCode, its Java extension fails parsing the Gradle file because of an error running the `git rev-parse` command. This change makes the Gradle `getGitHash` function more resilient and compatible with this IDE setup.

### Changes
- Refactored `getGitHash()` in build.gradle to use ProcessBuilder instead of Runtime.exec()
- Added proper error handling with graceful fallback to "unknown" when git command fails
- Improved compatibility with restricted environments (e.g., VS Code integrated terminals)

## Test plan
- [x] Verify builds work in normal environments with git available
- [ ] Test build in restricted environment (VS Code terminal, restricted PATH)
- [ ] Confirm "unknown" fallback works when git is unavailable
- [ ] Check that warning logs appear appropriately

🤖 Generated with [Claude Code](https://claude.com/claude-code)