### PR TITLE
fix: when updating rows with a ref array, if the list is null, replace with an empty array

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/utils/TypeUtils.java
@@ -551,14 +551,13 @@ public class TypeUtils {
 
   protected static void convertRefArrayToRow(
       List<Map<String, Object>> list, Row row, Column column) {
-    if (list == null) return;
     List<Reference> refs = column.getReferences();
     for (Reference ref : refs) {
       if (!ref.isOverlapping()) {
-        if (!list.isEmpty()) {
-          row.set(ref.getName(), getRefValueFromList(ref.getPath(), list));
+        if (list == null || list.isEmpty()) {
+          row.set(ref.getName(), null);
         } else {
-          row.set(ref.getName(), new ArrayList<>());
+          row.set(ref.getName(), getRefValueFromList(ref.getPath(), list));
         }
       }
     }

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTypeUtils.java
@@ -1,7 +1,9 @@
 package org.molgenis.emx2;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.molgenis.emx2.Column.column;
 import static org.molgenis.emx2.ColumnTypeGroups.*;
+import static org.molgenis.emx2.TableMetadata.table;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
@@ -169,6 +171,21 @@ class TestTypeUtils {
   @Test
   void testAllColumnTypesCoveredToJooqType() {
     EXCLUDE_REFERENCE_HEADING.forEach(TypeUtils::toJooqType);
+  }
+
+  @Test
+  void givenNullRefArrayValue_whenConvertingToRow_thenSetEmptyList() {
+    SchemaMetadata schema = new SchemaMetadata("test");
+    schema.create(
+        table("Tag", column("id").setType(ColumnType.STRING).setKey(1)),
+        table("Resource", column("tags").setType(ColumnType.REF_ARRAY).setRefTable("Tag")));
+
+    Column tagsColumn = schema.getTableMetadata("Resource").getColumn("tags");
+    Row row = new Row();
+    TypeUtils.addFieldObjectToRow(tagsColumn, null, row);
+
+    assertTrue(row.containsName("tags"), "field should be present even when input list is null");
+    assertEquals(null, row.getValueMap().get("tags"));
   }
 
   @Test


### PR DESCRIPTION
Addresses https://github.com/molgenis/GCC/issues/2821

### What are the main changes you did
- Null and empty lists are both mapped to null in the database for ref_arrays

### How to test
- unit test
- Execute reproduce steps in issue: https://github.com/molgenis/GCC/issues/2821

### Checklist
- [ ] updated docs in case of new feature
- [X] added/updated tests
- [X] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
