### PR TITLE
refactor(permissions): extract user permissions cache from the schema interface and delegate

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlSessionFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlSessionFieldFactory.java
@@ -201,7 +201,7 @@ public class GraphqlSessionFieldFactory {
   }
 
   private static List<Map<String, Object>> buildTablePermissions(Schema schema) {
-    return schema.getPermissionsForActiveUser().stream()
+    return schema.getUserPermissions().getAll().stream()
         .map(
             p ->
                 Map.<String, Object>of(

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
@@ -465,14 +465,7 @@ public class SqlSchema implements Schema {
   }
 
   @Override
-  public List<TablePermission> getPermissionsForActiveUser() {
-    // delegate to metadata so the result is cached (and reloaded) alongside rolesCache
-    return getMetadata().getPermissionsForActiveUser();
-  }
-
-  @Override
-  public Map<String, TablePermission> getPermissionsByTableForActiveUser() {
-    // delegate to metadata so the index is cached (and reloaded) alongside the permission list
-    return getMetadata().getPermissionsByTableForActiveUser();
+  public UserPermissions getUserPermissions() {
+    return getMetadata().getTablePermissions();
   }
 }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -11,6 +11,7 @@ import java.util.*;
 import java.util.stream.Collectors;
 import org.jooq.DSLContext;
 import org.molgenis.emx2.*;
+import org.molgenis.emx2.sql.cache.CachedUserPermissions;
 import org.molgenis.emx2.utils.TypeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -21,7 +22,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
   private List<String> rolesCache = null;
   // cache for the active user's table permissions, indexed by table name (insertion order
   // preserved)
-  private Map<String, TablePermission> permissionsByTableCache = null;
+  private final CachedUserPermissions permissions = new CachedUserPermissions(this);
 
   // copy constructor
   protected SqlSchemaMetadata(Database db, SqlSchemaMetadata copy) {
@@ -82,7 +83,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     MetadataUtils.loadSchemaMetadata(getDatabase().getJooq(), this);
     this.tables.clear();
     this.rolesCache = null;
-    this.permissionsByTableCache = null;
+    permissions.clearCache();
     for (TableMetadata table : MetadataUtils.loadTables(getDatabase().getJooq(), this)) {
       super.create(new SqlTableMetadata(this, table));
     }
@@ -270,22 +271,12 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     return rolesCache;
   }
 
-  public Map<String, TablePermission> getPermissionsByTableForActiveUser() {
-    // cached because per-table lookups in PermissionEvaluator are called very often during query
-    // and schema building; is cleared along with rolesCache in reload()
-    if (permissionsByTableCache == null) {
-      Map<String, TablePermission> byTable = new LinkedHashMap<>();
-      for (TablePermission p :
-          getDatabase().getRoleManager().getTablePermissionsForActiveUser(getName())) {
-        byTable.putIfAbsent(p.table(), p);
-      }
-      permissionsByTableCache = Collections.unmodifiableMap(byTable);
-    }
-    return permissionsByTableCache;
+  public UserPermissions getTablePermissions() {
+    return permissions;
   }
 
-  public List<TablePermission> getPermissionsForActiveUser() {
-    return List.copyOf(getPermissionsByTableForActiveUser().values());
+  public Map<String, TablePermission> getPermissionsByTableForActiveUser() {
+    return permissions.getByTable();
   }
 
   public String getRoleForUser(String user) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -18,17 +18,18 @@ import org.slf4j.LoggerFactory;
 
 public class SqlSchemaMetadata extends SchemaMetadata {
   private static Logger logger = LoggerFactory.getLogger(SqlSchemaMetadata.class);
+
   // cache for retrieved roles
   private List<String> rolesCache = null;
-  // cache for the active user's table permissions, indexed by table name (insertion order
-  // preserved)
-  private final CachedUserPermissions permissions = new CachedUserPermissions(this);
+
+  private final CachedUserPermissions permissions;
 
   // copy constructor
   protected SqlSchemaMetadata(Database db, SqlSchemaMetadata copy) {
     this.name = copy.getName();
     this.description = copy.getDescription();
     this.database = db;
+    this.permissions = new CachedUserPermissions(this);
     this.sync(copy);
   }
 
@@ -60,19 +61,17 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     }
   }
 
+  public SqlSchemaMetadata(Database db, String name) {
+    this(db, name, null);
+  }
+
   public SqlSchemaMetadata(Database db, String name, String description) {
     super(
         db,
         MetadataUtils.loadSchemaMetadata(((SqlDatabase) db).getJooq(), new SchemaMetadata(name)));
+    permissions = new CachedUserPermissions(this);
     this.reload();
     this.setDescription(description);
-  }
-
-  public SqlSchemaMetadata(Database db, String name) {
-    super(
-        db,
-        MetadataUtils.loadSchemaMetadata(((SqlDatabase) db).getJooq(), new SchemaMetadata(name)));
-    this.reload();
   }
 
   public void reload() {
@@ -121,10 +120,9 @@ public class SqlSchemaMetadata extends SchemaMetadata {
                 s.migrate(new SchemaMetadata().create(tables));
               } else {
                 TableMetadata table = tables[0];
-                List<TableMetadata> tableList = new ArrayList<>();
-                tableList.addAll(List.of(tables));
                 validateTableIdentifierIsUnique(sm, table);
-                SqlTableMetadata result = null;
+
+                SqlTableMetadata result;
                 if (TableType.ONTOLOGIES.equals(table.getTableType())) {
                   result =
                       new SqlTableMetadata(
@@ -157,11 +155,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
 
   @Override
   public void drop(String tableName) {
-    getDatabase()
-        .tx(
-            database -> {
-              sync(dropTransaction(tableName, database));
-            });
+    getDatabase().tx(database -> sync(dropTransaction(tableName, database)));
     getDatabase().getListener().schemaChanged(getName());
   }
 
@@ -179,11 +173,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
   @Override
   public SchemaMetadata setSettings(Map<String, String> settings) {
     if (PermissionEvaluator.canManage(getDatabase().getSchema(getName()))) {
-      getDatabase()
-          .tx(
-              db -> {
-                sync(setSettingsTransaction((SqlDatabase) db, getName(), settings));
-              });
+      getDatabase().tx(db -> sync(setSettingsTransaction((SqlDatabase) db, getName(), settings)));
       getDatabase().getListener().schemaChanged(getName());
       return this;
     } else {
@@ -231,11 +221,6 @@ public class SqlSchemaMetadata extends SchemaMetadata {
     }
   }
 
-  @Override
-  public Map<String, String> getSettings() {
-    return super.getSettings();
-  }
-
   protected DSLContext getJooq() {
     return getDatabase().getJooq();
   }
@@ -273,10 +258,6 @@ public class SqlSchemaMetadata extends SchemaMetadata {
 
   public UserPermissions getTablePermissions() {
     return permissions;
-  }
-
-  public Map<String, TablePermission> getPermissionsByTableForActiveUser() {
-    return permissions.getByTable();
   }
 
   public String getRoleForUser(String user) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/cache/CachedUserPermissions.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/cache/CachedUserPermissions.java
@@ -1,0 +1,51 @@
+package org.molgenis.emx2.sql.cache;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.molgenis.emx2.SchemaMetadata;
+import org.molgenis.emx2.TablePermission;
+import org.molgenis.emx2.UserPermissions;
+import org.molgenis.emx2.sql.SqlDatabase;
+
+public class CachedUserPermissions implements UserPermissions {
+
+  private final SqlDatabase database;
+  private final String schemaName;
+  private Map<String, TablePermission> tablePermissions;
+
+  public CachedUserPermissions(SchemaMetadata schema) {
+    this.schemaName = schema.getName();
+    this.database = (SqlDatabase) schema.getDatabase();
+  }
+
+  private Map<String, TablePermission> getValue() {
+    // cached because per-table lookups in PermissionEvaluator are called very often during query
+    // and schema building; is cleared along with rolesCache in reload()
+    if (tablePermissions == null) {
+      Map<String, TablePermission> byTable = new LinkedHashMap<>();
+      for (TablePermission p :
+          database.getRoleManager().getTablePermissionsForActiveUser(schemaName)) {
+        byTable.putIfAbsent(p.table(), p);
+      }
+      tablePermissions = Collections.unmodifiableMap(byTable);
+    }
+
+    return tablePermissions;
+  }
+
+  @Override
+  public Map<String, TablePermission> getByTable() {
+    return getValue();
+  }
+
+  @Override
+  public List<TablePermission> getAll() {
+    return List.copyOf(getValue().values());
+  }
+
+  public void clearCache() {
+    tablePermissions = null;
+  }
+}

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/SqlSchemaMetadataTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/SqlSchemaMetadataTest.java
@@ -1,13 +1,14 @@
 package org.molgenis.emx2.sql;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.molgenis.emx2.Column.column;
+import static org.molgenis.emx2.TableMetadata.table;
 
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
-import org.molgenis.emx2.Database;
-import org.molgenis.emx2.Privileges;
-import org.molgenis.emx2.Schema;
+import org.molgenis.emx2.*;
 
 class SqlSchemaMetadataTest {
 
@@ -20,5 +21,58 @@ class SqlSchemaMetadataTest {
     List<String> expectedRoles =
         Arrays.stream(Privileges.values()).map(Privileges::toString).toList();
     assertEquals(expectedRoles, schema.getInheritedRolesForActiveUser());
+  }
+
+  @Test
+  void copyConstructor_copiesNameAndDescription() {
+    Database db = TestDatabaseFactory.getTestDatabase();
+    Schema schema = db.dropCreateSchema("CopyConstructorNameTest");
+    schema.getMetadata().setDescription("test description");
+    SqlSchemaMetadata source = (SqlSchemaMetadata) schema.getMetadata();
+
+    SqlSchemaMetadata copy = new SqlSchemaMetadata(db, source);
+
+    assertEquals(source.getName(), copy.getName());
+    assertEquals(source.getDescription(), copy.getDescription());
+  }
+
+  @Test
+  void copyConstructor_copiesAllTables() {
+    Database db = TestDatabaseFactory.getTestDatabase();
+    Schema schema = db.dropCreateSchema("CopyConstructorTablesTest");
+    schema.create(
+        table("Person").add(column("id").setPkey()).add(column("name")),
+        table("Order").add(column("id").setPkey()));
+    SqlSchemaMetadata source = (SqlSchemaMetadata) schema.getMetadata();
+
+    SqlSchemaMetadata copy = new SqlSchemaMetadata(db, source);
+
+    assertEquals(source.getTableNames(), copy.getTableNames());
+    assertNotNull(copy.getTableMetadata("Person"));
+    assertNotNull(copy.getTableMetadata("Order"));
+    assertNotNull(copy.getTableMetadata("Person").getColumn("name"));
+  }
+
+  @Test
+  void copyConstructor_copiesSettings() {
+    Database db = TestDatabaseFactory.getTestDatabase();
+    Schema schema = db.dropCreateSchema("CopyConstructorSettingsTest");
+    schema.getMetadata().setSettingsWithoutReload(Map.of("key1", "value1", "key2", "value2"));
+    SqlSchemaMetadata source = (SqlSchemaMetadata) schema.getMetadata();
+
+    SqlSchemaMetadata copy = new SqlSchemaMetadata(db, source);
+
+    assertEquals(source.getSettings(), copy.getSettings());
+  }
+
+  @Test
+  void copyConstructor_hasIndependentPermissionsCache() {
+    Database db = TestDatabaseFactory.getTestDatabase();
+    Schema schema = db.dropCreateSchema("CopyConstructorPermissionsTest");
+    SqlSchemaMetadata source = (SqlSchemaMetadata) schema.getMetadata();
+
+    SqlSchemaMetadata copy = new SqlSchemaMetadata(db, source);
+
+    assertNotSame(source.getTablePermissions(), copy.getTablePermissions());
   }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestPermissionEvaluator.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestPermissionEvaluator.java
@@ -452,13 +452,13 @@ class TestPermissionEvaluator {
 
     @Test
     void permissionsByTableCacheIsStableWithinSchemaInstance() {
-      Schema s = schemaFor(USER_CUSTOM);
+      Schema schema = schemaFor(USER_CUSTOM);
+      UserPermissions permissions = schema.getUserPermissions();
       // repeated calls within the same (metadata) lifecycle return the cached index
-      assertSame(s.getPermissionsByTableForActiveUser(), s.getPermissionsByTableForActiveUser());
+      assertSame(permissions.getByTable(), permissions.getByTable());
       // and the index is consistent with the list it is derived from
-      assertEquals(
-          s.getPermissionsForActiveUser().size(), s.getPermissionsByTableForActiveUser().size());
-      assertTrue(s.getPermissionsByTableForActiveUser().containsKey(TABLE_A));
+      assertEquals(permissions.getAll().size(), permissions.getByTable().size());
+      assertTrue(permissions.getByTable().containsKey(TABLE_A));
     }
   }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestTableRoleManagement.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestTableRoleManagement.java
@@ -287,7 +287,7 @@ class TestTableRoleManagement {
     schema.addMember(USER_VIEWER, "ActiveUserRole");
 
     database.setActiveUser(USER_VIEWER);
-    List<TablePermission> perms = database.getSchema(SCHEMA).getPermissionsForActiveUser();
+    List<TablePermission> perms = database.getSchema(SCHEMA).getUserPermissions().getAll();
     assertEquals(1, perms.size());
     TablePermission p = perms.getFirst();
     assertEquals(TABLE_B, p.table());
@@ -305,7 +305,7 @@ class TestTableRoleManagement {
     schema.addMember(USER_NO_ACCESS, "NoGrantRole");
 
     database.setActiveUser(USER_NO_ACCESS);
-    List<TablePermission> perms = database.getSchema(SCHEMA).getPermissionsForActiveUser();
+    List<TablePermission> perms = database.getSchema(SCHEMA).getUserPermissions().getAll();
     assertTrue(
         perms.isEmpty() || perms.stream().noneMatch(p -> Boolean.TRUE.equals(p.select())),
         "User with no grants should have no select permissions");
@@ -321,7 +321,7 @@ class TestTableRoleManagement {
     schema.addMember(USER_EDITOR, "MergeGrantRole");
 
     database.setActiveUser(USER_EDITOR);
-    List<TablePermission> perms = database.getSchema(SCHEMA).getPermissionsForActiveUser();
+    List<TablePermission> perms = database.getSchema(SCHEMA).getUserPermissions().getAll();
     TablePermission merged =
         perms.stream()
             .filter(p -> TABLE_A.equals(p.table()))
@@ -360,7 +360,7 @@ class TestTableRoleManagement {
     // every user inherits anonymous privileges via PostgreSQL role inheritance,
     // so the user should see merged permissions: select from anonymous + insert from InsertOnly
     database.setActiveUser(USER_VIEWER);
-    List<TablePermission> perms = database.getSchema(SCHEMA).getPermissionsForActiveUser();
+    List<TablePermission> perms = database.getSchema(SCHEMA).getUserPermissions().getAll();
     TablePermission merged =
         perms.stream()
             .filter(p -> TABLE_A.equals(p.table()))

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/cache/CachedUserPermissionsTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/cache/CachedUserPermissionsTest.java
@@ -6,6 +6,7 @@ import static org.molgenis.emx2.TableMetadata.table;
 
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.sql.SqlSchemaMetadata;
@@ -19,13 +20,16 @@ class CachedUserPermissionsTest {
   private static final String USER = "tpc_user";
 
   private static Database database;
+  private CachedUserPermissions userPermissions;
 
   @BeforeAll
   static void setUp() {
     database = TestDatabaseFactory.getTestDatabase();
     database.becomeAdmin();
 
-    if (!database.hasUser(USER)) database.addUser(USER);
+    if (!database.hasUser(USER)) {
+      database.addUser(USER);
+    }
 
     Schema schema = database.dropCreateSchema(SCHEMA);
     schema.create(
@@ -36,17 +40,18 @@ class CachedUserPermissionsTest {
     schema.addMember(USER, "CacheTestRole");
   }
 
-  private SqlSchemaMetadata schemaMetadataFor(String user) {
+  @BeforeEach
+  void schemaMetadataFor() {
     database.becomeAdmin();
-    database.setActiveUser(user);
-    return (SqlSchemaMetadata) database.getSchema(SCHEMA).getMetadata();
+    database.setActiveUser(USER);
+
+    SqlSchemaMetadata metadata = (SqlSchemaMetadata) database.getSchema(SCHEMA).getMetadata();
+    userPermissions = new CachedUserPermissions(metadata);
   }
 
   @Test
   void getValue_returnsPermissionsForActiveUser() {
-    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
-
-    Map<String, TablePermission> permissions = metadata.getPermissionsByTableForActiveUser();
+    Map<String, TablePermission> permissions = userPermissions.getByTable();
 
     assertTrue(permissions.containsKey(TABLE_A), "granted table should be present");
     assertTrue(permissions.get(TABLE_A).hasSelect(), "granted select should be true");
@@ -54,29 +59,25 @@ class CachedUserPermissionsTest {
 
   @Test
   void getValue_onRepeatedCalls_returnsSameInstance() {
-    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
-
-    Map<String, TablePermission> first = metadata.getPermissionsByTableForActiveUser();
-    Map<String, TablePermission> second = metadata.getPermissionsByTableForActiveUser();
+    Map<String, TablePermission> first = userPermissions.getByTable();
+    Map<String, TablePermission> second = userPermissions.getByTable();
 
     assertSame(first, second, "repeated calls should return the cached map instance");
   }
 
   @Test
   void getValue_afterReset_returnsFreshInstance() {
-    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
-    Map<String, TablePermission> before = metadata.getPermissionsByTableForActiveUser();
+    Map<String, TablePermission> before = userPermissions.getByTable();
 
-    metadata.reload();
+    userPermissions.clearCache();
 
-    Map<String, TablePermission> after = metadata.getPermissionsByTableForActiveUser();
+    Map<String, TablePermission> after = userPermissions.getByTable();
     assertNotSame(before, after, "map should be a new instance after cache reset via reload()");
   }
 
   @Test
   void getValue_returnsUnmodifiableMap() {
-    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
-    Map<String, TablePermission> permissions = metadata.getPermissionsByTableForActiveUser();
+    Map<String, TablePermission> permissions = userPermissions.getByTable();
 
     TablePermission permission = new TablePermission("any");
     assertThrows(UnsupportedOperationException.class, () -> permissions.put("any", permission));
@@ -84,9 +85,7 @@ class CachedUserPermissionsTest {
 
   @Test
   void getValue_tableWithoutGrant_isAbsentFromCache() {
-    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
-
-    Map<String, TablePermission> permissions = metadata.getPermissionsByTableForActiveUser();
+    Map<String, TablePermission> permissions = userPermissions.getByTable();
 
     assertFalse(permissions.containsKey(TABLE_B), "non-granted table should not appear in cache");
   }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/cache/CachedUserPermissionsTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/cache/CachedUserPermissionsTest.java
@@ -1,0 +1,93 @@
+package org.molgenis.emx2.sql.cache;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.molgenis.emx2.Column.column;
+import static org.molgenis.emx2.TableMetadata.table;
+
+import java.util.Map;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.*;
+import org.molgenis.emx2.sql.SqlSchemaMetadata;
+import org.molgenis.emx2.sql.TestDatabaseFactory;
+
+class CachedUserPermissionsTest {
+
+  private static final String SCHEMA = "TablePermissionCacheTest";
+  private static final String TABLE_A = "TableA";
+  private static final String TABLE_B = "TableB";
+  private static final String USER = "tpc_user";
+
+  private static Database database;
+
+  @BeforeAll
+  static void setUp() {
+    database = TestDatabaseFactory.getTestDatabase();
+    database.becomeAdmin();
+
+    if (!database.hasUser(USER)) database.addUser(USER);
+
+    Schema schema = database.dropCreateSchema(SCHEMA);
+    schema.create(
+        table(TABLE_A).add(column("id").setPkey()), table(TABLE_B).add(column("id").setPkey()));
+
+    schema.createRole("CacheTestRole");
+    schema.grant("CacheTestRole", new TablePermission(TABLE_A).select(true));
+    schema.addMember(USER, "CacheTestRole");
+  }
+
+  private SqlSchemaMetadata schemaMetadataFor(String user) {
+    database.becomeAdmin();
+    database.setActiveUser(user);
+    return (SqlSchemaMetadata) database.getSchema(SCHEMA).getMetadata();
+  }
+
+  @Test
+  void getValue_returnsPermissionsForActiveUser() {
+    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
+
+    Map<String, TablePermission> permissions = metadata.getPermissionsByTableForActiveUser();
+
+    assertTrue(permissions.containsKey(TABLE_A), "granted table should be present");
+    assertTrue(permissions.get(TABLE_A).hasSelect(), "granted select should be true");
+  }
+
+  @Test
+  void getValue_onRepeatedCalls_returnsSameInstance() {
+    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
+
+    Map<String, TablePermission> first = metadata.getPermissionsByTableForActiveUser();
+    Map<String, TablePermission> second = metadata.getPermissionsByTableForActiveUser();
+
+    assertSame(first, second, "repeated calls should return the cached map instance");
+  }
+
+  @Test
+  void getValue_afterReset_returnsFreshInstance() {
+    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
+    Map<String, TablePermission> before = metadata.getPermissionsByTableForActiveUser();
+
+    metadata.reload();
+
+    Map<String, TablePermission> after = metadata.getPermissionsByTableForActiveUser();
+    assertNotSame(before, after, "map should be a new instance after cache reset via reload()");
+  }
+
+  @Test
+  void getValue_returnsUnmodifiableMap() {
+    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
+    Map<String, TablePermission> permissions = metadata.getPermissionsByTableForActiveUser();
+
+    TablePermission permission = new TablePermission("any");
+    assertThrows(UnsupportedOperationException.class, () -> permissions.put("any", permission));
+  }
+
+  @Test
+  void getValue_tableWithoutGrant_isAbsentFromCache() {
+    SqlSchemaMetadata metadata = schemaMetadataFor(USER);
+
+    Map<String, TablePermission> permissions = metadata.getPermissionsByTableForActiveUser();
+
+    assertFalse(permissions.containsKey(TABLE_B), "non-granted table should not appear in cache");
+  }
+}

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/cache/CachedUserPermissionsTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/cache/CachedUserPermissionsTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.molgenis.emx2.Column.column;
 import static org.molgenis.emx2.TableMetadata.table;
 
+import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -52,9 +53,18 @@ class CachedUserPermissionsTest {
   @Test
   void getValue_returnsPermissionsForActiveUser() {
     Map<String, TablePermission> permissions = userPermissions.getByTable();
+    TablePermission expected = new TablePermission(TABLE_A).select(true);
 
     assertTrue(permissions.containsKey(TABLE_A), "granted table should be present");
-    assertTrue(permissions.get(TABLE_A).hasSelect(), "granted select should be true");
+    assertEquals(permissions.get(TABLE_A), expected, "should be table a with select granted");
+  }
+
+  @Test
+  void getAll_returnsPermissionsForActiveUser() {
+    List<TablePermission> permissions = userPermissions.getAll();
+    List<TablePermission> expected = List.of(new TablePermission(TABLE_A).select(true));
+
+    assertEquals(permissions, expected, "list should contain table a with select");
   }
 
   @Test

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/PermissionEvaluator.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/PermissionEvaluator.java
@@ -64,7 +64,6 @@ public final class PermissionEvaluator {
   }
 
   private static Optional<TablePermission> permissionFor(Schema schema, TableMetadata table) {
-    return Optional.ofNullable(
-        schema.getPermissionsByTableForActiveUser().get(table.getTableName()));
+    return Optional.ofNullable(schema.getUserPermissions().getByTable().get(table.getTableName()));
   }
 }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Schema.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Schema.java
@@ -92,7 +92,5 @@ public interface Schema {
 
   List<Role> getRoleInfos();
 
-  List<TablePermission> getPermissionsForActiveUser();
-
-  Map<String, TablePermission> getPermissionsByTableForActiveUser();
+  UserPermissions getUserPermissions();
 }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TablePermission.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TablePermission.java
@@ -1,5 +1,7 @@
 package org.molgenis.emx2;
 
+import java.util.Objects;
+
 public class TablePermission {
   private final String table;
   private Boolean select;
@@ -65,5 +67,38 @@ public class TablePermission {
   public TablePermission delete(Boolean delete) {
     this.delete = delete;
     return this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    TablePermission that = (TablePermission) o;
+    return Objects.equals(table, that.table)
+        && Objects.equals(select, that.select)
+        && Objects.equals(insert, that.insert)
+        && Objects.equals(update, that.update)
+        && Objects.equals(delete, that.delete);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(table, select, insert, update, delete);
+  }
+
+  @Override
+  public String toString() {
+    return "TablePermission{"
+        + "table='"
+        + table
+        + '\''
+        + ", select="
+        + select
+        + ", insert="
+        + insert
+        + ", update="
+        + update
+        + ", delete="
+        + delete
+        + '}';
   }
 }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/UserPermissions.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/UserPermissions.java
@@ -1,0 +1,11 @@
+package org.molgenis.emx2;
+
+import java.util.List;
+import java.util.Map;
+
+public interface UserPermissions {
+
+  Map<String, TablePermission> getByTable();
+
+  List<TablePermission> getAll();
+}


### PR DESCRIPTION
### What are the main changes you did
Two closely related things were changed:

**1. Extracted the permission cache into its own class**
The lazy-loaded permission cache that lived in SqlSchemaMetadata as a raw `Map<String, TablePermission>` field (with a null-check pattern) has been moved into a
dedicated `CachedUserPermissions` class. This class implements the new `UserPermissions` interface and owns both the caching (`clearCache()`) and the two access
patterns (`getByTable()`, `getAll()`). The lifecycle hook (clearing on schema reload) is preserved — `SqlSchemaMetadata.reload()` now calls `permissions.clearCache()`.

**2. Simplified the Schema interface**
The two separate methods `getPermissionsForActiveUser()` and `getPermissionsByTableForActiveUser()` have been replaced by a single `getUserPermissions()` that returns
a UserPermissions object. Callers that previously picked one of the two methods now get the object and call `getAll()` or `getByTable()` explicitly. The
`UserPermissions` interface is defined in the core `molgenis-emx2` module so it stays decoupled from the SQL implementation.

**Essential considerations:**
- No behaviour is changed — the caching semantics (populate on first access, clear on reload) are identical.
- The UserPermissions interface is in the core module while CachedUserPermissions is in the sql module, preserving the existing layering.
- Any external implementation of Schema needs to implement getUserPermissions() instead of the two old methods.


### How to test
The cache contract (lazy init, stable identity on repeated calls, invalidation on reload, unmodifiable map) is covered by `CachedUserPermissionsTest` in
`molgenis-emx2-sql`.

The evaluator-level correctness (correct permission level per role, cache invalidation after a grant/revoke) is covered by `TestPermissionEvaluator`, which was
updated to use the new API.

Run both with:
`./gradlew :backend:molgenis-emx2-sql:test --tests "org.molgenis.emx2.sql.cache.CachedUserPermissionsTest"`
`./gradlew :backend:molgenis-emx2-sql:test --tests "org.molgenis.emx2.sql.TestPermissionEvaluator"`

Or run the full sql module suite:
`./gradlew :backend:molgenis-emx2-sql:test`


### Checklist
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [x] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
