### PR TITLE
chore: switch to pnpm v11 audit

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,10 +79,10 @@ commands:
           git config user.email "m.a.swertz@rug.nl"
           git config user.name "mswertz"
           git config url.https://.insteadOf git://
-#    - run:
-#        name: run-audit-ci
-#        command: npx audit-ci@^7 --config ./audit-ci.jsonc --critical
-#        working_directory: apps
+    - run:
+        name: run-pnpm-audit
+        command:  pnpm dlx --config.minimumReleaseAge=0 pnpm@11.0.0-rc.1 --config.manage-package-manager-versions=false audit --audit-level=critical
+        working_directory: apps
     - run:
           name: Concatenate Build Files as key for cache
           command: |


### PR DESCRIPTION
Due to changes in the npm audit endpoint the audit-ci tool ( use pnpm under the hood) stoped working pnpm v11-rc includes an updated endpoint

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
