### PR TITLE
fix(cranio-dashboard): remove progress meters from CLP dashboard

### DIFF
--- a/apps/cranio-provider/src/views/cleft_lip_palate/your_center.vue
+++ b/apps/cranio-provider/src/views/cleft_lip_palate/your_center.vue
@@ -75,33 +75,6 @@
         />
       </DashboardChart>
     </DashboardRow>
-    <DashboardRow :columns="1">
-      <LoadingScreen v-if="loading" style="height: 100%" />
-      <template v-else>
-        <DashboardChart>
-          <h3 class="dashboard-h3" style="margin-bottom: 1em">
-            Completeness of questionnaires
-          </h3>
-          <ProgressMeter
-            :chartId="icsCompletionChart?.chartId"
-            :title="icsCompletionChart?.chartTitle?.replace('${ageGroup}', (selectedCleftType as string))"
-            :value="icsCompletionChartData?.dataPointValue"
-            :totalValue="100"
-            :barHeight="20"
-            barFill="#9f6491"
-          />
-          <ProgressMeter
-            :chartId="cleftqCompletionChart?.chartId"
-            :title="cleftqCompletionChart?.chartTitle?.replace('${ageGroup}', (selectedCleftType as string))"
-            :value="cleftqCompletionChartData?.dataPointValue"
-            :totalValue="100"
-            :barHeight="20"
-            barFill="#66c2a4"
-            style="margin-top: 1em"
-          />
-        </DashboardChart>
-      </template>
-    </DashboardRow>
   </ProviderDashboard>
 </template>
 
@@ -112,7 +85,6 @@ import {
   DashboardChart,
   ColumnChart,
   PieChart2,
-  ProgressMeter,
   InputLabel,
   LoadingScreen,
   // @ts-expect-error
@@ -121,7 +93,7 @@ import LoadingBlock from "../../components/LoadingBlock.vue";
 import ProviderDashboard from "../../components/ProviderDashboard.vue";
 
 import { generateAxisTickData } from "../../utils/generateAxisTicks";
-import { asKeyValuePairs, sum, uniqueValues } from "../../utils";
+import { asKeyValuePairs, uniqueValues } from "../../utils";
 import { generateColorPalette } from "../../utils/generateColorPalette";
 import { getDashboardChart } from "../../utils/getDashboardData";
 
@@ -152,10 +124,6 @@ const patientsByPhenotypePalette = ref<IKeyValuePair>();
 const patientsByGenderChart = ref<ICharts>();
 const patientsByGenderChartData = ref<IKeyValuePair>();
 const patientsByGenderPalette = ref<IKeyValuePair>();
-const icsCompletionChart = ref<ICharts>();
-const icsCompletionChartData = ref<IChartData>();
-const cleftqCompletionChart = ref<ICharts>();
-const cleftqCompletionChartData = ref<IChartData>();
 
 async function getPageData() {
   const phenotypesResponse = await getDashboardChart(
@@ -168,20 +136,8 @@ async function getPageData() {
     "clp-provider-patients-by-gender"
   );
 
-  const icsResponse = await getDashboardChart(
-    props.api.graphql.current,
-    "clp-provider-ics-completed"
-  );
-
-  const cleftqResponse = await getDashboardChart(
-    props.api.graphql.current,
-    "clp-provider-cleft-q-completed"
-  );
-
   patientsByPhenotypeChart.value = phenotypesResponse[0];
   patientsByGenderChart.value = genderResponse[0];
-  icsCompletionChart.value = icsResponse[0];
-  cleftqCompletionChart.value = cleftqResponse[0];
 }
 
 function updateGenderChart() {
@@ -200,22 +156,8 @@ function updateGenderChart() {
   );
 }
 
-function updateProgressMeter() {
-  icsCompletionChartData.value = icsCompletionChart.value?.dataPoints?.filter(
-    (row: IChartData) => {
-      return row.dataPointPrimaryCategory === selectedCleftType.value;
-    }
-  )[0] as IChartData;
-
-  cleftqCompletionChartData.value =
-    cleftqCompletionChart.value?.dataPoints?.filter((row: IChartData) => {
-      return row.dataPointPrimaryCategory === selectedCleftType.value;
-    })[0] as IChartData;
-}
-
 function updateCharts() {
   updateGenderChart();
-  updateProgressMeter();
 }
 
 onMounted(() => {


### PR DESCRIPTION
### What are the main changes you did

This PR closes molgenis/GCC#2954.

- [x] Remove all code related to the progress meters that were displayed on CLP's _You Center's Overview page_

### How to test

- Go to the preview and open the `AT1` schema
- Go to the _Cleft lip and palate's_ >> _Your center's overview_
- Scroll down to the bottom. The progress meters are no longer shown. Compare with the beta server

### Checklist

- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
