### PR TITLE
fix(tailwind-components): don't have 2 scrollbars in modal

### DIFF
--- a/apps/tailwind-components/app/components/Modal.vue
+++ b/apps/tailwind-components/app/components/Modal.vue
@@ -88,7 +88,7 @@ function hide() {
               />
 
               <div
-                class="bg-modal w-3/4 relative rounded-theme h-[95vh] flex flex-col pointer-events-auto overflow-auto"
+                class="bg-modal w-3/4 relative rounded-theme h-[95vh] flex flex-col pointer-events-auto"
                 :class="[
                   {
                     'm-auto': type === 'center',


### PR DESCRIPTION
fixes: https://github.com/molgenis/GCC/issues/3154

### What are the main changes you did
- removed a `overflow-auto` to make sure the overflow only happens in one location in the modal

### How to test
- Follow the steps here: https://github.com/molgenis/GCC/issues/3154
- Check that the other modals like the sidemodal still functions

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)

### Note to self
- [x] Also check the the modal in the catalogue 
- [x] Lets check the codebase for unexpected uses of the modal