### PR TITLE
fix(cranio): adjust graphql order

### DIFF
--- a/apps/cranio-provider/src/utils/getDashboardData.ts
+++ b/apps/cranio-provider/src/utils/getDashboardData.ts
@@ -36,11 +36,11 @@ export async function getDashboardPage(
           leftMargin
           legendPosition
           dataPoints(
-            orderby: {
-              dataPointPrimaryCategory: ASC
-              dataPointSecondaryCategory: ASC
-              dataPointOrder: ASC
-            }
+            orderby: [
+              { dataPointPrimaryCategory: ASC }
+              { dataPointSecondaryCategory: ASC }
+              { dataPointOrder: ASC }
+            ]
           ) {
             dataPointId
             dataPointName
@@ -100,11 +100,11 @@ export async function getDashboardChart(
         leftMargin
         legendPosition
         dataPoints(
-          orderby: {
-            dataPointPrimaryCategory: ASC
-            dataPointSecondaryCategory: ASC
-            dataPointOrder: ASC
-          }
+          orderby: [
+            { dataPointPrimaryCategory: ASC }
+            { dataPointSecondaryCategory: ASC }
+            { dataPointOrder: ASC }
+          ]
         ) {
           dataPointId
           dataPointName


### PR DESCRIPTION
### What are the main changes you did

In PR molgenis/molgenis-emx2#6001, the graphql ordering was changed to an array. This PR fixes the query in the cranio-provider app

- [x] `getDashboardChart`: order by is now an array

Part of molgenis/GCC#2516 and molgenis/GCC#2248

### How to test

There are be no changes to the dashboards

 - Go to the preview and open the AT1 schema
 - View all the pages. There should be no graphql errors

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation