### PR TITLE
feat(cranio-dashboard): updates to genetic hearing loss pages

### DIFF
--- a/apps/cranio-provider/src/App.vue
+++ b/apps/cranio-provider/src/App.vue
@@ -17,7 +17,7 @@
               : 'img/banner-diagnoses.jpg'
           "
         />
-        <Dashboard class="provider-dashboard-container" :horizontalPadding="5">
+        <Dashboard class="provider-dashboard-container" :horizontalPadding="2">
           <ProviderSidebar />
           <router-view
             :organisation="currentOrganisation"

--- a/apps/cranio-provider/src/utils/getGeneticHearingLossData.ts
+++ b/apps/cranio-provider/src/utils/getGeneticHearingLossData.ts
@@ -1,48 +1,38 @@
 import { getDashboardChart } from "./getDashboardData";
-import type { ICharts, IChartData } from "../types/schema";
+import type { IChartData } from "../types/schema";
 
 export async function getGeneticLossData(url: string, type: string) {
   const hearingLossTypeLeft = (
-    (await getDashboardChart(url, "ghl-type-of-hearing-loss-left")) as ICharts[]
-  )[0] as ICharts;
+    await getDashboardChart(url, "ghl-type-of-hearing-loss-left")
+  )[0];
 
   const hearingLossTypeRight = (
-    (await getDashboardChart(
-      url,
-      "ghl-type-of-hearing-loss-right"
-    )) as ICharts[]
-  )[0] as ICharts;
+    await getDashboardChart(url, "ghl-type-of-hearing-loss-right")
+  )[0];
 
   const severityChart = (
-    (await getDashboardChart(
-      url,
-      "severity-of-hearing-loss-by-ear"
-    )) as ICharts[]
-  )[0] as ICharts;
+    await getDashboardChart(url, "severity-of-hearing-loss-by-ear")
+  )[0];
 
   const onsetChart = (
-    (await getDashboardChart(url, "age-of-hearing-loss-onset")) as ICharts[]
-  )[0] as ICharts;
+    await getDashboardChart(url, "age-of-hearing-loss-onset")
+  )[0];
 
   const dxTypeChart = (
-    (await getDashboardChart(url, "genetic-diagnosis-type")) as ICharts[]
-  )[0] as ICharts;
+    await getDashboardChart(url, "genetic-diagnosis-type")
+  )[0];
 
-  const dxGenes = (
-    (await getDashboardChart(url, "genes")) as ICharts[]
-  )[0] as ICharts;
+  const dxGenes = (await getDashboardChart(url, "genes"))[0];
 
