### PR TITLE
fix(forms-tw): array types with _ not displaying

### DIFF
--- a/apps/tailwind-components/app/components/value/List.vue
+++ b/apps/tailwind-components/app/components/value/List.vue
@@ -23,7 +23,9 @@ const props = withDefaults(
   }
 );
 
-const elementType = computed(() => props.metadata.columnType.split("_")[0]);
+const elementType = computed(
+  () => props.metadata.columnType.split("_ARRAY")[0]
+);
 </script>
 
 <template>


### PR DESCRIPTION
### What are the main changes you did
- fixes arrays types containing extra _ in their name, such as AUTO_ID and NON_NEGATIVE_INT

### How to test
- go to the new tw ui
- go to the types test schema 
- go to the types table
- the mentioned types should now not display only   `TYPE , TYPE` (e.g. `NON, NON)`

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation