### PR TITLE
feat: remove filter from graphql

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -1219,7 +1219,7 @@ public class SqlQuery extends QueryBean {
     switch (operator) {
       case MATCH_ANY, EQUALS: // equals to be deprecated for ref columns,
         return whereContainsAnyOrEquals(tableAlias, columnName, column, values);
-      case MATCH_NONE, NOT_EQUALS: // non_equals to be deprecated for ref columns,
+      case NOT_EQUALS: // non_equals to be deprecated for ref columns,
         return or(
             whereColumnIsNullOrNotNull(tableAlias, columnName, column, new Boolean[] {true}),
             not(whereContainsAnyOrEquals(tableAlias, columnName, column, values)));

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/ColumnType.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/ColumnType.java
@@ -42,8 +42,8 @@ public enum ColumnType {
   PERIOD_ARRAY(Period[].class, ORDINAL_ARRAY_OPERATORS),
 
   // RELATIONSHIP
-  REF(Object.class, MATCH_ANY, EQUALS, MATCH_NONE, IS_NULL),
-  REF_ARRAY(Object[].class, MATCH_ANY, MATCH_ALL, EQUALS, MATCH_NONE, IS_NULL),
+  REF(Object.class, MATCH_ANY, EQUALS, IS_NULL),
+  REF_ARRAY(Object[].class, MATCH_ANY, MATCH_ALL, EQUALS, IS_NULL),
   REFBACK(Object[].class, REF_ARRAY.operators), // same as ref_array
 
   // LAYOUT and other constants

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Constants.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Constants.java
@@ -104,22 +104,20 @@ public class Constants {
   protected static final Operator[] EXISTS_OPERATIONS = {EQUALS};
 
   protected static final Operator[] ORDINAL_OPERATORS = {
-    EQUALS, NOT_EQUALS, MATCH_ANY, BETWEEN, NOT_BETWEEN, IS_NULL, MATCH_NONE
+    EQUALS, NOT_EQUALS, MATCH_ANY, BETWEEN, NOT_BETWEEN, IS_NULL
   };
   protected static final Operator[] ORDINAL_ARRAY_OPERATORS =
       Stream.concat(Arrays.stream(ORDINAL_OPERATORS), Stream.of(MATCH_ALL))
           .toArray(Operator[]::new);
 
   protected static final Operator[] STRING_OPERATORS = {
-    EQUALS, NOT_EQUALS, LIKE, NOT_LIKE, TRIGRAM_SEARCH, TEXT_SEARCH, IS_NULL, MATCH_ANY, MATCH_NONE
+    EQUALS, NOT_EQUALS, LIKE, NOT_LIKE, TRIGRAM_SEARCH, TEXT_SEARCH, IS_NULL, MATCH_ANY
   };
 
   protected static final Operator[] STRING_ARRAY_OPERATORS =
       Stream.concat(Arrays.stream(STRING_OPERATORS), Stream.of(MATCH_ALL)).toArray(Operator[]::new);
 
-  protected static final Operator[] EQUALITY_OPERATORS = {
-    EQUALS, NOT_EQUALS, IS_NULL, MATCH_ANY, MATCH_NONE
-  };
+  protected static final Operator[] EQUALITY_OPERATORS = {EQUALS, NOT_EQUALS, IS_NULL, MATCH_ANY};
 
   protected static final Operator[] EQUALITY_ARRAY_OPERATORS =
       Stream.concat(Arrays.stream(EQUALITY_OPERATORS), Stream.of(MATCH_ALL))

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Operator.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Operator.java
@@ -11,7 +11,6 @@ public enum Operator {
   MATCH_ANY(
       "match_any", "For arrays if there is any overlap with column values. Used to be 'equals'"),
   MATCH_ALL("match_all", "For arrays if all values are included in the column value"),
-  MATCH_NONE("match_none", "For arrays to check if none of the values are include"),
   NOT_EQUALS(
       "not_equals",
       "Uses != operator. In case of array 'NOT (= ANY)'. Will be deprecated for arrays, use CONTAINS_NONE"),

--- a/docs/molgenis/dev_graphql.md
+++ b/docs/molgenis/dev_graphql.md
@@ -841,7 +841,6 @@ the following function are available:
 - _is_null - use this filter to find null (true) or not null (false) values
 - _match_any(value)
 - _match_all(value)
-- _match_none(value)
 - _match_path(name) - use to filter ontology terms, = or(match_any_including_children(name),match_any_including_parents(name))
 - _match_any_including_children(name) - use this to filter in ontology columns matching also when overlap exists in children of 'name' term
 - _match_any_including_parents(name) - use this to filter in ontology columns matching also when overlap exists in children of 'name' term


### PR DESCRIPTION
### What are the main changes you did
- Removed match_none from our graphql spec, as it currently doesn't work as expected

### How to test
- The following query shouldn't work anymore:
```graphql
{
	Pet(
		filter: {
			_and: [
				{
					tags: {
						name: {
							match_none: ["red"]
						}
					}
				},
				{
					status: {
						equals: "available"
					}
				}
			]
		}
	)
	{
		name
		tags {
			name
		}
		status
	}
}
```
- match_none should also not be found anymore in the retrospection that the playground provides in the sidebar.

### Checklist
- [x] updated docs in case of new feature
- [x] added/updated tests
- [x] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
