### PR TITLE
fix(viz): renamed chart context component to chart title

### DIFF
--- a/apps/tailwind-components/app/components/viz/ChartTitle.vue
+++ b/apps/tailwind-components/app/components/viz/ChartTitle.vue
@@ -1,7 +1,7 @@
 <script lang="ts" setup>
-import type { ChartContext } from "../../../types/viz";
+import type { ChartTitle } from "../../../types/viz";
 
-defineProps<ChartContext>();
+defineProps<ChartTitle>();
 </script>
 
 <template>

--- a/apps/tailwind-components/app/components/viz/ColumnChart/ColumnChart.vue
+++ b/apps/tailwind-components/app/components/viz/ColumnChart/ColumnChart.vue
@@ -23,7 +23,7 @@ const d3 = {
   axisLeft,
 };
 
-import ChartContext from "../ChartContext.vue";
+import ChartTitle from "../ChartTitle.vue";
 
 import type {
   DatasetRow,
@@ -69,8 +69,9 @@ const xScale = ref();
 const yScale = ref();
 
 const yAxisData = computed<NumericAxisTickData>(() => {
-  const autoTickData = generateAxisTickData(props.data, props.yvar);
-  const ticks: NumericAxisTickData = { ...autoTickData };
+  const ticks: NumericAxisTickData = {
+    ...generateAxisTickData(props.data, props.yvar),
+  };
 
   if (props.ymax) {
     ticks.limit = props.ymax;
@@ -298,7 +299,7 @@ watch(
 
 <template>
   <div ref="container" class="grid gap-2.5 w-full chart_layout_default">
-    <ChartContext
+    <ChartTitle
       :title="title"
       :description="description"
       style="grid-area: context"

--- a/apps/tailwind-components/app/components/viz/PieChart/PieChart.vue
+++ b/apps/tailwind-components/app/components/viz/PieChart/PieChart.vue
@@ -2,7 +2,7 @@
 import { useEventListener } from "@vueuse/core";
 import { computed, useTemplateRef, ref, onMounted, watch } from "vue";
 
-import ChartContext from "../ChartContext.vue";
+import ChartTitle from "../ChartTitle.vue";
 import ChartLegend from "../ChartLegend/ChartLegend.vue";
 
 import {
@@ -290,7 +290,7 @@ watch(
 
 <template>
   <div ref="container" class="grid gap-2.5 w-full" :class="[chartLayoutCss]">
-    <ChartContext
+    <ChartTitle
       :title="title"
       :description="description"
       style="grid-area: context"

--- a/apps/tailwind-components/types/viz.ts
+++ b/apps/tailwind-components/types/viz.ts
@@ -8,7 +8,7 @@ export interface Charts {
 
 export type LegendPosition = "top" | "bottom";
 
-export interface ChartContext {
+export interface ChartTitle {
   title: string;
   description?: string;
 }


### PR DESCRIPTION
### What are the main changes you did

It was proposed in molgenis/molgenis-emx2#5967 that the component `<ChartContext>` should be renamed to ensure it isn't confused with other context mechanisms.

- [x] Renamed `ChartContext.vue` to `ChartTitle.vue`
- [x] Updated interfaces
- [x] Updated imports
- [x] Resolved typescript issue pointed out [here](https://github.com/molgenis/molgenis-emx2/pull/5967/changes/BASE..acac19e7717db6c024762979f64c6545851a04cb#r2847149851) 

Related stories: molgenis/GCC#1143, molgenis/GCC#1368

### How to test

- Go to the new component gallery
- View the PieChart and ColumnChart stories. The title /description are still present and there are no TS issues.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation