### PR TITLE
chore: send preview slack notification after restart completed

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -203,16 +203,6 @@ jobs:
             sleep 10
           done
 
-    - run:
-        name: message slack about preview
-        command: |
-          export $( cat build/ci.properties | xargs )
-          curl -d "token=${SLACK_TOKEN}" \
-          -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
-          PR Preview available on https://preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}.dev.molgenis.org" \
-          -d "channel=C02AZDG6QQ7" \
-          -X POST https://slack.com/api/chat.postMessage
-
     - post_steps
 
   test:
@@ -429,6 +419,33 @@ jobs:
           export $( cat build/ci.properties | xargs )
           bash ci/set_kubectl_config-azure.sh molgenis-emx2-13.79.1-SNAPSHOT-all.jar molgenis-emx2-13.79.1-SNAPSHOT-all.jar
           bash ci/create_or_update_k8s-azure.sh "preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}" ${TAG_NAME} true false
+
+    - run:
+        name: Wait for pr preview restart, poll every 10 seconds
+        command: |
+          GETURL="https://preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}.dev.molgenis.org/directory-demo/directory/"           
+          while true; 
+              do 
+                  STATUS=$(curl --silent --head $GETURL | awk '/^HTTP/{print $2}')
+                  echo ${STATUS} ${GETURL}
+                  if [[ "$STATUS" == "200" ]]; then 
+                      echo "test data is loaded";
+                      break; 
+                  else 
+                      echo "preview is not ready yet, waiting 10 seconds...";
+                  fi; 
+                  sleep 10; 
+              done
+
+    - run:
+        name: message slack about preview
+        command: |
+          export $( cat build/ci.properties | xargs )
+          curl -d "token=${SLACK_TOKEN}" \
+          -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
+          PR Preview available on https://preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}.dev.molgenis.org" \
+          -d "channel=C02AZDG6QQ7" \
+          -X POST https://slack.com/api/chat.postMessage
 
     - post_steps
 


### PR DESCRIPTION
### What are the main changes you did

move notification until after restart ( and wait for server to be up and demo-data loaded ) 

Closes #https://github.com/molgenis/GCC/issues/2822

### How to test
- inspect the preview output ( see issue for details )

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
