### PR TITLE
fix: remove warning when running

### DIFF
--- a/apps/tailwind-components/nuxt.config.ts
+++ b/apps/tailwind-components/nuxt.config.ts
@@ -59,17 +59,7 @@ export default defineNuxtConfig({
     },
   },
 
-  components: [
-    {
-      path: "~/components/global/icons",
-      global: true,
-    },
-    {
-      path: "~/components/viz",
-      pathPrefix: false,
-    },
-    "~/components",
-  ],
+  components: ["~/components"],
 
   runtimeConfig: {
     public: {

--- a/apps/tailwind-components/nuxt.config.ts
+++ b/apps/tailwind-components/nuxt.config.ts
@@ -59,8 +59,6 @@ export default defineNuxtConfig({
     },
   },
 
-  components: ["~/components"],
-
   runtimeConfig: {
     public: {
       apiBase: "https://emx2.dev.molgenis.org/",


### PR DESCRIPTION
### What are the main changes you did
-gets rid of reference to non-existent folder warnings during next build

### How to test
- run `pnpm build` or `pnpm dev` in the catalogue or ui folder, 
- (no longer) see the warning below:
``` WARN  Components directory not found: /home/git/molgenis-emx2/apps/catalogue/app/components/global/icons                                                                                                                                                                  nuxt 9:59:22 AM
 WARN  Components directory not found: /home/git/molgenis-emx2/apps/catalogue/app/components/viz                                                                                                                                                                           nuxt 9:59:22 AM
 ```

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
