### PR TITLE
docs(permissions): document settings authorization model

### DIFF
--- a/docs/molgenis/dev_graphql.md
+++ b/docs/molgenis/dev_graphql.md
@@ -235,6 +235,10 @@ mutation {
 }
 ```
 
+> **Permissions:** these mutations are subject to authorization — e.g. changing table settings
+> requires update permission on that table, schema settings require the Manager role. See
+> [Permissions](use_permissions.md) for the full model.
+
 User settings (only as admin, or settings of current user):
 
 ```graphql

--- a/docs/molgenis/use_permissions.md
+++ b/docs/molgenis/use_permissions.md
@@ -17,6 +17,18 @@ In addition we have special roles to allow for specific permissions around aggre
 * **exists** - context: schema: Has permission to see if data exists given certain filters, and to view ontology data
 
 
+## Permissions to change settings
+
+Settings can be stored at schema level and at table level (see [database settings](use_database_settings.md)):
+
+* **Schema settings** can be changed by users with the **manager** role (or higher).
+* **Table settings** can be changed by anyone with update permission on that table. This includes the
+  schema-wide **editor** role, but also a custom role that grants table-level **UPDATE** on that
+  specific table — i.e. a user does not need the schema-wide editor role to change a table's settings
+  if they have been granted update on that table directly.
+
+The **admin** user can change any setting.
+
 ## Users can get roles in a schema
 
 Access to databases is controlled by providing roles to users. A user with a role we call a 'member' of a


### PR DESCRIPTION
Follow-up to #6071 (now merged).

During review of #6071, a comment ([r3347084067](https://github.com/molgenis/molgenis-emx2/pull/6071/changes#r3347084067)) flagged an **undocumented behaviour change** in `SqlTableMetadata.setSettings`: it now delegates to `PermissionEvaluator.canUpdate(...)`. As a result, **table settings can be changed by a custom role with a table-level UPDATE grant**, not only by admin or the schema-wide Editor role as before.

This PR documents that authorization rule.

## Changes
- **`use_permissions.md`** — new *"Permissions to change settings"* section. The functional auth model lives here, next to the existing role descriptions:
  - schema settings → **Manager** role (or higher)
  - table settings → update permission on the table (schema-wide **Editor**, *or* a custom role with table-level **UPDATE** on that table)
  - admin can change any setting
- **`dev_graphql.md`** — short note on the settings mutation pointing to the permissions doc, rather than inlining functional auth logic in the API reference (kept at the right altitude).

No behaviour change — documentation only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)