### PR TITLE
fix: ontolgies typo in tailwind tables overview

### DIFF
--- a/apps/ui/app/pages/[schema]/index.vue
+++ b/apps/ui/app/pages/[schema]/index.vue
@@ -100,7 +100,7 @@ crumbs.push({ label: "tables", url: "" });
     <ContentBlock
       v-if="ontologies.length"
       class="mt-1"
-      title="ontolgies"
+      title="ontologies"
       description="description"
     >
       <Table>


### PR DESCRIPTION
### What are the main changes you did
- fix typo in ONTOLGIES header on table overview tailwind UI
- fixes https://github.com/molgenis/GCC/issues/2719

### How to test
- Go to tailwind UI
- Open a schema including ontologies (for example CatalogueOntologies) and see that ONTOLOGIES is properly spelled
- Do the same on for example emx2.dev => see the typo there: ONTOLGIES.


By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
