### PR TITLE
fix(rd3): add missing required fields and tags to ontologies

### DIFF
--- a/data/_models/shared/Processes.csv
+++ b/data/_models/shared/Processes.csv
@@ -3,7 +3,7 @@ Processes,,,,,,,,,,,,,,,http://purl.obolibrary.org/obo/NCIT_C29862,"An event (e.
 Processes,,General Information,heading,,,,,,,,,,,,,,"Patient registry, Patient registry staging, FAIR Genomes"
 Processes,,id,auto_id,,ERD-E-${mg_autoid},1,TRUE,,,,,,,,http://purl.obolibrary.org/obo/NCIT_C25364,"One or more characters used to identify, name, or characterize the nature, properties, or contents of a thing","Patient registry, Patient registry staging, FAIR Genomes"
 Processes,,individuals,multiselect,,,,,,Individuals,,,,,,http://purl.obolibrary.org/obo/NCIT_C164337,A reference to one or more individuals associated to the process,"Patient registry, FAIR Genomes"
-Processes,,individuals,multiselect,,,,,erdera,Individuals,,,,,,http://purl.obolibrary.org/obo/NCIT_C164337,A reference to one or more individuals associated to the process,"Patient registry staging"
+Processes,,individuals,multiselect,,,,TRUE,erdera,Individuals,,,,,,http://purl.obolibrary.org/obo/NCIT_C164337,A reference to one or more individuals associated to the process,"Patient registry staging"
 Processes,,alternate ids,string_array,,,,,,,,,,,,http://purl.obolibrary.org/obo/NCIT_C90353,Additional identifiers that identify a process,"Patient registry, Patient registry staging, FAIR Genomes"
 Processes,,affiliated organisations,multiselect,,,,,CatalogueOntologies,Organisations,,,,,,http://purl.obolibrary.org/obo/NCIT_C25412,One or more associations between the individual and an organisation.,"Patient registry, Patient registry staging, FAIR Genomes"
 Analyses,Processes,,,,,,,,,,,,,,"http://purl.obolibrary.org/obo/NCIT_C25391,http://edamontology.org/operation_2945",An analysis (examination and interpretation) relating to an individual,"Patient registry, FAIR Genomes"

