### PR TITLE
fix(mg-components): close breadcrumbs schema select on click outide

### DIFF
--- a/apps/molgenis-components/package.json
+++ b/apps/molgenis-components/package.json
@@ -33,6 +33,7 @@
   "dependencies": {
     "@fortawesome/fontawesome-free": "^6.4.2",
     "@popperjs/core": "2.11.8",
+    "@vueuse/components": "10.7.0",
     "@vueuse/core": "10.7.0",
     "@vueuse/integrations": "10.7.0",
     "axios": "1.15.0",

--- a/apps/molgenis-components/src/components/layout/Breadcrumb.vue
+++ b/apps/molgenis-components/src/components/layout/Breadcrumb.vue
@@ -24,7 +24,15 @@
               class="text-primary dropdown-toggle dropdown-toggle-split pr-0"
               @click="toggleDropdown"
             />
-            <div class="dropdown-menu" :class="{ show: showDropdown }">
+            <div
+              class="dropdown-menu"
+              :class="{ show: showDropdown }"
+              v-on-click-outside="
+                () => {
+                  showDropdown = false;
+                }
+              "
+            >
               <InputSearch
                 id="breadcrumb-dropdown-search"
                 v-model="dropdownSearch"
@@ -65,12 +73,16 @@
 <script>
 import InputSearch from "../forms/InputSearch.vue";
 import { RouterLink } from "vue-router";
+import { vOnClickOutside } from "@vueuse/components";
 
 export default {
   name: "Breadcrumb",
   components: {
     InputSearch,
     RouterLink,
+  },
+  directives: {
+    "on-click-outside": vOnClickOutside,
   },
   props: {
     /* list of crumbs, map of  {'label':'url'} */

--- a/apps/pnpm-lock.yaml
+++ b/apps/pnpm-lock.yaml
@@ -62,7 +62,7 @@ importers:
         version: 10.7.0(vue@3.5.22(typescript@5.6.2))
       floating-vue:
         specifier: 5.2.2
-        version: 5.2.2(@nuxt/kit@4.4.2(magicast@0.5.2))(vue@3.5.22(typescript@5.6.2))
+        version: 5.2.2(@nuxt/kit@3.21.2(magicast@0.5.2))(vue@3.5.22(typescript@5.6.2))
       graphql:
         specifier: 16.12.0
         version: 16.12.0
@@ -600,6 +600,9 @@ importers:
       '@popperjs/core':
         specifier: 2.11.8
         version: 2.11.8
+      '@vueuse/components':
+        specifier: 10.7.0
+        version: 10.7.0(vue@3.5.22(typescript@5.6.2))
       '@vueuse/core':
         specifier: 10.7.0
         version: 10.7.0(vue@3.5.22(typescript@5.6.2))
@@ -977,7 +980,7 @@ importers:
         version: 3.2.3
       floating-vue:
         specifier: 5.2.2
-        version: 5.2.2(@nuxt/kit@3.21.2(magicast@0.5.2))(vue@3.5.22(typescript@5.6.2))
+        version: 5.2.2(@nuxt/kit@4.4.2(magicast@0.5.2))(vue@3.5.22(typescript@5.6.2))
       focus-trap:
         specifier: ^8.0.0
         version: 8.0.0
@@ -3853,6 +3856,9 @@ packages:
     engines: {node: '>=18.12.0'}
     peerDependencies:
       vue: '>=3.3.0'
+
+  '@vueuse/components@10.7.0':
+    resolution: {integrity: sha512-ycyF+fZtipP/8WVWZ5y6Cb9twJ0EeVHIqcqkCcTpmAJdheRjorT8v6cHk3h144HHTMgIfBWC6TaSukDG7QFmsw==}
 
   '@vueuse/components@12.8.2':
     resolution: {integrity: sha512-Nj27u1KsDWzoTthlChzVndJ9g0sW5APCXO3EJkSxlG11nN/ANTUlPPeoJOFvtbdDRnvsMJalboJyE0rRyg7yNg==}
@@ -12050,6 +12056,15 @@ snapshots:
     dependencies:
       date-fns: 4.1.0
       vue: 3.5.22(typescript@5.6.2)
+
+  '@vueuse/components@10.7.0(vue@3.5.22(typescript@5.6.2))':
+    dependencies:
+      '@vueuse/core': 10.7.0(vue@3.5.22(typescript@5.6.2))
+      '@vueuse/shared': 10.7.0(vue@3.5.22(typescript@5.6.2))
+      vue-demi: 0.14.10(vue@3.5.22(typescript@5.6.2))
+    transitivePeerDependencies:
+      - '@vue/composition-api'
+      - vue
 
   '@vueuse/components@12.8.2(typescript@5.6.2)':
     dependencies:


### PR DESCRIPTION
fix(molgenis-components): close breadcrumbs schema select on click outside

Closes #https://github.com/molgenis/molgenis-emx2/issues/6199

### What are the main changes you did
- add usevue directive to add missing close functionality 

### How to test
- see issue
- open the dropdown, click outside the dropdown -> it closes 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