-  const etiologyChart = (
-    (await getDashboardChart(url, "etiology")) as ICharts[]
-  )[0] as ICharts;
+  const etiologyChart = (await getDashboardChart(url, "etiology"))[0];
 
   const classificationChart = (
-    (await getDashboardChart(url, "syndromic-classification")) as ICharts[]
-  )[0] as ICharts;
+    await getDashboardChart(url, "syndromic-classification")
+  )[0];
 
   const rehabilitationChart = (
-    (await getDashboardChart(url, "ghl-rehabilitation-type")) as ICharts[]
-  )[0] as ICharts;
+    await getDashboardChart(url, "ghl-rehabilitation-type")
+  )[0];
 
   const data = {
     hearingLossTypeLeft: hearingLossTypeLeft,

--- a/apps/cranio-provider/src/utils/getGeneticHearingLossData.ts
+++ b/apps/cranio-provider/src/utils/getGeneticHearingLossData.ts
@@ -40,6 +40,10 @@ export async function getGeneticLossData(url: string, type: string) {
     (await getDashboardChart(url, "syndromic-classification")) as ICharts[]
   )[0] as ICharts;
 
+  const rehabilitationChart = (
+    (await getDashboardChart(url, "ghl-rehabilitation-type")) as ICharts[]
+  )[0] as ICharts;
+
   const data = {
     hearingLossTypeLeft: hearingLossTypeLeft,
     hearingLossTypeRight: hearingLossTypeRight,
@@ -49,6 +53,7 @@ export async function getGeneticLossData(url: string, type: string) {
     diagnosisGenes: dxGenes,
     etiology: etiologyChart,
     syndromicClassification: classificationChart,
+    rehabilitationChart: rehabilitationChart,
   };
 
   Object.keys(data).forEach((key) => {

--- a/apps/cranio-provider/src/utils/getGeneticHearingLossData.ts
+++ b/apps/cranio-provider/src/utils/getGeneticHearingLossData.ts
@@ -2,8 +2,15 @@ import { getDashboardChart } from "./getDashboardData";
 import type { ICharts, IChartData } from "../types/schema";
 
 export async function getGeneticLossData(url: string, type: string) {
-  const hearingLossType = (
-    (await getDashboardChart(url, "type-of-hearing-loss")) as ICharts[]
+  const hearingLossTypeLeft = (
+    (await getDashboardChart(url, "ghl-type-of-hearing-loss-left")) as ICharts[]
+  )[0] as ICharts;
+
+  const hearingLossTypeRight = (
+    (await getDashboardChart(
+      url,
+      "ghl-type-of-hearing-loss-right"
+    )) as ICharts[]
   )[0] as ICharts;
 
   const severityChart = (
@@ -34,7 +41,8 @@ export async function getGeneticLossData(url: string, type: string) {
   )[0] as ICharts;
 
   const data = {
-    hearingLossTypes: hearingLossType,
+    hearingLossTypeLeft: hearingLossTypeLeft,
+    hearingLossTypeRight: hearingLossTypeRight,
     severity: severityChart,
     ageOfOnset: onsetChart,
     diagnosisTypes: dxTypeChart,

--- a/apps/cranio-provider/src/utils/index.ts
+++ b/apps/cranio-provider/src/utils/index.ts
@@ -103,3 +103,14 @@ export function sortByDataPointName(data: IChartData[]) {
     return a.dataPointName?.localeCompare(b.dataPointName as string) as number;
   });
 }
+
+export function sortByDataPointOrder(data: IChartData[]) {
+  return data.sort((a: IChartData, b: IChartData) => {
+    return (
+      (a.dataPointOrder as number) - (b.dataPointOrder as number) ||
+      (b.dataPointSecondaryCategory as string).localeCompare(
+        a.dataPointSecondaryCategory as string
+      )
+    );
+  });
+}

--- a/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
+++ b/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
@@ -16,7 +16,7 @@ import {
 import ProviderDashboard from "../../components/ProviderDashboard.vue";
 import { generateAxisTickData } from "../../utils/generateAxisTicks";
 import { getGeneticLossData } from "../../utils/getGeneticHearingLossData";
-import { sortByDataPointName } from "../../utils";
+import { sortByDataPointName, sortByDataPointOrder } from "../../utils";
 
 import type { ICharts, IChartData } from "../../types/schema";
 import type { IAppPage } from "../../types/app";
@@ -67,46 +67,25 @@ onMounted(async () => {
   rehabilitationTypeChart.value = yourCenter.rehabilitationChart;
 
   // combine data
-  hearingLossTypeLeftChart.value.dataPoints = [
+  hearingLossTypeLeftChart.value.dataPoints = sortByDataPointOrder([
     ...(hearingLossTypeLeftChart.value.dataPoints as IChartData[]),
     ...(allCenters.hearingLossTypeLeft.dataPoints as IChartData[]),
-  ].sort((a, b) => {
-    return (
-      (a.dataPointOrder as number) - (b.dataPointOrder as number) ||
-      (b.dataPointSecondaryCategory as string).localeCompare(
-        a.dataPointSecondaryCategory as string
-      )
-    );
-  });
+  ]);
 
-  hearingLossTypeRightChart.value.dataPoints = [
+  hearingLossTypeRightChart.value.dataPoints = sortByDataPointOrder([
     ...(hearingLossTypeRightChart.value.dataPoints as IChartData[]),
     ...(allCenters.hearingLossTypeRight.dataPoints as IChartData[]),
-  ].sort((a, b) => {
-    return (
-      (a.dataPointOrder as number) - (b.dataPointOrder as number) ||
-      (b.dataPointSecondaryCategory as string).localeCompare(
-        a.dataPointSecondaryCategory as string
-      )
-    );
-  });
+  ]);
 
   hearingLossSeverityChart.value.dataPoints = sortByDataPointName([
     ...(hearingLossSeverityChart.value.dataPoints as IChartData[]),
     ...(allCenters.severity.dataPoints as IChartData[]),
   ]);
 
-  hearingLossOnsetChart.value.dataPoints = [
+  hearingLossOnsetChart.value.dataPoints = sortByDataPointOrder([
     ...(hearingLossOnsetChart.value.dataPoints as IChartData[]),
     ...(allCenters.ageOfOnset.dataPoints as IChartData[]),
-  ].sort((a, b) => {
-    return (
-      (a.dataPointOrder as number) - (b.dataPointOrder as number) ||
-      (b.dataPointSecondaryCategory as string).localeCompare(
-        a.dataPointSecondaryCategory as string
-      )
-    );
-  });
+  ]);
 
   geneticDiagnosisGenesChart.value.dataPoints = sortByDataPointName([
     ...(geneticDiagnosisGenesChart.value.dataPoints as IChartData[]),
@@ -133,13 +112,8 @@ onMounted(async () => {
     ...(allCenters.rehabilitationChart.dataPoints as IChartData[]),
   ]);
 
-  // create data for type of hearing loss chart
+  // Chart axis data for type of hearing loss (left ear)
   const hearingLossLeftAxis = generateAxisTickData(
-    hearingLossTypeLeftChart.value?.dataPoints as IChartData[],
-    "dataPointValue"
-  );
-
-  const hearingLossRightAxis = generateAxisTickData(
     hearingLossTypeLeftChart.value?.dataPoints as IChartData[],
     "dataPointValue"
   );
@@ -148,6 +122,12 @@ onMounted(async () => {
     hearingLossTypeLeftChart.value.yAxisMaxValue = hearingLossLeftAxis.limit;
     hearingLossTypeLeftChart.value.yAxisTicks = hearingLossLeftAxis.ticks;
   }
+
+  // Chart axis data for type of hearing loss (right ear)
+  const hearingLossRightAxis = generateAxisTickData(
+    hearingLossTypeRightChart.value?.dataPoints as IChartData[],
+    "dataPointValue"
+  );
 
   if (hearingLossTypeRightChart.value) {
     hearingLossTypeRightChart.value.yAxisMaxValue = hearingLossRightAxis.limit;
@@ -224,6 +204,7 @@ onMounted(async () => {
     syndromicClassifcationChart.value?.dataPoints as IChartData[],
     "dataPointValue"
   );
+
   if (syndromicClassifcationChart.value) {
     syndromicClassifcationChart.value.yAxisMaxValue = syndomicAxis.limit;
     syndromicClassifcationChart.value.yAxisTicks = syndomicAxis.ticks;

--- a/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
+++ b/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
@@ -67,15 +67,29 @@ onMounted(async () => {
   rehabilitationTypeChart.value = yourCenter.rehabilitationChart;
 
   // combine data
-  hearingLossTypeLeftChart.value.dataPoints =
-    hearingLossTypeLeftChart.value.dataPoints?.concat(
-      allCenters.hearingLossTypeLeft.dataPoints as IChartData[]
+  hearingLossTypeLeftChart.value.dataPoints = [
+    ...(hearingLossTypeLeftChart.value.dataPoints as IChartData[]),
+    ...(allCenters.hearingLossTypeLeft.dataPoints as IChartData[]),
+  ].sort((a, b) => {
+    return (
+      (a.dataPointOrder as number) - (b.dataPointOrder as number) ||
+      (b.dataPointSecondaryCategory as string).localeCompare(
+        a.dataPointSecondaryCategory as string
+      )
     );
+  });
 
-  hearingLossTypeRightChart.value.dataPoints =
-    hearingLossTypeRightChart.value.dataPoints?.concat(
-      allCenters.hearingLossTypeRight.dataPoints as IChartData[]
+  hearingLossTypeRightChart.value.dataPoints = [
+    ...(hearingLossTypeRightChart.value.dataPoints as IChartData[]),
+    ...(allCenters.hearingLossTypeRight.dataPoints as IChartData[]),
+  ].sort((a, b) => {
+    return (
+      (a.dataPointOrder as number) - (b.dataPointOrder as number) ||
+      (b.dataPointSecondaryCategory as string).localeCompare(
+        a.dataPointSecondaryCategory as string
+      )
     );
+  });
 
   hearingLossSeverityChart.value.dataPoints = sortByDataPointName([
     ...(hearingLossSeverityChart.value.dataPoints as IChartData[]),

--- a/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
+++ b/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
@@ -24,7 +24,8 @@ import type { IAppPage } from "../../types/app";
 const props = defineProps<IAppPage>();
 const loading = ref<boolean>(true);
 
-const hearingLossTypeChart = ref<ICharts>();
+const hearingLossTypeLeftChart = ref<ICharts>();
+const hearingLossTypeRightChart = ref<ICharts>();
 const hearingLossSeverityChart = ref<ICharts>();
 const hearingLossOnsetChart = ref<ICharts>();
 const geneticDiagnosisTypeChart = ref<ICharts>();
@@ -54,7 +55,8 @@ onMounted(async () => {
     "ERN"
   );
 
-  hearingLossTypeChart.value = yourCenter.hearingLossTypes;
+  hearingLossTypeLeftChart.value = yourCenter.hearingLossTypeLeft;
+  hearingLossTypeRightChart.value = yourCenter.hearingLossTypeRight;
   hearingLossSeverityChart.value = yourCenter.severity;
   hearingLossOnsetChart.value = yourCenter.ageOfOnset;
   geneticDiagnosisGenesChart.value = yourCenter.diagnosisGenes;
@@ -63,9 +65,14 @@ onMounted(async () => {
   syndromicClassifcationChart.value = yourCenter.syndromicClassification;
 
   // combine data
-  hearingLossTypeChart.value.dataPoints = sortByDataPointName([
-    ...(hearingLossTypeChart.value.dataPoints as IChartData[]),
-    ...(allCenters.hearingLossTypes.dataPoints as IChartData[]),
+  hearingLossTypeLeftChart.value.dataPoints = sortByDataPointName([
+    ...(hearingLossTypeLeftChart.value.dataPoints as IChartData[]),
+    ...(allCenters.hearingLossTypeLeft.dataPoints as IChartData[]),
+  ]);
+
+  hearingLossTypeRightChart.value.dataPoints = sortByDataPointName([
+    ...(hearingLossTypeRightChart.value.dataPoints as IChartData[]),
+    ...(allCenters.hearingLossTypeRight.dataPoints as IChartData[]),
   ]);
 
   hearingLossSeverityChart.value.dataPoints = sortByDataPointName([
@@ -104,15 +111,26 @@ onMounted(async () => {
     ...(syndromicClassifcationChart.value.dataPoints as IChartData[]),
     ...(allCenters.syndromicClassification.dataPoints as IChartData[]),
   ]);
+
   // create data for type of hearing loss chart
-  const hearingAxis = generateAxisTickData(
-    hearingLossTypeChart.value?.dataPoints as IChartData[],
+  const hearingLossLeftAxis = generateAxisTickData(
+    hearingLossTypeLeftChart.value?.dataPoints as IChartData[],
     "dataPointValue"
   );
 
-  if (hearingLossTypeChart.value) {
-    hearingLossTypeChart.value.yAxisMaxValue = hearingAxis.limit;
-    hearingLossTypeChart.value.yAxisTicks = hearingAxis.ticks;
+  const hearingLossRightAxis = generateAxisTickData(
+    hearingLossTypeLeftChart.value?.dataPoints as IChartData[],
+    "dataPointValue"
+  );
+
+  if (hearingLossTypeLeftChart.value) {
+    hearingLossTypeLeftChart.value.yAxisMaxValue = hearingLossLeftAxis.limit;
+    hearingLossTypeLeftChart.value.yAxisTicks = hearingLossLeftAxis.ticks;
+  }
+
+  if (hearingLossTypeRightChart.value) {
+    hearingLossTypeRightChart.value.yAxisMaxValue = hearingLossRightAxis.limit;
+    hearingLossTypeRightChart.value.yAxisTicks = hearingLossRightAxis.ticks;
   }
 
   // prep chart for severity of hearing loss
@@ -197,31 +215,58 @@ onMounted(async () => {
 <template>
   <ProviderDashboard>
     <h2 class="dashboard-h2">Overview for all centers</h2>
-    <DashboardRow :columns="1">
+    <DashboardRow :columns="2">
       <DashboardChart>
         <LoadingScreen v-if="loading" style="height: 250px" />
         <GroupedColumnChart
           v-else
-          :chartId="hearingLossTypeChart?.chartId"
-          :title="hearingLossTypeChart?.chartTitle"
-          :description="hearingLossTypeChart?.chartSubtitle"
-          :chartData="hearingLossTypeChart?.dataPoints"
+          :chartId="hearingLossTypeLeftChart?.chartId"
+          :title="hearingLossTypeLeftChart?.chartTitle"
+          :description="hearingLossTypeLeftChart?.chartSubtitle"
+          :chartData="hearingLossTypeLeftChart?.dataPoints"
           xvar="dataPointSecondaryCategory"
           yvar="dataPointValue"
           group="dataPointName"
-          :xAxisLabel="hearingLossTypeChart?.xAxisLabel"
-          :yAxisLabel="hearingLossTypeChart?.yAxisLabel"
+          :xAxisLabel="hearingLossTypeLeftChart?.xAxisLabel"
+          :yAxisLabel="hearingLossTypeLeftChart?.yAxisLabel"
           :yMin="0"
-          :yMax="hearingLossTypeChart?.yAxisMaxValue"
-          :yTickValues="hearingLossTypeChart?.yAxisTicks"
+          :yMax="hearingLossTypeLeftChart?.yAxisMaxValue"
+          :yTickValues="hearingLossTypeLeftChart?.yAxisTicks"
           :columnColorPalette="colorPalette"
           columnHoverFill="#EE7032"
           :chartHeight="250"
           :chartMargins="{
-            top: hearingLossTypeChart?.topMargin,
-            right: hearingLossTypeChart?.rightMargin,
-            bottom: hearingLossTypeChart?.bottomMargin,
-            left: hearingLossTypeChart?.leftMargin,
+            top: hearingLossTypeLeftChart?.topMargin,
+            right: hearingLossTypeLeftChart?.rightMargin,
+            bottom: hearingLossTypeLeftChart?.bottomMargin,
+            left: hearingLossTypeLeftChart?.leftMargin,
+          }"
+        />
+      </DashboardChart>
+      <DashboardChart>
+        <LoadingScreen v-if="loading" style="height: 250px" />
+        <GroupedColumnChart
+          v-else
+          :chartId="hearingLossTypeRightChart?.chartId"
+          :title="hearingLossTypeRightChart?.chartTitle"
+          :description="hearingLossTypeRightChart?.chartSubtitle"
+          :chartData="hearingLossTypeRightChart?.dataPoints"
+          xvar="dataPointSecondaryCategory"
+          yvar="dataPointValue"
+          group="dataPointName"
+          :xAxisLabel="hearingLossTypeRightChart?.xAxisLabel"
+          :yAxisLabel="hearingLossTypeRightChart?.yAxisLabel"
+          :yMin="0"
+          :yMax="hearingLossTypeRightChart?.yAxisMaxValue"
+          :yTickValues="hearingLossTypeRightChart?.yAxisTicks"
+          :columnColorPalette="colorPalette"
+          columnHoverFill="#EE7032"
+          :chartHeight="250"
+          :chartMargins="{
+            top: hearingLossTypeRightChart?.topMargin,
+            right: hearingLossTypeRightChart?.rightMargin,
+            bottom: hearingLossTypeRightChart?.bottomMargin,
+            left: hearingLossTypeRightChart?.leftMargin,
           }"
         />
       </DashboardChart>

--- a/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
+++ b/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
@@ -32,6 +32,7 @@ const geneticDiagnosisTypeChart = ref<ICharts>();
 const geneticDiagnosisGenesChart = ref<ICharts>();
 const etiologyChart = ref<ICharts>();
 const syndromicClassifcationChart = ref<ICharts>();
+const rehabilitationTypeChart = ref<ICharts>();
 
 interface GenesSummaryData {
   Gene: string;
@@ -63,6 +64,7 @@ onMounted(async () => {
   geneticDiagnosisTypeChart.value = yourCenter.diagnosisTypes;
   etiologyChart.value = yourCenter.etiology;
   syndromicClassifcationChart.value = yourCenter.syndromicClassification;
+  rehabilitationTypeChart.value = yourCenter.rehabilitationChart;
 
   // combine data
   hearingLossTypeLeftChart.value.dataPoints =
@@ -110,6 +112,11 @@ onMounted(async () => {
   syndromicClassifcationChart.value.dataPoints = sortByDataPointName([
     ...(syndromicClassifcationChart.value.dataPoints as IChartData[]),
     ...(allCenters.syndromicClassification.dataPoints as IChartData[]),
+  ]);
+
+  rehabilitationTypeChart.value.dataPoints = sortByDataPointName([
+    ...(rehabilitationTypeChart.value.dataPoints as IChartData[]),
+    ...(allCenters.rehabilitationChart.dataPoints as IChartData[]),
   ]);
 
   // create data for type of hearing loss chart
@@ -206,6 +213,17 @@ onMounted(async () => {
   if (syndromicClassifcationChart.value) {
     syndromicClassifcationChart.value.yAxisMaxValue = syndomicAxis.limit;
     syndromicClassifcationChart.value.yAxisTicks = syndomicAxis.ticks;
+  }
+
+  // prepare rehabilitation type chart
+  const rehabilitationAxis = generateAxisTickData(
+    rehabilitationTypeChart.value?.dataPoints as IChartData[],
+    "dataPointValue"
+  );
+
+  if (rehabilitationTypeChart.value) {
+    rehabilitationTypeChart.value.yAxisMaxValue = rehabilitationAxis.limit;
+    rehabilitationTypeChart.value.yAxisTicks = rehabilitationAxis.ticks;
   }
 
   loading.value = false;
@@ -447,6 +465,35 @@ onMounted(async () => {
             right: syndromicClassifcationChart?.rightMargin,
             bottom: syndromicClassifcationChart?.bottomMargin,
             left: syndromicClassifcationChart?.leftMargin,
+          }"
+        />
+      </DashboardChart>
+    </DashboardRow>
+    <DashboardRow :columns="1">
+      <DashboardChart>
+        <LoadingScreen v-if="loading" style="height: 250px" />
+        <GroupedColumnChart
+          v-else
+          :chartId="rehabilitationTypeChart?.chartId"
+          :title="rehabilitationTypeChart?.chartTitle"
+          :description="rehabilitationTypeChart?.chartSubtitle"
+          :chartData="rehabilitationTypeChart?.dataPoints"
+          xvar="dataPointSecondaryCategory"
+          yvar="dataPointValue"
+          group="dataPointName"
+          :xAxisLabel="rehabilitationTypeChart?.xAxisLabel"
+          :yAxisLabel="rehabilitationTypeChart?.yAxisLabel"
+          :yMin="0"
+          :yMax="rehabilitationTypeChart?.yAxisMaxValue"
+          :yTickValues="rehabilitationTypeChart?.yAxisTicks"
+          :columnColorPalette="colorPalette"
+          columnHoverFill="#EE7032"
+          :chartHeight="250"
+          :chartMargins="{
+            top: rehabilitationTypeChart?.topMargin,
+            right: rehabilitationTypeChart?.rightMargin,
+            bottom: rehabilitationTypeChart?.bottomMargin,
+            left: rehabilitationTypeChart?.leftMargin,
           }"
         />
       </DashboardChart>

--- a/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
+++ b/apps/cranio-provider/src/views/genetic_hearing_loss/all_centers.vue
@@ -65,15 +65,15 @@ onMounted(async () => {
   syndromicClassifcationChart.value = yourCenter.syndromicClassification;
 
   // combine data
-  hearingLossTypeLeftChart.value.dataPoints = sortByDataPointName([
-    ...(hearingLossTypeLeftChart.value.dataPoints as IChartData[]),
-    ...(allCenters.hearingLossTypeLeft.dataPoints as IChartData[]),
-  ]);
+  hearingLossTypeLeftChart.value.dataPoints =
+    hearingLossTypeLeftChart.value.dataPoints?.concat(
+      allCenters.hearingLossTypeLeft.dataPoints as IChartData[]
+    );
 
-  hearingLossTypeRightChart.value.dataPoints = sortByDataPointName([
-    ...(hearingLossTypeRightChart.value.dataPoints as IChartData[]),
-    ...(allCenters.hearingLossTypeRight.dataPoints as IChartData[]),
-  ]);
+  hearingLossTypeRightChart.value.dataPoints =
+    hearingLossTypeRightChart.value.dataPoints?.concat(
+      allCenters.hearingLossTypeRight.dataPoints as IChartData[]
+    );
 
   hearingLossSeverityChart.value.dataPoints = sortByDataPointName([
     ...(hearingLossSeverityChart.value.dataPoints as IChartData[]),

--- a/apps/cranio-provider/src/views/genetic_hearing_loss/your_center.vue
+++ b/apps/cranio-provider/src/views/genetic_hearing_loss/your_center.vue
@@ -28,6 +28,7 @@ const geneticDiagnosisTypeChart = ref<ICharts>();
 const geneticDiagnosisGenesChart = ref<ICharts>();
 const etiologyChart = ref<ICharts>();
 const syndromicClassifcationChart = ref<ICharts>();
+const rehabilitationTypeChart = ref<ICharts>();
 
 onMounted(async () => {
   const yourCenter = await getGeneticLossData(
@@ -43,6 +44,7 @@ onMounted(async () => {
   geneticDiagnosisTypeChart.value = yourCenter.diagnosisTypes;
   etiologyChart.value = yourCenter.etiology;
   syndromicClassifcationChart.value = yourCenter.syndromicClassification;
+  rehabilitationTypeChart.value = yourCenter.rehabilitationChart;
 
   // create data for type of hearing loss chart left
   const hearingLossLeftAxis = generateAxisTickData(
@@ -151,6 +153,16 @@ onMounted(async () => {
   if (syndromicClassifcationChart.value) {
     syndromicClassifcationChart.value.yAxisMaxValue = syndomicAxis.limit;
     syndromicClassifcationChart.value.yAxisTicks = syndomicAxis.ticks;
+  }
+
+  // prep rehabilitation type chart
+  const rehabilitationTypeAxis = generateAxisTickData(
+    rehabilitationTypeChart.value?.dataPoints as IChartData[],
+    "dataPointValue"
+  );
+  if (rehabilitationTypeChart.value) {
+    rehabilitationTypeChart.value.yAxisMaxValue = rehabilitationTypeAxis.limit;
+    rehabilitationTypeChart.value.yAxisTicks = rehabilitationTypeAxis.ticks;
   }
 
   loading.value = false;
@@ -366,6 +378,34 @@ onMounted(async () => {
             right: syndromicClassifcationChart?.rightMargin,
             bottom: syndromicClassifcationChart?.bottomMargin,
             left: syndromicClassifcationChart?.leftMargin,
+          }"
+        />
+      </DashboardChart>
+    </DashboardRow>
+    <DashboardRow :columns="2">
+      <DashboardChart>
+        <LoadingScreen v-if="loading" style="height: 250px" />
+        <ColumnChart
+          v-else
+          :chartId="rehabilitationTypeChart?.chartId"
+          :title="rehabilitationTypeChart?.chartTitle"
+          :description="rehabilitationTypeChart?.chartSubtitle"
+          :chartData="rehabilitationTypeChart?.dataPoints"
+          xvar="dataPointName"
+          yvar="dataPointValue"
+          :xAxisLabel="rehabilitationTypeChart?.xAxisLabel"
+          :yAxisLabel="rehabilitationTypeChart?.yAxisLabel"
+          :yMin="0"
+          :yMax="rehabilitationTypeChart?.yAxisMaxValue"
+          :yTickValues="rehabilitationTypeChart?.yAxisTicks"
+          columnFill="#A7DCCB"
+          columnHoverFill="#EE7032"
+          :chartHeight="250"
+          :chartMargins="{
+            top: rehabilitationTypeChart?.topMargin,
+            right: rehabilitationTypeChart?.rightMargin,
+            bottom: rehabilitationTypeChart?.bottomMargin,
+            left: rehabilitationTypeChart?.leftMargin,
           }"
         />
       </DashboardChart>

--- a/apps/cranio-provider/src/views/genetic_hearing_loss/your_center.vue
+++ b/apps/cranio-provider/src/views/genetic_hearing_loss/your_center.vue
@@ -20,7 +20,8 @@ import type { IAppPage } from "../../types/app";
 const props = defineProps<IAppPage>();
 const loading = ref<boolean>(true);
 
-const hearingLossTypeChart = ref<ICharts>();
+const hearingLossTypeLeftChart = ref<ICharts>();
+const hearingLossTypeRightChart = ref<ICharts>();
 const hearingLossSeverityChart = ref<ICharts>();
 const hearingLossOnsetChart = ref<ICharts>();
 const geneticDiagnosisTypeChart = ref<ICharts>();
@@ -34,7 +35,8 @@ onMounted(async () => {
     "Your center"
   );
 
-  hearingLossTypeChart.value = yourCenter.hearingLossTypes;
+  hearingLossTypeLeftChart.value = yourCenter.hearingLossTypeLeft;
+  hearingLossTypeRightChart.value = yourCenter.hearingLossTypeRight;
   hearingLossSeverityChart.value = yourCenter.severity;
   hearingLossOnsetChart.value = yourCenter.ageOfOnset;
   geneticDiagnosisGenesChart.value = yourCenter.diagnosisGenes;
@@ -42,15 +44,26 @@ onMounted(async () => {
   etiologyChart.value = yourCenter.etiology;
   syndromicClassifcationChart.value = yourCenter.syndromicClassification;
 
-  // create data for type of hearing loss chart
-  const hearingAxis = generateAxisTickData(
-    hearingLossTypeChart.value?.dataPoints as IChartData[],
+  // create data for type of hearing loss chart left
+  const hearingLossLeftAxis = generateAxisTickData(
+    hearingLossTypeLeftChart.value?.dataPoints as IChartData[],
     "dataPointValue"
   );
 
-  if (hearingLossTypeChart.value) {
-    hearingLossTypeChart.value.yAxisMaxValue = hearingAxis.limit;
-    hearingLossTypeChart.value.yAxisTicks = hearingAxis.ticks;
+  if (hearingLossTypeLeftChart.value) {
+    hearingLossTypeLeftChart.value.yAxisMaxValue = hearingLossLeftAxis.limit;
+    hearingLossTypeLeftChart.value.yAxisTicks = hearingLossLeftAxis.ticks;
+  }
+
+  // create data for type of hearing loss chart right
+  const hearingLossRightAxis = generateAxisTickData(
+    hearingLossTypeRightChart.value?.dataPoints as IChartData[],
+    "dataPointValue"
+  );
+
+  if (hearingLossTypeRightChart.value) {
+    hearingLossTypeRightChart.value.yAxisMaxValue = hearingLossRightAxis.limit;
+    hearingLossTypeRightChart.value.yAxisTicks = hearingLossRightAxis.ticks;
   }
 
   // prep chart for severity of hearing loss
@@ -147,30 +160,56 @@ onMounted(async () => {
 <template>
   <ProviderDashboard>
     <h2 class="dashboard-h2">General overview for your center</h2>
-    <DashboardRow :columns="1">
+    <DashboardRow :columns="2">
       <DashboardChart>
         <LoadingScreen v-if="loading" style="height: 250px" />
         <ColumnChart
           v-else
-          :chartId="hearingLossTypeChart?.chartId"
-          :title="hearingLossTypeChart?.chartTitle"
-          :description="hearingLossTypeChart?.chartSubtitle"
-          :chartData="hearingLossTypeChart?.dataPoints"
+          :chartId="hearingLossTypeLeftChart?.chartId"
+          :title="hearingLossTypeLeftChart?.chartTitle"
+          :description="hearingLossTypeLeftChart?.chartSubtitle"
+          :chartData="hearingLossTypeLeftChart?.dataPoints"
           xvar="dataPointName"
           yvar="dataPointValue"
-          :xAxisLabel="hearingLossTypeChart?.xAxisLabel"
-          :yAxisLabel="hearingLossTypeChart?.yAxisLabel"
+          :xAxisLabel="hearingLossTypeLeftChart?.xAxisLabel"
+          :yAxisLabel="hearingLossTypeLeftChart?.yAxisLabel"
           :yMin="0"
-          :yMax="hearingLossTypeChart?.yAxisMaxValue"
-          :yTickValues="hearingLossTypeChart?.yAxisTicks"
+          :yMax="hearingLossTypeLeftChart?.yAxisMaxValue"
+          :yTickValues="hearingLossTypeLeftChart?.yAxisTicks"
           columnFill="#A7DCCB"
           columnHoverFill="#EE7032"
           :chartHeight="250"
           :chartMargins="{
-            top: hearingLossTypeChart?.topMargin,
-            right: hearingLossTypeChart?.rightMargin,
-            bottom: hearingLossTypeChart?.bottomMargin,
-            left: hearingLossTypeChart?.leftMargin,
+            top: hearingLossTypeLeftChart?.topMargin,
+            right: hearingLossTypeLeftChart?.rightMargin,
+            bottom: hearingLossTypeLeftChart?.bottomMargin,
+            left: hearingLossTypeLeftChart?.leftMargin,
+          }"
+        />
+      </DashboardChart>
+      <DashboardChart>
+        <LoadingScreen v-if="loading" style="height: 250px" />
+        <ColumnChart
+          v-else
+          :chartId="hearingLossTypeRightChart?.chartId"
+          :title="hearingLossTypeRightChart?.chartTitle"
+          :description="hearingLossTypeRightChart?.chartSubtitle"
+          :chartData="hearingLossTypeRightChart?.dataPoints"
+          xvar="dataPointName"
+          yvar="dataPointValue"
+          :xAxisLabel="hearingLossTypeRightChart?.xAxisLabel"
+          :yAxisLabel="hearingLossTypeRightChart?.yAxisLabel"
+          :yMin="0"
+          :yMax="hearingLossTypeRightChart?.yAxisMaxValue"
+          :yTickValues="hearingLossTypeRightChart?.yAxisTicks"
+          columnFill="#A7DCCB"
+          columnHoverFill="#EE7032"
+          :chartHeight="250"
+          :chartMargins="{
+            top: hearingLossTypeRightChart?.topMargin,
+            right: hearingLossTypeRightChart?.rightMargin,
+            bottom: hearingLossTypeRightChart?.bottomMargin,
+            left: hearingLossTypeRightChart?.leftMargin,
           }"
         />
       </DashboardChart>


### PR DESCRIPTION
### What are the main changes you did

This PR closes molgenis/GCC#3089 and closes molgenis/GCC#3090. It was decided to combine these issues into the same PR as they both focus on the genetic hearing loss pages.

- [x] fix: decrease horizontal padding of the parent layout component to maximise the space for the charts
- [x] molgenis/GCC#3089
    - [x] Remove chart `type-of-hearing-loss`  and all demo data from the provider schema and the aggregates schema
    - [x] Rewrite html and js code to produce the charts for left and right ear
    - [x] Apply changes to the "All Centers" page
- [x] molgenis/GCC#3090
    - [x] Create chart for rehabilitation type `ghl-rehabilitation-type`
    - [x] Create demo data
    - [x] Create new chart:
        - [x] Your center's overview
        - [x] All centers

This PR is also part of the epic molgenis/GCC#2248

### How to test

- Go to the preview and click on the `AT1` schema
- Test for type of hearing loss charts
    - Go to Genetic Hearing loss >> You center's overview
        - Observe two charts: Type of hearing loss left and right ear
    - Go to Genetic Hearing loss >> All centers
        - Observe two charts: Type of hearing loss left and right ear
- Test for rehabilitation type charts
    - Go to Genetic Hearing loss >> You center's overview
        - Observe new chart (at the bottom of the page)
    - Go to Genetic Hearing loss >> All centers
        - Observe new chart (at the bottom of the page)

### Checklist

- [x] updated docs in case of new feature
- ~added/updated tests~
- ~added/updated testplan to include a test for this fix, including ref to bug using # notation~

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)

## Implementation Notes

To add these charts to the production server, import the following files in-

- Every data provider schema
- The Dashboard schema

The following archive contains the record(s) for the dashboard page, the chart configuration, and the chart data.

> [!NOTE]
> The data included in this file contains demo data. You may want to change the values to `0` before importing the files.

[PR_6371.csv.zip](https://github.com/user-attachments/files/28957787/PR_6371.csv.zip)

