### PR TITLE
fix: pageviews are now being sent to google analytics, if user accepts cookiebanner

### DIFF
--- a/apps/directory/src/main.ts
+++ b/apps/directory/src/main.ts
@@ -24,8 +24,23 @@ self.MonacoEnvironment = {
 export const app = createApp(App);
 
 app.use(createPinia());
-app.use(router);
 
+/* Add manual page view tracking for Google Analytics, since the app is a SPA and GA doesn't track page views automatically
+ * We already have the cookiebanner which loads GTAG. So we can just add it here after each route change.
+ */
+router.afterEach((to) => {
+  // @ts-ignore
+  if (window.gtag) {
+    // @ts-ignore
+    window.gtag("event", "page_view", {
+      page_title: document.title,
+      page_location: window.location.origin + to.fullPath,
+      page_path: to.fullPath,
+    });
+  }
+});
+
+app.use(router);
 app.mount("#app");
 
 // Used by Matomo for tracking events


### PR DESCRIPTION
### What are the main changes you did
- added a pageview tracker on router.

### How to test
- add analytics id in settings, accept cookiebanner, navigate and see in GA, do use realtime overview.