### PR TITLE
fix: added if exists when dropping triggers

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnRefArrayExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnRefArrayExecutor.java
@@ -31,12 +31,16 @@ class SqlColumnRefArrayExecutor {
 
   static void removeRefArrayConstraints(DSLContext jooq, Column ref) {
     jooq.execute(
-        "DROP TRIGGER {0} ON {1}", name(getReferenceExistsCheckName(ref)), ref.getJooqTable());
-    jooq.execute("DROP FUNCTION {0} ", name(ref.getSchemaName(), getReferenceExistsCheckName(ref)));
+        "DROP TRIGGER IF EXISTS {0} ON {1}",
+        name(getReferenceExistsCheckName(ref)), ref.getJooqTable());
     jooq.execute(
-        "DROP TRIGGER {0} ON {1}",
+        "DROP FUNCTION IF EXISTS {0} ",
+        name(ref.getSchemaName(), getReferenceExistsCheckName(ref)));
+    jooq.execute(
+        "DROP TRIGGER IF EXISTS {0} ON {1}",
         name(getReferedCheckName(ref)), ref.getRefTable().getJooqTable());
-    jooq.execute("DROP FUNCTION {0}", name(ref.getSchemaName(), getReferedCheckName(ref)));
+    jooq.execute(
+        "DROP FUNCTION IF EXISTS {0}", name(ref.getSchemaName(), getReferedCheckName(ref)));
   }
 
   // this trigger is to check for foreign violations: to prevent that referenced records cannot be


### PR DESCRIPTION
Fixes https://github.com/molgenis/GCC/issues/2764

Changing meta data in the catalogue fails sometimes. The issue is for changing data models that ref array triggers not always exist. 

This will fix the issue, but I do not fully understand where the aliases in the [issue](https://github.com/molgenis/GCC/issues/2764) come from

### What are the main changes you did
Added if exists clauses 

### How to test
- Could not reproduce this locally by importing the datamodel.
- So should deploy the fix to the molgeniscatalogue

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
