### PR TITLE
fix: catalogue paging

### DIFF
--- a/apps/tailwind-components/app/components/Pagination.vue
+++ b/apps/tailwind-components/app/components/Pagination.vue
@@ -15,12 +15,14 @@ const props = withDefaults(
     inverted?: boolean;
     jumpToEdge?: boolean;
     showPageSelector?: boolean;
+    showPageSizeSelector?: boolean;
   }>(),
   {
     preventDefault: false,
     inverted: false,
     jumpToEdge: false,
     showPageSelector: true,
+    showPageSizeSelector: false,
     pageSize: constants.PAGE_SIZE_DEFAULT,
   }
 );
@@ -179,7 +181,7 @@ function changeCurrentPage(event: Event) {
         </a>
       </li>
 
-      <li class="flex justify-center items-center">
+      <li class="flex justify-center items-center" v-if="showPageSizeSelector">
         <div class="px-4 tracking-widest sm:px-5 whitespace-nowrap">
           <span
             class="text-pagination"
@@ -192,7 +194,7 @@ function changeCurrentPage(event: Event) {
         </div>
       </li>
 
-      <li class="flex justify-center items-center">
+      <li class="flex justify-center items-center" v-if="showPageSizeSelector">
         <div class="tracking-widest whitespace-nowrap w-32">
           <span
             class="text-pagination"

--- a/apps/tailwind-components/app/components/input/Select.vue
+++ b/apps/tailwind-components/app/components/input/Select.vue
@@ -24,7 +24,7 @@ const emit = defineEmits(["update:modelValue", "focus"]);
         $emit('update:modelValue', ($event.target as HTMLSelectElement).value)
     "
     :id="id"
-    class="w-full pr-16 font-sans text-black text-gray-300 bg-white rounded-search-input h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input search-input-mobile border border-transparent border-r-8 outline outline-1 outline-select"
+    class="w-full pr-16 text-black text-gray-300 bg-white rounded-search-input h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input search-input-mobile border border-transparent border-r-8 outline outline-1 outline-select"
     :class="{ 'border-red-500 text-red-500': invalid }"
   >
     <option disabled value="" :selected="modelValue === ''">

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -161,7 +161,7 @@
   </div>
 
   <Pagination
-    v-if="count > settings.pageSize || settings.page > 1"
+    v-if="count > smallestPageSize"
     class="pt-[30px] pb-[30px]"
     :current-page="settings.page"
     :totalPages="Math.ceil(count / settings.pageSize)"
@@ -423,6 +423,14 @@ function handleSearchRequest(search: string) {
   settings.value.page = 1;
   refresh();
 }
+
+const smallestPageSize = computed(() =>
+  Math.min(
+    ...constants.PAGE_SIZE_OPTIONS.filter(
+      (size) => size >= settings.value.pageSize
+    )
+  )
+);
 
 function handlePagingRequest(page: number) {
   settings.value.page = page;

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -161,7 +161,7 @@
   </div>
 
   <Pagination
-    v-if="count > settings.pageSize"
+    v-if="count > settings.pageSize || settings.page > 1"
     class="pt-[30px] pb-[30px]"
     :current-page="settings.page"
     :totalPages="Math.ceil(count / settings.pageSize)"

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -161,12 +161,13 @@
   </div>
 
   <Pagination
+    v-if="count > settings.pageSize"
     class="pt-[30px] pb-[30px]"
     :current-page="settings.page"
     :totalPages="Math.ceil(count / settings.pageSize)"
     :jump-to-edge="true"
-    :show-page-selector="count > settings.pageSize"
     :page-size="settings.pageSize"
+    :show-page-size-selector="true"
     @update="handlePagingRequest($event)"
     @update:pageSize="handlePageSizeChange($event)"
   />

--- a/apps/tailwind-components/app/pages/Pagination.story.vue
+++ b/apps/tailwind-components/app/pages/Pagination.story.vue
@@ -8,6 +8,7 @@
     @update="updatePage"
   />
 
+  <p>jumpToEdge = true:</p>
   <Pagination
     :currentPage="24"
     :totalPages="999"
@@ -16,11 +17,13 @@
     @update="updatePage"
   />
 
+  <p>showPageSizeSelector = true:</p>
   <Pagination
     :currentPage="24"
     :totalPages="999"
     :preventDefault="true"
     :jumpToEdge="true"
+    :showPageSizeSelector="true"
     @update="updatePage"
   />
 

--- a/apps/tailwind-components/tests/vitest/components/__snapshots__/Pagination.spec.ts.snap
+++ b/apps/tailwind-components/tests/vitest/components/__snapshots__/Pagination.spec.ts.snap
@@ -19,12 +19,8 @@ exports[`should render the pagination component with jump to edge 1`] = `
     <li><a href="#" class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to last page</span>
         <!---->
       </a></li>
-    <li class="flex justify-center items-center">
-      <div class="px-4 tracking-widest sm:px-5 whitespace-nowrap"><span class="text-pagination">with size</span></div>
-    </li>
-    <li class="flex justify-center items-center">
-      <div class="tracking-widest whitespace-nowrap w-32"><span class="text-pagination"><select modelvalue="20" id="page-size-select" class="w-full pr-16 font-sans text-black text-gray-300 bg-white rounded-search-input h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input search-input-mobile border border-transparent border-r-8 outline outline-1 outline-select !p-0 text-center border border-input rounded-theme !bg-input text-pagination-input !hover:text-pagination-hover hover:outline-pagination-hover hover:bg-pagination-hover h-15 flex items-center tracking-widest" required=""><option disabled="" value="">Select an option</option><option value="10">10</option><option selected="" value="20">20</option><option value="50">50</option><option value="100">100</option></select></span></div>
-    </li>
+    <!--v-if-->
+    <!--v-if-->
   </ul>
 </nav>"
 `;


### PR DESCRIPTION
### What are the main changes you did

Changed to paging component default behaviour to not show ( hide ) the page size selector by default 
This fixed issue where the page size selector was show without connecting the event to the data fetcher ( see #https://github.com/molgenis/GCC/issues/2825) 

- add prop to toggle page size selector
- fix select font to have consistent font style
- update usage in table explorer

- fix font style 
- fix issue there page size selector is show without page selectors ( example: table explorer table contains 3 rows and page size if set to 20)

Closes #https://github.com/molgenis/GCC/issues/2825

### How to test
- see issue
- compare font style with style in master , see that the pr uses the same font style for the selected page and the page size ( the master show inconsistent font style)


### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
