### PR TITLE
fix(tw-explorer): displayed row numbering

### DIFF
--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -159,7 +159,7 @@
       </table>
       <div
         class="sticky left-0 flex justify-center items-center py-2.5"
-        v-if="!rows"
+        v-if="!rows.length"
       >
         <TextNoResultsMessage
           class="w-full text-center"

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -172,9 +172,7 @@
   <div
     class="p-2.5 text-right font-normal align-middle text-table-column-header"
   >
-    Showing {{ (settings.page - 1) * settings.pageSize + 1 }} to
-    {{ Math.min(settings.page * settings.pageSize, count) }} of
-    {{ count }} items
+    {{ countMessage }}
   </div>
 
   <Pagination
@@ -296,13 +294,14 @@ import Modal from "../Modal.vue";
 
 import { useColumnResize } from "../../composables/useColumnResize";
 import constants from "../../utils/constants";
+import { getCountMessage } from "../../utils/getCountMessage";
+import { isArrayLikeDetail, isRefLikeDetail } from "../../utils/refUtils";
 import { toRefColumn, toRefColumnValue } from "../../utils/typeUtils";
 import Button from "../Button.vue";
 import DraftLabel from "../label/DraftLabel.vue";
 import Pagination from "../Pagination.vue";
 import TextNoResultsMessage from "../text/NoResultsMessage.vue";
 import TableCellDetailRef from "./cellDetail/TableCellDetailRef.vue";
-import { isRefLikeDetail, isArrayLikeDetail } from "../../utils/refUtils";
 import TableControlColumns from "./control/Columns.vue";
 import TableEMX2Head from "./TableEMX2Head.vue";
 
@@ -382,6 +381,10 @@ onUnmounted(async () => {
   window.removeEventListener("scroll", handleStickyHeaderScroll);
   window.removeEventListener("resize", updateStickyHeaderWidth);
 });
+
+const countMessage = computed(() =>
+  getCountMessage(settings.value.page, settings.value.pageSize, count.value)
+);
 
 function handleStickyHeaderScroll(event: Event) {
   const rect = tableContainer?.value?.getBoundingClientRect();

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -159,7 +159,7 @@
       </table>
       <div
         class="sticky left-0 flex justify-center items-center py-2.5"
-        v-if="!rows.length"
+        v-if="!rows?.length"
       >
         <TextNoResultsMessage
           class="w-full text-center"

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -172,7 +172,7 @@
   <div
     class="p-2.5 text-right font-normal align-middle text-table-column-header"
   >
-    Showing {{ (settings.page - 1) * settings.pageSize }} to
+    Showing {{ (settings.page - 1) * settings.pageSize + 1 }} to
     {{ Math.min(settings.page * settings.pageSize, count) }} of
     {{ count }} items
   </div>

--- a/apps/tailwind-components/app/utils/getCountMessage.ts
+++ b/apps/tailwind-components/app/utils/getCountMessage.ts
@@ -1,0 +1,13 @@
+export function getCountMessage(
+  page: number,
+  pageSize: number,
+  totalCount: number
+) {
+  if (totalCount === 0) {
+    return "";
+  }
+
+  const start = (page - 1) * pageSize + 1;
+  const end = Math.min(page * pageSize, totalCount);
+  return `Showing ${start} to ${end} of ${totalCount} items`;
+}

--- a/apps/tailwind-components/tests/vitest/utils/getCountMessage.spec.ts
+++ b/apps/tailwind-components/tests/vitest/utils/getCountMessage.spec.ts
@@ -1,0 +1,24 @@
+import { expect, it, describe } from "vitest";
+import { getCountMessage } from "../../../app/utils/getCountMessage";
+
+describe("getCountMessage", () => {
+  it("should return correct message for page 1", () => {
+    expect(getCountMessage(1, 10, 50)).toBe("Showing 1 to 10 of 50 items");
+  });
+
+  it("should return correct message for page 2", () => {
+    expect(getCountMessage(2, 10, 50)).toBe("Showing 11 to 20 of 50 items");
+  });
+
+  it("should return correct message for last page with fewer items", () => {
+    expect(getCountMessage(5, 10, 45)).toBe("Showing 41 to 45 of 45 items");
+  });
+
+  it("should return correct message when totalCount is less than pageSize", () => {
+    expect(getCountMessage(1, 10, 5)).toBe("Showing 1 to 5 of 5 items");
+  });
+
+  it("should return correct message when totalCount is zero", () => {
+    expect(getCountMessage(1, 10, 0)).toBe("");
+  });
+});


### PR DESCRIPTION
### What are the main changes you did
- 1: The the current displayed rowed indexing was displaying an off-by-one number e.g. `Showing 0 to 20 of 110 items ` it should display `Showing 1 to 20 of 110 items`.
- 2: The no rows found message is not displaying if a table has no rows.

### How to test 1
- Go to the tw ui
- Go to the catalogue
- Go to the resources table
- Check at the bottom of the table if the number of displayed rows is correct
- optionally: use the pagination to change the page size or the page number to check if the number is still correct

### How to test 2
- Go to the tw ui
- Go to the catalogue
- Go to the Samplesets table
- A message `No records found` should display 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
