### PR TITLE
fix: table explorer loading

### DIFF
--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -161,7 +161,7 @@
       </table>
       <div
         class="sticky left-0 flex justify-center items-center py-2.5"
-        v-if="!rows?.length"
+        v-if="status === 'success' || !rows?.length"
       >
         <TextNoResultsMessage
           class="w-full text-center"
@@ -304,7 +304,7 @@ const settings = defineModel<ITableSettings>("settings", {
   }),
 });
 
-const { data, refresh } = useAsyncData(
+const { data, refresh, status } = useAsyncData(
   `tableEMX2-${props.schemaId}-${props.tableId}`,
   async () => {
     const tableMetadata = await fetchTableMetadata(

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -161,7 +161,7 @@
       </table>
       <div
         class="sticky left-0 flex justify-center items-center py-2.5"
-        v-if="status === 'success' || !rows?.length"
+        v-if="status === 'success' && !rows?.length"
       >
         <TextNoResultsMessage
           class="w-full text-center"


### PR DESCRIPTION
Do not show 'No records found' while data is being loaded

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- View a table with a large data set ( lost of rows , lots of columns, for example catalogue-demo.Resources), while the data is being loaded the user should NOT be shown then message 'No records found' , as there might be rows 
- View a table without any rows , the message 'No records found' should be shown
- filter the data in a table with data rows until there are no rows left, the message should be shown

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
