### PR TITLE
fix: return the real number of deleted rows

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -515,26 +515,28 @@ public class SqlTable implements Table {
   public int delete(Iterable<Row> rows) {
     long start = System.currentTimeMillis();
 
-    AtomicInteger count = new AtomicInteger(0);
+    AtomicInteger nrDeleted = new AtomicInteger(0);
     try {
       db.tx(
           db2 -> {
-            SqlTable table = (SqlTable) db2.getSchema(getSchema().getName()).getTable(getName());
-
-            // delete in batches
             int batchSize = 1000;
+            int currentBatchSize = 0;
+
+            SqlTable table = (SqlTable) db2.getSchema(getSchema().getName()).getTable(getName());
             List<Row> batch = new ArrayList<>();
+
             for (Row row : rows) {
               batch.add(row);
-              count.set(count.get() + 1);
-              if (count.get() % batchSize == 0) {
-                deleteBatch(table, batch);
+              currentBatchSize++;
+              if (currentBatchSize % batchSize == 0) {
+                nrDeleted.addAndGet(deleteBatch(table, batch));
                 batch.clear();
+                currentBatchSize = 0;
               }
             }
 
             // delete remaining elements
-            deleteBatch(table, batch);
+            nrDeleted.addAndGet(deleteBatch(table, batch));
 
             // finally delete in superclass
             if (table.getMetadata().getInheritName() != null) {
@@ -550,9 +552,8 @@ public class SqlTable implements Table {
       throw new SqlMolgenisException("Delete into table " + getName() + " failed", e);
     }
 
-    log(db.getActiveUser(), getName(), start, count, "deleted");
-
-    return count.get();
+    log(db.getActiveUser(), getName(), start, nrDeleted, "deleted");
+    return nrDeleted.get();
   }
 
   @Override
@@ -584,7 +585,7 @@ public class SqlTable implements Table {
     return delete(Arrays.asList(rows));
   }
 
-  private static void deleteBatch(SqlTable table, Collection<Row> rows) {
+  private static int deleteBatch(SqlTable table, Collection<Row> rows) {
     if (!rows.isEmpty()) {
       List<String> keyNames =
           table.getMetadata().getPrimaryKeyFields().stream()
@@ -597,8 +598,10 @@ public class SqlTable implements Table {
             "Delete on table " + table.getName() + " failed: no primary key set");
       }
       Condition whereCondition = table.getWhereConditionForBatchDelete(rows);
-      table.getJooq().deleteFrom(table.getJooqTable()).where(whereCondition).execute();
+      return table.getJooq().deleteFrom(table.getJooqTable()).where(whereCondition).execute();
     }
+
+    return 0;
   }
 
   private DSLContext getJooq() {

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestDeletingTableRows.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestDeletingTableRows.java
@@ -1,0 +1,77 @@
+package org.molgenis.emx2.sql;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.*;
+import org.molgenis.emx2.Query.Option;
+import org.molgenis.emx2.datamodels.util.CompareTools;
+
+class TestDeletingTableRows {
+
+  private static Table table;
+
+  @BeforeEach
+  void setup() {
+    Database db = TestDatabaseFactory.getTestDatabase();
+    Schema schema = db.dropCreateSchema(TestDeletingTableRows.class.getSimpleName());
+    table =
+        schema.create(
+            TableMetadata.table(
+                "to_delete_rows",
+                Column.column("id", ColumnType.INT).setPkey(),
+                Column.column("name", ColumnType.STRING)));
+  }
+
+  @Test
+  void whenDeletingRowsWithPrimaryKey_thenDeleteGivenRows() {
+    table.insert(Row.row("id", 1, "name", "foo"));
+    table.insert(Row.row("id", 2, "name", "bar"));
+    table.insert(Row.row("id", 3, "name", "baz"));
+
+    int nrDeleted = table.delete(Row.row("id", 1), Row.row("id", 2));
+    assertEquals(2, nrDeleted);
+
+    CompareTools.assertEquals(
+        table.retrieveRows(Option.EXCLUDE_MG_COLUMNS), List.of(Row.row("id", 3, "name", "baz")));
+  }
+
+  @Test
+  void whenDeletingNonExistingRows_thenDontDelete() {
+    table.insert(Row.row("id", 1, "name", "a"));
+    table.insert(Row.row("id", 2, "name", "b"));
+
+    int nrDeleted = table.delete(Row.row("id", 123));
+    assertEquals(0, nrDeleted);
+
+    CompareTools.assertEquals(
+        table.retrieveRows(Option.EXCLUDE_MG_COLUMNS),
+        List.of(Row.row("id", 1, "name", "a"), Row.row("id", 2, "name", "b")));
+  }
+
+  @Test
+  void whenDeletingRowsWithAllFields_thenDelete() {
+    table.insert(Row.row("id", 1, "name", "foo"));
+    table.insert(Row.row("id", 2, "name", "bar"));
+
+    int nrDeleted = table.delete(Row.row("id", 2, "name", "bar"));
+    assertEquals(1, nrDeleted);
+
+    CompareTools.assertEquals(
+        table.retrieveRows(Option.EXCLUDE_MG_COLUMNS), List.of(Row.row("id", 1, "name", "foo")));
+  }
+
+  @Test
+  void whenDeletingMatchingPrimaryKeyWithUnknownColumn_thenDeleteRow() {
+    table.insert(Row.row("id", 1, "name", "foo"));
+    table.insert(Row.row("id", 2, "name", "bar"));
+
+    int nrDeleted = table.delete(Row.row("id", 1, "unknown-field", "foo"));
+    assertEquals(1, nrDeleted);
+
+    CompareTools.assertEquals(
+        table.retrieveRows(Option.EXCLUDE_MG_COLUMNS), List.of(Row.row("id", 2, "name", "bar")));
+  }
+}


### PR DESCRIPTION
Fixes: https://github.com/molgenis/molgenis-emx2/issues/6138#issue-4223546548

### What are the main changes you did
return the real number of deleted rows. Don't assume that every batch clears up 1000 rows.

- This fixes an issue where users would get a false impression of rows being deleted if they gave up non-existing key values.
- Improved test coverage for SqlTable#delete to define expected behaviour.

### How to test
- New unit tests
- Reproduction steps in https://github.com/molgenis/molgenis-emx2/issues/6138#issue-4223546548

### Checklist
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [x] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
