### PR TITLE
fix(clean): commit during sql for-loops to reduce nr of transaction locks during db clean

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/utility-sql/clean-molgenis-database.sql
+++ b/backend/molgenis-emx2-sql/src/main/resources/org/molgenis/emx2/sql/utility-sql/clean-molgenis-database.sql
@@ -16,24 +16,6 @@ BEGIN
         END LOOP;
 END$$;
 
-DO $$
-DECLARE
-    r RECORD;
-BEGIN
-    FOR r IN
-        SELECT
-            table_schema, table_name, constraint_name
-        FROM information_schema.table_constraints
-        WHERE constraint_type = 'FOREIGN KEY'
-            AND table_schema NOT LIKE 'pg_%'
-            AND table_schema <> 'information_schema'
-            AND table_schema <> 'public'
-    LOOP
-        EXECUTE
-            format('ALTER TABLE %I.%I DROP CONSTRAINT %I;',
-                r.table_schema, r.table_name, r.constraint_name);
-    END LOOP;
-END$$;
 
 DO $$
 DECLARE
@@ -44,10 +26,10 @@ BEGIN
         SELECT rolname
         FROM pg_roles
         WHERE rolname LIKE 'MG\_%' ESCAPE '\'
-           OR rolname LIKE 'test%'
-           OR rolname LIKE 'user_%'
-    LOOP
-        EXECUTE format('REVOKE ALL PRIVILEGES ON DATABASE %I FROM %I;', dbname, r.rolname);
-        EXECUTE format('DROP ROLE %I;', r.rolname);
-    END LOOP;
+            OR rolname LIKE 'test%'
+            OR rolname LIKE 'user_%'
+        LOOP
+            EXECUTE format('REVOKE ALL PRIVILEGES ON DATABASE %I FROM %I;', dbname, r.rolname);
+            EXECUTE format('DROP ROLE %I;', r.rolname);
+        END LOOP;
 END$$;


### PR DESCRIPTION
Fixes https://github.com/molgenis/GCC/issues/2535

### What are the main changes you did
https://github.com/molgenis/molgenis-emx2/pull/5606 introduced a bug.
When running the cleanDb task with a lot of schemas to clean, the script would break because for each db it had to delete, it would use a new transaction lock.
This PR adds commits in the clean script for-loops to clear transaction locks and prevent the script to break on a high number of schemas to delete. 

### How to test
1. Create a high nr of schemas, `./gradlew build` runs all Java tests, which create a high number of schemas to clean
2. Clean the database `./gradlew cleanDb`

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [x] added/updated testplan to include a test for this fix, including ref to bug using # notation