### PR TITLE
feat(catalogue): 5611 use acronym instead of id in list of catalogues

### DIFF
--- a/apps/catalogue/app/components/content/ContentBlockCatalogues.vue
+++ b/apps/catalogue/app/components/content/ContentBlockCatalogues.vue
@@ -48,7 +48,7 @@ defineProps<{
             <NuxtLink :to="`/${catalogue.id}`">
               <span
                 class="text-body-base font-extrabold text-link hover:underline hover:bg-link-hover"
-                >{{ catalogue.acronym ?? catalogue.id }}</span
+                >{{ catalogue.acronym || catalogue.id }}</span
               >
             </NuxtLink>
           </TableCell>

--- a/apps/catalogue/app/components/content/ContentBlockCatalogues.vue
+++ b/apps/catalogue/app/components/content/ContentBlockCatalogues.vue
@@ -48,7 +48,7 @@ defineProps<{
             <NuxtLink :to="`/${catalogue.id}`">
               <span
                 class="text-body-base font-extrabold text-link hover:underline hover:bg-link-hover"
-                >{{ catalogue.id }}</span
+                >{{ catalogue.acronym ?? catalogue.id }}</span
               >
             </NuxtLink>
           </TableCell>


### PR DESCRIPTION
Use acronym instead of id, use id as fallback

Closes #https://github.com/molgenis/molgenis-emx2/issues/5611

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
