### PR TITLE
fix(tw): table-explorer row action empty column hover

### DIFF
--- a/apps/tailwind-components/app/components/table/CellEMX2.vue
+++ b/apps/tailwind-components/app/components/table/CellEMX2.vue
@@ -104,12 +104,11 @@
         />
       </template>
       <template v-else>
-        <span></span>
+        <span class="min-h-4 inline-block"></span>
       </template>
     </slot>
   </td>
 </template>
-
 <script setup lang="ts">
 import type {
   columnValue,


### PR DESCRIPTION


### What are the main changes you did
- add style to set minimum empty column height
### How to test
- compare the on hover row actions styling when the fist column is empty or has a value. In both cases the row actions should be place in the center of the row 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