--- a/data/_ontologies/File formats.csv
+++ b/data/_ontologies/File formats.csv
@@ -1,583 +1,583 @@
-name,definition,codesystem,code,ontologyTermURI
-.csv,.csv,SWO,SWO_3000082,http://www.ebi.ac.uk/swo/data/SWO_3000082
-.fastq,.fastq,EDAM,format_1930,http://edamontology.org/format_1930
-.maf,.maf,EDAM,format_3008,http://edamontology.org/format_3008
-.mgf,.mgf,SWO,SWO_3000083,http://www.ebi.ac.uk/swo/data/SWO_3000083
-.mysql,.mysql,SWO,SWO_3000084,http://www.ebi.ac.uk/swo/data/SWO_3000084
-.nib,.nib,EDAM,format_3010,http://edamontology.org/format_3010
-.raw files,".raw files",SWO,SWO_0000682,http://www.ebi.ac.uk/swo/SWO_0000682
-.sam,.sam,EDAM,format_2573,http://edamontology.org/format_2573
-.sql,.sql,SWO,SWO_3000085,http://www.ebi.ac.uk/swo/data/SWO_3000085
-.wig,.wig,EDAM,format_3005,http://edamontology.org/format_3005
-2bit,2bit,EDAM,format_3009,http://edamontology.org/format_3009
-3D-1D scoring matrix format,3D-1D scoring matrix format,EDAM,format_2064,http://edamontology.org/format_2064
-A2M,A2M,EDAM,format_3281,http://edamontology.org/format_3281
-aaindex,aaindex,EDAM,format_1504,http://edamontology.org/format_1504
-AB1,AB1,EDAM,format_3000,http://edamontology.org/format_3000
-ABCD format,ABCD format,EDAM,format_3708,http://edamontology.org/format_3708
-ABI,ABI,EDAM,format_1628,http://edamontology.org/format_1628
-ACE,ACE,EDAM,format_3001,http://edamontology.org/format_3001
-acedb,acedb,EDAM,format_1923,http://edamontology.org/format_1923
-affymetrix,affymetrix,EDAM,format_1639,http://edamontology.org/format_1639
-affymetrix-exp,affymetrix-exp,EDAM,format_1641,http://edamontology.org/format_1641
-afg,afg,EDAM,format_3582,http://edamontology.org/format_3582
-AGP,AGP,EDAM,format_3693,http://edamontology.org/format_3693
-Alignment format,Alignment format,EDAM,format_1921,http://edamontology.org/format_1921
-Alignment format (pair only),Alignment format (pair only),EDAM,format_2920,http://edamontology.org/format_2920
-Alignment format (text),Alignment format (text),EDAM,format_2554,http://edamontology.org/format_2554
-Alignment format (XML),Alignment format (XML),EDAM,format_2555,http://edamontology.org/format_2555
-ambiguous,ambiguous,EDAM,format_2097,http://edamontology.org/format_2097
-Amino acid index format,Amino acid index format,EDAM,format_2017,http://edamontology.org/format_2017
-Annotated text format,Annotated text format,EDAM,format_3780,http://edamontology.org/format_3780
-ARB,ARB,EDAM,format_3830,http://edamontology.org/format_3830
-arff,arff,EDAM,format_3581,http://edamontology.org/format_3581
-ARR,ARR,SWO,SWO_1100014,http://www.ebi.ac.uk/swo/SWO_1100014
-Article format,Article format,EDAM,format_2020,http://edamontology.org/format_2020
-ASCII format,ASCII format,SWO,SWO_3000042,http://www.ebi.ac.uk/swo/data/SWO_3000042
-ASN.1 sequence format,ASN.1 sequence format,EDAM,format_1966,http://edamontology.org/format_1966
-axt,axt,EDAM,format_3013,http://edamontology.org/format_3013
-BAI,BAM indexing format,EDAM,format_3327,http://edamontology.org/format_3327
-BAM,"BAM format, the binary, BGZF-formatted compressed version of SAM format for alignment of nucleotide sequences (e.g. sequencing reads) to (a) reference sequence(s). May contain base-call and alignment qualities and other data.",EDAM,format_2572,http://edamontology.org/format_2572
-BAR,BAR,SWO,SWO_3000058,http://www.ebi.ac.uk/swo/data/SWO_3000058
-BCF,BCF,EDAM,format_3020,http://edamontology.org/format_3020
-BCML,BCML,EDAM,format_3689,http://edamontology.org/format_3689
-BDML,BDML,EDAM,format_3690,http://edamontology.org/format_3690
-BED,"Browser Extensible Data (BED) format of sequence annotation track, typically to be displayed in a genome browser.",EDAM,format_3003,http://edamontology.org/format_3003
-BED format,BED format,EDAM,format_3003,http://edamontology.org/format_3003
-bed12,bed12,EDAM,format_3586,http://edamontology.org/format_3586
-bed6,bed6,EDAM,format_3585,http://edamontology.org/format_3585
-bedgraph,bedgraph,EDAM,format_3583,http://edamontology.org/format_3583
-BedGraph,BedGraph,SWO,SWO_3000072,http://www.ebi.ac.uk/swo/data/SWO_3000072
-bedstrict,bedstrict,EDAM,format_3584,http://edamontology.org/format_3584
-BEL,BEL,EDAM,format_3691,http://edamontology.org/format_3691
-bgzip,bgzip,EDAM,format_3615,http://edamontology.org/format_3615
-Bibliographic reference format,Bibliographic reference format,EDAM,format_2848,http://edamontology.org/format_2848
-bigBed,bigBed,EDAM,format_3004,http://edamontology.org/format_3004
-bigWig,bigWig,EDAM,format_3006,http://edamontology.org/format_3006
-binary format,binary format,EDAM,format_2333,http://edamontology.org/format_2333
-BioC,BioC,EDAM,format_3782,http://edamontology.org/format_3782
-Biodiversity data format,Biodiversity data format,EDAM,format_3706,http://edamontology.org/format_3706
-BioJSON (BioXSD),BioJSON (BioXSD),EDAM,format_3772,http://edamontology.org/format_3772
-BioJSON (Jalview),BioJSON (Jalview),EDAM,format_3774,http://edamontology.org/format_3774
-Biological pathway or network format,Biological pathway or network format,EDAM,format_2013,http://edamontology.org/format_2013
-Biological pathway or network report format,Biological pathway or network report format,EDAM,format_3166,http://edamontology.org/format_3166
-BIOM format,BIOM format,EDAM,format_3746,http://edamontology.org/format_3746
-BioNLP Shared Task format,BioNLP Shared Task format,EDAM,format_3785,http://edamontology.org/format_3785
-BioPAX,BioPAX,EDAM,format_3156,http://edamontology.org/format_3156
-BioPAX Manchester OWL Syntax format,BioPAX Manchester OWL Syntax format,SWO,SWO_3000056,http://www.ebi.ac.uk/swo/data/SWO_3000056
-BioPAX RDF/XML format,BioPAX RDF/XML format,SWO,SWO_3000055,http://www.ebi.ac.uk/swo/data/SWO_3000055
-BioXSD (XML),BioXSD (XML),EDAM,format_2352,http://edamontology.org/format_2352
-BioYAML,BioYAML,EDAM,format_3773,http://edamontology.org/format_3773
-BLAST results,BLAST results,EDAM,format_1333,http://edamontology.org/format_1333
-BLAST XML results format,BLAST XML results format,EDAM,format_3331,http://edamontology.org/format_3331
-BLAST XML v2 results format,BLAST XML v2 results format,EDAM,format_3836,http://edamontology.org/format_3836
-BLC,BLC,EDAM,format_3313,http://edamontology.org/format_3313
-bmp,bmp,EDAM,format_3592,http://edamontology.org/format_3592
-BPMAP,BPMAP,SWO,SWO_1100035,http://www.ebi.ac.uk/swo/SWO_1100035
-BSML,BSML,EDAM,format_3487,http://edamontology.org/format_3487
-BTrack,BTrack,EDAM,format_3776,http://edamontology.org/format_3776
-CAF,CAF,EDAM,format_1630,http://edamontology.org/format_1630
-CATH domain report format,CATH domain report format,EDAM,format_3100,http://edamontology.org/format_3100
-CDF ASCII format,CDF ASCII format,SWO,SWO_3000057,http://www.ebi.ac.uk/swo/data/SWO_3000057
-CDF binary format,CDF binary format,SWO,SWO_1100054,http://www.ebi.ac.uk/swo/SWO_1100054
-cdsxml,cdsxml,EDAM,format_2184,http://edamontology.org/format_2184
-cdt,cdt,SWO,SWO_0000493,http://www.ebi.ac.uk/swo/SWO_0000493
-cel,cel,EDAM,format_1638,http://edamontology.org/format_1638
-CEL ASCII format,CEL ASCII format,SWO,SWO_3000059,http://www.ebi.ac.uk/swo/data/SWO_3000059
-CEL binary format,CEL binary format,SWO,SWO_0000084,http://www.ebi.ac.uk/swo/SWO_0000084
-CellML,CellML,EDAM,format_3240,http://edamontology.org/format_3240
-Chemical data format,Chemical data format,EDAM,format_2030,http://edamontology.org/format_2030
-Chemical formula format,Chemical formula format,EDAM,format_2035,http://edamontology.org/format_2035
-CHP,CHP,EDAM,format_1644,http://edamontology.org/format_1644
-CHP binary format,CHP binary format,SWO,SWO_1100122,http://www.ebi.ac.uk/swo/SWO_1100122
-chrominfo,chrominfo,EDAM,format_3587,http://edamontology.org/format_3587
-CiteXplore-all,CiteXplore-all,EDAM,format_1737,http://edamontology.org/format_1737
-CiteXplore-core,CiteXplore-core,EDAM,format_1736,http://edamontology.org/format_1736
-cls,cls,SWO,SWO_0000498,http://www.ebi.ac.uk/swo/SWO_0000498
-ClustalW dendrogram,ClustalW dendrogram,EDAM,format_1424,http://edamontology.org/format_1424
-ClustalW format,ClustalW format,EDAM,format_1982,http://edamontology.org/format_1982
-codata,codata,EDAM,format_1925,http://edamontology.org/format_1925
-COMBINE OMEX,COMBINE OMEX,EDAM,format_3686,http://edamontology.org/format_3686
-completely unambiguous,completely unambiguous,EDAM,format_2566,http://edamontology.org/format_2566
-completely unambiguous pure,completely unambiguous pure,EDAM,format_2567,http://edamontology.org/format_2567
-completely unambiguous pure dna,completely unambiguous pure dna,EDAM,format_2569,http://edamontology.org/format_2569
-completely unambiguous pure nucleotide,completely unambiguous pure nucleotide,EDAM,format_2568,http://edamontology.org/format_2568
-completely unambiguous pure protein,completely unambiguous pure protein,EDAM,format_2607,http://edamontology.org/format_2607
-completely unambiguous pure rna sequence,completely unambiguous pure rna sequence,EDAM,format_2570,http://edamontology.org/format_2570
-consensus,consensus,EDAM,format_1209,http://edamontology.org/format_1209
-consensusXML,consensusXML,EDAM,format_3832,http://edamontology.org/format_3832
-CopasiML,CopasiML,EDAM,format_3239,http://edamontology.org/format_3239
-crai,CRAI,,,
-CRAM,Reference-based compression of alignment format,EDAM,format_3462,http://edamontology.org/format_3462
-csfasta,csfasta,EDAM,format_3589,http://edamontology.org/format_3589
-CSV,CSV,EDAM,format_3752,http://edamontology.org/format_3752
-CT,CT,EDAM,format_3309,http://edamontology.org/format_3309
-customtrack,customtrack,EDAM,format_3588,http://edamontology.org/format_3588
-Cytoband format,Cytoband format,EDAM,format_3235,http://edamontology.org/format_3235
-Cytoscape input file format,Cytoscape input file format,EDAM,format_3477,http://edamontology.org/format_3477
-daf,daf,EDAM,format_1393,http://edamontology.org/format_1393
-DAS format,DAS format,EDAM,format_1967,http://edamontology.org/format_1967
-dasdna,dasdna,EDAM,format_1968,http://edamontology.org/format_1968
-DASGFF,DASGFF,EDAM,format_1978,http://edamontology.org/format_1978
-dat,dat,EDAM,format_1637,http://edamontology.org/format_1637
-Data File Standard for Flow Cytometry,Data File Standard for Flow Cytometry,SWO,SWO_3000061,http://www.ebi.ac.uk/swo/data/SWO_3000061
-Data index format,Data index format,EDAM,format_3326,http://edamontology.org/format_3326
-Database hits (sequence) format,Database hits (sequence) format,EDAM,format_2066,http://edamontology.org/format_2066
-dbGaP format,dbGaP format,EDAM,format_3729,http://edamontology.org/format_3729
-dbid,dbid,EDAM,format_1926,http://edamontology.org/format_1926
-dcf,dcf,SWO,SWO_0000518,http://www.ebi.ac.uk/swo/SWO_0000518
-debug,debug,EDAM,format_1983,http://edamontology.org/format_1983
-debug-feat,debug-feat,EDAM,format_1979,http://edamontology.org/format_1979
-debug-seq,debug-seq,EDAM,format_1969,http://edamontology.org/format_1969
-dhf,dhf,EDAM,format_1336,http://edamontology.org/format_1336
-DIALIGN format,DIALIGN format,EDAM,format_1392,http://edamontology.org/format_1392
-DICOM format,DICOM format,EDAM,format_3548,http://edamontology.org/format_3548
-Dirichlet distribution format,Dirichlet distribution format,EDAM,format_2074,http://edamontology.org/format_2074
-dna,dna,EDAM,format_1212,http://edamontology.org/format_1212
-Document format,Document format,EDAM,format_3507,http://edamontology.org/format_3507
-docx,docx,EDAM,format_3506,http://edamontology.org/format_3506
-Dot-bracket format,Dot-bracket format,EDAM,format_1457,http://edamontology.org/format_1457
-dssp,dssp,EDAM,format_1454,http://edamontology.org/format_1454
-DSV,DSV,EDAM,format_3751,http://edamontology.org/format_3751
-dta,dta,EDAM,format_3652,http://edamontology.org/format_3652
-EBI Application Result XML,EBI Application Result XML,EDAM,format_3157,http://edamontology.org/format_3157
-ebwt,ebwt,EDAM,format_3484,http://edamontology.org/format_3484
-ebwtl,ebwtl,EDAM,format_3491,http://edamontology.org/format_3491
-ELAND format,ELAND format,EDAM,format_3818,http://edamontology.org/format_3818
-EMBL feature location,EMBL feature location,EDAM,format_1248,http://edamontology.org/format_1248
-EMBL format,EMBL format,EDAM,format_1927,http://edamontology.org/format_1927
-EMBL format (XML),EMBL format (XML),EDAM,format_2204,http://edamontology.org/format_2204
-EMBL-HTML,EMBL-HTML,EDAM,format_2311,http://edamontology.org/format_2311
-EMBL-like (text),EMBL-like (text),EDAM,format_2181,http://edamontology.org/format_2181
-EMBL-like (XML),EMBL-like (XML),EDAM,format_2558,http://edamontology.org/format_2558
-EMBL-like format,EMBL-like format,EDAM,format_2543,http://edamontology.org/format_2543
-EMBLXML,EMBLXML,EDAM,format_2183,http://edamontology.org/format_2183
-EMBOSS repeat,EMBOSS repeat,EDAM,format_1297,http://edamontology.org/format_1297
-EMBOSS sequence pattern,EMBOSS sequence pattern,EDAM,format_1357,http://edamontology.org/format_1357
-EMBOSS simple format,EMBOSS simple format,EDAM,format_2001,http://edamontology.org/format_2001
-ENCODE broad peak format,ENCODE broad peak format,EDAM,format_3614,http://edamontology.org/format_3614
-ENCODE narrow peak format,ENCODE narrow peak format,EDAM,format_3613,http://edamontology.org/format_3613
-ENCODE peak format,ENCODE peak format,EDAM,format_3612,http://edamontology.org/format_3612
-Ensembl variation file format,Ensembl variation file format,EDAM,format_3499,http://edamontology.org/format_3499
-Enzyme kinetics report format,Enzyme kinetics report format,EDAM,format_2027,http://edamontology.org/format_2027
-EPS,EPS,EDAM,format_3466,http://edamontology.org/format_3466
-est2genome format,est2genome format,EDAM,format_1316,http://edamontology.org/format_1316
-EXP,EXP,EDAM,format_1631,http://edamontology.org/format_1631
-Experiment annotation format,Experiment annotation format,EDAM,format_3167,http://edamontology.org/format_3167
-FASTA,FASTA,EDAM,format_1929,http://edamontology.org/format_1929
-FASTA format,FASTA format,EDAM,format_1929,http://edamontology.org/format_1929
-FASTA search results format,FASTA search results format,EDAM,format_1332,http://edamontology.org/format_1332
-FASTA-aln,FASTA-aln,EDAM,format_1984,http://edamontology.org/format_1984
-FASTA-HTML,FASTA-HTML,EDAM,format_2310,http://edamontology.org/format_2310
-FASTA-like,FASTA-like,EDAM,format_2546,http://edamontology.org/format_2546
-FASTA-like (text),FASTA-like (text),EDAM,format_2200,http://edamontology.org/format_2200
-FASTG,FASTG,EDAM,format_3823,http://edamontology.org/format_3823
-FASTQ,FASTQ short read format ignoring quality scores.,EDAM,format_1930,http://edamontology.org/format_1930
-FASTQ-illumina,FASTQ-illumina,EDAM,format_1931,http://edamontology.org/format_1931
-FASTQ-like format,FASTQ-like format,EDAM,format_2545,http://edamontology.org/format_2545
-FASTQ-like format (text),FASTQ-like format (text),EDAM,format_2182,http://edamontology.org/format_2182
-FASTQ-sanger,FASTQ-sanger,EDAM,format_1932,http://edamontology.org/format_1932
-FASTQ-solexa,FASTQ-solexa,EDAM,format_1933,http://edamontology.org/format_1933
-FASTQ1,FASTQ1,EDAM,format_1930,http://edamontology.org/format_1930
-FASTQ2,FASTQ2,EDAM,format_1930,http://edamontology.org/format_1930
-FCS3.0,FCS3.0,SWO,SWO_3000062,http://www.ebi.ac.uk/swo/data/SWO_3000062
-featureXML,featureXML,EDAM,format_3833,http://edamontology.org/format_3833
-FieldML,FieldML,SWO,SWO_3000075,http://www.ebi.ac.uk/swo/data/SWO_3000075
-findkm,findkm,EDAM,format_1582,http://edamontology.org/format_1582
-fitch program,fitch program,EDAM,format_1934,http://edamontology.org/format_1934
-Format,Format,EDAM,format_1915,http://edamontology.org/format_1915
-Format (by type of data),Format (by type of data),EDAM,format_2350,http://edamontology.org/format_2350
-GCDML,GCDML,EDAM,format_3163,http://edamontology.org/format_3163
-GCG,GCG,EDAM,format_1935,http://edamontology.org/format_1935
-GCG format variant,GCG format variant,EDAM,format_3486,http://edamontology.org/format_3486
-GCG MSF,GCG MSF,EDAM,format_1947,http://edamontology.org/format_1947
-gct,gct,SWO,SWO_0000548,http://www.ebi.ac.uk/swo/SWO_0000548
-GCT/Res format,GCT/Res format,EDAM,format_3709,http://edamontology.org/format_3709
-GDE,GDE,EDAM,format_3312,http://edamontology.org/format_3312
-GelML,GelML,EDAM,format_3249,http://edamontology.org/format_3249
-Gemini SQLite format,Gemini SQLite format,EDAM,format_3622,http://edamontology.org/format_3622
-GEN,GEN,EDAM,format_3812,http://edamontology.org/format_3812
-GenBank format,GenBank format,EDAM,format_1936,http://edamontology.org/format_1936
-GenBank-HTML,GenBank-HTML,EDAM,format_2532,http://edamontology.org/format_2532
-GenBank-like format,GenBank-like format,EDAM,format_2559,http://edamontology.org/format_2559
-GenBank-like format (text),GenBank-like format (text),EDAM,format_2205,http://edamontology.org/format_2205
-Gene annotation format,Gene annotation format,EDAM,format_2031,http://edamontology.org/format_2031
-Gene expression report format,Gene expression report format,EDAM,format_2058,http://edamontology.org/format_2058
-genePred,genePred,EDAM,format_3011,http://edamontology.org/format_3011
-geneseq,geneseq,EDAM,format_2186,http://edamontology.org/format_2186
-genpept,genpept,EDAM,format_1937,http://edamontology.org/format_1937
-GEO Matrix Series format,GEO Matrix Series format,SWO,SWO_1100126,http://www.ebi.ac.uk/swo/SWO_1100126
-GFF,GFF,EDAM,format_2305,http://edamontology.org/format_2305
-GFF2,GFF2,EDAM,format_1974,http://edamontology.org/format_1974
-GFF2-seq,GFF2-seq,EDAM,format_1938,http://edamontology.org/format_1938
-GFF3,GFF3,EDAM,format_1975,http://edamontology.org/format_1975
-GFF3-seq,GFF3-seq,EDAM,format_1939,http://edamontology.org/format_1939
-GIF,GIF,EDAM,format_3467,http://edamontology.org/format_3467
-giFASTA format,giFASTA format,EDAM,format_1940,http://edamontology.org/format_1940
-GML,GML,EDAM,format_3822,http://edamontology.org/format_3822
-GPML,GPML,EDAM,format_3657,http://edamontology.org/format_3657
-GPR,GPR,EDAM,format_3829,http://edamontology.org/format_3829
-gpr format,gpr format,SWO,SWO_0000566,http://www.ebi.ac.uk/swo/SWO_0000566
-Graph format,Graph format,EDAM,format_3617,http://edamontology.org/format_3617
-GSuite,GSuite,EDAM,format_3775,http://edamontology.org/format_3775
-GTF,GTF,EDAM,format_2306,http://edamontology.org/format_2306
-gtr,gtr,SWO,SWO_0000569,http://www.ebi.ac.uk/swo/SWO_0000569
-GTrack,"GTrack",EDAM,format_3164,http://edamontology.org/format_3164
-gVCF,"Genomic Variant Call Format (VCF) for sequence variation (indels, polymorphisms, structural variation).",EDAM,format:3016,http://edamontology.org/format_3016
-GVF,GVF,EDAM,format_3019,http://edamontology.org/format_3019
-gxl format,gxl format,SWO,SWO_0000570,http://www.ebi.ac.uk/swo/SWO_0000570
-hdf5,hdf5,EDAM,format_3590,http://edamontology.org/format_3590
-hennig86,hennig86,EDAM,format_1941,http://edamontology.org/format_1941
-HET group dictionary entry format,HET group dictionary entry format,EDAM,format_1705,http://edamontology.org/format_1705
-Hidden Markov model format,Hidden Markov model format,EDAM,format_2072,http://edamontology.org/format_2072
-HMM emission and transition counts format,HMM emission and transition counts format,EDAM,format_2075,http://edamontology.org/format_2075
-HMMER Dirichlet prior,HMMER Dirichlet prior,EDAM,format_1349,http://edamontology.org/format_1349
-HMMER emission and transition,HMMER emission and transition,EDAM,format_1351,http://edamontology.org/format_1351
-HMMER format,HMMER format,EDAM,format_1370,http://edamontology.org/format_1370
-HMMER profile alignment (HMM versus sequences),HMMER profile alignment (HMM versus sequences),EDAM,format_1422,http://edamontology.org/format_1422
-HMMER profile alignment (sequences versus HMMs),HMMER profile alignment (sequences versus HMMs),EDAM,format_1421,http://edamontology.org/format_1421
-HMMER-aln,HMMER-aln,EDAM,format_1391,http://edamontology.org/format_1391
-HMMER2,HMMER2,EDAM,format_3328,http://edamontology.org/format_3328
-HMMER3,HMMER3,EDAM,format_3329,http://edamontology.org/format_3329
-hssp,hssp,EDAM,format_1455,http://edamontology.org/format_1455
-html,html,EDAM,format_2331,http://edamontology.org/format_2331
-ibd,ibd,EDAM,format_3839,http://edamontology.org/format_3839
-IDAT,IDAT,EDAM,format_3578,http://edamontology.org/format_3578
-idXML,idXML,EDAM,format_3764,http://edamontology.org/format_3764
-ig,ig,EDAM,format_1942,http://edamontology.org/format_1942
-igstrict,igstrict,EDAM,format_1943,http://edamontology.org/format_1943
-iHOP format,iHOP format,EDAM,format_1740,http://edamontology.org/format_1740
-im,im,EDAM,format_3593,http://edamontology.org/format_3593
-Image format,Image format,EDAM,format_3547,http://edamontology.org/format_3547
-imzML metadata file,imzML metadata file,EDAM,format_3682,http://edamontology.org/format_3682
-InChI,InChI,EDAM,format_1197,http://edamontology.org/format_1197
-InChIKey,InChIKey,EDAM,format_1199,http://edamontology.org/format_1199
-Individual genetic data format,Individual genetic data format,EDAM,format_3287,http://edamontology.org/format_3287
-insdxml,insdxml,EDAM,format_2185,http://edamontology.org/format_2185
-InterPro hits format,InterPro hits format,EDAM,format_1341,http://edamontology.org/format_1341
-InterPro match table format,InterPro match table format,EDAM,format_1343,http://edamontology.org/format_1343
-InterPro protein view report format,InterPro protein view report format,EDAM,format_1342,http://edamontology.org/format_1342
-ISA-TAB,ISA-TAB,EDAM,format_3687,http://edamontology.org/format_3687
-jackknifer,jackknifer,EDAM,format_1944,http://edamontology.org/format_1944
-jackknifernon,jackknifernon,EDAM,format_1970,http://edamontology.org/format_1970
-JASPAR format,JASPAR format,EDAM,format_1367,http://edamontology.org/format_1367
-JPG,JPG,EDAM,format_3579,http://edamontology.org/format_3579
-JSON,JSON,EDAM,format_3464,http://edamontology.org/format_3464
-JSON-LD,JSON-LD,EDAM,format_3749,http://edamontology.org/format_3749
-K-mer countgraph,K-mer countgraph,EDAM,format_3665,http://edamontology.org/format_3665
-KGML,KGML,SWO,SWO_0000249,http://www.ebi.ac.uk/swo/SWO_0000249
-KNIME datatable format,KNIME datatable format,EDAM,format_3765,http://edamontology.org/format_3765
-KRSS2 Syntax,KRSS2 Syntax,EDAM,format_3254,http://edamontology.org/format_3254
-latex,latex,EDAM,format_3817,http://edamontology.org/format_3817
-LAV,LAV,EDAM,format_3014,http://edamontology.org/format_3014
-lhf,lhf,EDAM,format_1337,http://edamontology.org/format_1337
-Linked data format,Linked data format,EDAM,format_3748,http://edamontology.org/format_3748
-lma,lma,SWO,SWO_0000596,http://www.ebi.ac.uk/swo/SWO_0000596
-LocARNA PP,LocARNA PP,EDAM,format_3728,http://edamontology.org/format_3728
-MAF,MAF,EDAM,format_3008,http://edamontology.org/format_3008
-MAGE-ML,MAGE-ML,EDAM,format_3161,http://edamontology.org/format_3161
-MAGE-TAB,MAGE-TAB,EDAM,format_3162,http://edamontology.org/format_3162
-Manchester OWL Syntax,Manchester OWL Syntax,EDAM,format_3253,http://edamontology.org/format_3253
-MAP,MAP,EDAM,format_3285,http://edamontology.org/format_3285
-Map format,Map format,EDAM,format_2060,http://edamontology.org/format_2060
-markx0,markx0,EDAM,format_1985,http://edamontology.org/format_1985
-markx0 variant,markx0 variant,EDAM,format_2922,http://edamontology.org/format_2922
-markx1,markx1,EDAM,format_1986,http://edamontology.org/format_1986
-markx10,markx10,EDAM,format_1987,http://edamontology.org/format_1987
-markx2,markx2,EDAM,format_1988,http://edamontology.org/format_1988
-markx3,markx3,EDAM,format_1989,http://edamontology.org/format_1989
-mas5 format,mas5 format,SWO,SWO_0000615,http://www.ebi.ac.uk/swo/SWO_0000615
-Mascot .dat file,Mascot .dat file,EDAM,format_3713,http://edamontology.org/format_3713
-mase format,mase format,EDAM,format_1945,http://edamontology.org/format_1945
-Mass spectrometry data format,Mass spectrometry data format,EDAM,format_3245,http://edamontology.org/format_3245
-MAT,MAT,EDAM,format_3626,http://edamontology.org/format_3626
-match,match,EDAM,format_1990,http://edamontology.org/format_1990
-MathML 2.0,MathML 2.0,SWO,SWO_3000074,http://www.ebi.ac.uk/swo/data/SWO_3000074
-Matrix format,Matrix format,EDAM,format_3033,http://edamontology.org/format_3033
-MaxQuant APL peaklist format,MaxQuant APL peaklist format,EDAM,format_3714,http://edamontology.org/format_3714
-MCPD,"MCPD",EDAM,format_3777,http://edamontology.org/format_3777
-md5,MD5 Checksum,NCIT,NCIT_C171276,http://purl.obolibrary.org/obo/NCIT_C171276
-medline,medline,EDAM,format_2194,http://edamontology.org/format_2194
-Medline Display Format,Medline Display Format,EDAM,format_1735,http://edamontology.org/format_1735
-mega,mega,EDAM,format_1991,http://edamontology.org/format_1991
-mega variant,mega variant,EDAM,format_2923,http://edamontology.org/format_2923
-mega-seq,mega-seq,EDAM,format_1946,http://edamontology.org/format_1946
-meganon,meganon,EDAM,format_1992,http://edamontology.org/format_1992
-MEME background Markov model,MEME background Markov model,EDAM,format_1369,http://edamontology.org/format_1369
-MEME Dirichlet prior,MEME Dirichlet prior,EDAM,format_1350,http://edamontology.org/format_1350
-meme-motif,meme-motif,EDAM,format_1360,http://edamontology.org/format_1360
-mf,mf,EDAM,format_1198,http://edamontology.org/format_1198
-MGF,MGF,EDAM,format_3651,http://edamontology.org/format_3651
-mhd,mhd,EDAM,format_3550,http://edamontology.org/format_3550
-MHTML,MHTML,EDAM,format_3556,http://edamontology.org/format_3556
-Microarray experiment data format,Microarray experiment data format,EDAM,format_2056,http://edamontology.org/format_2056
-mira,mira,EDAM,format_1629,http://edamontology.org/format_1629
-mmCIF,mmCIF,EDAM,format_1477,http://edamontology.org/format_1477
-Mol2,Mol2,EDAM,format_3816,http://edamontology.org/format_3816
-Molfile,Molfile,EDAM,format_3815,http://edamontology.org/format_3815
-MSF,MSF,EDAM,format_3702,http://edamontology.org/format_3702
-mspcrunch,mspcrunch,EDAM,format_1334,http://edamontology.org/format_1334
-mzData,mzData,EDAM,format_3834,http://edamontology.org/format_3834
-mzIdentML,mzIdentML,EDAM,format_3247,http://edamontology.org/format_3247
-mzML,mzML,EDAM,format_3244,http://edamontology.org/format_3244
-mzQuantML,mzQuantML,EDAM,format_3248,http://edamontology.org/format_3248
-mzTab,mzTab,EDAM,format_3681,http://edamontology.org/format_3681
-mzXML,mzXML,EDAM,format_3654,http://edamontology.org/format_3654
-N-Triples,N-Triples,EDAM,format_3256,http://edamontology.org/format_3256
-nbrf/pir,nbrf/pir,EDAM,format_1948,http://edamontology.org/format_1948
-NCBI format,NCBI format,EDAM,format_1972,http://edamontology.org/format_1972
-netCDF,netCDF,EDAM,format_3650,http://edamontology.org/format_3650
-newick,newick,EDAM,format_1910,http://edamontology.org/format_1910
-NeXML,NeXML,EDAM,format_3160,http://edamontology.org/format_3160
-Nexus format,Nexus format,EDAM,format_1912,http://edamontology.org/format_1912
-nexus-seq,nexus-seq,EDAM,format_1949,http://edamontology.org/format_1949
-nexusnon,nexusnon,EDAM,format_1973,http://edamontology.org/format_1973
-nii,nii,EDAM,format_3549,http://edamontology.org/format_3549
-nmrML,nmrML,EDAM,format_3825,http://edamontology.org/format_3825
-Notation3,Notation3,EDAM,format_3257,http://edamontology.org/format_3257
-nrrd,nrrd,EDAM,format_3551,http://edamontology.org/format_3551
-Nucleic acid features (primers) format,Nucleic acid features (primers) format,EDAM,format_2061,http://edamontology.org/format_2061
-Nucleic acid features (restriction sites) format,Nucleic acid features (restriction sites) format,EDAM,format_2158,http://edamontology.org/format_2158
-nucleotide,nucleotide,EDAM,format_1207,http://edamontology.org/format_1207
-OBO,OBO,EDAM,format_2549,http://edamontology.org/format_2549
-OBO Flat File Format,OBO Flat File Format,EDAM,format_2549,http://edamontology.org/format_2549
-OBO format,OBO format,EDAM,format_2196,http://edamontology.org/format_2196
-OBO-XML,OBO-XML,EDAM,format_2550,http://edamontology.org/format_2550
-OME-TIFF,OME-TIFF,EDAM,format_3727,http://edamontology.org/format_3727
-Ontology format,Ontology format,EDAM,format_2195,http://edamontology.org/format_2195
-Open Annotation format,Open Annotation format,EDAM,format_3784,http://edamontology.org/format_3784
-OSCAR format,OSCAR format,EDAM,format_1741,http://edamontology.org/format_1741
-OWL format,OWL format,EDAM,format_2197,http://edamontology.org/format_2197
-OWL Functional Syntax,OWL Functional Syntax,EDAM,format_3252,http://edamontology.org/format_3252
-OWL-XML,OWL-XML,SWO,SWO_3000038,http://www.ebi.ac.uk/swo/data/SWO_3000038
-OWL/XML,OWL/XML,EDAM,format_3262,http://edamontology.org/format_3262
-OWL2-XML,OWL2-XML,SWO,SWO_3000039,http://www.ebi.ac.uk/swo/data/SWO_3000039
-pair,pair,EDAM,format_1996,http://edamontology.org/format_1996
-pbm,pbm,EDAM,format_3601,http://edamontology.org/format_3601
-pcd,pcd,EDAM,format_3594,http://edamontology.org/format_3594
-Pcons report format,Pcons report format,EDAM,format_1551,http://edamontology.org/format_1551
-pcx,pcx,EDAM,format_3595,http://edamontology.org/format_3595
-PDB,PDB,EDAM,format_1476,http://edamontology.org/format_1476
-PDB database entry format,PDB database entry format,EDAM,format_1475,http://edamontology.org/format_1475
-pdbatom,pdbatom,EDAM,format_1950,http://edamontology.org/format_1950
-pdbatomnuc,pdbatomnuc,EDAM,format_1951,http://edamontology.org/format_1951
-pdbml,pdbml,EDAM,format_1478,http://edamontology.org/format_1478
-pdbseqres,pdbseqres,EDAM,format_1953,http://edamontology.org/format_1953
-pdbseqresnuc,pdbseqresnuc,EDAM,format_1952,http://edamontology.org/format_1952
-PDF,PDF,EDAM,format_3508,http://edamontology.org/format_3508
-Pearson format,Pearson format,EDAM,format_1954,http://edamontology.org/format_1954
-PED,The PED file describes individuals and genetic data and is used by the Plink package.,EDAM,format_3286,http://edamontology.org/format_3286
-PED/MAP,PED/MAP,EDAM,format_3288,http://edamontology.org/format_3288
-pepXML,pepXML,EDAM,format_3655,http://edamontology.org/format_3655
-pgm,pgm,EDAM,format_3602,http://edamontology.org/format_3602
-pgSnp,pgSnp,EDAM,format_3012,http://edamontology.org/format_3012
-PHD,PHD,EDAM,format_1633,http://edamontology.org/format_1633
-phenopacketJSON,"JavaScript Object Notation PhenoPacket a lightweight, text-based format to represent tree-structured data using key-value pairs.",EDAM,format:3464,http://edamontology.org/format_3464
-Phylip character frequencies format,Phylip character frequencies format,EDAM,format_1432,http://edamontology.org/format_1432
-Phylip cliques format,Phylip cliques format,EDAM,format_1434,http://edamontology.org/format_1434
-Phylip continuous quantitative characters,Phylip continuous quantitative characters,EDAM,format_1430,http://edamontology.org/format_1430
-Phylip discrete states format,Phylip discrete states format,EDAM,format_1433,http://edamontology.org/format_1433
-Phylip distance matrix,Phylip distance matrix,EDAM,format_1423,http://edamontology.org/format_1423
-PHYLIP format,PHYLIP format,EDAM,format_1997,http://edamontology.org/format_1997
-Phylip format variant,Phylip format variant,EDAM,format_2924,http://edamontology.org/format_2924
-PHYLIP sequential,PHYLIP sequential,EDAM,format_1998,http://edamontology.org/format_1998
-Phylip tree distance format,Phylip tree distance format,EDAM,format_1445,http://edamontology.org/format_1445
-Phylip tree format,Phylip tree format,EDAM,format_1435,http://edamontology.org/format_1435
-Phylip tree raw,Phylip tree raw,EDAM,format_1425,http://edamontology.org/format_1425
-Phylogenetic character data format,Phylogenetic character data format,EDAM,format_2036,http://edamontology.org/format_2036
-Phylogenetic continuous quantitative character format,Phylogenetic continuous quantitative character format,EDAM,format_2037,http://edamontology.org/format_2037
-Phylogenetic discrete states format,Phylogenetic discrete states format,EDAM,format_2038,http://edamontology.org/format_2038
-Phylogenetic tree format,Phylogenetic tree format,EDAM,format_2006,http://edamontology.org/format_2006
-Phylogenetic tree format (text),Phylogenetic tree format (text),EDAM,format_2556,http://edamontology.org/format_2556
-Phylogenetic tree format (XML),Phylogenetic tree format (XML),EDAM,format_2557,http://edamontology.org/format_2557
-Phylogenetic tree report (cliques) format,Phylogenetic tree report (cliques) format,EDAM,format_2039,http://edamontology.org/format_2039
-Phylogenetic tree report (invariants) format,Phylogenetic tree report (invariants) format,EDAM,format_2040,http://edamontology.org/format_2040
-Phylogenetic tree report (tree distances) format,Phylogenetic tree report (tree distances) format,EDAM,format_2049,http://edamontology.org/format_2049
-phyloXML,phyloXML,EDAM,format_3159,http://edamontology.org/format_3159
-Pileup,Pileup,EDAM,format_3015,http://edamontology.org/format_3015
-pkl,pkl,EDAM,format_3653,http://edamontology.org/format_3653
-plain text file format,plain text file format,SWO,SWO_3000043,http://www.ebi.ac.uk/swo/data/SWO_3000043
-plain text format (unformatted),plain text format (unformatted),EDAM,format_1964,http://edamontology.org/format_1964
-PlasMapper TextMap,PlasMapper TextMap,EDAM,format_1861,http://edamontology.org/format_1861
-pmc,pmc,EDAM,format_1739,http://edamontology.org/format_1739
-PMML,PMML,EDAM,format_3726,http://edamontology.org/format_3726
-PNG,PNG,EDAM,format_3603,http://edamontology.org/format_3603
-PO,PO,EDAM,format_3330,http://edamontology.org/format_3330
-ppm,ppm,EDAM,format_3596,http://edamontology.org/format_3596
-pptx,pptx,EDAM,format_3838,http://edamontology.org/format_3838
-PRIDE XML,PRIDE XML,EDAM,format_3684,http://edamontology.org/format_3684
-Primer3 primer,Primer3 primer,EDAM,format_1627,http://edamontology.org/format_1627
-proBAM,proBAM,EDAM,format_3826,http://edamontology.org/format_3826
-proBED,proBED,EDAM,format_3827,http://edamontology.org/format_3827
-ProQ report format,ProQ report format,EDAM,format_1552,http://edamontology.org/format_1552
-prosite-pattern,prosite-pattern,EDAM,format_1356,http://edamontology.org/format_1356
-prosite-profile,prosite-profile,EDAM,format_1366,http://edamontology.org/format_1366
-protein,protein,EDAM,format_1208,http://edamontology.org/format_1208
-Protein domain classification format,Protein domain classification format,EDAM,format_3097,http://edamontology.org/format_3097
-Protein family report format,Protein family report format,EDAM,format_2052,http://edamontology.org/format_2052
-Protein interaction format,Protein interaction format,EDAM,format_2054,http://edamontology.org/format_2054
-Protein report format,Protein report format,EDAM,format_2062,http://edamontology.org/format_2062
-Protein secondary structure format,Protein secondary structure format,EDAM,format_2077,http://edamontology.org/format_2077
-Protein structure report (quality evaluation) format,Protein structure report (quality evaluation) format,EDAM,format_2065,http://edamontology.org/format_2065
-protXML,protXML,EDAM,format_3747,http://edamontology.org/format_3747
-PS,PS,EDAM,format_3696,http://edamontology.org/format_3696
-psd,psd,EDAM,format_3597,http://edamontology.org/format_3597
-PSI MI TAB (MITAB),PSI MI TAB (MITAB),EDAM,format_3242,http://edamontology.org/format_3242
-PSI MI XML (MIF),PSI MI XML (MIF),EDAM,format_3158,http://edamontology.org/format_3158
-PSI-PAR,PSI-PAR,EDAM,format_3243,http://edamontology.org/format_3243
-PSL,PSL,EDAM,format_3007,http://edamontology.org/format_3007
-PubAnnotation format,PubAnnotation format,EDAM,format_3781,http://edamontology.org/format_3781
-PubMed citation,PubMed citation,EDAM,format_1734,http://edamontology.org/format_1734
-PubTator format,PubTator format,EDAM,format_3783,http://edamontology.org/format_3783
-pure,pure,EDAM,format_2094,http://edamontology.org/format_2094
-pure dna,pure dna,EDAM,format_1215,http://edamontology.org/format_1215
-pure nucleotide,pure nucleotide,EDAM,format_1210,http://edamontology.org/format_1210
-pure protein,pure protein,EDAM,format_1219,http://edamontology.org/format_1219
-pure rna,pure rna,EDAM,format_1217,http://edamontology.org/format_1217
-qcML,qcML,EDAM,format_3683,http://edamontology.org/format_3683
-qual,qual,EDAM,format_3607,http://edamontology.org/format_3607
-qual454,qual454,EDAM,format_3611,http://edamontology.org/format_3611
-qualillumina,qualillumina,EDAM,format_3609,http://edamontology.org/format_3609
-qualsolexa,qualsolexa,EDAM,format_3608,http://edamontology.org/format_3608
-qualsolid,qualsolid,EDAM,format_3610,http://edamontology.org/format_3610
-Query language,Query language,EDAM,format_3787,http://edamontology.org/format_3787
-quicktandem,quicktandem,EDAM,format_1295,http://edamontology.org/format_1295
-R data frame,R data frame,SWO,SWO_0000409,http://www.ebi.ac.uk/swo/SWO_0000409
-R file format,R file format,EDAM,format_3554,http://edamontology.org/format_3554
-rast,rast,EDAM,format_3605,http://edamontology.org/format_3605
-raw,raw,EDAM,format_1957,http://edamontology.org/format_1957
-Raw CATH domain classification format,Raw CATH domain classification format,EDAM,format_3099,http://edamontology.org/format_3099
-Raw microarray data format,Raw microarray data format,EDAM,format_3828,http://edamontology.org/format_3828
-Raw NMR data format,Raw NMR data format,EDAM,format_3824,http://edamontology.org/format_3824
-Raw SCOP domain classification format,Raw SCOP domain classification format,EDAM,format_3098,http://edamontology.org/format_3098
-Raw sequence format,Raw sequence format,EDAM,format_2571,http://edamontology.org/format_2571
-rcc,rcc,EDAM,format_3580,http://edamontology.org/format_3580
-rda,rda,SWO,SWO_0000684,http://www.ebi.ac.uk/swo/SWO_0000684
-RDF format,RDF format,EDAM,format_2376,http://edamontology.org/format_2376
-RDF-XML,RDF-XML,SWO,SWO_3000007,http://www.ebi.ac.uk/swo/data/SWO_3000007
-RDF/XML,RDF/XML,EDAM,format_3261,http://edamontology.org/format_3261
-REBASE restriction sites,REBASE restriction sites,EDAM,format_1320,http://edamontology.org/format_1320
-refseqp,refseqp,EDAM,format_1958,http://edamontology.org/format_1958
-Relaxed PHYLIP Interleaved,Relaxed PHYLIP Interleaved,EDAM,format_3819,http://edamontology.org/format_3819
-Relaxed PHYLIP Sequential,Relaxed PHYLIP Sequential,EDAM,format_3820,http://edamontology.org/format_3820
-restover format,restover format,EDAM,format_1319,http://edamontology.org/format_1319
-restrict format,restrict format,EDAM,format_1318,http://edamontology.org/format_1318
-rgb,rgb,EDAM,format_3600,http://edamontology.org/format_3600
-rna,rna,EDAM,format_1213,http://edamontology.org/format_1213
-RNA secondary structure format,RNA secondary structure format,EDAM,format_2076,http://edamontology.org/format_2076
-RNAML,RNAML,EDAM,format_3311,http://edamontology.org/format_3311
-Rnw,Rnw,SWO,SWO_0000363,http://www.ebi.ac.uk/swo/SWO_0000363
-RSF,RSF,EDAM,format_3485,http://edamontology.org/format_3485
-SAM,SAM,EDAM,format_2573,http://edamontology.org/format_2573
-SAMPLE file format,SAMPLE file format,EDAM,format_3813,http://edamontology.org/format_3813
-Sanger inverted repeats,Sanger inverted repeats,EDAM,format_1296,http://edamontology.org/format_1296
-SBGN-ML,SBGN-ML,EDAM,format_3692,http://edamontology.org/format_3692
-SBML,SBML,EDAM,format_2585,http://edamontology.org/format_2585
-SBMLR format,SBMLR format,SWO,SWO_0000378,http://www.ebi.ac.uk/swo/SWO_0000378
-SBOL,SBOL,EDAM,format_3725,http://edamontology.org/format_3725
-SBRML,SBRML,EDAM,format_3155,http://edamontology.org/format_3155
-SBtab,SBtab,EDAM,format_3688,http://edamontology.org/format_3688
-SCF,SCF,EDAM,format_1632,http://edamontology.org/format_1632
-scores format,scores format,EDAM,format_1999,http://edamontology.org/format_1999
-SDF,SDF,EDAM,format_3814,http://edamontology.org/format_3814
-SDF format,SDF format,SWO,SWO_0000381,http://www.ebi.ac.uk/swo/SWO_0000381
-SED-ML,SED-ML,EDAM,format_3685,http://edamontology.org/format_3685
-selex,selex,EDAM,format_2000,http://edamontology.org/format_2000
-Sequence annotation track format,Sequence annotation track format,EDAM,format_2919,http://edamontology.org/format_2919
-Sequence assembly format,Sequence assembly format,EDAM,format_2055,http://edamontology.org/format_2055
-Sequence assembly format (text),Sequence assembly format (text),EDAM,format_2561,http://edamontology.org/format_2561
-Sequence cluster format,Sequence cluster format,EDAM,format_2170,http://edamontology.org/format_2170
-Sequence cluster format (nucleic acid),Sequence cluster format (nucleic acid),EDAM,format_2172,http://edamontology.org/format_2172
-Sequence cluster format (protein),Sequence cluster format (protein),EDAM,format_2171,http://edamontology.org/format_2171
-Sequence distance matrix format,Sequence distance matrix format,EDAM,format_2067,http://edamontology.org/format_2067
-Sequence feature annotation format,Sequence feature annotation format,EDAM,format_1920,http://edamontology.org/format_1920
-Sequence feature table format,Sequence feature table format,EDAM,format_2548,http://edamontology.org/format_2548
-Sequence feature table format (text),Sequence feature table format (text),EDAM,format_2206,http://edamontology.org/format_2206
-Sequence feature table format (XML),Sequence feature table format (XML),EDAM,format_2553,http://edamontology.org/format_2553
-Sequence features (repeats) format,Sequence features (repeats) format,EDAM,format_2155,http://edamontology.org/format_2155
-Sequence motif format,Sequence motif format,EDAM,format_2068,http://edamontology.org/format_2068
-Sequence profile format,Sequence profile format,EDAM,format_2069,http://edamontology.org/format_2069
-Sequence quality report format (text),Sequence quality report format (text),EDAM,format_3606,http://edamontology.org/format_3606
-Sequence range format,Sequence range format,EDAM,format_2078,http://edamontology.org/format_2078
-Sequence record format,Sequence record format,EDAM,format_1919,http://edamontology.org/format_1919
-Sequence record format (text),Sequence record format (text),EDAM,format_2551,http://edamontology.org/format_2551
-Sequence record format (XML),Sequence record format (XML),EDAM,format_2552,http://edamontology.org/format_2552
-Sequence trace format,Sequence trace format,EDAM,format_2057,http://edamontology.org/format_2057
-Sequence variation annotation format,Sequence variation annotation format,EDAM,format_2921,http://edamontology.org/format_2921
-Sequence-MEME profile alignment,Sequence-MEME profile alignment,EDAM,format_1419,http://edamontology.org/format_1419
-Sequence-profile alignment format,Sequence-profile alignment format,EDAM,format_2014,http://edamontology.org/format_2014
-SEQUEST .out file,SEQUEST .out file,EDAM,format_3758,http://edamontology.org/format_3758
-Sequin format,Sequin format,EDAM,format_3701,http://edamontology.org/format_3701
-SFF,SFF,EDAM,format_3284,http://edamontology.org/format_3284
-sif,sif,EDAM,format_3619,http://edamontology.org/format_3619
-SIF,SIF,SWO,SWO_3000049,http://www.ebi.ac.uk/swo/data/SWO_3000049
-smarts,smarts,EDAM,format_1200,http://edamontology.org/format_1200
-SMILES,SMILES,EDAM,format_1196,http://edamontology.org/format_1196
-Smith-Waterman format,Smith-Waterman format,EDAM,format_1335,http://edamontology.org/format_1335
-snpeffdb,snpeffdb,EDAM,format_3624,http://edamontology.org/format_3624
-SPARQL,SPARQL,EDAM,format_3790,http://edamontology.org/format_3790
-spML,spML,EDAM,format_3250,http://edamontology.org/format_3250
-SPSS,SPSS,EDAM,format_3555,http://edamontology.org/format_3555
-SQL,SQL,EDAM,format_3788,http://edamontology.org/format_3788
-SQLite format,SQLite format,EDAM,format_3621,http://edamontology.org/format_3621
-SRA format,SRA format,EDAM,format_3698,http://edamontology.org/format_3698
-SRF,SRF,EDAM,format_3017,http://edamontology.org/format_3017
-srs format,srs format,EDAM,format_2002,http://edamontology.org/format_2002
-srspair,srspair,EDAM,format_2003,http://edamontology.org/format_2003
-SS,SS,EDAM,format_3310,http://edamontology.org/format_3310
-Staden experiment format,Staden experiment format,EDAM,format_1928,http://edamontology.org/format_1928
-Staden format,Staden format,EDAM,format_1960,http://edamontology.org/format_1960
-Stockholm format,Stockholm format,EDAM,format_1961,http://edamontology.org/format_1961
-strider format,strider format,EDAM,format_1962,http://edamontology.org/format_1962
-STRING entry format (XML),STRING entry format (XML),EDAM,format_2304,http://edamontology.org/format_2304
-SVG,SVG,EDAM,format_3604,http://edamontology.org/format_3604
-T-Coffee format,T-Coffee format,EDAM,format_2004,http://edamontology.org/format_2004
-tab delimited file format,tab delimited file format,SWO,SWO_3000046,http://www.ebi.ac.uk/swo/data/SWO_3000046
-tabix,tabix,EDAM,format_3616,http://edamontology.org/format_3616
-Tabix index file format,Tabix index file format,EDAM,format_3700,http://edamontology.org/format_3700
-taverna workflow format,taverna workflow format,EDAM,format_1665,http://edamontology.org/format_1665
-Tertiary structure format,Tertiary structure format,EDAM,format_2033,http://edamontology.org/format_2033
-Text mining report format,Text mining report format,EDAM,format_2021,http://edamontology.org/format_2021
-Textual format,Textual format,EDAM,format_2330,http://edamontology.org/format_2330
-Thermo RAW,Thermo RAW,EDAM,format_3712,http://edamontology.org/format_3712
-TIDE TXT,TIDE TXT,EDAM,format_3835,http://edamontology.org/format_3835
-tiff,tiff,EDAM,format_3591,http://edamontology.org/format_3591
-TraML,TraML,EDAM,format_3246,http://edamontology.org/format_3246
-TreeBASE format,TreeBASE format,EDAM,format_1436,http://edamontology.org/format_1436
-TreeCon format,TreeCon format,EDAM,format_1911,http://edamontology.org/format_1911
-TreeCon-seq,TreeCon-seq,EDAM,format_2005,http://edamontology.org/format_2005
-TreeFam format,TreeFam format,EDAM,format_1437,http://edamontology.org/format_1437
-TSV,TSV,EDAM,format_3475,http://edamontology.org/format_3475
-Turtle,Turtle,EDAM,format_3255,http://edamontology.org/format_3255
-unambiguous pure,unambiguous pure,EDAM,format_1206,http://edamontology.org/format_1206
-unambiguous pure dna,unambiguous pure dna,EDAM,format_1214,http://edamontology.org/format_1214
-unambiguous pure nucleotide,unambiguous pure nucleotide,EDAM,format_1211,http://edamontology.org/format_1211
-unambiguous pure protein,unambiguous pure protein,EDAM,format_1218,http://edamontology.org/format_1218
-unambiguous pure rna sequence,unambiguous pure rna sequence,EDAM,format_1216,http://edamontology.org/format_1216
-unambiguous sequence,unambiguous sequence,EDAM,format_2096,http://edamontology.org/format_2096
-UniProt-like (text),UniProt-like (text),EDAM,format_2187,http://edamontology.org/format_2187
-UniProtKB format,UniProtKB format,EDAM,format_1963,http://edamontology.org/format_1963
-UniProtKB RDF,UniProtKB RDF,EDAM,format_3771,http://edamontology.org/format_3771
-UniProtKB XML,UniProtKB XML,EDAM,format_3770,http://edamontology.org/format_3770
-uniprotkb-like format,uniprotkb-like format,EDAM,format_2547,http://edamontology.org/format_2547
-unpure,unpure,EDAM,format_2095,http://edamontology.org/format_2095
-VCF,VCF,EDAM,format_3016,http://edamontology.org/format_3016
-VDB,VDB,EDAM,format_3699,http://edamontology.org/format_3699
-Vienna local RNA secondary structure format,Vienna local RNA secondary structure format,EDAM,format_1458,http://edamontology.org/format_1458
-VisML,VisML,EDAM,format_3821,http://edamontology.org/format_3821
-WIFF format,WIFF format,EDAM,format_3710,http://edamontology.org/format_3710
-WIG,WIG,EDAM,format_3005,http://edamontology.org/format_3005
-Workflow format,Workflow format,EDAM,format_2032,http://edamontology.org/format_2032
-X!Tandem XML,X!Tandem XML,EDAM,format_3711,http://edamontology.org/format_3711
-xbm,xbm,EDAM,format_3598,http://edamontology.org/format_3598
-xgmml,xgmml,EDAM,format_3618,http://edamontology.org/format_3618
-XGMML,XGMML,SWO,SWO_3000051,http://www.ebi.ac.uk/swo/data/SWO_3000051
-xls,xls,EDAM,format_3468,http://edamontology.org/format_3468
-xlsx,xlsx,EDAM,format_3620,http://edamontology.org/format_3620
-XMFA,XMFA,EDAM,format_3811,http://edamontology.org/format_3811
-XML,XML,EDAM,format_2332,http://edamontology.org/format_2332
-xpm,xpm,EDAM,format_3599,http://edamontology.org/format_3599
-XQuery,XQuery,EDAM,format_3789,http://edamontology.org/format_3789
-xsd,xsd,EDAM,format_3804,http://edamontology.org/format_3804
-YAML,YAML,EDAM,format_3750,http://edamontology.org/format_3750
-ZTR,ZTR,EDAM,format_3018,http://edamontology.org/format_3018
+name,tags,definition,codesystem,code,ontologyTermURI
+.csv,,.csv,SWO,SWO_3000082,http://www.ebi.ac.uk/swo/data/SWO_3000082
+.fastq,,.fastq,EDAM,format_1930,http://edamontology.org/format_1930
+.maf,,.maf,EDAM,format_3008,http://edamontology.org/format_3008
+.mgf,,.mgf,SWO,SWO_3000083,http://www.ebi.ac.uk/swo/data/SWO_3000083
+.mysql,,.mysql,SWO,SWO_3000084,http://www.ebi.ac.uk/swo/data/SWO_3000084
+.nib,,.nib,EDAM,format_3010,http://edamontology.org/format_3010
+.raw files,,.raw files,SWO,SWO_0000682,http://www.ebi.ac.uk/swo/SWO_0000682
+.sam,,.sam,EDAM,format_2573,http://edamontology.org/format_2573
+.sql,,.sql,SWO,SWO_3000085,http://www.ebi.ac.uk/swo/data/SWO_3000085
+.wig,,.wig,EDAM,format_3005,http://edamontology.org/format_3005
+2bit,,2bit,EDAM,format_3009,http://edamontology.org/format_3009
+3D-1D scoring matrix format,,3D-1D scoring matrix format,EDAM,format_2064,http://edamontology.org/format_2064
+A2M,,A2M,EDAM,format_3281,http://edamontology.org/format_3281
+aaindex,,aaindex,EDAM,format_1504,http://edamontology.org/format_1504
+AB1,,AB1,EDAM,format_3000,http://edamontology.org/format_3000
+ABCD format,,ABCD format,EDAM,format_3708,http://edamontology.org/format_3708
+ABI,,ABI,EDAM,format_1628,http://edamontology.org/format_1628
+ACE,,ACE,EDAM,format_3001,http://edamontology.org/format_3001
+acedb,,acedb,EDAM,format_1923,http://edamontology.org/format_1923
+affymetrix,,affymetrix,EDAM,format_1639,http://edamontology.org/format_1639
+affymetrix-exp,,affymetrix-exp,EDAM,format_1641,http://edamontology.org/format_1641
+afg,,afg,EDAM,format_3582,http://edamontology.org/format_3582
+AGP,,AGP,EDAM,format_3693,http://edamontology.org/format_3693
+Alignment format,,Alignment format,EDAM,format_1921,http://edamontology.org/format_1921
+Alignment format (pair only),,Alignment format (pair only),EDAM,format_2920,http://edamontology.org/format_2920
+Alignment format (text),,Alignment format (text),EDAM,format_2554,http://edamontology.org/format_2554
+Alignment format (XML),,Alignment format (XML),EDAM,format_2555,http://edamontology.org/format_2555
+ambiguous,,ambiguous,EDAM,format_2097,http://edamontology.org/format_2097
+Amino acid index format,,Amino acid index format,EDAM,format_2017,http://edamontology.org/format_2017
+Annotated text format,,Annotated text format,EDAM,format_3780,http://edamontology.org/format_3780
+ARB,,ARB,EDAM,format_3830,http://edamontology.org/format_3830
+arff,,arff,EDAM,format_3581,http://edamontology.org/format_3581
+ARR,,ARR,SWO,SWO_1100014,http://www.ebi.ac.uk/swo/SWO_1100014
+Article format,,Article format,EDAM,format_2020,http://edamontology.org/format_2020
+ASCII format,,ASCII format,SWO,SWO_3000042,http://www.ebi.ac.uk/swo/data/SWO_3000042
+ASN.1 sequence format,,ASN.1 sequence format,EDAM,format_1966,http://edamontology.org/format_1966
+axt,,axt,EDAM,format_3013,http://edamontology.org/format_3013
+BAI,erdera,BAM indexing format,EDAM,format_3327,http://edamontology.org/format_3327
+BAM,erdera,"BAM format, the binary, BGZF-formatted compressed version of SAM format for alignment of nucleotide sequences (e.g. sequencing reads) to (a) reference sequence(s). May contain base-call and alignment qualities and other data.",EDAM,format_2572,http://edamontology.org/format_2572
+BAR,,BAR,SWO,SWO_3000058,http://www.ebi.ac.uk/swo/data/SWO_3000058
+BCF,,BCF,EDAM,format_3020,http://edamontology.org/format_3020
+BCML,,BCML,EDAM,format_3689,http://edamontology.org/format_3689
+BDML,,BDML,EDAM,format_3690,http://edamontology.org/format_3690
+BED,erdera,"Browser Extensible Data (BED) format of sequence annotation track, typically to be displayed in a genome browser.",EDAM,format_3003,http://edamontology.org/format_3003
+BED format,,BED format,EDAM,format_3003,http://edamontology.org/format_3003
+bed12,,bed12,EDAM,format_3586,http://edamontology.org/format_3586
+bed6,,bed6,EDAM,format_3585,http://edamontology.org/format_3585
+bedgraph,,bedgraph,EDAM,format_3583,http://edamontology.org/format_3583
+BedGraph,,BedGraph,SWO,SWO_3000072,http://www.ebi.ac.uk/swo/data/SWO_3000072
+bedstrict,,bedstrict,EDAM,format_3584,http://edamontology.org/format_3584
+BEL,,BEL,EDAM,format_3691,http://edamontology.org/format_3691
+bgzip,,bgzip,EDAM,format_3615,http://edamontology.org/format_3615
+Bibliographic reference format,,Bibliographic reference format,EDAM,format_2848,http://edamontology.org/format_2848
+bigBed,,bigBed,EDAM,format_3004,http://edamontology.org/format_3004
+bigWig,,bigWig,EDAM,format_3006,http://edamontology.org/format_3006
+binary format,,binary format,EDAM,format_2333,http://edamontology.org/format_2333
+BioC,,BioC,EDAM,format_3782,http://edamontology.org/format_3782
+Biodiversity data format,,Biodiversity data format,EDAM,format_3706,http://edamontology.org/format_3706
+BioJSON (BioXSD),,BioJSON (BioXSD),EDAM,format_3772,http://edamontology.org/format_3772
+BioJSON (Jalview),,BioJSON (Jalview),EDAM,format_3774,http://edamontology.org/format_3774
+Biological pathway or network format,,Biological pathway or network format,EDAM,format_2013,http://edamontology.org/format_2013
+Biological pathway or network report format,,Biological pathway or network report format,EDAM,format_3166,http://edamontology.org/format_3166
+BIOM format,,BIOM format,EDAM,format_3746,http://edamontology.org/format_3746
+BioNLP Shared Task format,,BioNLP Shared Task format,EDAM,format_3785,http://edamontology.org/format_3785
+BioPAX,,BioPAX,EDAM,format_3156,http://edamontology.org/format_3156
+BioPAX Manchester OWL Syntax format,,BioPAX Manchester OWL Syntax format,SWO,SWO_3000056,http://www.ebi.ac.uk/swo/data/SWO_3000056
+BioPAX RDF/XML format,,BioPAX RDF/XML format,SWO,SWO_3000055,http://www.ebi.ac.uk/swo/data/SWO_3000055
+BioXSD (XML),,BioXSD (XML),EDAM,format_2352,http://edamontology.org/format_2352
+BioYAML,,BioYAML,EDAM,format_3773,http://edamontology.org/format_3773
+BLAST results,,BLAST results,EDAM,format_1333,http://edamontology.org/format_1333
+BLAST XML results format,,BLAST XML results format,EDAM,format_3331,http://edamontology.org/format_3331
+BLAST XML v2 results format,,BLAST XML v2 results format,EDAM,format_3836,http://edamontology.org/format_3836
+BLC,,BLC,EDAM,format_3313,http://edamontology.org/format_3313
+bmp,,bmp,EDAM,format_3592,http://edamontology.org/format_3592
+BPMAP,,BPMAP,SWO,SWO_1100035,http://www.ebi.ac.uk/swo/SWO_1100035
+BSML,,BSML,EDAM,format_3487,http://edamontology.org/format_3487
+BTrack,,BTrack,EDAM,format_3776,http://edamontology.org/format_3776
+CAF,,CAF,EDAM,format_1630,http://edamontology.org/format_1630
+CATH domain report format,,CATH domain report format,EDAM,format_3100,http://edamontology.org/format_3100
+CDF ASCII format,,CDF ASCII format,SWO,SWO_3000057,http://www.ebi.ac.uk/swo/data/SWO_3000057
+CDF binary format,,CDF binary format,SWO,SWO_1100054,http://www.ebi.ac.uk/swo/SWO_1100054
+cdsxml,,cdsxml,EDAM,format_2184,http://edamontology.org/format_2184
+cdt,,cdt,SWO,SWO_0000493,http://www.ebi.ac.uk/swo/SWO_0000493
+cel,,cel,EDAM,format_1638,http://edamontology.org/format_1638
+CEL ASCII format,,CEL ASCII format,SWO,SWO_3000059,http://www.ebi.ac.uk/swo/data/SWO_3000059
+CEL binary format,,CEL binary format,SWO,SWO_0000084,http://www.ebi.ac.uk/swo/SWO_0000084
+CellML,,CellML,EDAM,format_3240,http://edamontology.org/format_3240
+Chemical data format,,Chemical data format,EDAM,format_2030,http://edamontology.org/format_2030
+Chemical formula format,,Chemical formula format,EDAM,format_2035,http://edamontology.org/format_2035
+CHP,,CHP,EDAM,format_1644,http://edamontology.org/format_1644
+CHP binary format,,CHP binary format,SWO,SWO_1100122,http://www.ebi.ac.uk/swo/SWO_1100122
+chrominfo,,chrominfo,EDAM,format_3587,http://edamontology.org/format_3587
+CiteXplore-all,,CiteXplore-all,EDAM,format_1737,http://edamontology.org/format_1737
+CiteXplore-core,,CiteXplore-core,EDAM,format_1736,http://edamontology.org/format_1736
+cls,,cls,SWO,SWO_0000498,http://www.ebi.ac.uk/swo/SWO_0000498
+ClustalW dendrogram,,ClustalW dendrogram,EDAM,format_1424,http://edamontology.org/format_1424
+ClustalW format,,ClustalW format,EDAM,format_1982,http://edamontology.org/format_1982
+codata,,codata,EDAM,format_1925,http://edamontology.org/format_1925
+COMBINE OMEX,,COMBINE OMEX,EDAM,format_3686,http://edamontology.org/format_3686
+completely unambiguous,,completely unambiguous,EDAM,format_2566,http://edamontology.org/format_2566
+completely unambiguous pure,,completely unambiguous pure,EDAM,format_2567,http://edamontology.org/format_2567
+completely unambiguous pure dna,,completely unambiguous pure dna,EDAM,format_2569,http://edamontology.org/format_2569
+completely unambiguous pure nucleotide,,completely unambiguous pure nucleotide,EDAM,format_2568,http://edamontology.org/format_2568
+completely unambiguous pure protein,,completely unambiguous pure protein,EDAM,format_2607,http://edamontology.org/format_2607
+completely unambiguous pure rna sequence,,completely unambiguous pure rna sequence,EDAM,format_2570,http://edamontology.org/format_2570
+consensus,,consensus,EDAM,format_1209,http://edamontology.org/format_1209
+consensusXML,,consensusXML,EDAM,format_3832,http://edamontology.org/format_3832
+CopasiML,,CopasiML,EDAM,format_3239,http://edamontology.org/format_3239
+crai,erdera,CRAI,,,
+CRAM,erdera,Reference-based compression of alignment format,EDAM,format_3462,http://edamontology.org/format_3462
+csfasta,,csfasta,EDAM,format_3589,http://edamontology.org/format_3589
+CSV,,CSV,EDAM,format_3752,http://edamontology.org/format_3752
+CT,,CT,EDAM,format_3309,http://edamontology.org/format_3309
+customtrack,,customtrack,EDAM,format_3588,http://edamontology.org/format_3588
+Cytoband format,,Cytoband format,EDAM,format_3235,http://edamontology.org/format_3235
+Cytoscape input file format,,Cytoscape input file format,EDAM,format_3477,http://edamontology.org/format_3477
+daf,,daf,EDAM,format_1393,http://edamontology.org/format_1393
+DAS format,,DAS format,EDAM,format_1967,http://edamontology.org/format_1967
+dasdna,,dasdna,EDAM,format_1968,http://edamontology.org/format_1968
+DASGFF,,DASGFF,EDAM,format_1978,http://edamontology.org/format_1978
+dat,,dat,EDAM,format_1637,http://edamontology.org/format_1637
+Data File Standard for Flow Cytometry,,Data File Standard for Flow Cytometry,SWO,SWO_3000061,http://www.ebi.ac.uk/swo/data/SWO_3000061
+Data index format,,Data index format,EDAM,format_3326,http://edamontology.org/format_3326
+Database hits (sequence) format,,Database hits (sequence) format,EDAM,format_2066,http://edamontology.org/format_2066
+dbGaP format,,dbGaP format,EDAM,format_3729,http://edamontology.org/format_3729
+dbid,,dbid,EDAM,format_1926,http://edamontology.org/format_1926
+dcf,,dcf,SWO,SWO_0000518,http://www.ebi.ac.uk/swo/SWO_0000518
+debug,,debug,EDAM,format_1983,http://edamontology.org/format_1983
+debug-feat,,debug-feat,EDAM,format_1979,http://edamontology.org/format_1979
+debug-seq,,debug-seq,EDAM,format_1969,http://edamontology.org/format_1969
+dhf,,dhf,EDAM,format_1336,http://edamontology.org/format_1336
+DIALIGN format,,DIALIGN format,EDAM,format_1392,http://edamontology.org/format_1392
+DICOM format,,DICOM format,EDAM,format_3548,http://edamontology.org/format_3548
+Dirichlet distribution format,,Dirichlet distribution format,EDAM,format_2074,http://edamontology.org/format_2074
+dna,,dna,EDAM,format_1212,http://edamontology.org/format_1212
+Document format,,Document format,EDAM,format_3507,http://edamontology.org/format_3507
+docx,,docx,EDAM,format_3506,http://edamontology.org/format_3506
+Dot-bracket format,,Dot-bracket format,EDAM,format_1457,http://edamontology.org/format_1457
+dssp,,dssp,EDAM,format_1454,http://edamontology.org/format_1454
+DSV,,DSV,EDAM,format_3751,http://edamontology.org/format_3751
+dta,,dta,EDAM,format_3652,http://edamontology.org/format_3652
+EBI Application Result XML,,EBI Application Result XML,EDAM,format_3157,http://edamontology.org/format_3157
+ebwt,,ebwt,EDAM,format_3484,http://edamontology.org/format_3484
+ebwtl,,ebwtl,EDAM,format_3491,http://edamontology.org/format_3491
+ELAND format,,ELAND format,EDAM,format_3818,http://edamontology.org/format_3818
+EMBL feature location,,EMBL feature location,EDAM,format_1248,http://edamontology.org/format_1248
+EMBL format,,EMBL format,EDAM,format_1927,http://edamontology.org/format_1927
+EMBL format (XML),,EMBL format (XML),EDAM,format_2204,http://edamontology.org/format_2204
+EMBL-HTML,,EMBL-HTML,EDAM,format_2311,http://edamontology.org/format_2311
+EMBL-like (text),,EMBL-like (text),EDAM,format_2181,http://edamontology.org/format_2181
+EMBL-like (XML),,EMBL-like (XML),EDAM,format_2558,http://edamontology.org/format_2558
+EMBL-like format,,EMBL-like format,EDAM,format_2543,http://edamontology.org/format_2543
+EMBLXML,,EMBLXML,EDAM,format_2183,http://edamontology.org/format_2183
+EMBOSS repeat,,EMBOSS repeat,EDAM,format_1297,http://edamontology.org/format_1297
+EMBOSS sequence pattern,,EMBOSS sequence pattern,EDAM,format_1357,http://edamontology.org/format_1357
+EMBOSS simple format,,EMBOSS simple format,EDAM,format_2001,http://edamontology.org/format_2001
+ENCODE broad peak format,,ENCODE broad peak format,EDAM,format_3614,http://edamontology.org/format_3614
+ENCODE narrow peak format,,ENCODE narrow peak format,EDAM,format_3613,http://edamontology.org/format_3613
+ENCODE peak format,,ENCODE peak format,EDAM,format_3612,http://edamontology.org/format_3612
+Ensembl variation file format,,Ensembl variation file format,EDAM,format_3499,http://edamontology.org/format_3499
+Enzyme kinetics report format,,Enzyme kinetics report format,EDAM,format_2027,http://edamontology.org/format_2027
+EPS,,EPS,EDAM,format_3466,http://edamontology.org/format_3466
+est2genome format,,est2genome format,EDAM,format_1316,http://edamontology.org/format_1316
+EXP,,EXP,EDAM,format_1631,http://edamontology.org/format_1631
+Experiment annotation format,,Experiment annotation format,EDAM,format_3167,http://edamontology.org/format_3167
+FASTA,,FASTA,EDAM,format_1929,http://edamontology.org/format_1929
+FASTA format,,FASTA format,EDAM,format_1929,http://edamontology.org/format_1929
+FASTA search results format,,FASTA search results format,EDAM,format_1332,http://edamontology.org/format_1332
+FASTA-aln,,FASTA-aln,EDAM,format_1984,http://edamontology.org/format_1984
+FASTA-HTML,,FASTA-HTML,EDAM,format_2310,http://edamontology.org/format_2310
+FASTA-like,,FASTA-like,EDAM,format_2546,http://edamontology.org/format_2546
+FASTA-like (text),,FASTA-like (text),EDAM,format_2200,http://edamontology.org/format_2200
+FASTG,,FASTG,EDAM,format_3823,http://edamontology.org/format_3823
+FASTQ,erdera,FASTQ short read format ignoring quality scores.,EDAM,format_1930,http://edamontology.org/format_1930
+FASTQ-illumina,,FASTQ-illumina,EDAM,format_1931,http://edamontology.org/format_1931
+FASTQ-like format,,FASTQ-like format,EDAM,format_2545,http://edamontology.org/format_2545
+FASTQ-like format (text),,FASTQ-like format (text),EDAM,format_2182,http://edamontology.org/format_2182
+FASTQ-sanger,,FASTQ-sanger,EDAM,format_1932,http://edamontology.org/format_1932
+FASTQ-solexa,,FASTQ-solexa,EDAM,format_1933,http://edamontology.org/format_1933
+FASTQ1,erdera,FASTQ1,EDAM,format_1930,http://edamontology.org/format_1930
+FASTQ2,erdera,FASTQ2,EDAM,format_1930,http://edamontology.org/format_1930
+FCS3.0,,FCS3.0,SWO,SWO_3000062,http://www.ebi.ac.uk/swo/data/SWO_3000062
+featureXML,,featureXML,EDAM,format_3833,http://edamontology.org/format_3833
+FieldML,,FieldML,SWO,SWO_3000075,http://www.ebi.ac.uk/swo/data/SWO_3000075
+findkm,,findkm,EDAM,format_1582,http://edamontology.org/format_1582
+fitch program,,fitch program,EDAM,format_1934,http://edamontology.org/format_1934
+Format,,Format,EDAM,format_1915,http://edamontology.org/format_1915
+Format (by type of data),,Format (by type of data),EDAM,format_2350,http://edamontology.org/format_2350
+GCDML,,GCDML,EDAM,format_3163,http://edamontology.org/format_3163
+GCG,,GCG,EDAM,format_1935,http://edamontology.org/format_1935
+GCG format variant,,GCG format variant,EDAM,format_3486,http://edamontology.org/format_3486
+GCG MSF,,GCG MSF,EDAM,format_1947,http://edamontology.org/format_1947
+gct,,gct,SWO,SWO_0000548,http://www.ebi.ac.uk/swo/SWO_0000548
+GCT/Res format,,GCT/Res format,EDAM,format_3709,http://edamontology.org/format_3709
+GDE,,GDE,EDAM,format_3312,http://edamontology.org/format_3312
+GelML,,GelML,EDAM,format_3249,http://edamontology.org/format_3249
+Gemini SQLite format,,Gemini SQLite format,EDAM,format_3622,http://edamontology.org/format_3622
+GEN,,GEN,EDAM,format_3812,http://edamontology.org/format_3812
+GenBank format,,GenBank format,EDAM,format_1936,http://edamontology.org/format_1936
+GenBank-HTML,,GenBank-HTML,EDAM,format_2532,http://edamontology.org/format_2532
+GenBank-like format,,GenBank-like format,EDAM,format_2559,http://edamontology.org/format_2559
+GenBank-like format (text),,GenBank-like format (text),EDAM,format_2205,http://edamontology.org/format_2205
+Gene annotation format,,Gene annotation format,EDAM,format_2031,http://edamontology.org/format_2031
+Gene expression report format,,Gene expression report format,EDAM,format_2058,http://edamontology.org/format_2058
+genePred,,genePred,EDAM,format_3011,http://edamontology.org/format_3011
+geneseq,,geneseq,EDAM,format_2186,http://edamontology.org/format_2186
+genpept,,genpept,EDAM,format_1937,http://edamontology.org/format_1937
+GEO Matrix Series format,,GEO Matrix Series format,SWO,SWO_1100126,http://www.ebi.ac.uk/swo/SWO_1100126
+GFF,,GFF,EDAM,format_2305,http://edamontology.org/format_2305
+GFF2,,GFF2,EDAM,format_1974,http://edamontology.org/format_1974
+GFF2-seq,,GFF2-seq,EDAM,format_1938,http://edamontology.org/format_1938
+GFF3,,GFF3,EDAM,format_1975,http://edamontology.org/format_1975
+GFF3-seq,,GFF3-seq,EDAM,format_1939,http://edamontology.org/format_1939
+GIF,,GIF,EDAM,format_3467,http://edamontology.org/format_3467
+giFASTA format,,giFASTA format,EDAM,format_1940,http://edamontology.org/format_1940
+GML,,GML,EDAM,format_3822,http://edamontology.org/format_3822
+GPML,,GPML,EDAM,format_3657,http://edamontology.org/format_3657
+GPR,,GPR,EDAM,format_3829,http://edamontology.org/format_3829
+gpr format,,gpr format,SWO,SWO_0000566,http://www.ebi.ac.uk/swo/SWO_0000566
+Graph format,,Graph format,EDAM,format_3617,http://edamontology.org/format_3617
+GSuite,,GSuite,EDAM,format_3775,http://edamontology.org/format_3775
+GTF,,GTF,EDAM,format_2306,http://edamontology.org/format_2306
+gtr,,gtr,SWO,SWO_0000569,http://www.ebi.ac.uk/swo/SWO_0000569
+GTrack,,GTrack,EDAM,format_3164,http://edamontology.org/format_3164
+gVCF,erdera,"Genomic Variant Call Format (VCF) for sequence variation (indels, polymorphisms, structural variation).",EDAM,format:3016,http://edamontology.org/format_3016
+GVF,,GVF,EDAM,format_3019,http://edamontology.org/format_3019
+gxl format,,gxl format,SWO,SWO_0000570,http://www.ebi.ac.uk/swo/SWO_0000570
+hdf5,,hdf5,EDAM,format_3590,http://edamontology.org/format_3590
+hennig86,,hennig86,EDAM,format_1941,http://edamontology.org/format_1941
+HET group dictionary entry format,,HET group dictionary entry format,EDAM,format_1705,http://edamontology.org/format_1705
+Hidden Markov model format,,Hidden Markov model format,EDAM,format_2072,http://edamontology.org/format_2072
+HMM emission and transition counts format,,HMM emission and transition counts format,EDAM,format_2075,http://edamontology.org/format_2075
+HMMER Dirichlet prior,,HMMER Dirichlet prior,EDAM,format_1349,http://edamontology.org/format_1349
+HMMER emission and transition,,HMMER emission and transition,EDAM,format_1351,http://edamontology.org/format_1351
+HMMER format,,HMMER format,EDAM,format_1370,http://edamontology.org/format_1370
+HMMER profile alignment (HMM versus sequences),,HMMER profile alignment (HMM versus sequences),EDAM,format_1422,http://edamontology.org/format_1422
+HMMER profile alignment (sequences versus HMMs),,HMMER profile alignment (sequences versus HMMs),EDAM,format_1421,http://edamontology.org/format_1421
+HMMER-aln,,HMMER-aln,EDAM,format_1391,http://edamontology.org/format_1391
+HMMER2,,HMMER2,EDAM,format_3328,http://edamontology.org/format_3328
+HMMER3,,HMMER3,EDAM,format_3329,http://edamontology.org/format_3329
+hssp,,hssp,EDAM,format_1455,http://edamontology.org/format_1455
+html,,html,EDAM,format_2331,http://edamontology.org/format_2331
+ibd,,ibd,EDAM,format_3839,http://edamontology.org/format_3839
+IDAT,,IDAT,EDAM,format_3578,http://edamontology.org/format_3578
+idXML,,idXML,EDAM,format_3764,http://edamontology.org/format_3764
+ig,,ig,EDAM,format_1942,http://edamontology.org/format_1942
+igstrict,,igstrict,EDAM,format_1943,http://edamontology.org/format_1943
+iHOP format,,iHOP format,EDAM,format_1740,http://edamontology.org/format_1740
+im,,im,EDAM,format_3593,http://edamontology.org/format_3593
+Image format,,Image format,EDAM,format_3547,http://edamontology.org/format_3547
+imzML metadata file,,imzML metadata file,EDAM,format_3682,http://edamontology.org/format_3682
+InChI,,InChI,EDAM,format_1197,http://edamontology.org/format_1197
+InChIKey,,InChIKey,EDAM,format_1199,http://edamontology.org/format_1199
+Individual genetic data format,,Individual genetic data format,EDAM,format_3287,http://edamontology.org/format_3287
+insdxml,,insdxml,EDAM,format_2185,http://edamontology.org/format_2185
+InterPro hits format,,InterPro hits format,EDAM,format_1341,http://edamontology.org/format_1341
+InterPro match table format,,InterPro match table format,EDAM,format_1343,http://edamontology.org/format_1343
+InterPro protein view report format,,InterPro protein view report format,EDAM,format_1342,http://edamontology.org/format_1342
+ISA-TAB,,ISA-TAB,EDAM,format_3687,http://edamontology.org/format_3687
+jackknifer,,jackknifer,EDAM,format_1944,http://edamontology.org/format_1944
+jackknifernon,,jackknifernon,EDAM,format_1970,http://edamontology.org/format_1970
+JASPAR format,,JASPAR format,EDAM,format_1367,http://edamontology.org/format_1367
+JPG,,JPG,EDAM,format_3579,http://edamontology.org/format_3579
+JSON,erdera,JSON,EDAM,format_3464,http://edamontology.org/format_3464
+JSON-LD,,JSON-LD,EDAM,format_3749,http://edamontology.org/format_3749
+K-mer countgraph,,K-mer countgraph,EDAM,format_3665,http://edamontology.org/format_3665
+KGML,,KGML,SWO,SWO_0000249,http://www.ebi.ac.uk/swo/SWO_0000249
+KNIME datatable format,,KNIME datatable format,EDAM,format_3765,http://edamontology.org/format_3765
+KRSS2 Syntax,,KRSS2 Syntax,EDAM,format_3254,http://edamontology.org/format_3254
+latex,,latex,EDAM,format_3817,http://edamontology.org/format_3817
+LAV,,LAV,EDAM,format_3014,http://edamontology.org/format_3014
+lhf,,lhf,EDAM,format_1337,http://edamontology.org/format_1337
+Linked data format,,Linked data format,EDAM,format_3748,http://edamontology.org/format_3748
+lma,,lma,SWO,SWO_0000596,http://www.ebi.ac.uk/swo/SWO_0000596
+LocARNA PP,,LocARNA PP,EDAM,format_3728,http://edamontology.org/format_3728
+MAF,,MAF,EDAM,format_3008,http://edamontology.org/format_3008
+MAGE-ML,,MAGE-ML,EDAM,format_3161,http://edamontology.org/format_3161
+MAGE-TAB,,MAGE-TAB,EDAM,format_3162,http://edamontology.org/format_3162
+Manchester OWL Syntax,,Manchester OWL Syntax,EDAM,format_3253,http://edamontology.org/format_3253
+MAP,,MAP,EDAM,format_3285,http://edamontology.org/format_3285
+Map format,,Map format,EDAM,format_2060,http://edamontology.org/format_2060
+markx0,,markx0,EDAM,format_1985,http://edamontology.org/format_1985
+markx0 variant,,markx0 variant,EDAM,format_2922,http://edamontology.org/format_2922
+markx1,,markx1,EDAM,format_1986,http://edamontology.org/format_1986
+markx10,,markx10,EDAM,format_1987,http://edamontology.org/format_1987
+markx2,,markx2,EDAM,format_1988,http://edamontology.org/format_1988
+markx3,,markx3,EDAM,format_1989,http://edamontology.org/format_1989
+mas5 format,,mas5 format,SWO,SWO_0000615,http://www.ebi.ac.uk/swo/SWO_0000615
+Mascot .dat file,,Mascot .dat file,EDAM,format_3713,http://edamontology.org/format_3713
+mase format,,mase format,EDAM,format_1945,http://edamontology.org/format_1945
+Mass spectrometry data format,,Mass spectrometry data format,EDAM,format_3245,http://edamontology.org/format_3245
+MAT,,MAT,EDAM,format_3626,http://edamontology.org/format_3626
+match,,match,EDAM,format_1990,http://edamontology.org/format_1990
+MathML 2.0,,MathML 2.0,SWO,SWO_3000074,http://www.ebi.ac.uk/swo/data/SWO_3000074
+Matrix format,,Matrix format,EDAM,format_3033,http://edamontology.org/format_3033
+MaxQuant APL peaklist format,,MaxQuant APL peaklist format,EDAM,format_3714,http://edamontology.org/format_3714
+MCPD,,MCPD,EDAM,format_3777,http://edamontology.org/format_3777
+md5,,MD5 Checksum,NCIT,NCIT_C171276,http://purl.obolibrary.org/obo/NCIT_C171276
+medline,,medline,EDAM,format_2194,http://edamontology.org/format_2194
+Medline Display Format,,Medline Display Format,EDAM,format_1735,http://edamontology.org/format_1735
+mega,,mega,EDAM,format_1991,http://edamontology.org/format_1991
+mega variant,,mega variant,EDAM,format_2923,http://edamontology.org/format_2923
+mega-seq,,mega-seq,EDAM,format_1946,http://edamontology.org/format_1946
+meganon,,meganon,EDAM,format_1992,http://edamontology.org/format_1992
+MEME background Markov model,,MEME background Markov model,EDAM,format_1369,http://edamontology.org/format_1369
+MEME Dirichlet prior,,MEME Dirichlet prior,EDAM,format_1350,http://edamontology.org/format_1350
+meme-motif,,meme-motif,EDAM,format_1360,http://edamontology.org/format_1360
+mf,,mf,EDAM,format_1198,http://edamontology.org/format_1198
+MGF,,MGF,EDAM,format_3651,http://edamontology.org/format_3651
+mhd,,mhd,EDAM,format_3550,http://edamontology.org/format_3550
+MHTML,,MHTML,EDAM,format_3556,http://edamontology.org/format_3556
+Microarray experiment data format,,Microarray experiment data format,EDAM,format_2056,http://edamontology.org/format_2056
+mira,,mira,EDAM,format_1629,http://edamontology.org/format_1629
+mmCIF,,mmCIF,EDAM,format_1477,http://edamontology.org/format_1477
+Mol2,,Mol2,EDAM,format_3816,http://edamontology.org/format_3816
+Molfile,,Molfile,EDAM,format_3815,http://edamontology.org/format_3815
+MSF,,MSF,EDAM,format_3702,http://edamontology.org/format_3702
+mspcrunch,,mspcrunch,EDAM,format_1334,http://edamontology.org/format_1334
+mzData,,mzData,EDAM,format_3834,http://edamontology.org/format_3834
+mzIdentML,,mzIdentML,EDAM,format_3247,http://edamontology.org/format_3247
+mzML,,mzML,EDAM,format_3244,http://edamontology.org/format_3244
+mzQuantML,,mzQuantML,EDAM,format_3248,http://edamontology.org/format_3248
+mzTab,,mzTab,EDAM,format_3681,http://edamontology.org/format_3681
+mzXML,,mzXML,EDAM,format_3654,http://edamontology.org/format_3654
+N-Triples,,N-Triples,EDAM,format_3256,http://edamontology.org/format_3256
+nbrf/pir,,nbrf/pir,EDAM,format_1948,http://edamontology.org/format_1948
+NCBI format,,NCBI format,EDAM,format_1972,http://edamontology.org/format_1972
+netCDF,,netCDF,EDAM,format_3650,http://edamontology.org/format_3650
+newick,,newick,EDAM,format_1910,http://edamontology.org/format_1910
+NeXML,,NeXML,EDAM,format_3160,http://edamontology.org/format_3160
+Nexus format,,Nexus format,EDAM,format_1912,http://edamontology.org/format_1912
+nexus-seq,,nexus-seq,EDAM,format_1949,http://edamontology.org/format_1949
+nexusnon,,nexusnon,EDAM,format_1973,http://edamontology.org/format_1973
+nii,,nii,EDAM,format_3549,http://edamontology.org/format_3549
+nmrML,,nmrML,EDAM,format_3825,http://edamontology.org/format_3825
+Notation3,,Notation3,EDAM,format_3257,http://edamontology.org/format_3257
+nrrd,,nrrd,EDAM,format_3551,http://edamontology.org/format_3551
+Nucleic acid features (primers) format,,Nucleic acid features (primers) format,EDAM,format_2061,http://edamontology.org/format_2061
+Nucleic acid features (restriction sites) format,,Nucleic acid features (restriction sites) format,EDAM,format_2158,http://edamontology.org/format_2158
+nucleotide,,nucleotide,EDAM,format_1207,http://edamontology.org/format_1207
+OBO,,OBO,EDAM,format_2549,http://edamontology.org/format_2549
+OBO Flat File Format,,OBO Flat File Format,EDAM,format_2549,http://edamontology.org/format_2549
+OBO format,,OBO format,EDAM,format_2196,http://edamontology.org/format_2196
+OBO-XML,,OBO-XML,EDAM,format_2550,http://edamontology.org/format_2550
+OME-TIFF,,OME-TIFF,EDAM,format_3727,http://edamontology.org/format_3727
+Ontology format,,Ontology format,EDAM,format_2195,http://edamontology.org/format_2195
+Open Annotation format,,Open Annotation format,EDAM,format_3784,http://edamontology.org/format_3784
+OSCAR format,,OSCAR format,EDAM,format_1741,http://edamontology.org/format_1741
+OWL format,,OWL format,EDAM,format_2197,http://edamontology.org/format_2197
+OWL Functional Syntax,,OWL Functional Syntax,EDAM,format_3252,http://edamontology.org/format_3252
+OWL-XML,,OWL-XML,SWO,SWO_3000038,http://www.ebi.ac.uk/swo/data/SWO_3000038
+OWL/XML,,OWL/XML,EDAM,format_3262,http://edamontology.org/format_3262
+OWL2-XML,,OWL2-XML,SWO,SWO_3000039,http://www.ebi.ac.uk/swo/data/SWO_3000039
+pair,,pair,EDAM,format_1996,http://edamontology.org/format_1996
+pbm,,pbm,EDAM,format_3601,http://edamontology.org/format_3601
+pcd,,pcd,EDAM,format_3594,http://edamontology.org/format_3594
+Pcons report format,,Pcons report format,EDAM,format_1551,http://edamontology.org/format_1551
+pcx,,pcx,EDAM,format_3595,http://edamontology.org/format_3595
+PDB,,PDB,EDAM,format_1476,http://edamontology.org/format_1476
+PDB database entry format,,PDB database entry format,EDAM,format_1475,http://edamontology.org/format_1475
+pdbatom,,pdbatom,EDAM,format_1950,http://edamontology.org/format_1950
+pdbatomnuc,,pdbatomnuc,EDAM,format_1951,http://edamontology.org/format_1951
+pdbml,,pdbml,EDAM,format_1478,http://edamontology.org/format_1478
+pdbseqres,,pdbseqres,EDAM,format_1953,http://edamontology.org/format_1953
+pdbseqresnuc,,pdbseqresnuc,EDAM,format_1952,http://edamontology.org/format_1952
+PDF,,PDF,EDAM,format_3508,http://edamontology.org/format_3508
+Pearson format,,Pearson format,EDAM,format_1954,http://edamontology.org/format_1954
+PED,erdera,The PED file describes individuals and genetic data and is used by the Plink package.,EDAM,format_3286,http://edamontology.org/format_3286
+PED/MAP,,PED/MAP,EDAM,format_3288,http://edamontology.org/format_3288
+pepXML,,pepXML,EDAM,format_3655,http://edamontology.org/format_3655
+pgm,,pgm,EDAM,format_3602,http://edamontology.org/format_3602
+pgSnp,,pgSnp,EDAM,format_3012,http://edamontology.org/format_3012
+PHD,,PHD,EDAM,format_1633,http://edamontology.org/format_1633
+phenopacketJSON,erdera,"JavaScript Object Notation PhenoPacket a lightweight, text-based format to represent tree-structured data using key-value pairs.",EDAM,format:3464,http://edamontology.org/format_3464
+Phylip character frequencies format,,Phylip character frequencies format,EDAM,format_1432,http://edamontology.org/format_1432
+Phylip cliques format,,Phylip cliques format,EDAM,format_1434,http://edamontology.org/format_1434
+Phylip continuous quantitative characters,,Phylip continuous quantitative characters,EDAM,format_1430,http://edamontology.org/format_1430
+Phylip discrete states format,,Phylip discrete states format,EDAM,format_1433,http://edamontology.org/format_1433
+Phylip distance matrix,,Phylip distance matrix,EDAM,format_1423,http://edamontology.org/format_1423
+PHYLIP format,,PHYLIP format,EDAM,format_1997,http://edamontology.org/format_1997
+Phylip format variant,,Phylip format variant,EDAM,format_2924,http://edamontology.org/format_2924
+PHYLIP sequential,,PHYLIP sequential,EDAM,format_1998,http://edamontology.org/format_1998
+Phylip tree distance format,,Phylip tree distance format,EDAM,format_1445,http://edamontology.org/format_1445
+Phylip tree format,,Phylip tree format,EDAM,format_1435,http://edamontology.org/format_1435
+Phylip tree raw,,Phylip tree raw,EDAM,format_1425,http://edamontology.org/format_1425
+Phylogenetic character data format,,Phylogenetic character data format,EDAM,format_2036,http://edamontology.org/format_2036
+Phylogenetic continuous quantitative character format,,Phylogenetic continuous quantitative character format,EDAM,format_2037,http://edamontology.org/format_2037
+Phylogenetic discrete states format,,Phylogenetic discrete states format,EDAM,format_2038,http://edamontology.org/format_2038
+Phylogenetic tree format,,Phylogenetic tree format,EDAM,format_2006,http://edamontology.org/format_2006
+Phylogenetic tree format (text),,Phylogenetic tree format (text),EDAM,format_2556,http://edamontology.org/format_2556
+Phylogenetic tree format (XML),,Phylogenetic tree format (XML),EDAM,format_2557,http://edamontology.org/format_2557
+Phylogenetic tree report (cliques) format,,Phylogenetic tree report (cliques) format,EDAM,format_2039,http://edamontology.org/format_2039
+Phylogenetic tree report (invariants) format,,Phylogenetic tree report (invariants) format,EDAM,format_2040,http://edamontology.org/format_2040
+Phylogenetic tree report (tree distances) format,,Phylogenetic tree report (tree distances) format,EDAM,format_2049,http://edamontology.org/format_2049
+phyloXML,,phyloXML,EDAM,format_3159,http://edamontology.org/format_3159
+Pileup,,Pileup,EDAM,format_3015,http://edamontology.org/format_3015
+pkl,,pkl,EDAM,format_3653,http://edamontology.org/format_3653
+plain text file format,,plain text file format,SWO,SWO_3000043,http://www.ebi.ac.uk/swo/data/SWO_3000043
+plain text format (unformatted),,plain text format (unformatted),EDAM,format_1964,http://edamontology.org/format_1964
+PlasMapper TextMap,,PlasMapper TextMap,EDAM,format_1861,http://edamontology.org/format_1861
+pmc,,pmc,EDAM,format_1739,http://edamontology.org/format_1739
+PMML,,PMML,EDAM,format_3726,http://edamontology.org/format_3726
+PNG,,PNG,EDAM,format_3603,http://edamontology.org/format_3603
+PO,,PO,EDAM,format_3330,http://edamontology.org/format_3330
+ppm,,ppm,EDAM,format_3596,http://edamontology.org/format_3596
+pptx,,pptx,EDAM,format_3838,http://edamontology.org/format_3838
+PRIDE XML,,PRIDE XML,EDAM,format_3684,http://edamontology.org/format_3684
+Primer3 primer,,Primer3 primer,EDAM,format_1627,http://edamontology.org/format_1627
+proBAM,,proBAM,EDAM,format_3826,http://edamontology.org/format_3826
+proBED,,proBED,EDAM,format_3827,http://edamontology.org/format_3827
+ProQ report format,,ProQ report format,EDAM,format_1552,http://edamontology.org/format_1552
+prosite-pattern,,prosite-pattern,EDAM,format_1356,http://edamontology.org/format_1356
+prosite-profile,,prosite-profile,EDAM,format_1366,http://edamontology.org/format_1366
+protein,,protein,EDAM,format_1208,http://edamontology.org/format_1208
+Protein domain classification format,,Protein domain classification format,EDAM,format_3097,http://edamontology.org/format_3097
+Protein family report format,,Protein family report format,EDAM,format_2052,http://edamontology.org/format_2052
+Protein interaction format,,Protein interaction format,EDAM,format_2054,http://edamontology.org/format_2054
+Protein report format,,Protein report format,EDAM,format_2062,http://edamontology.org/format_2062
+Protein secondary structure format,,Protein secondary structure format,EDAM,format_2077,http://edamontology.org/format_2077
+Protein structure report (quality evaluation) format,,Protein structure report (quality evaluation) format,EDAM,format_2065,http://edamontology.org/format_2065
+protXML,,protXML,EDAM,format_3747,http://edamontology.org/format_3747
+PS,,PS,EDAM,format_3696,http://edamontology.org/format_3696
+psd,,psd,EDAM,format_3597,http://edamontology.org/format_3597
+PSI MI TAB (MITAB),,PSI MI TAB (MITAB),EDAM,format_3242,http://edamontology.org/format_3242
+PSI MI XML (MIF),,PSI MI XML (MIF),EDAM,format_3158,http://edamontology.org/format_3158
+PSI-PAR,,PSI-PAR,EDAM,format_3243,http://edamontology.org/format_3243
+PSL,,PSL,EDAM,format_3007,http://edamontology.org/format_3007
+PubAnnotation format,,PubAnnotation format,EDAM,format_3781,http://edamontology.org/format_3781
+PubMed citation,,PubMed citation,EDAM,format_1734,http://edamontology.org/format_1734
+PubTator format,,PubTator format,EDAM,format_3783,http://edamontology.org/format_3783
+pure,,pure,EDAM,format_2094,http://edamontology.org/format_2094
+pure dna,,pure dna,EDAM,format_1215,http://edamontology.org/format_1215
+pure nucleotide,,pure nucleotide,EDAM,format_1210,http://edamontology.org/format_1210
+pure protein,,pure protein,EDAM,format_1219,http://edamontology.org/format_1219
+pure rna,,pure rna,EDAM,format_1217,http://edamontology.org/format_1217
+qcML,,qcML,EDAM,format_3683,http://edamontology.org/format_3683
+qual,,qual,EDAM,format_3607,http://edamontology.org/format_3607
+qual454,,qual454,EDAM,format_3611,http://edamontology.org/format_3611
+qualillumina,,qualillumina,EDAM,format_3609,http://edamontology.org/format_3609
+qualsolexa,,qualsolexa,EDAM,format_3608,http://edamontology.org/format_3608
+qualsolid,,qualsolid,EDAM,format_3610,http://edamontology.org/format_3610
+Query language,,Query language,EDAM,format_3787,http://edamontology.org/format_3787
+quicktandem,,quicktandem,EDAM,format_1295,http://edamontology.org/format_1295
+R data frame,,R data frame,SWO,SWO_0000409,http://www.ebi.ac.uk/swo/SWO_0000409
+R file format,,R file format,EDAM,format_3554,http://edamontology.org/format_3554
+rast,,rast,EDAM,format_3605,http://edamontology.org/format_3605
+raw,,raw,EDAM,format_1957,http://edamontology.org/format_1957
+Raw CATH domain classification format,,Raw CATH domain classification format,EDAM,format_3099,http://edamontology.org/format_3099
+Raw microarray data format,,Raw microarray data format,EDAM,format_3828,http://edamontology.org/format_3828
+Raw NMR data format,,Raw NMR data format,EDAM,format_3824,http://edamontology.org/format_3824
+Raw SCOP domain classification format,,Raw SCOP domain classification format,EDAM,format_3098,http://edamontology.org/format_3098
+Raw sequence format,,Raw sequence format,EDAM,format_2571,http://edamontology.org/format_2571
+rcc,,rcc,EDAM,format_3580,http://edamontology.org/format_3580
+rda,,rda,SWO,SWO_0000684,http://www.ebi.ac.uk/swo/SWO_0000684
+RDF format,,RDF format,EDAM,format_2376,http://edamontology.org/format_2376
+RDF-XML,,RDF-XML,SWO,SWO_3000007,http://www.ebi.ac.uk/swo/data/SWO_3000007
+RDF/XML,,RDF/XML,EDAM,format_3261,http://edamontology.org/format_3261
+REBASE restriction sites,,REBASE restriction sites,EDAM,format_1320,http://edamontology.org/format_1320
+refseqp,,refseqp,EDAM,format_1958,http://edamontology.org/format_1958
+Relaxed PHYLIP Interleaved,,Relaxed PHYLIP Interleaved,EDAM,format_3819,http://edamontology.org/format_3819
+Relaxed PHYLIP Sequential,,Relaxed PHYLIP Sequential,EDAM,format_3820,http://edamontology.org/format_3820
+restover format,,restover format,EDAM,format_1319,http://edamontology.org/format_1319
+restrict format,,restrict format,EDAM,format_1318,http://edamontology.org/format_1318
+rgb,,rgb,EDAM,format_3600,http://edamontology.org/format_3600
+rna,,rna,EDAM,format_1213,http://edamontology.org/format_1213
+RNA secondary structure format,,RNA secondary structure format,EDAM,format_2076,http://edamontology.org/format_2076
+RNAML,,RNAML,EDAM,format_3311,http://edamontology.org/format_3311
+Rnw,,Rnw,SWO,SWO_0000363,http://www.ebi.ac.uk/swo/SWO_0000363
+RSF,,RSF,EDAM,format_3485,http://edamontology.org/format_3485
+SAM,,SAM,EDAM,format_2573,http://edamontology.org/format_2573
+SAMPLE file format,,SAMPLE file format,EDAM,format_3813,http://edamontology.org/format_3813
+Sanger inverted repeats,,Sanger inverted repeats,EDAM,format_1296,http://edamontology.org/format_1296
+SBGN-ML,,SBGN-ML,EDAM,format_3692,http://edamontology.org/format_3692
+SBML,,SBML,EDAM,format_2585,http://edamontology.org/format_2585
+SBMLR format,,SBMLR format,SWO,SWO_0000378,http://www.ebi.ac.uk/swo/SWO_0000378
+SBOL,,SBOL,EDAM,format_3725,http://edamontology.org/format_3725
+SBRML,,SBRML,EDAM,format_3155,http://edamontology.org/format_3155
+SBtab,,SBtab,EDAM,format_3688,http://edamontology.org/format_3688
+SCF,,SCF,EDAM,format_1632,http://edamontology.org/format_1632
+scores format,,scores format,EDAM,format_1999,http://edamontology.org/format_1999
+SDF,,SDF,EDAM,format_3814,http://edamontology.org/format_3814
+SDF format,,SDF format,SWO,SWO_0000381,http://www.ebi.ac.uk/swo/SWO_0000381
+SED-ML,,SED-ML,EDAM,format_3685,http://edamontology.org/format_3685
+selex,,selex,EDAM,format_2000,http://edamontology.org/format_2000
+Sequence annotation track format,,Sequence annotation track format,EDAM,format_2919,http://edamontology.org/format_2919
+Sequence assembly format,,Sequence assembly format,EDAM,format_2055,http://edamontology.org/format_2055
+Sequence assembly format (text),,Sequence assembly format (text),EDAM,format_2561,http://edamontology.org/format_2561
+Sequence cluster format,,Sequence cluster format,EDAM,format_2170,http://edamontology.org/format_2170
+Sequence cluster format (nucleic acid),,Sequence cluster format (nucleic acid),EDAM,format_2172,http://edamontology.org/format_2172
+Sequence cluster format (protein),,Sequence cluster format (protein),EDAM,format_2171,http://edamontology.org/format_2171
+Sequence distance matrix format,,Sequence distance matrix format,EDAM,format_2067,http://edamontology.org/format_2067
+Sequence feature annotation format,,Sequence feature annotation format,EDAM,format_1920,http://edamontology.org/format_1920
+Sequence feature table format,,Sequence feature table format,EDAM,format_2548,http://edamontology.org/format_2548
+Sequence feature table format (text),,Sequence feature table format (text),EDAM,format_2206,http://edamontology.org/format_2206
+Sequence feature table format (XML),,Sequence feature table format (XML),EDAM,format_2553,http://edamontology.org/format_2553
+Sequence features (repeats) format,,Sequence features (repeats) format,EDAM,format_2155,http://edamontology.org/format_2155
+Sequence motif format,,Sequence motif format,EDAM,format_2068,http://edamontology.org/format_2068
+Sequence profile format,,Sequence profile format,EDAM,format_2069,http://edamontology.org/format_2069
+Sequence quality report format (text),,Sequence quality report format (text),EDAM,format_3606,http://edamontology.org/format_3606
+Sequence range format,,Sequence range format,EDAM,format_2078,http://edamontology.org/format_2078
+Sequence record format,,Sequence record format,EDAM,format_1919,http://edamontology.org/format_1919
+Sequence record format (text),,Sequence record format (text),EDAM,format_2551,http://edamontology.org/format_2551
+Sequence record format (XML),,Sequence record format (XML),EDAM,format_2552,http://edamontology.org/format_2552
+Sequence trace format,,Sequence trace format,EDAM,format_2057,http://edamontology.org/format_2057
+Sequence variation annotation format,,Sequence variation annotation format,EDAM,format_2921,http://edamontology.org/format_2921
+Sequence-MEME profile alignment,,Sequence-MEME profile alignment,EDAM,format_1419,http://edamontology.org/format_1419
+Sequence-profile alignment format,,Sequence-profile alignment format,EDAM,format_2014,http://edamontology.org/format_2014
+SEQUEST .out file,,SEQUEST .out file,EDAM,format_3758,http://edamontology.org/format_3758
+Sequin format,,Sequin format,EDAM,format_3701,http://edamontology.org/format_3701
+SFF,,SFF,EDAM,format_3284,http://edamontology.org/format_3284
+sif,,sif,EDAM,format_3619,http://edamontology.org/format_3619
+SIF,,SIF,SWO,SWO_3000049,http://www.ebi.ac.uk/swo/data/SWO_3000049
+smarts,,smarts,EDAM,format_1200,http://edamontology.org/format_1200
+SMILES,,SMILES,EDAM,format_1196,http://edamontology.org/format_1196
+Smith-Waterman format,,Smith-Waterman format,EDAM,format_1335,http://edamontology.org/format_1335
+snpeffdb,,snpeffdb,EDAM,format_3624,http://edamontology.org/format_3624
+SPARQL,,SPARQL,EDAM,format_3790,http://edamontology.org/format_3790
+spML,,spML,EDAM,format_3250,http://edamontology.org/format_3250
+SPSS,,SPSS,EDAM,format_3555,http://edamontology.org/format_3555
+SQL,,SQL,EDAM,format_3788,http://edamontology.org/format_3788
+SQLite format,,SQLite format,EDAM,format_3621,http://edamontology.org/format_3621
+SRA format,,SRA format,EDAM,format_3698,http://edamontology.org/format_3698
+SRF,,SRF,EDAM,format_3017,http://edamontology.org/format_3017
+srs format,,srs format,EDAM,format_2002,http://edamontology.org/format_2002
+srspair,,srspair,EDAM,format_2003,http://edamontology.org/format_2003
+SS,,SS,EDAM,format_3310,http://edamontology.org/format_3310
+Staden experiment format,,Staden experiment format,EDAM,format_1928,http://edamontology.org/format_1928
+Staden format,,Staden format,EDAM,format_1960,http://edamontology.org/format_1960
+Stockholm format,,Stockholm format,EDAM,format_1961,http://edamontology.org/format_1961
+strider format,,strider format,EDAM,format_1962,http://edamontology.org/format_1962
+STRING entry format (XML),,STRING entry format (XML),EDAM,format_2304,http://edamontology.org/format_2304
+SVG,,SVG,EDAM,format_3604,http://edamontology.org/format_3604
+T-Coffee format,,T-Coffee format,EDAM,format_2004,http://edamontology.org/format_2004
+tab delimited file format,,tab delimited file format,SWO,SWO_3000046,http://www.ebi.ac.uk/swo/data/SWO_3000046
+tabix,,tabix,EDAM,format_3616,http://edamontology.org/format_3616
+Tabix index file format,,Tabix index file format,EDAM,format_3700,http://edamontology.org/format_3700
+taverna workflow format,,taverna workflow format,EDAM,format_1665,http://edamontology.org/format_1665
+Tertiary structure format,,Tertiary structure format,EDAM,format_2033,http://edamontology.org/format_2033
+Text mining report format,,Text mining report format,EDAM,format_2021,http://edamontology.org/format_2021
+Textual format,,Textual format,EDAM,format_2330,http://edamontology.org/format_2330
+Thermo RAW,,Thermo RAW,EDAM,format_3712,http://edamontology.org/format_3712
+TIDE TXT,,TIDE TXT,EDAM,format_3835,http://edamontology.org/format_3835
+tiff,,tiff,EDAM,format_3591,http://edamontology.org/format_3591
+TraML,,TraML,EDAM,format_3246,http://edamontology.org/format_3246
+TreeBASE format,,TreeBASE format,EDAM,format_1436,http://edamontology.org/format_1436
+TreeCon format,,TreeCon format,EDAM,format_1911,http://edamontology.org/format_1911
+TreeCon-seq,,TreeCon-seq,EDAM,format_2005,http://edamontology.org/format_2005
+TreeFam format,,TreeFam format,EDAM,format_1437,http://edamontology.org/format_1437
+TSV,,TSV,EDAM,format_3475,http://edamontology.org/format_3475
+Turtle,,Turtle,EDAM,format_3255,http://edamontology.org/format_3255
+unambiguous pure,,unambiguous pure,EDAM,format_1206,http://edamontology.org/format_1206
+unambiguous pure dna,,unambiguous pure dna,EDAM,format_1214,http://edamontology.org/format_1214
+unambiguous pure nucleotide,,unambiguous pure nucleotide,EDAM,format_1211,http://edamontology.org/format_1211
+unambiguous pure protein,,unambiguous pure protein,EDAM,format_1218,http://edamontology.org/format_1218
+unambiguous pure rna sequence,,unambiguous pure rna sequence,EDAM,format_1216,http://edamontology.org/format_1216
+unambiguous sequence,,unambiguous sequence,EDAM,format_2096,http://edamontology.org/format_2096
+UniProt-like (text),,UniProt-like (text),EDAM,format_2187,http://edamontology.org/format_2187
+UniProtKB format,,UniProtKB format,EDAM,format_1963,http://edamontology.org/format_1963
+UniProtKB RDF,,UniProtKB RDF,EDAM,format_3771,http://edamontology.org/format_3771
+UniProtKB XML,,UniProtKB XML,EDAM,format_3770,http://edamontology.org/format_3770
+uniprotkb-like format,,uniprotkb-like format,EDAM,format_2547,http://edamontology.org/format_2547
+unpure,,unpure,EDAM,format_2095,http://edamontology.org/format_2095
+VCF,erdera,VCF,EDAM,format_3016,http://edamontology.org/format_3016
+VDB,,VDB,EDAM,format_3699,http://edamontology.org/format_3699
+Vienna local RNA secondary structure format,,Vienna local RNA secondary structure format,EDAM,format_1458,http://edamontology.org/format_1458
+VisML,,VisML,EDAM,format_3821,http://edamontology.org/format_3821
+WIFF format,,WIFF format,EDAM,format_3710,http://edamontology.org/format_3710
+WIG,,WIG,EDAM,format_3005,http://edamontology.org/format_3005
+Workflow format,,Workflow format,EDAM,format_2032,http://edamontology.org/format_2032
+X!Tandem XML,,X!Tandem XML,EDAM,format_3711,http://edamontology.org/format_3711
+xbm,,xbm,EDAM,format_3598,http://edamontology.org/format_3598
+xgmml,,xgmml,EDAM,format_3618,http://edamontology.org/format_3618
+XGMML,,XGMML,SWO,SWO_3000051,http://www.ebi.ac.uk/swo/data/SWO_3000051
+xls,,xls,EDAM,format_3468,http://edamontology.org/format_3468
+xlsx,,xlsx,EDAM,format_3620,http://edamontology.org/format_3620
+XMFA,,XMFA,EDAM,format_3811,http://edamontology.org/format_3811
+XML,,XML,EDAM,format_2332,http://edamontology.org/format_2332
+xpm,,xpm,EDAM,format_3599,http://edamontology.org/format_3599
+XQuery,,XQuery,EDAM,format_3789,http://edamontology.org/format_3789
+xsd,,xsd,EDAM,format_3804,http://edamontology.org/format_3804
+YAML,,YAML,EDAM,format_3750,http://edamontology.org/format_3750
+ZTR,,ZTR,EDAM,format_3018,http://edamontology.org/format_3018

