### PR TITLE
ref: change QueryGenerator#generate return type to String

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/generators/query/TableQueryGenerator.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/generators/query/TableQueryGenerator.java
@@ -24,7 +24,7 @@ public class TableQueryGenerator {
   private static final Variable ANY_OBJECT = SparqlBuilder.var("anyObject");
   private static final Variable TYPE_VARIABLE = SparqlBuilder.var("_type_");
 
-  public SelectQuery generate(TableMetadata tableMetadata) {
+  public String generate(TableMetadata tableMetadata) {
     List<Projectable> selectors = new ArrayList<>();
     List<GraphPattern> whereClauses = new ArrayList<>();
     List<Groupable> groups = new ArrayList<>();
@@ -62,7 +62,8 @@ public class TableQueryGenerator {
     return query
         .select(selectors.toArray(new Projectable[0]))
         .where(whereClauses.toArray(new GraphPattern[0]))
-        .groupBy(groups.toArray(new Groupable[0]));
+        .groupBy(groups.toArray(new Groupable[0]))
+        .getQueryString();
   }
 
   private static boolean hasSemantics(String[] semantics) {

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
@@ -38,14 +38,27 @@ class SparqlQueryingExampleTest {
         });
   }
 
+  /**
+   * Manual test that executes a SPARQL SELECT query from a file against a Turtle RDF dataset
+   * loaded from a file, writing the results to a CSV file.
+   *
+   * <p>To use this test:
+   * <ol>
+   *   <li>Set {@code absoluteQueryPath} to the absolute path of a file containing a SPARQL SELECT query.</li>
+   *   <li>Set {@code absoluteTtlPath} to the absolute path of a file containing RDF data in Turtle (.ttl) format.</li>
+   *   <li>Results will be written to {@code results.csv} in the working directory.</li>
+   * </ol>
+   */
   @Disabled("Used for manual testing purposes")
   @Test
   void fileBasedTest() {
     assertDoesNotThrow(
         () -> {
+          // Absolute path of a file containing a SPARQL SELECT query.
           String absoluteQueryPath = "";
           String query = new String(new FileInputStream(absoluteQueryPath).readAllBytes());
 
+          // Absolute path of a file containing RDF data in Turtle (.ttl) format.
           String absoluteTtlPath = "";
           SailRepository repository = setupRepositoryFromFile(absoluteTtlPath);
 

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
@@ -39,14 +39,17 @@ class SparqlQueryingExampleTest {
   }
 
   /**
-   * Manual test that executes a SPARQL SELECT query from a file against a Turtle RDF dataset
-   * loaded from a file, writing the results to a CSV file.
+   * Manual test that executes a SPARQL SELECT query from a file against a Turtle RDF dataset loaded
+   * from a file, writing the results to a CSV file.
    *
    * <p>To use this test:
+   *
    * <ol>
-   *   <li>Set {@code absoluteQueryPath} to the absolute path of a file containing a SPARQL SELECT query.</li>
-   *   <li>Set {@code absoluteTtlPath} to the absolute path of a file containing RDF data in Turtle (.ttl) format.</li>
-   *   <li>Results will be written to {@code results.csv} in the working directory.</li>
+   *   <li>Set {@code absoluteQueryPath} to the absolute path of a file containing a SPARQL SELECT
+   *       query.
+   *   <li>Set {@code absoluteTtlPath} to the absolute path of a file containing RDF data in Turtle
+   *       (.ttl) format.
+   *   <li>Results will be written to {@code results.csv} in the working directory.
    * </ol>
    */
   @Disabled("Used for manual testing purposes")

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
@@ -9,7 +9,6 @@ import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.rio.RDFFormat;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
-import org.eclipse.rdf4j.sparqlbuilder.core.query.SelectQuery;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.Database;
@@ -34,8 +33,8 @@ class SparqlQueryingExampleTest {
           SchemaMetadata schema =
               TestDatabaseFactory.getTestDatabase().getSchema("harvesting").getMetadata();
           TableQueryGenerator generator = new TableQueryGenerator();
-          SelectQuery query = generator.generate(schema.getTableMetadata("Collections"));
-          System.out.println(query.getQueryString());
+          String query = generator.generate(schema.getTableMetadata("Collections"));
+          System.out.println(query);
         });
   }
 

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/TableQueryGeneratorTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/TableQueryGeneratorTest.java
@@ -47,16 +47,15 @@ class TableQueryGeneratorTest {
                     .setType(ColumnType.STRING)
                     .setPkey()
                     .setSemantics("xsd:name")));
-    SelectQuery generate = new TableQueryGenerator().generate(table);
-    String query = removePrefixesFromQuery(generate.getQueryString());
+    String query = new TableQueryGenerator().generate(table);
     assertEquals(
         """
-              SELECT ?TableSemantics ?name
-              WHERE { ?TableSemantics ?anyPredicate ?anyObject .
-              ?TableSemantics xsd:name ?name . }
-              GROUP BY ?TableSemantics ?name
-              """,
-        query);
+        SELECT ?TableSemantics ?name
+        WHERE { ?TableSemantics ?anyPredicate ?anyObject .
+        ?TableSemantics xsd:name ?name . }
+        GROUP BY ?TableSemantics ?name
+        """,
+        removePrefixesFromQuery(query));
   }
 
   @Test
@@ -71,8 +70,7 @@ class TableQueryGeneratorTest {
                         .setSemantics("xsd:name"))
                 .setSemantics());
 
-    SelectQuery generate = new TableQueryGenerator().generate(table);
-    String query = removePrefixesFromQuery(generate.getQueryString());
+    String query = new TableQueryGenerator().generate(table);
     assertEquals(
         """
                   SELECT ?TableSemantics ?name
@@ -80,7 +78,7 @@ class TableQueryGeneratorTest {
                   ?TableSemantics xsd:name ?name . }
                   GROUP BY ?TableSemantics ?name
                   """,
-        query);
+        removePrefixesFromQuery(query));
   }
 
   @Test
@@ -95,8 +93,7 @@ class TableQueryGeneratorTest {
                         .setSemantics("xsd:name"))
                 .setSemantics("xsd:foo", "xsd:bar"));
 
-    SelectQuery generate = new TableQueryGenerator().generate(table);
-    String query = removePrefixesFromQuery(generate.getQueryString());
+    String query = new TableQueryGenerator().generate(table);
     assertEquals(
         """
         SELECT ?TableSemantics ?name
@@ -109,7 +106,7 @@ class TableQueryGeneratorTest {
         }
 
         """,
-        query);
+        removePrefixesFromQuery(query));
   }
 
   @Test
@@ -124,8 +121,7 @@ class TableQueryGeneratorTest {
                         .setSemantics("xsd:name"))
                 .setSemantics("xsd:foo"));
 
-    SelectQuery generate = new TableQueryGenerator().generate(table);
-    String query = removePrefixesFromQuery(generate.getQueryString());
+    String query = new TableQueryGenerator().generate(table);
     assertEquals(
         """
             SELECT ?TableSemantics ?name
@@ -133,7 +129,7 @@ class TableQueryGeneratorTest {
             ?TableSemantics xsd:name ?name . }
             GROUP BY ?TableSemantics ?name
             """,
-        query);
+        removePrefixesFromQuery(query));
   }
 
   @Test
@@ -152,7 +148,7 @@ class TableQueryGeneratorTest {
                     .setSemantics("xsd:bar"),
                 Column.column("baz").setType(ColumnType.STRING).setPkey().setSemantics("xsd:baz")));
 
-    SelectQuery generate = new TableQueryGenerator().generate(table);
+    String query = new TableQueryGenerator().generate(table);
     assertEquals(
         """
         SELECT ?QueryOptionals ?foo ?bar ?baz
@@ -162,7 +158,7 @@ class TableQueryGeneratorTest {
         ?QueryOptionals xsd:baz ?baz . }
         GROUP BY ?QueryOptionals ?foo ?bar ?baz
         """,
-        removePrefixesFromQuery(generate.getQueryString()));
+        removePrefixesFromQuery(query));
   }
 
   @Test
@@ -176,15 +172,15 @@ class TableQueryGeneratorTest {
                     .setPkey()
                     .setSemantics("xsd:name")));
 
-    SelectQuery generate = new TableQueryGenerator().generate(table);
+    String query = new TableQueryGenerator().generate(table);
     assertEquals(
-        removePrefixesFromQuery(generate.getQueryString()),
         """
       SELECT ?Propogation ?name
       WHERE { ?Propogation ?anyPredicate ?anyObject .
       ?Propogation xsd:name ?name . }
       GROUP BY ?Propogation ?name
-      """);
+      """,
+        removePrefixesFromQuery(query));
   }
 
   @Test
