### PR TITLE
Revert "chore(deps): update plugin com.gradleup.shadow to v9"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java"
     id "org.sonarqube" version "7.2.3.7755"
     id 'maven-publish'
-    id 'com.gradleup.shadow' version '9.4.1'
+    id 'com.gradleup.shadow' version '8.3.10'
     id 'application'
 }
 


### PR DESCRIPTION
Reverts molgenis/molgenis-emx2#6188

If we want to upgrade to a v9.x release, we will need additional changes.

See also:
* #5873
* The "chore: update shadow plugin" story