### PR TITLE
fix: save inherited autoids

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -15,6 +15,7 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.jooq.*;
+import org.jooq.Record;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.Query;
 import org.molgenis.emx2.Row;
@@ -336,7 +337,7 @@ public class SqlTable implements Table {
       List<Row> rows = applyValidationAndComputed(insertColumns, subclassRows.get(subclassName));
       count.set(
           count.get()
-              + table.insertBatch(table, rows, SAVE.equals(transactionType), insertColumns));
+              + table.insertBatch(table, rows, SAVE.equals(transactionType), insertColumns).size());
     } else {
       throw new MolgenisException(
           "Internal error in executeBatch: transaction type "
@@ -377,27 +378,38 @@ public class SqlTable implements Table {
     return this.tableListener;
   }
 
-  private int insertBatch(
+  private List<Record> insertBatch(
       SqlTable table, List<Row> rows, boolean updateOnConflict, List<Column> updateColumns) {
     boolean inherit = table.getMetadata().getInheritName() != null;
-    int count = 0;
     if (inherit) {
       SqlTable inheritedTable = table.getInheritedTable();
-      count = inheritedTable.insertBatch(inheritedTable, rows, updateOnConflict, updateColumns);
+      List<Record> records =
+          inheritedTable.insertBatch(inheritedTable, rows, updateOnConflict, updateColumns);
+
+      List<Column> autoIdColumns =
+          inheritedTable.getMetadata().getPrimaryKeyColumns().stream()
+              .filter(c -> AUTO_ID.equals(c.getColumnType()))
+              .toList();
+
+      // Copy the generated auto id's from the parent table
+      for (int i = 0; i < records.size(); i++) {
+        copyRecordValuesIntoRows(rows.get(i), records.get(i), autoIdColumns);
+      }
     }
 
     List<Column> columns = getLocalStoredColumns(table, updateColumns);
-    if (columns.size() == 0) return count;
-    List<Field> insertFields =
-        columns.stream().map(c -> c.getJooqField()).collect(Collectors.toList());
+    if (columns.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    List<Field> insertFields = columns.stream().map(Column::getJooqField).toList();
     InsertValuesStepN<org.jooq.Record> step =
         table.getJooq().insertInto(table.getJooqTable(), insertFields.toArray(new Field[0]));
 
     // add all the rows as steps
     LocalDateTime now = LocalDateTime.now();
     for (Row row : rows) {
-      // get values
-      Map values = getSelectedRowValues(columns, row);
+      Map<String, Object> values = getSelectedRowValues(columns, row);
       if (!inherit) {
         values.put(MG_INSERTEDBY, getActiveUser(table));
         values.put(MG_INSERTEDON, now);
@@ -428,7 +440,13 @@ public class SqlTable implements Table {
       }
     }
 
-    return step.execute();
+    return step.returningResult(table.getMetadata().getPrimaryKeyFields()).fetch();
+  }
+
+  private static void copyRecordValuesIntoRows(Row row, Record from, List<Column> toCopy) {
+    for (Column column : toCopy) {
+      row.set(column.getName(), from.getValue(column.getName()));
+    }
   }
 
   private static String getActiveUser(SqlTable table) {

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestAutoIdGeneration.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestAutoIdGeneration.java
@@ -3,6 +3,7 @@ package org.molgenis.emx2.sql;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.molgenis.emx2.TableMetadata.table;
 
+import java.util.List;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.junit.jupiter.api.BeforeAll;
@@ -11,12 +12,11 @@ import org.molgenis.emx2.*;
 
 class TestAutoIdGeneration {
 
-  private static Database db;
   private static Schema schema;
 
   @BeforeAll
   static void setUp() {
-    db = TestDatabaseFactory.getTestDatabase();
+    Database db = TestDatabaseFactory.getTestDatabase();
     schema = db.dropCreateSchema(TestAutoIdGeneration.class.getSimpleName());
   }
 
@@ -47,5 +47,50 @@ class TestAutoIdGeneration {
     String generatedId = row.get("id", String.class);
     Matcher matcher = Pattern.compile("\\d").matcher(generatedId);
     assertTrue(matcher.find());
+  }
+
+  @Test
+  void givenTableInheritance_whenInserting_thenGenerateAutoId() {
+    schema.create(
+        table(
+            "test_inheritance_A",
+            new Column("a_id")
+                .setType(ColumnType.AUTO_ID)
+                .setComputed("${mg_autoid(length=1, format=numbers)}")
+                .setPkey(),
+            new Column("a_label").setType(ColumnType.INT)),
+        table(
+                "test_inheritance_B",
+                new Column("b_id")
+                    .setType(ColumnType.AUTO_ID)
+                    .setComputed("${mg_autoid(length=2, format=numbers)}")
+                    .setPkey(),
+                new Column("b_label").setType(ColumnType.INT))
+            .setInheritName("test_inheritance_A"));
+
+    Table tableC =
+        schema.create(
+            table(
+                    "test_inheritance_C",
+                    new Column("c_id")
+                        .setType(ColumnType.AUTO_ID)
+                        .setComputed("${mg_autoid(length=3, format=numbers)}")
+                        .setPkey(),
+                    new Column("c_label").setType(ColumnType.INT))
+                .setInheritName("test_inheritance_B"));
+
+    int nrInserted = tableC.insert(Row.row());
+    assertEquals(1, nrInserted);
+
+    List<Row> rows = tableC.retrieveRows();
+    assertEquals(1, rows.size());
+    Row row = rows.getFirst();
+    assertRowValueMatchesPattern(row, "a_id", "\\d");
+    assertRowValueMatchesPattern(row, "b_id", "\\d{2}");
+    assertRowValueMatchesPattern(row, "c_id", "\\d{3}");
+  }
+
+  private void assertRowValueMatchesPattern(Row row, String value, String pattern) {
+    assertTrue(Pattern.compile(pattern).matcher(row.getString(value)).matches());
   }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestInherits.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestInherits.java
@@ -13,20 +13,23 @@ import static org.molgenis.emx2.SelectColumn.s;
 import static org.molgenis.emx2.TableMetadata.table;
 
 import java.time.LocalDate;
+import java.util.List;
+import java.util.stream.IntStream;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.*;
 
-public class TestInherits {
+class TestInherits {
+
   private static Database db;
 
   @BeforeAll
-  public static void setUp() {
+  static void setUp() {
     db = TestDatabaseFactory.getTestDatabase();
   }
 
   @Test
-  public void testExtends() {
+  void testExtends() {
 
     db.dropSchemaIfExists(
         TestInherits.class.getSimpleName() + "1"); // is a related schema, drop that first
@@ -299,7 +302,7 @@ public class TestInherits {
             .get(0)
             .getName());
 
-    // try to add faulty reftable
+    // try to add faulty ref-table
     assertThrows(
         MolgenisException.class,
         () -> {
@@ -313,5 +316,38 @@ public class TestInherits {
     studentTable.getMetadata().drop();
     personTable.getMetadata().drop();
     // todo add test that trigger actually is deleted
+  }
+
+  /**
+   * When inserting rows into a table (A) that inherits a different one (B), we first insert values
+   * into B, then insert into A afterward, using the values of B. We do this to ensure generated IDs
+   * are reused across all inherited tables. With this test, we want to ensure that the ordering of
+   * these values stay intact.
+   */
+  @Test
+  void whenInsertingInheritedTable_thenReuseInheritedValues() {
+    Schema schema = db.dropCreateSchema(TestInherits.class.getSimpleName() + "_insert");
+    schema.create(
+        table(
+            "test_inheritance_A",
+            new Column("a_id")
+                .setType(ColumnType.AUTO_ID)
+                .setComputed("${mg_autoid(length=10, format=numbers)}")
+                .setPkey(),
+            new Column("a_label").setType(ColumnType.INT)));
+
+    Table tableB =
+        schema.create(
+            table("test_inheritance_B", new Column("b_label").setType(ColumnType.INT))
+                .setInheritName("test_inheritance_A"));
+
+    List<Row> rows =
+        IntStream.range(0, 100).boxed().map(i -> Row.row("a_label", i, "b_label", i)).toList();
+
+    tableB.insert(rows);
+
+    for (Row row : tableB.retrieveRows()) {
+      assertEquals(row.getInteger("a_label"), row.getInteger("b_label"));
+    }
   }
 }


### PR DESCRIPTION
Fixes: https://github.com/molgenis/molgenis-emx2/issues/6101

### What are the main changes you did
- When storing rows into a table (`A`) that inherits another (`B`), we first store that data in `B`. Once stored, we now reuse that values from the stored rows in `B` when inserting into `A`. This fixes a bug where values that are generated during insert (auto-id), are no longer generated again.

### How to test
- Added two unit tests:
  1. Checks whether id's arent generated twice, but we reuse the generated value of `A`.
  2. In the solution we assume that we get the inserted rows from jooq in the same order as we insert the data. We added a test that verifies this assumption for us.
- Running the steps that @davidruvolo51 provided in the [issue](https://github.com/molgenis/molgenis-emx2/issues/6101) should no longer result in an error.

### Checklist
- [ ] updated docs in case of new feature
- [X] added/updated tests
- [x] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
