### PR TITLE
fix(tw): display pagination if more rows than minimum rows per page

### DIFF
--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -300,6 +300,7 @@ import TableCellDetailRef from "./cellDetail/TableCellDetailRef.vue";
 import { toRefColumn, toRefColumnValue } from "../../utils/typeUtils";
 import constants from "../../utils/constants";
 import TableEMX2Head from "./TableEMX2Head.vue";
+import type { s } from "vitest/dist/chunks/reporters.QZ837uWx.js";
 
 const props = withDefaults(
   defineProps<{
@@ -498,8 +499,8 @@ function handlePagingRequest(page: number) {
   refresh();
 }
 
-function handlePageSizeChange(pageSize: number) {
-  settings.value.pageSize = pageSize;
+function handlePageSizeChange(pageSize: string) {
+  settings.value.pageSize = Number.parseInt(pageSize);
   settings.value.page = 1;
   refresh();
 }

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -259,16 +259,16 @@
 import {
   computed,
   nextTick,
+  onMounted,
+  onUnmounted,
   ref,
   useId,
   watch,
-  onMounted,
-  onUnmounted,
 } from "vue";
 import type {
-  IRow,
-  IColumn,
   columnValue,
+  IColumn,
+  IRow,
 } from "../../../../metadata-utils/src/types";
 import type {
   cellPayload,
@@ -285,22 +285,21 @@ import { fetchTableData, fetchTableMetadata } from "#imports";
 
 import TableCellEMX2 from "./CellEMX2.vue";
 
-import EditModal from "../form/EditModal.vue";
 import DeleteModal from "../form/DeleteModal.vue";
-import Modal from "../Modal.vue";
+import EditModal from "../form/EditModal.vue";
 import InputSearch from "../input/Search.vue";
+import Modal from "../Modal.vue";
 
-import Button from "../Button.vue";
-import Pagination from "../Pagination.vue";
-import TableControlColumns from "./control/Columns.vue";
-import TextNoResultsMessage from "../text/NoResultsMessage.vue";
-import DraftLabel from "../label/DraftLabel.vue";
 import { useColumnResize } from "../../composables/useColumnResize";
-import TableCellDetailRef from "./cellDetail/TableCellDetailRef.vue";
-import { toRefColumn, toRefColumnValue } from "../../utils/typeUtils";
 import constants from "../../utils/constants";
+import { toRefColumn, toRefColumnValue } from "../../utils/typeUtils";
+import Button from "../Button.vue";
+import DraftLabel from "../label/DraftLabel.vue";
+import Pagination from "../Pagination.vue";
+import TextNoResultsMessage from "../text/NoResultsMessage.vue";
+import TableCellDetailRef from "./cellDetail/TableCellDetailRef.vue";
+import TableControlColumns from "./control/Columns.vue";
 import TableEMX2Head from "./TableEMX2Head.vue";
-import type { s } from "vitest/dist/chunks/reporters.QZ837uWx.js";
 
 const props = withDefaults(
   defineProps<{

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -268,7 +268,6 @@ import {
 import type {
   IRow,
   IColumn,
-  IRefColumn,
   columnValue,
 } from "../../../../metadata-utils/src/types";
 import type {
@@ -327,7 +326,6 @@ const cellDetailSubtitle = ref<string>();
 const cellDetailValue = ref<columnValue>();
 const columns = ref<IColumn[]>([]);
 const showStickyHeader = ref(false);
-const stickyHeaderOffset = ref(0);
 const tableContainer = ref<HTMLElement | null>(null);
 const tableHeaderFixed = ref<HTMLElement | null>(null);
 const tableHead = ref<HTMLElement | null>(null);
@@ -381,7 +379,6 @@ onUnmounted(async () => {
 });
 
 function handleStickyHeaderScroll(event: Event) {
-  const target = event.target as HTMLElement;
   const rect = tableContainer?.value?.getBoundingClientRect();
   const top = rect?.top ?? 0;
   showStickyHeader.value = top <= 0;
@@ -430,7 +427,7 @@ const rows = computed(() =>
 );
 
 const showDraftColumn = computed(() =>
-  rows.value.some((row) => row?.mg_draft === true)
+  rows.value.some((row: IRow) => row?.mg_draft === true)
 );
 
 const count = computed(() => data.value?.tableData?.count ?? 0);
@@ -450,7 +447,7 @@ watch(
   (newMetadata) => {
     if (newMetadata) {
       columns.value = newMetadata.columns.filter(
-        (c) =>
+        (c: IColumn) =>
           !c.id.startsWith("mg") &&
           !["HEADING", "SECTION"].includes(c.columnType)
       );
@@ -493,11 +490,7 @@ function handleSearchRequest(search: string) {
 }
 
 const smallestPageSize = computed(() =>
-  Math.min(
-    ...constants.PAGE_SIZE_OPTIONS.filter(
-      (size) => size >= settings.value.pageSize
-    )
-  )
+  Math.min(...constants.PAGE_SIZE_OPTIONS)
 );
 
 function handlePagingRequest(page: number) {


### PR DESCRIPTION
### What are the main changes you did
- Fixes the problem that the pagination is not displayed when there are less than the current page size of rows.
- The intended behaviour: display the pagination if there are more rows than the minimum per page (10), even is they all fit on the screen with the current page size.

### How to test
- Go to, or create, a table with >10 and <20 rows (tw ui).
- See that the pagination is available and can be used.

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
