### PR TITLE
fix(tw): fix 6189 update cache key for api change

### DIFF
--- a/apps/ui/app/pages/[schema]/index.vue
+++ b/apps/ui/app/pages/[schema]/index.vue
@@ -42,7 +42,7 @@ interface Schema {
 }
 
 const { data } = await useFetch<Resp<Schema>>(`/${schema}/graphql`, {
-  key: "tables",
+  key: `fetch-tables-for-${schema}`,
   method: "POST",
   body: {
     query: `{_schema{id,label,tables{id,label,tableType,description}}}`,


### PR DESCRIPTION
### What are the main changes you did
update use for query key for updated nuxt api
default behaviour is now to cache request, so key should include schema name to allow refresh on schema change

Closes #https://github.com/molgenis/molgenis-emx2/issues/6189

### How to test
- see steps in issue https://github.com/molgenis/molgenis-emx2/issues/6189

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
