### PR TITLE
fix: command for the parse icons script

### DIFF
--- a/apps/tailwind-components/package.json
+++ b/apps/tailwind-components/package.json
@@ -17,7 +17,7 @@
     "coverage": "vitest run --coverage",
     "test-ci": "vitest run",
     "e2e": "playwright test",
-    "parse-icons": "node ../node_modules/svgo/bin/svgo -f ./app/assets/icons -o ./app/assets/minified-icons --config ./svgo.config.cjs && node ./scripts/create_vue_components_from_icons.cjs",
+    "parse-icons": "node ../node_modules/.pnpm/svgo@2.8.2/node_modules/svgo/bin/svgo -f ./app/assets/icons -o ./app/assets/minified-icons --config ./svgo.config.cjs && node ./scripts/create_vue_components_from_icons.cjs",
     "typecheck": "nuxi typecheck"
   },
   "dependencies": {


### PR DESCRIPTION
### What are the main changes you did
- fixes the command to parse icons to the tailwind library
- Note that this does not fix current issues with the script, it just makes it work again. See also https://github.com/molgenis/GCC/issues/2865

### How to test
- go to the tailwind-components folder and run `pnpm parse-icons`
- See that the script runs without error

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
