### PR TITLE
feat: delete rows should give error when setting 'strict=true'

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -959,6 +959,9 @@ public class GraphqlTableFieldFactory {
             .type(typeForMutationResult)
             .dataFetcher(fetcher(schema, MutationType.DELETE));
 
+    fieldBuilder.argument(
+        GraphQLArgument.newArgument().name("strict").type(Scalars.GraphQLBoolean).build());
+
     for (Table table : schema.getTablesSorted()) {
       // if no pkey is provided, you cannot delete rows
       if (!schema.getMetadata().getTableMetadata(table.getName()).getPrimaryKeys().isEmpty()) {
@@ -985,22 +988,24 @@ public class GraphqlTableFieldFactory {
         if (rowsAslistOfMaps != null) {
           String tableName = tableMetadata.getTableName();
           Table table = tableMetadata.getTable();
-          int count = 0;
+          int count;
+          List<Row> rows = TypeUtils.convertToRows(table.getMetadata(), rowsAslistOfMaps);
           switch (mutationType) {
             case UPDATE:
-              count = table.update(TypeUtils.convertToRows(table.getMetadata(), rowsAslistOfMaps));
+              count = table.update(rows);
               result.append("updated " + count + " records to " + tableName + "\n");
               break;
             case INSERT:
-              count = table.insert(TypeUtils.convertToRows(table.getMetadata(), rowsAslistOfMaps));
+              count = table.insert(rows);
               result.append("inserted " + count + " records to " + tableName + "\n");
               break;
             case SAVE:
-              count = table.save(TypeUtils.convertToRows(table.getMetadata(), rowsAslistOfMaps));
+              count = table.save(rows);
               result.append("upserted " + count + " records to " + tableName + "\n");
               break;
             case DELETE:
-              count = table.delete(TypeUtils.convertToRows(table.getMetadata(), rowsAslistOfMaps));
+              boolean strict = dataFetchingEnvironment.getArgumentOrDefault("strict", false);
+              count = table.delete(rows, strict);
               result.append("delete " + count + " records from " + tableName + "\n");
               break;
           }

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlSchemaFields.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlSchemaFields.java
@@ -829,8 +829,6 @@ class TestGraphqlSchemaFields {
       execute("mutation{delete(Some:{id:\"one\"}){message}}");
       execute(
           "mutation{delete(PersonDetails:{firstName:\"blaata\",last_name:\"blaata2\"}){message}}");
-      execute(
-          "mutation{delete(PersonDetails:{firstName:\"blaatb\",last_name:\"blaata2\"}){message}}");
       assertEquals(
           count, execute("{PersonDetails_agg{count}}").at("/PersonDetails_agg/count").intValue());
 

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlSchemaFields.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlSchemaFields.java
@@ -668,6 +668,26 @@ class TestGraphqlSchemaFields {
   }
 
   @Test
+  void strictDeleteRows() throws IOException {
+    String message =
+        execute("mutation{delete(Tag:{name:\"non-existent\"}){message}}")
+            .get("delete")
+            .get("message")
+            .textValue();
+    assertEquals("delete 0 records from Tag\n", message);
+  }
+
+  @Test
+  void nonStrictDeleteRows() {
+    MolgenisException exception =
+        assertThrows(
+            MolgenisException.class,
+            () -> execute("mutation{delete(strict: true, Tag:{name:\"non-existent\"}){message}}"));
+    assertTrue(
+        exception.getMessage().contains("attempted to delete 1 rows but only deleted 0 rows"));
+  }
+
+  @Test
   void testAddAlterDropColumn() throws IOException {
     execute("mutation{change(columns:{table:\"Pet\",name:\"test\"}){message}}");
     assertNotNull(database.getSchema(schemaName).getTable("Pet").getMetadata().getColumn("test"));

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -26,6 +26,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class SqlTable implements Table {
+
   private SqlDatabase db;
   private SqlTableMetadata metadata;
   private TableListener tableListener;
@@ -512,7 +513,7 @@ public class SqlTable implements Table {
   }
 
   @Override
-  public int delete(Iterable<Row> rows) {
+  public int delete(Iterable<Row> rows, boolean strict) {
     long start = System.currentTimeMillis();
 
     AtomicInteger nrDeleted = new AtomicInteger(0);
@@ -546,7 +547,7 @@ public class SqlTable implements Table {
             }
 
             // Validate that we deleted exactly the number of rows we intended to delete
-            if (nrDeleted.get() != nrRowsToDelete) {
+            if (nrDeleted.get() != nrRowsToDelete && strict) {
               throw new MolgenisException(
                   "Delete failed: attempted to delete "
                       + nrRowsToDelete
@@ -594,11 +595,6 @@ public class SqlTable implements Table {
   // @Override
   public Query search(String terms) {
     return query().search(terms);
-  }
-
-  @Override
-  public int delete(Row... rows) {
-    return delete(Arrays.asList(rows));
   }
 
   private static int deleteBatch(SqlTable table, Collection<Row> rows) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -552,8 +552,11 @@ public class SqlTable implements Table {
                       + nrRowsToDelete
                       + " rows but only deleted "
                       + nrDeleted.get()
-                      + " rows. Some specified rows do not exist in table "
-                      + getName());
+                      + " row"
+                      + (nrDeleted.get() == 1 ? "" : "s")
+                      + ". Some specified rows do not exist in table "
+                      + getName()
+                      + ". Transaction rolled back.");
             }
 
             // notify handlers

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -521,11 +521,13 @@ public class SqlTable implements Table {
           db2 -> {
             int batchSize = 1000;
             int currentBatchSize = 0;
+            int nrRowsToDelete = 0;
 
             SqlTable table = (SqlTable) db2.getSchema(getSchema().getName()).getTable(getName());
             List<Row> batch = new ArrayList<>();
 
             for (Row row : rows) {
+              nrRowsToDelete++;
               batch.add(row);
               currentBatchSize++;
               if (currentBatchSize % batchSize == 0) {
@@ -541,6 +543,17 @@ public class SqlTable implements Table {
             // finally delete in superclass
             if (table.getMetadata().getInheritName() != null) {
               table.getInheritedTable().delete(rows);
+            }
+
+            // Validate that we deleted exactly the number of rows we intended to delete
+            if (nrDeleted.get() != nrRowsToDelete) {
+              throw new MolgenisException(
+                  "Delete failed: attempted to delete "
+                      + nrRowsToDelete
+                      + " rows but only deleted "
+                      + nrDeleted.get()
+                      + " rows. Some specified rows do not exist in table "
+                      + getName());
             }
 
             // notify handlers

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestDeletingTableRows.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestDeletingTableRows.java
@@ -39,15 +39,32 @@ class TestDeletingTableRows {
   }
 
   @Test
-  void whenDeletingNonExistingRows_thenThrowException() {
+  void givenNonExistingRows_whenDeletingWithStrict_thenThrowException() {
     table.insert(Row.row("id", 1, "name", "a"));
     table.insert(Row.row("id", 2, "name", "b"));
 
     Row nonExistentRow = Row.row("id", 123);
     assertThrows(
         MolgenisException.class,
-        () -> table.delete(nonExistentRow),
+        () -> table.delete(List.of(nonExistentRow), true),
         "Should throw exception when deleting a row that doesn't exist in the table");
+
+    // Verify transaction is rolled back
+    CompareTools.assertEquals(
+        table.retrieveRows(Option.EXCLUDE_MG_COLUMNS),
+        List.of(Row.row("id", 1, "name", "a"), Row.row("id", 2, "name", "b")));
+  }
+
+  @Test
+  void givenNonExistingRows_whenDeletingWithoutStrict_thenDoNothing() {
+    table.insert(Row.row("id", 1, "name", "a"));
+    table.insert(Row.row("id", 2, "name", "b"));
+
+    Row nonExistentRow = Row.row("id", 123);
+    assertEquals(
+        0,
+        table.delete(nonExistentRow),
+        "Should ignore when deleting a row that doesn't exist in the table");
 
     // Verify transaction is rolled back
     CompareTools.assertEquals(
@@ -87,12 +104,30 @@ class TestDeletingTableRows {
 
     assertThrows(
         MolgenisException.class,
-        () -> table.delete(nonExistentRow),
+        () -> table.delete(List.of(nonExistentRow), true),
         "Should throw exception when deleting a row that doesn't exist in the table");
   }
 
   @Test
-  void whenDeletingRowsWithMixedValidAndInvalidRows_thenThrowException() {
+  void givenRowsWithMixedValidAndInvalidRows_whenStrict_thenThrowException() {
+    table.insert(Row.row("id", 1, "name", "test1"));
+    table.insert(Row.row("id", 2, "name", "test2"));
+
+    Row validRow = Row.row("id", 1, "name", "test1");
+    Row invalidRow = Row.row("id", 999, "name", "non-existent");
+
+    assertEquals(
+        1,
+        table.delete(validRow, invalidRow),
+        "Should ignore when deleting a row that doesn't exist in the table");
+
+    // Verify transaction is rolled back
+    CompareTools.assertEquals(
+        table.retrieveRows(Option.EXCLUDE_MG_COLUMNS), List.of(Row.row("id", 2, "name", "test2")));
+  }
+
+  @Test
+  void givenRowsWithMixedValidAndInvalidRows_whenNotStrict_thenDeleteExisting() {
     table.insert(Row.row("id", 1, "name", "test1"));
     table.insert(Row.row("id", 2, "name", "test2"));
 
@@ -101,7 +136,12 @@ class TestDeletingTableRows {
 
     assertThrows(
         MolgenisException.class,
-        () -> table.delete(validRow, invalidRow),
+        () -> table.delete(List.of(validRow, invalidRow), true),
         "Should throw exception when any row in the batch doesn't exist in the table");
+
+    // Verify transaction is rolled back
+    CompareTools.assertEquals(
+        table.retrieveRows(Option.EXCLUDE_MG_COLUMNS),
+        List.of(Row.row("id", 1, "name", "test1"), Row.row("id", 2, "name", "test2")));
   }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestDeletingTableRows.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestDeletingTableRows.java
@@ -43,10 +43,11 @@ class TestDeletingTableRows {
     table.insert(Row.row("id", 1, "name", "a"));
     table.insert(Row.row("id", 2, "name", "b"));
 
-    Row nonExistentRow = Row.row("id", 123);
+    List<Row> nonExistentRows = List.of(Row.row("id", 123));
+
     assertThrows(
         MolgenisException.class,
-        () -> table.delete(List.of(nonExistentRow), true),
+        () -> table.delete(nonExistentRows, true),
         "Should throw exception when deleting a row that doesn't exist in the table");
 
     // Verify transaction is rolled back
@@ -99,12 +100,11 @@ class TestDeletingTableRows {
   @Test
   void whenDeletingRowNotInTable_thenThrowException() {
     table.insert(Row.row("id", 1, "name", "test"));
-
-    Row nonExistentRow = Row.row("id", 999, "name", "non-existent");
+    List<Row> rows = List.of(Row.row("id", 999, "name", "non-existent"));
 
     assertThrows(
         MolgenisException.class,
-        () -> table.delete(List.of(nonExistentRow), true),
+        () -> table.delete(rows, true),
         "Should throw exception when deleting a row that doesn't exist in the table");
   }
 
@@ -133,10 +133,11 @@ class TestDeletingTableRows {
 
     Row validRow = Row.row("id", 1, "name", "test1");
     Row invalidRow = Row.row("id", 999, "name", "non-existent");
+    List<Row> rows = List.of(validRow, invalidRow);
 
     assertThrows(
         MolgenisException.class,
-        () -> table.delete(List.of(validRow, invalidRow), true),
+        () -> table.delete(rows, true),
         "Should throw exception when any row in the batch doesn't exist in the table");
 
     // Verify transaction is rolled back

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestDeletingTableRows.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestDeletingTableRows.java
@@ -1,6 +1,6 @@
 package org.molgenis.emx2.sql;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -39,13 +39,17 @@ class TestDeletingTableRows {
   }
 
   @Test
-  void whenDeletingNonExistingRows_thenDontDelete() {
+  void whenDeletingNonExistingRows_thenThrowException() {
     table.insert(Row.row("id", 1, "name", "a"));
     table.insert(Row.row("id", 2, "name", "b"));
 
-    int nrDeleted = table.delete(Row.row("id", 123));
-    assertEquals(0, nrDeleted);
+    Row nonExistentRow = Row.row("id", 123);
+    assertThrows(
+        MolgenisException.class,
+        () -> table.delete(nonExistentRow),
+        "Should throw exception when deleting a row that doesn't exist in the table");
 
+    // Verify transaction is rolled back
     CompareTools.assertEquals(
         table.retrieveRows(Option.EXCLUDE_MG_COLUMNS),
         List.of(Row.row("id", 1, "name", "a"), Row.row("id", 2, "name", "b")));
@@ -73,5 +77,31 @@ class TestDeletingTableRows {
 
     CompareTools.assertEquals(
         table.retrieveRows(Option.EXCLUDE_MG_COLUMNS), List.of(Row.row("id", 2, "name", "bar")));
+  }
+
+  @Test
+  void whenDeletingRowNotInTable_thenThrowException() {
+    table.insert(Row.row("id", 1, "name", "test"));
+
+    Row nonExistentRow = Row.row("id", 999, "name", "non-existent");
+
+    assertThrows(
+        MolgenisException.class,
+        () -> table.delete(nonExistentRow),
+        "Should throw exception when deleting a row that doesn't exist in the table");
+  }
+
+  @Test
+  void whenDeletingRowsWithMixedValidAndInvalidRows_thenThrowException() {
+    table.insert(Row.row("id", 1, "name", "test1"));
+    table.insert(Row.row("id", 2, "name", "test2"));
+
+    Row validRow = Row.row("id", 1, "name", "test1");
+    Row invalidRow = Row.row("id", 999, "name", "non-existent");
+
+    assertThrows(
+        MolgenisException.class,
+        () -> table.delete(validRow, invalidRow),
+        "Should throw exception when any row in the batch doesn't exist in the table");
   }
 }

--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/WebApiSmokeTests.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/WebApiSmokeTests.java
@@ -1512,7 +1512,11 @@ class WebApiSmokeTests extends ApiTestBase {
   void testScriptScheduling() throws JsonProcessingException, InterruptedException {
     // make sure the 'test' script is not there already from a previous test
     database.getSchema(SYSTEM_SCHEMA).getTable("Jobs").truncate();
-    database.getSchema(SYSTEM_SCHEMA).getTable("Scripts").delete(row("name", "test"));
+    try {
+      database.getSchema(SYSTEM_SCHEMA).getTable("Scripts").delete(row("name", "test"));
+    } catch (MolgenisException e) {
+      // ignore error when there is nothing to clean up
+    }
 
     String token = getToken("admin", "admin");
     String result;

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Table.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Table.java
@@ -1,5 +1,6 @@
 package org.molgenis.emx2;
 
+import java.util.Arrays;
 import java.util.List;
 
 public interface Table {
@@ -22,9 +23,15 @@ public interface Table {
 
   int save(Iterable<Row> rows);
 
-  int delete(Row... row);
+  default int delete(Row... rows) {
+    return delete(Arrays.asList(rows));
+  }
 
-  int delete(Iterable<Row> rows);
+  default int delete(Iterable<Row> rows) {
+    return delete(rows, false);
+  }
+
+  int delete(Iterable<Row> rows, boolean strict);
 
   void truncate();
 


### PR DESCRIPTION
Fixes: https://github.com/molgenis/GCC/issues/2595

### What are the main changes you did
- We now throw an exception if we try to delete non-existing rows

### How to test
- Added unit tests
- Executing the following graphql query in the pet store now results in a `MolgenisException` when strict is enabled:
```graphql
mutation {
  delete(strict: true|false, Pet: [ 
    {name: "sylvester"},
    {name: "blaaaa"}
  ]) {
    status
    message
  }
}
```

Test with and without the strict mode

### Checklist
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
