### PR TITLE
fix(cranio-dashboard): add organisation name to document title

### DIFF
--- a/apps/cranio-provider/src/App.vue
+++ b/apps/cranio-provider/src/App.vue
@@ -77,6 +77,10 @@ onBeforeMount(async () => {
       `/${cranioSchemas.value?.CRANIO_PUBLIC_SCHEMA}/api/graphql`,
       currentSchemaName.value
     );
+
+    if (window && currentOrganisation.value) {
+      window.document.title = `${window.document.title} | ${currentOrganisation.value.name}`;
+    }
   } catch (err: unknown) {
     if (Object.hasOwn(err as Error, "response")) {
       const message = (err as IMgErrorResponse).response.errors[0].message;


### PR DESCRIPTION
### What are the main changes you did

This PR closes molgenis/molgenis-emx2#3574. 

- [x] Add organisation name to `window.document.title`: since organisation metadata is retrieved in an earlier step (`currentOrganisation`), it is possible to append it to the existing document title.

### How to test

- Go to the preview server
- Test 1
    - Click on the schema `AT1`
    - Confirm that "University Hospital Salzburg" is the last item in `window.document.title`
- Test 2 
    - Click on the schema `NL3`
    - Confirm that "Radboud MC" is the last item in `window.document.title`

### Checklist

- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