--- a/data/_ontologies/Sequencing methods.csv
+++ b/data/_ontologies/Sequencing methods.csv
@@ -1,48 +1,48 @@
-name,definition,codesystem,code,ontologyTermURI
-Next Generation Sequencing,Next Generation Sequencing,NCIT,C101293,http://purl.obolibrary.org/obo/NCIT_C101293
-Whole Genome Sequencing,Whole Genome Sequencing,NCIT,C101294,http://purl.obolibrary.org/obo/NCIT_C101294
-Whole Exome Sequencing,Whole Exome Sequencing,NCIT,C101295,http://purl.obolibrary.org/obo/NCIT_C101295
-Large-Scale Sequencing,Large-Scale Sequencing,NCIT,C19645,http://purl.obolibrary.org/obo/NCIT_C19645
-454 Sequencing,454 Sequencing,NCIT,C146809,http://purl.obolibrary.org/obo/NCIT_C146809
-ABI SOLiD Sequencing,ABI SOLiD Sequencing,NCIT,C146811,http://purl.obolibrary.org/obo/NCIT_C146811
-BGISEQ-500 Sequencing,BGISEQ-500 Sequencing,NCIT,C146812,http://purl.obolibrary.org/obo/NCIT_C146812
-Capillary Sequencing,Capillary Sequencing,NCIT,C146814,http://purl.obolibrary.org/obo/NCIT_C146814
-Complete Genomics Sequencing,Complete Genomics Sequencing,NCIT,C146815,http://purl.obolibrary.org/obo/NCIT_C146815
-Helicos Sequencing,Helicos Sequencing,NCIT,C146816,http://purl.obolibrary.org/obo/NCIT_C146816
-Illumina Sequencing,Illumina Sequencing,NCIT,C146817,http://purl.obolibrary.org/obo/NCIT_C146817
-Oxford Nanopore Sequencing,Oxford Nanopore Sequencing,NCIT,C146818,http://purl.obolibrary.org/obo/NCIT_C146818
-SMRT Sequencing,SMRT Sequencing,NCIT,C146819,http://purl.obolibrary.org/obo/NCIT_C146819
-Immune Repertoire Deep Sequencing,Immune Repertoire Deep Sequencing,NCIT,C158249,http://purl.obolibrary.org/obo/NCIT_C158249
-Targeted Transcriptome Sequencing,Targeted Transcriptome Sequencing,NCIT,C158252,http://purl.obolibrary.org/obo/NCIT_C158252
-Targeted Genome Sequencing,Targeted Genome Sequencing,NCIT,C158253,http://purl.obolibrary.org/obo/NCIT_C158253
-mRNA Sequencing,mRNA Sequencing,NCIT,C129432,http://purl.obolibrary.org/obo/NCIT_C129432
-Next Generation Targeted Sequencing,Next Generation Targeted Sequencing,NCIT,C130177,http://purl.obolibrary.org/obo/NCIT_C130177
-Sequence-based Typing,Sequence-based Typing,NCIT,C130180,http://purl.obolibrary.org/obo/NCIT_C130180
-Dideoxy Chain Termination DNA Sequencing,Dideoxy Chain Termination DNA Sequencing,NCIT,C19641,http://purl.obolibrary.org/obo/NCIT_C19641
-Shotgun Sequencing,Shotgun Sequencing,NCIT,C19646,http://purl.obolibrary.org/obo/NCIT_C19646
-Whole-Genome Shotgun Sequencing,Whole-Genome Shotgun Sequencing,NCIT,C19653,http://purl.obolibrary.org/obo/NCIT_C19653
-Radioactive Sequencing,Radioactive Sequencing,NCIT,C19658,http://purl.obolibrary.org/obo/NCIT_C19658
-Paired-End Sequencing,Paired-End Sequencing,NCIT,C150423,http://purl.obolibrary.org/obo/NCIT_C150423
-Second-strand Library Sequencing,Second-strand Library Sequencing,NCIT,C150426,http://purl.obolibrary.org/obo/NCIT_C150426
-Unstranded Library Sequencing,Unstranded Library Sequencing,NCIT,C150427,http://purl.obolibrary.org/obo/NCIT_C150427
-First-strand Library Sequencing,First-strand Library Sequencing,NCIT,C150428,http://purl.obolibrary.org/obo/NCIT_C150428
-Whole Transcriptome Sequencing,Whole Transcriptome Sequencing,NCIT,C124261,http://purl.obolibrary.org/obo/NCIT_C124261
-Population Sequencing,Population Sequencing,NCIT,C135457,http://purl.obolibrary.org/obo/NCIT_C135457
-Pyrosequencing,Pyrosequencing,NCIT,C99481,http://purl.obolibrary.org/obo/NCIT_C99481
-Ion Semiconductor Sequencing,Ion Semiconductor Sequencing,NCIT,C125894,http://purl.obolibrary.org/obo/NCIT_C125894
-Nucleic Acid Sequencing,Nucleic Acid Sequencing,NCIT,C18881,http://purl.obolibrary.org/obo/NCIT_C18881
-DNA Resequencing,DNA Resequencing,NCIT,C41254,http://purl.obolibrary.org/obo/NCIT_C41254
-DNA Sequencing,DNA Sequencing,NCIT,C153598,http://purl.obolibrary.org/obo/NCIT_C153598
-MicroRNA Sequencing,MicroRNA Sequencing,NCIT,C156057,http://purl.obolibrary.org/obo/NCIT_C156057
-Reduced Representation Bisulfite Sequencing,Reduced Representation Bisulfite Sequencing,,RRBS,
-Single read,Single read,,SR,
-SR 35-bp,SR 35-bp,,,
-ssRNA-seq,ssRNA-seq,,,
-PE 150-bp,Paired-end 150-bp,,,
-Panel,Gene panel sequencing,,,
-Array,Genotyping array,,,
-sr-RNAseq,Short-read RNA sequencing,EDAM,EDAM:3170,http://edamontology.org/topic_3170
-lr-RNAseq,Long-read RNA sequencing,EDAM,EDAM:3170,http://edamontology.org/topic_3170
-sr-WGS,Short-read Whole Genome Sequencing,NCIT,NCIT:C101294,http://purl.obolibrary.org/obo/NCIT_C101294
-lr-WGS,Long-read Whole Genome Sequencing,NCIT,NCIT:C101294,http://purl.obolibrary.org/obo/NCIT_C101294
-OGM,Optical Genome Mapping,NCIT,NCIT:C116162,http://purl.obolibrary.org/obo/NCIT_C116162
+name,tags,definition,codesystem,code,ontologyTermURI
+Next Generation Sequencing,,Next Generation Sequencing,NCIT,C101293,http://purl.obolibrary.org/obo/NCIT_C101293
+Whole Genome Sequencing,erdera,Whole Genome Sequencing,NCIT,C101294,http://purl.obolibrary.org/obo/NCIT_C101294
+Whole Exome Sequencing,erdera,Whole Exome Sequencing,NCIT,C101295,http://purl.obolibrary.org/obo/NCIT_C101295
+Large-Scale Sequencing,,Large-Scale Sequencing,NCIT,C19645,http://purl.obolibrary.org/obo/NCIT_C19645
+454 Sequencing,,454 Sequencing,NCIT,C146809,http://purl.obolibrary.org/obo/NCIT_C146809
+ABI SOLiD Sequencing,,ABI SOLiD Sequencing,NCIT,C146811,http://purl.obolibrary.org/obo/NCIT_C146811
+BGISEQ-500 Sequencing,,BGISEQ-500 Sequencing,NCIT,C146812,http://purl.obolibrary.org/obo/NCIT_C146812
+Capillary Sequencing,,Capillary Sequencing,NCIT,C146814,http://purl.obolibrary.org/obo/NCIT_C146814
+Complete Genomics Sequencing,,Complete Genomics Sequencing,NCIT,C146815,http://purl.obolibrary.org/obo/NCIT_C146815
+Helicos Sequencing,,Helicos Sequencing,NCIT,C146816,http://purl.obolibrary.org/obo/NCIT_C146816
+Illumina Sequencing,,Illumina Sequencing,NCIT,C146817,http://purl.obolibrary.org/obo/NCIT_C146817
+Oxford Nanopore Sequencing,,Oxford Nanopore Sequencing,NCIT,C146818,http://purl.obolibrary.org/obo/NCIT_C146818
+SMRT Sequencing,,SMRT Sequencing,NCIT,C146819,http://purl.obolibrary.org/obo/NCIT_C146819
+Immune Repertoire Deep Sequencing,,Immune Repertoire Deep Sequencing,NCIT,C158249,http://purl.obolibrary.org/obo/NCIT_C158249
+Targeted Transcriptome Sequencing,,Targeted Transcriptome Sequencing,NCIT,C158252,http://purl.obolibrary.org/obo/NCIT_C158252
+Targeted Genome Sequencing,,Targeted Genome Sequencing,NCIT,C158253,http://purl.obolibrary.org/obo/NCIT_C158253
+mRNA Sequencing,,mRNA Sequencing,NCIT,C129432,http://purl.obolibrary.org/obo/NCIT_C129432
+Next Generation Targeted Sequencing,,Next Generation Targeted Sequencing,NCIT,C130177,http://purl.obolibrary.org/obo/NCIT_C130177
+Sequence-based Typing,,Sequence-based Typing,NCIT,C130180,http://purl.obolibrary.org/obo/NCIT_C130180
+Dideoxy Chain Termination DNA Sequencing,,Dideoxy Chain Termination DNA Sequencing,NCIT,C19641,http://purl.obolibrary.org/obo/NCIT_C19641
+Shotgun Sequencing,,Shotgun Sequencing,NCIT,C19646,http://purl.obolibrary.org/obo/NCIT_C19646
+Whole-Genome Shotgun Sequencing,,Whole-Genome Shotgun Sequencing,NCIT,C19653,http://purl.obolibrary.org/obo/NCIT_C19653
+Radioactive Sequencing,,Radioactive Sequencing,NCIT,C19658,http://purl.obolibrary.org/obo/NCIT_C19658
+Paired-End Sequencing,,Paired-End Sequencing,NCIT,C150423,http://purl.obolibrary.org/obo/NCIT_C150423
+Second-strand Library Sequencing,,Second-strand Library Sequencing,NCIT,C150426,http://purl.obolibrary.org/obo/NCIT_C150426
+Unstranded Library Sequencing,,Unstranded Library Sequencing,NCIT,C150427,http://purl.obolibrary.org/obo/NCIT_C150427
+First-strand Library Sequencing,,First-strand Library Sequencing,NCIT,C150428,http://purl.obolibrary.org/obo/NCIT_C150428
+Whole Transcriptome Sequencing,,Whole Transcriptome Sequencing,NCIT,C124261,http://purl.obolibrary.org/obo/NCIT_C124261
+Population Sequencing,,Population Sequencing,NCIT,C135457,http://purl.obolibrary.org/obo/NCIT_C135457
+Pyrosequencing,,Pyrosequencing,NCIT,C99481,http://purl.obolibrary.org/obo/NCIT_C99481
+Ion Semiconductor Sequencing,,Ion Semiconductor Sequencing,NCIT,C125894,http://purl.obolibrary.org/obo/NCIT_C125894
+Nucleic Acid Sequencing,,Nucleic Acid Sequencing,NCIT,C18881,http://purl.obolibrary.org/obo/NCIT_C18881
+DNA Resequencing,,DNA Resequencing,NCIT,C41254,http://purl.obolibrary.org/obo/NCIT_C41254
+DNA Sequencing,,DNA Sequencing,NCIT,C153598,http://purl.obolibrary.org/obo/NCIT_C153598
+MicroRNA Sequencing,,MicroRNA Sequencing,NCIT,C156057,http://purl.obolibrary.org/obo/NCIT_C156057
+Reduced Representation Bisulfite Sequencing,,Reduced Representation Bisulfite Sequencing,,RRBS,
+Single read,,Single read,,SR,
+SR 35-bp,,SR 35-bp,,,
+ssRNA-seq,,ssRNA-seq,,,
+PE 150-bp,,Paired-end 150-bp,,,
+Panel,,Gene panel sequencing,,,
+Array,,Genotyping array,,,
+srRNA,erdera,Short-read RNA sequencing,EDAM,EDAM:3170,http://edamontology.org/topic_3170
+lrRNA,erdera,Long-read RNA sequencing,EDAM,EDAM:3170,http://edamontology.org/topic_3170
+srGS,erdera,Short-read Whole Genome Sequencing,NCIT,NCIT:C101294,http://purl.obolibrary.org/obo/NCIT_C101294
+lrGS,erdera,Long-read Whole Genome Sequencing,NCIT,NCIT:C101294,http://purl.obolibrary.org/obo/NCIT_C101294
+OGM,erdera,Optical Genome Mapping,NCIT,NCIT:C116162,http://purl.obolibrary.org/obo/NCIT_C116162


### PR DESCRIPTION

### What are the main changes you did

This PR fixes the following aspects of the RD3 model

- [x] Processes.individuals: added missing required property for individuals
- [x] Ontologies.FileFormats: added ERDERA tag
- [x] Ontologies.SequencingMethods: added ERDERA tag

This PR is part of molgenis/GCC#2499

### How to test

- Create a new schema using the `PATIENT_REGISTRY` template and include demo data. Please use the name `erdera`
- In the `CatalogueOntologies` schema, go to-
    - File formats: search for the "ERDERA" tag
    - Sequencing methods: search for the "ERDERA" tag
- Create a new schema using the `PATIENT_REGISTRY_STAGING` template
     -  Go to any of the Experiments table and click on the add row button.
     - Confirm that the field "Individuals" is not required

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
