### PR TITLE
feat(ui): Add prop to render menu in fullscreen mode

### DIFF
--- a/apps/tailwind-components/app/components/Container.vue
+++ b/apps/tailwind-components/app/components/Container.vue
@@ -1,5 +1,18 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    fullScreen?: boolean;
+  }>(),
+  {
+    fullScreen: false,
+  }
+);
+</script>
 <template>
-  <div class="max-w-lg mx-auto lg:px-[30px] px-0">
+  <div
+    class="mx-auto lg:px-[30px] px-0"
+    :class="fullScreen ? 'max-w-full' : 'max-w-lg'"
+  >
     <slot></slot>
   </div>
 </template>

--- a/apps/tailwind-components/app/components/Header.vue
+++ b/apps/tailwind-components/app/components/Header.vue
@@ -4,6 +4,15 @@ import Container from "./Container.vue";
 import HeaderButton from "./HeaderButton.vue";
 import ThemeSwitch from "./ThemeSwitch.vue";
 
+const props = withDefaults(
+  defineProps<{
+    fullScreen?: boolean;
+  }>(),
+  {
+    fullScreen: false,
+  }
+);
+
 const config = useRuntimeConfig();
 
 // only show the theme switch if the emx2Theme is not set to a specific theme ( for example molgenis )
@@ -15,7 +24,7 @@ const showThemeSwitch =
   <header
     class="antialiased px-5 lg:px-0 xl:bg-navigation border-b-theme border-color-theme box-border"
   >
-    <Container>
+    <Container :fullScreen="fullScreen">
       <div class="items-center hidden xl:flex h-20">
         <slot name="logo"></slot>
 

--- a/apps/ui/app/layouts/default.vue
+++ b/apps/ui/app/layouts/default.vue
@@ -8,7 +8,7 @@
       <BackgroundGradient class="z-10" />
     </div>
     <div class="z-30 relative min-h-screen flex flex-col">
-      <Header>
+      <Header :fullScreen="fullScreen">
         <template #logo>
           <Logo link="/" />
         </template>
@@ -88,6 +88,7 @@ const config = useRuntimeConfig();
 const route = useRoute();
 const schema = computed(() => route.params.schema as string);
 const { session, signOut } = await useSession(schema.value);
+const fullScreen = computed(() => !!route.meta.layoutProps?.fullScreen);
 
 const faviconHref = config.public.emx2Theme
   ? `/_nuxt-styles/img/${config.public.emx2Theme}.ico`

--- a/apps/ui/app/pages/[schema]/[table]/index.vue
+++ b/apps/ui/app/pages/[schema]/[table]/index.vue
@@ -17,6 +17,7 @@ import type { IRow } from "../../../../../metadata-utils/src/types";
 import { getPrimaryKey } from "../../../../../tailwind-components/app/utils/getPrimaryKey";
 import { keySlug } from "../../../../../tailwind-components/app/utils/navigationUtils";
 import Button from "../../../../../tailwind-components/app/components/Button.vue";
+import { definePageMeta } from "#imports";
 
 const route = useRoute();
 const router = useRouter();
@@ -24,6 +25,13 @@ const schemaId = route.params.schema as string;
 const tableId = route.params.table as string;
 
 useHead({ title: `${tableId} - ${schemaId}  - Molgenis` });
+
+definePageMeta({
+  layout: "default",
+  layoutProps: {
+    fullScreen: true,
+  },
+});
 
 const currentPage = computed(() => {
   const queryPageNumber = Number(route.query?.page);


### PR DESCRIPTION
The default layout centers the content
Some pages ( tables page) want to use all available screen width ( large screen , table with lots of columns) Passing the fullscreen option form the page to the layout allow the menu to be rendered in fullscreen mode ( align with content)

### What are the main changes you did
- explain what you changed and essential considerations.
before
<img width="696" height="389" alt="Screenshot 2026-04-16 at 10 16 31" src="https://github.com/user-attachments/assets/ffd47376-59d5-4a21-8f5e-122495159e1b" />

after 

<img width="558" height="413" alt="Screenshot 2026-04-16 at 10 17 09" src="https://github.com/user-attachments/assets/b2c59ae2-9366-4e08-9bd2-6269b444fb22" />

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
