### PR TITLE
doc(e2e): Add playwright installation step to readme

### DIFF
--- a/e2e/README.md
+++ b/e2e/README.md
@@ -22,6 +22,7 @@ git switch -c feat/e2e-...
 
 ```bash
 pnpm install
+npx playwright install
 ```
 
 ### Running the tests


### PR DESCRIPTION
The `pnpm install` only installs:
```
dependencies:
+ @playwright/test 1.58.0 (1.58.2 is available)
+ install 0.13.0

devDependencies:
+ @types/node 22.5.5 (25.2.3 is available)
```

To run `npx playwright test`, playwright installation is stil required. This PR adds the extra step to the `e2e/README.md`

### What are the main changes you did
- Added extra setup step to README

### How to test
- On a clean setup, follow the setup steps in e2e/README.md
- Verify that `npc playwright test` works 
