### PR TITLE
fix(data): remove file attachment check for row that is deleted with `mg_delete=true`

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/InMemoryTableAndFileStore.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/InMemoryTableAndFileStore.java
@@ -1,0 +1,21 @@
+package org.molgenis.emx2.io.tablestore;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.molgenis.emx2.BinaryFileWrapper;
+
+public class InMemoryTableAndFileStore extends TableStoreForCsvInMemory
+    implements TableAndFileStore {
+
+  Map<String, byte[]> data = new HashMap<>();
+
+  @Override
+  public void writeFile(String fileName, byte[] binary) {
+    data.put(fileName, binary);
+  }
+
+  @Override
+  public BinaryFileWrapper getBinaryFileWrapper(String name) {
+    return new BinaryFileWrapper("bytes", name, data.get(name));
+  }
+}

--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessor.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessor.java
@@ -36,12 +36,12 @@ public class ImportRowProcessor implements RowProcessor {
       }
 
       boolean isDrop = row.getValueMap().get(MG_DELETE) != null && row.getBoolean(MG_DELETE);
-      addFileAttachmentsToRow(source, columns, row, index);
 
-      if (!isDrop) {
-        importBatch.add(row);
-      } else {
+      if (isDrop) {
         deleteBatch.add(row);
+      } else {
+        addFileAttachmentsToRow(source, columns, row, index);
+        importBatch.add(row);
       }
       index++;
 

--- a/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessorTest.java
+++ b/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessorTest.java
@@ -1,8 +1,10 @@
 package org.molgenis.emx2.io.tablestore.processor;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.molgenis.emx2.Column.column;
-import static org.molgenis.emx2.Row.*;
+import static org.molgenis.emx2.Query.Option.INCLUDE_FILE_CONTENTS;
+import static org.molgenis.emx2.Row.row;
 
 import java.util.List;
 import java.util.Map;
@@ -69,7 +71,8 @@ class ImportRowProcessorTest {
     ImportRowProcessor processor = new ImportRowProcessor(table, task);
     processor.process(rows.iterator(), store);
 
-    List<Map<String, Object>> list = table.retrieveRows().stream().map(Row::getValueMap).toList();
+    List<Map<String, Object>> list =
+        table.retrieveRows(INCLUDE_FILE_CONTENTS).stream().map(Row::getValueMap).toList();
     assertEquals(1, list.size());
     Map<String, Object> uploadedRow = list.getFirst();
 
@@ -78,7 +81,7 @@ class ImportRowProcessorTest {
     assertEquals("txt", uploadedRow.get("passport_extension"));
     assertEquals("bytes", uploadedRow.get("passport_mimetype"));
     assertEquals(11, uploadedRow.get("passport_size"));
-    //    assertEquals("Hello world", new String((byte[]) uploadedRow.get("passport_contents")));
+    assertEquals("Hello world", new String((byte[]) uploadedRow.get("passport_contents")));
     Pattern hexPattern = Pattern.compile("\\p{XDigit}{32}");
     assertTrue(hexPattern.matcher(uploadedRow.get("passport").toString()).find());
   }

--- a/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessorTest.java
+++ b/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessorTest.java
@@ -86,6 +86,32 @@ class ImportRowProcessorTest {
     assertTrue(hexPattern.matcher(uploadedRow.get("passport").toString()).find());
   }
 
+  @Test
+  void givenRow_whenDropping_skipAddFileAttachmentsToRow() {
+    table.getMetadata().add(column("passport").setType(ColumnType.FILE));
+    List<Row> insertRows = List.of(row("name", "Lewis", "passport", "passport_example.txt"));
+
+    Task task = new Task();
+
+    InMemoryTableAndFileStore store = new InMemoryTableAndFileStore();
+    store.writeFile("passport_example.txt", "Hello world".getBytes());
+    ImportRowProcessor processor = new ImportRowProcessor(table, task);
+    processor.process(insertRows.iterator(), store);
+
+    List<Map<String, Object>> list = table.retrieveRows().stream().map(Row::getValueMap).toList();
+    assertEquals(1, list.size());
+
+    List<Row> deleteRows =
+        List.of(row("name", "Lewis", "passport", "passport_example.txt", "mg_delete", "true"));
+    task = new Task();
+    store = new InMemoryTableAndFileStore();
+    processor = new ImportRowProcessor(table, task);
+    processor.process(deleteRows.iterator(), store);
+
+    list = table.retrieveRows().stream().map(Row::getValueMap).toList();
+    assertEquals(0, list.size());
+  }
+
   private List<Map<String, Object>> importRows(Row... rows) {
     Task task = new Task();
     ImportRowProcessor processor = new ImportRowProcessor(table, task);

--- a/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessorTest.java
+++ b/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessorTest.java
@@ -6,11 +6,13 @@ import static org.molgenis.emx2.Row.*;
 
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Pattern;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.*;
+import org.molgenis.emx2.io.tablestore.InMemoryTableAndFileStore;
 import org.molgenis.emx2.io.tablestore.TableStoreForCsvInMemory;
 import org.molgenis.emx2.sql.TestDatabaseFactory;
 import org.molgenis.emx2.tasks.Task;
@@ -53,6 +55,32 @@ class ImportRowProcessorTest {
         importRows(row("name", "Lewis"), row(), row("name", null), row("name", "Marnie"));
     List<Map<String, String>> expected = List.of(Map.of("name", "Lewis"), Map.of("name", "Marnie"));
     assertEquals(expected, actual);
+  }
+
+  @Test
+  void givenRow_whenNotDropping_thenAddFileAttachmentsToRow() {
+    table.getMetadata().add(column("passport").setType(ColumnType.FILE));
+    List<Row> rows = List.of(row("name", "Lewis", "passport", "passport_example.txt"));
+
+    Task task = new Task();
+
+    InMemoryTableAndFileStore store = new InMemoryTableAndFileStore();
+    store.writeFile("passport_example.txt", "Hello world".getBytes());
+    ImportRowProcessor processor = new ImportRowProcessor(table, task);
+    processor.process(rows.iterator(), store);
+
+    List<Map<String, Object>> list = table.retrieveRows().stream().map(Row::getValueMap).toList();
+    assertEquals(1, list.size());
+    Map<String, Object> uploadedRow = list.getFirst();
+
+    assertEquals("Lewis", uploadedRow.get("name"));
+    assertEquals("passport_example.txt", uploadedRow.get("passport_filename"));
+    assertEquals("txt", uploadedRow.get("passport_extension"));
+    assertEquals("bytes", uploadedRow.get("passport_mimetype"));
+    assertEquals(11, uploadedRow.get("passport_size"));
+    //    assertEquals("Hello world", new String((byte[]) uploadedRow.get("passport_contents")));
+    Pattern hexPattern = Pattern.compile("\\p{XDigit}{32}");
+    assertTrue(hexPattern.matcher(uploadedRow.get("passport").toString()).find());
   }
 
   private List<Map<String, Object>> importRows(Row... rows) {

--- a/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessorTest.java
+++ b/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/tablestore/processor/ImportRowProcessorTest.java
@@ -3,6 +3,7 @@ package org.molgenis.emx2.io.tablestore.processor;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.molgenis.emx2.Column.column;
+import static org.molgenis.emx2.Constants.MG_DELETE;
 import static org.molgenis.emx2.Query.Option.INCLUDE_FILE_CONTENTS;
 import static org.molgenis.emx2.Row.row;
 
@@ -102,14 +103,15 @@ class ImportRowProcessorTest {
     assertEquals(1, list.size());
 
     List<Row> deleteRows =
-        List.of(row("name", "Lewis", "passport", "passport_example.txt", "mg_delete", "true"));
+        List.of(row("name", "Lewis", "passport", "passport_example.txt", MG_DELETE, "true"));
     task = new Task();
+    // test that row with file is deleted without supplying the files in a store
     store = new InMemoryTableAndFileStore();
     processor = new ImportRowProcessor(table, task);
     processor.process(deleteRows.iterator(), store);
 
     list = table.retrieveRows().stream().map(Row::getValueMap).toList();
-    assertEquals(0, list.size());
+    assertTrue(list.isEmpty());
   }
 
   private List<Map<String, Object>> importRows(Row... rows) {


### PR DESCRIPTION
### What are the main changes you did
The `ImportRowProcessor` expects a file attachment when uploading a row containing a _file_ column even if this row is marked for deletion with `mg_delete=true`. 
This PR removes the addition of the file attachment in the `ImportRowProcessor` for such records.
### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
