### PR TITLE
chore: disable run-audit-ci step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,10 @@ commands:
           git config user.email "m.a.swertz@rug.nl"
           git config user.name "mswertz"
           git config url.https://.insteadOf git://
-    - run:
-        name: run-audit-ci
-        command: npx audit-ci@^7 --config ./audit-ci.jsonc --critical
-        working_directory: apps      
+#    - run:
+#        name: run-audit-ci
+#        command: npx audit-ci@^7 --config ./audit-ci.jsonc --critical
+#        working_directory: apps
     - run:
           name: Concatenate Build Files as key for cache
           command: |


### PR DESCRIPTION
### What are the main changes you did
- The endpoint used by audit-ci ( pnpm internally ) is broken

### How to test
-  Ci should skip disabled check and continue 
- 
### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
