### PR TITLE
chore: update ci-build images

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,7 @@ orbs:
 definitions:
   build_config: &build_config
     docker:
-    - image: molgenis/ci-build:1.5.0
+    - image: molgenis/ci-build:1.5.1
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -30,7 +30,7 @@ definitions:
       TERM: dumb
   test_config: &test_config
     docker:
-    - image: molgenis/ci-build:1.5.0
+    - image: molgenis/ci-build:1.5.1
     - image: postgres:15-alpine
       environment:
         POSTGRES_USER: postgres
@@ -44,7 +44,7 @@ definitions:
       TERM: dumb
   release_config: &release_config
     docker:
-      - image: molgenis/ci-build:1.5.0
+      - image: molgenis/ci-build:1.5.1
       - image: postgres:15-alpine
         environment:
           POSTGRES_USER: postgres

--- a/ci-build-images/Dockerfile
+++ b/ci-build-images/Dockerfile
@@ -26,7 +26,7 @@ RUN npm --version
 # Install pnpm (via Corepack)
 # ------------------------
 RUN corepack enable
-RUN corepack prepare pnpm@10.24.0 --activate
+RUN corepack prepare pnpm@latest --activate
 RUN pnpm --version
 
 USER root 


### PR DESCRIPTION
- use ci config  to use version 1.5.1
- update image to use latest pnpm version
- pnpm update includes fix for fallback on remote cve outage

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation