### PR TITLE
fix(rd3): add forgotten RNA tag in ontology

### DIFF
--- a/data/_ontologies/Library layout.csv
+++ b/data/_ontologies/Library layout.csv
@@ -1,3 +1,3 @@
 name,definition,tags
-SINGLE,Single-end reads,"erdera,lrGS"
-PAIRED,Paired-end reads,
+SINGLE,Single-end reads,"erdera,lrGS,RNA"
+PAIRED,Paired-end reads,"erdera,RNA"


### PR DESCRIPTION
### What are the main changes you did
An RNA tag was forgotten in the `library layout` ontology. Both ontology options need to be in the RNA template. 

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
