### PR TITLE
fix(catalogue): use correct provider name site-improve in docs

### DIFF
--- a/apps/catalogue/Dockerfile
+++ b/apps/catalogue/Dockerfile
@@ -45,7 +45,7 @@ ENV NUXT_PUBLIC_COHORT_ONLY=$NUXT_PUBLIC_COHORT_ONLY
 # Optional analytics key
 ENV NUXT_PUBLIC_ANALYTICS_KEY=$NUXT_PUBLIC_ANALYTICS_KEY
 
-# Optional name of analytics provider (for example: "google-analytics" or "siteimprove")
+# Optional name of analytics provider (for example: "google-analytics" or "site-improve")
 ENV NUXT_PUBLIC_ANALYTICS_PROVIDER=$NUXT_PUBLIC_ANALYTICS_PROVIDER
 
 # Optional domain for analytics provider

--- a/docs/catalogue/cat_admin.md
+++ b/docs/catalogue/cat_admin.md
@@ -185,7 +185,7 @@ Analytics can be enabled by setting the following environment variables:
 
 `NUXT_PUBLIC_ANALYTICS_KEY`: The analytics measurement id.
 
-`NUXT_PUBLIC_ANALYTICS_PROVIDER`: The analytics provider. Either `siteimprove` for [Siteimprove](https://www.siteimprove.com/)
+`NUXT_PUBLIC_ANALYTICS_PROVIDER`: The analytics provider. Either `site-improve` for [Siteimprove](https://www.siteimprove.com/)
 or `google-analytics` for [Google Analytics](https://marketingplatform.google.com/about/analytics/).
 
 `NUXT_PUBLIC_ANALYTICS_DOMAIN`: optional analytics domain as used by some providers.


### PR DESCRIPTION
## Summary
- Fix analytics provider name from `siteimprove` to `site-improve` in Dockerfile comment and documentation
- Addresses review feedback from #5972 ([discussion](https://github.com/molgenis/molgenis-emx2/pull/5972#discussion_r2878963777))

## Test plan
- [ ] Verify Dockerfile comment at line 48 shows `"site-improve"` instead of `"siteimprove"`
- [ ] Verify docs at `docs/catalogue/cat_admin.md` line 188 shows `site-improve` instead of `siteimprove`

🤖 Generated with [Claude Code](https://claude.com/claude-code)