@@ -195,20 +191,20 @@ class TableQueryGeneratorTest {
                 "Propogation",
                 Column.column("names").setType(ColumnType.STRING_ARRAY).setSemantics("xsd:name")));
 
-    SelectQuery generate = new TableQueryGenerator().generate(table);
+    String query = new TableQueryGenerator().generate(table);
     assertEquals(
-        removePrefixesFromQuery(generate.getQueryString()),
         """
           SELECT ?Propogation ( GROUP_CONCAT( DISTINCT STR( ?names_single ) ; SEPARATOR = ',' ) AS ?names )
           WHERE { ?Propogation ?anyPredicate ?anyObject .
           OPTIONAL { ?Propogation xsd:name ?names_single . } }
           GROUP BY ?Propogation
-          """);
+          """,
+        removePrefixesFromQuery(query));
   }
 
   @Test
   void shouldPropagateReferences() {
-    SelectQuery query = new TableQueryGenerator().generate(order);
+    String query = new TableQueryGenerator().generate(order);
 
     assertEquals(
         """
@@ -219,7 +215,7 @@ class TableQueryGeneratorTest {
         ?product xsd:name ?product__name . }
         GROUP BY ?Order ?id ?product__name
         """,
-        removePrefixesFromQuery(query.getQueryString()));
+        removePrefixesFromQuery(query));
   }
 
   private String removePrefixesFromQuery(String query) {
@@ -233,7 +229,7 @@ class TableQueryGeneratorTest {
 
     String prefixes = select.getQueryString().replace("SELECT * \n" + "WHERE {}", "").trim();
     TableQueryGenerator generator = new TableQueryGenerator();
-    String actualQuery = generator.generate(order).getQueryString();
+    String actualQuery = generator.generate(order);
     assertTrue(actualQuery.startsWith(prefixes));
   }
 
@@ -247,12 +243,12 @@ class TableQueryGeneratorTest {
 
     Schema petSchema = database.getSchema(schemaName);
     Table pet = petSchema.getTable("Pet");
-    SelectQuery generate = new TableQueryGenerator().generate(pet.getMetadata());
     SailRepository repository = setupRepositoryFromFile("queries/pets.ttl");
     TupleQuery query =
         repository
             .getConnection()
-            .prepareTupleQuery(QueryLanguage.SPARQL, generate.getQueryString());
+            .prepareTupleQuery(
+                QueryLanguage.SPARQL, new TableQueryGenerator().generate(pet.getMetadata()));
 
     StringWriter writer = new StringWriter();
     query.evaluate(new SPARQLResultsCSVWriter(writer));


### PR DESCRIPTION
### What are the main changes you did
Change QueryGenerator#generate return type to String instead of SelectQuery to remove SparqlBuilder dependency in interface, making it more interoperable.


### How to test
- backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
- backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/TableQueryGeneratorTest.java

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
