### PR TITLE
fix: Add missing import of ValueInt component in ValueList component

### DIFF
--- a/apps/tailwind-components/app/components/value/List.vue
+++ b/apps/tailwind-components/app/components/value/List.vue
@@ -3,6 +3,7 @@ import { computed } from "vue";
 import type { IColumn } from "../../../../metadata-utils/src/types";
 import ValueString from "./String.vue";
 import ValueDecimal from "./Decimal.vue";
+import ValueInt from "./Int.vue";
 import ValueLong from "./Long.vue";
 import ValueBool from "./Bool.vue";
 import ValueEmail from "./Email.vue";


### PR DESCRIPTION
### What are the main changes you did
- Add missing import of ValueInt component in ValueList component
### How to test
- Run the ui app in dev mode
- Go to http://localhost:3000/type%20test/Types
- In dev mode look at the warnings in the developer console
- On the master see that there are multiple warning shown mentioning a missing import for the  ValueInt component
- On this brach see that there are no warnings  shown mentioning a missing import for the  ValueInt component


### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation