### PR TITLE
chore: restored viz e2e tests

### DIFF
--- a/apps/tailwind-components/app/components/viz/ChartLegend/ChartLegend.vue
+++ b/apps/tailwind-components/app/components/viz/ChartLegend/ChartLegend.vue
@@ -66,6 +66,7 @@
 
 <script setup lang="ts">
 import { ref } from "vue";
+import ChartLegendMarker from "./ChartLegendMarker.vue";
 
 interface ILegendProps {
   legendId: string;

--- a/apps/tailwind-components/app/pages/viz/ChartLegend.story.vue
+++ b/apps/tailwind-components/app/pages/viz/ChartLegend.story.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
+import ChartLegend from "../../../app/components/viz/ChartLegend/ChartLegend.vue";
 
 const stackLegend = ref<boolean>(false);
 const legendMarkerShape = ref<"circle" | "square">("circle");

--- a/apps/tailwind-components/tests/e2e/components/viz/ColumnChart.spec.ts
+++ b/apps/tailwind-components/tests/e2e/components/viz/ColumnChart.spec.ts
@@ -8,9 +8,8 @@ const route = playwrightConfig?.use?.baseURL?.startsWith("http://localhost")
 test.describe("ColumnChart", { tag: "@tw-components @tw-viz" }, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`${route}viz/ColumnChart.story`);
-    await page
-      .getByRole("heading", { name: "VizColumnChart" })
-      .click({ delay: 500 });
+    const title = await page.getByRole("heading", { name: "VizColumnChart" });
+    await title.waitFor();
   });
 
   test("columns and labels are rendered:", async ({ page }) => {

--- a/apps/tailwind-components/tests/e2e/components/viz/PieChart.spec.ts
+++ b/apps/tailwind-components/tests/e2e/components/viz/PieChart.spec.ts
@@ -8,7 +8,8 @@ const route = playwrightConfig?.use?.baseURL?.startsWith("http://localhost")
 test.describe("PieChart", { tag: "@tw-components @tw-viz" }, () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(`${route}viz/PieChart.story`);
-    await expect(page.locator("#pie-chart-demo")).toBeVisible();
+    const title = await page.getByRole("heading", { name: "VizPieChart" });
+    await title.waitFor();
   });
 
   test("segements and labels are rendered", async ({ page }) => {
@@ -30,9 +31,10 @@ test.describe("PieChart", { tag: "@tw-components @tw-viz" }, () => {
   });
 
   test("legend is rendered", async ({ page }) => {
-    await expect(page.locator("#pie-chart-demo")).toMatchAriaSnapshot(
-      `- img: Group A48% Group B32% Group C11% Other9%`
-    );
+    const itemMarkers = await page.locator("ul.list-style-none li svg").all();
+    const itemText = await page.locator("ul.list-style-none li span").all();
+    expect(itemMarkers.length).toEqual(4);
+    expect(itemText.length).toEqual(4);
   });
 
   test("hovering emphasizes corresponding segment", async ({ page }) => {


### PR DESCRIPTION
### What are the main changes you did

PR #6290 provided a temporary fix for the failing viz tests. The real issue was the missing imports in the ChartLegend component which was likely caused by an update to the dependencies or recent changes to the vite configuration. (It is quite strange that the tests did not fail sooner). This PR addresses this issue and restores the e2e tests to the previous version.

- [x] Resolved missing import in ChartLegend component
- [x] Restored PieChart test to original version (I prefer not to use screenshots to evaluate the component)
- [x] implemented `waitFor` in other viz tests (this is the preferred method as opposed to using `delay`)

### How to test

- All CI jobs should pass

### Checklist

- ~updated docs in case of new feature~
- [x] added/updated tests
- ~added/updated testplan to include a test for this fix, including ref to bug using # notation~

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
