### PR TITLE
fix: assume rowEdit is editable by default

### DIFF
--- a/apps/molgenis-components/src/components/forms/RowEdit.vue
+++ b/apps/molgenis-components/src/components/forms/RowEdit.vue
@@ -95,7 +95,7 @@ export default {
     canEdit: {
       type: Boolean,
       required: false,
-      default: () => false,
+      default: () => true,
     },
     tablePermissions: {
       type: Array,


### PR DESCRIPTION
its meant to edit a row so at this point in the tree, true seems like a reasonable default

Closes #6166

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
