### PR TITLE
feat(cms): enable page creation in the page gallery

### DIFF
--- a/apps/tailwind-components/app/gql/cmsPages.ts
+++ b/apps/tailwind-components/app/gql/cmsPages.ts
@@ -1,4 +1,4 @@
-export const getContainers = `query getContainers($filter:ContainersFilter) {
+export const getContainersQuery = `query getContainers($filter:ContainersFilter) {
     Containers(filter:$filter) {
         
         # Containers
@@ -127,49 +127,5 @@ export const getContainers = `query getContainers($filter:ContainersFilter) {
           defaultValue
         }
       }
-    }
-}`;
-
-export const getContainersAndMetadata = `{
-    Containers (orderby: { name: ASC }) {
-        name
-        mg_tableclass
-    }
-    _schema {
-        id
-        label
-        tables {
-          id
-          schemaId
-          name
-          label
-          description
-          tableType
-          columns {
-            columnType
-            id
-            label
-            section
-            heading
-            computed
-            description
-            formLabel
-            key
-            position
-            refBackId
-            refLabel
-            refLabelDefault
-            refLinkId
-            refSchemaId
-            refTableId
-            required
-            validation
-            visible
-            table
-            name
-            inherited
-            defaultValue
-          }
-        }
     }
 }`;

--- a/apps/tailwind-components/app/gql/cmsPages.ts
+++ b/apps/tailwind-components/app/gql/cmsPages.ts
@@ -1,4 +1,4 @@
-export default `query getContainers($filter:ContainersFilter) {
+export const getContainers = `query getContainers($filter:ContainersFilter) {
     Containers(filter:$filter) {
         
         # Containers
@@ -127,5 +127,49 @@ export default `query getContainers($filter:ContainersFilter) {
           defaultValue
         }
       }
+    }
+}`;
+
+export const getContainersAndMetadata = `{
+    Containers (orderby: { name: ASC }) {
+        name
+        mg_tableclass
+    }
+    _schema {
+        id
+        label
+        tables {
+          id
+          schemaId
+          name
+          label
+          description
+          tableType
+          columns {
+            columnType
+            id
+            label
+            section
+            heading
+            computed
+            description
+            formLabel
+            key
+            position
+            refBackId
+            refLabel
+            refLabelDefault
+            refLinkId
+            refSchemaId
+            refTableId
+            required
+            validation
+            visible
+            table
+            name
+            inherited
+            defaultValue
+          }
+        }
     }
 }`;

--- a/apps/tailwind-components/app/utils/cms.ts
+++ b/apps/tailwind-components/app/utils/cms.ts
@@ -5,7 +5,7 @@ import type {
   IDependenciesJS,
 } from "../../types/cms";
 
-import cmsPagesQuery from "../gql/cmsPages";
+import { getContainersQuery } from "../gql/cmsPages";
 
 import type {
   IContainerMetadata,
@@ -34,7 +34,7 @@ export async function getPage(
   const { data } = await $fetch(`/${schema}/graphql`, {
     method: "POST",
     body: {
-      query: cmsPagesQuery,
+      query: getContainersQuery,
       variables: { filter: { name: { equals: page } } },
     },
   });

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -11,11 +11,13 @@ import BaseIcon from "../../../../../tailwind-components/app/components/BaseIcon
 import Button from "../../../../../tailwind-components/app/components/Button.vue";
 import ButtonDropdown from "../../../../../tailwind-components/app/components/button/Dropdown.vue";
 import EditModal from "../../../../../tailwind-components/app/components/form/EditModal.vue";
-
-import type { Crumb } from "../../../../../tailwind-components/types/types";
+import Message from "../../../../../tailwind-components/app/components/Message.vue";
+import NoResultsMessage from "../../../../../tailwind-components/app/components/text/NoResultsMessage.vue";
 
 import fetchTableMetadata from "../../../../../tailwind-components/app/composables/fetchTableMetadata";
 import fetchTableData from "../../../../../tailwind-components/app/composables/fetchTableData";
+
+import type { Crumb } from "../../../../../tailwind-components/types/types";
 
 const route = useRoute();
 const schema = Array.isArray(route.params.schema)
@@ -32,25 +34,28 @@ const crumbs: Crumb[] = [
 const formMetadata = ref();
 const showFormModal = ref<boolean>(false);
 
-const { data, refresh } = useAsyncData(`containers-${schema}`, async () => {
-  const configurablePageMetadata = await fetchTableMetadata(
-    schema,
-    "ConfigurablePages"
-  );
-  const developerPageMetadata = await fetchTableMetadata(
-    schema,
-    "DeveloperPages"
-  );
-  const containers = await fetchTableData(schema, "Containers", {
-    orderby: { name: "ASC" },
-  });
+const { data, refresh, error } = useAsyncData(
+  `containers-${schema}`,
+  async () => {
+    const configurablePageMetadata = await fetchTableMetadata(
+      schema,
+      "ConfigurablePages"
+    );
+    const developerPageMetadata = await fetchTableMetadata(
+      schema,
+      "DeveloperPages"
+    );
+    const containers = await fetchTableData(schema, "Containers", {
+      orderby: { name: "ASC" },
+    });
 
-  return {
-    configurablePageMetadata,
-    developerPageMetadata,
-    containers,
-  };
-});
+    return {
+      configurablePageMetadata,
+      developerPageMetadata,
+      containers,
+    };
+  }
+);
 
 function onAddNewPageClick(type: string) {
   if (type === "ConfigurablePage") {
@@ -100,7 +105,7 @@ function setNuxtLink(value: string, page: string): string {
     </div>
     <div
       class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 flew-wrap justify-start items-center gap-7.5"
-      v-if="data && data.containers"
+      v-if="data?.containers?.rows"
     >
       <div
         v-for="container in data.containers.rows"
@@ -125,6 +130,19 @@ function setNuxtLink(value: string, page: string): string {
           {{ container.name }}
         </NuxtLink>
       </div>
+    </div>
+    <div
+      v-else-if="data && data.containers && !data.containers.rows"
+      class="w-full text-center"
+    >
+      <NoResultsMessage
+        label="No pages found. Add a new page to get started."
+      />
+    </div>
+    <div v-else-if="error">
+      <Message id="pages-schema-error" :invalid="true">
+        {{ error }}
+      </Message>
     </div>
   </Container>
   <EditModal

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -8,8 +8,19 @@ import BreadCrumbs from "../../../../../tailwind-components/app/components/Bread
 import PageHeader from "../../../../../tailwind-components/app/components/PageHeader.vue";
 import BaseIcon from "../../../../../tailwind-components/app/components/BaseIcon.vue";
 import Message from "../../../../../tailwind-components/app/components/Message.vue";
+import Button from "../../../../../tailwind-components/app/components/Button.vue";
+import ButtonDropdown from "../../../../../tailwind-components/app/components/button/Dropdown.vue";
+import EditModal from "../../../../../tailwind-components/app/components/form/EditModal.vue";
+import InputSearch from "../../../../../tailwind-components/app/components/input/Search.vue";
+
 import type { Crumb } from "../../../../../tailwind-components/types/types";
 import type { IContainers } from "../../../../../tailwind-components/types/cms";
+import type {
+  ISchemaMetaData,
+  ITableMetaData,
+} from "../../../../../metadata-utils/src/types.js";
+
+import { getContainersAndMetadata } from "../../../../../tailwind-components/app/gql/cmsPages.js";
 
 interface ICmsPage extends IContainers {
   mg_tableclass: string;
@@ -23,7 +34,7 @@ const schema = Array.isArray(route.params.schema)
 useHead({ title: `Pages - ${schema} - Molgenis` });
 
 interface PagesResponse {
-  data: { Containers: ICmsPage[] };
+  data: { Containers: ICmsPage[]; _schema?: ISchemaMetaData };
   error: Record<string, any>[];
 }
 
@@ -31,12 +42,39 @@ const error = ref<string>("");
 const { data } = await $fetch<PagesResponse>(`/${schema}/graphql`, {
   method: "POST",
   body: {
-    query: `{ Containers (orderby: { name: ASC }) { name mg_tableclass } }`,
+    query: getContainersAndMetadata,
   },
 }).catch((err) => {
   error.value = err;
   throw new Error(err);
 });
+
+const configurablePageTableMetadata = ref<ITableMetaData>();
+const developerPageTableMetadata = ref<ITableMetaData>();
+const formMetadata = ref();
+const showFormModal = ref<boolean>(false);
+const search = ref<string>();
+
+developerPageTableMetadata.value = data._schema?.tables.filter(
+  (row: ITableMetaData) => {
+    return row.id === "DeveloperPages";
+  }
+)[0];
+
+configurablePageTableMetadata.value = data._schema?.tables.filter(
+  (row: ITableMetaData) => {
+    return row.id === "ConfigurablePages";
+  }
+)[0];
+
+function onAddNewPageClick(type: string) {
+  if (type === "ConfigurablePage") {
+    formMetadata.value = configurablePageTableMetadata.value;
+  } else {
+    formMetadata.value = developerPageTableMetadata.value;
+  }
+  showFormModal.value = true;
+}
 
 const crumbs: Crumb[] = [
   { label: schema as string, url: `/${schema}` },
@@ -59,6 +97,31 @@ function setNuxtLink(value: string, page: string): string | undefined {
         <BreadCrumbs :crumbs="crumbs" align="left" />
       </template>
     </PageHeader>
+    <div class="flex pb-7.5 justify-between">
+      <div class="w-3/5 xl:w-2/5 2xl:w-1/5">
+        <label for="page-search" class="sr-only"> Search for pages </label>
+        <InputSearch
+          id="page-search"
+          size="medium"
+          v-model="search"
+          placeholder="Search for pages"
+        />
+      </div>
+      <div class="flex gap-2.5">
+        <ButtonDropdown label="Add new page">
+          <Button
+            type="secondary"
+            class="w-full"
+            @click="onAddNewPageClick('ConfigurablePage')"
+          >
+            Simple page
+          </Button>
+          <Button type="secondary" @click="onAddNewPageClick('DeveloperPage')">
+            developer page
+          </Button>
+        </ButtonDropdown>
+      </div>
+    </div>
     <div
       class="flex flew-wrap justify-start items-center gap-7.5"
       v-if="data && data.Containers"
@@ -93,4 +156,13 @@ function setNuxtLink(value: string, page: string): string | undefined {
       </Message>
     </div>
   </Container>
+  <EditModal
+    v-if="formMetadata"
+    key="edit-modal-configurable-page"
+    :show-button="false"
+    :schema-id="(schema as string)"
+    :metadata="formMetadata"
+    :is-insert="false"
+    v-model:visible="showFormModal"
+  />
 </template>

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -9,7 +9,6 @@ import BreadCrumbs from "../../../../../tailwind-components/app/components/Bread
 import PageHeader from "../../../../../tailwind-components/app/components/PageHeader.vue";
 import BaseIcon from "../../../../../tailwind-components/app/components/BaseIcon.vue";
 import Button from "../../../../../tailwind-components/app/components/Button.vue";
-import ButtonDropdown from "../../../../../tailwind-components/app/components/button/Dropdown.vue";
 import EditModal from "../../../../../tailwind-components/app/components/form/EditModal.vue";
 import Message from "../../../../../tailwind-components/app/components/Message.vue";
 import NoResultsMessage from "../../../../../tailwind-components/app/components/text/NoResultsMessage.vue";
@@ -33,6 +32,7 @@ const crumbs: Crumb[] = [
 
 const formMetadata = ref();
 const showFormModal = ref<boolean>(false);
+const showPageDropdown = ref<boolean>(false);
 
 const { data, refresh, error } = useAsyncData(
   `containers-${schema}`,
@@ -58,6 +58,7 @@ const { data, refresh, error } = useAsyncData(
 );
 
 function onAddNewPageClick(type: string) {
+  showPageDropdown.value = false;
   if (type === "ConfigurablePage") {
     formMetadata.value = data.value?.configurablePageMetadata;
   } else {
@@ -68,6 +69,7 @@ function onAddNewPageClick(type: string) {
 
 async function onClose() {
   await refresh();
+  formMetadata.value = undefined;
 }
 
 function setNuxtLink(value: string, page: string): string {
@@ -89,18 +91,45 @@ function setNuxtLink(value: string, page: string): string {
     <div class="flex pb-7.5 justify-between">
       <div class="w-3/5 xl:w-2/5 2xl:w-1/5" />
       <div class="flex gap-2.5">
-        <ButtonDropdown label="Add new page">
+        <div class="relative">
           <Button
-            type="secondary"
-            class="w-full"
-            @click="onAddNewPageClick('ConfigurablePage')"
+            id="openAddNewPageDropdown"
+            type="outline"
+            icon="CaretDown"
+            iconPosition="right"
+            :aria-expanded="showPageDropdown"
+            aria-controls="addNewPageDropdown"
+            @click="showPageDropdown = !showPageDropdown"
           >
-            Simple page
+            Add new page
           </Button>
-          <Button type="secondary" @click="onAddNewPageClick('DeveloperPage')">
-            developer page
-          </Button>
-        </ButtonDropdown>
+          <div
+            id="addNewPageDropdown"
+            aria-labelledby="openAddNewPageDropdown"
+            class="absolute z-10 w-full shadow-md rounded-sm"
+            :class="{
+              block: showPageDropdown,
+              hidden: !showPageDropdown,
+            }"
+          >
+            <Button
+              id="addNewConfigurablePageBtn"
+              type="secondary"
+              class="w-full"
+              @click="onAddNewPageClick('ConfigurablePage')"
+            >
+              Simple page
+            </Button>
+            <Button
+              id="addNewDeveloperPageBtn"
+              type="secondary"
+              class="w-full"
+              @click="onAddNewPageClick('DeveloperPage')"
+            >
+              developer page
+            </Button>
+          </div>
+        </div>
       </div>
     </div>
     <div

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -151,10 +151,10 @@ function setNuxtLink(value: string, page: string): string | undefined {
   <EditModal
     v-if="formMetadata"
     key="edit-modal-configurable-page"
-    :show-button="false"
-    :schema-id="(schema as string)"
+    :showButton="false"
+    :schemaId="(schema as string)"
     :metadata="formMetadata"
-    :is-insert="false"
+    :isInsert="true"
     v-model:visible="showFormModal"
   />
 </template>

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -2,86 +2,70 @@
 import { ref } from "vue";
 import { useRoute } from "vue-router";
 import { useHead } from "#app";
+import { useAsyncData } from "nuxt/app";
 
 import Container from "../../../../../tailwind-components/app/components/Container.vue";
 import BreadCrumbs from "../../../../../tailwind-components/app/components/BreadCrumbs.vue";
 import PageHeader from "../../../../../tailwind-components/app/components/PageHeader.vue";
 import BaseIcon from "../../../../../tailwind-components/app/components/BaseIcon.vue";
-import Message from "../../../../../tailwind-components/app/components/Message.vue";
 import Button from "../../../../../tailwind-components/app/components/Button.vue";
 import ButtonDropdown from "../../../../../tailwind-components/app/components/button/Dropdown.vue";
 import EditModal from "../../../../../tailwind-components/app/components/form/EditModal.vue";
-import InputSearch from "../../../../../tailwind-components/app/components/input/Search.vue";
 
 import type { Crumb } from "../../../../../tailwind-components/types/types";
-import type { IContainers } from "../../../../../tailwind-components/types/cms";
-import type {
-  ISchemaMetaData,
-  ITableMetaData,
-} from "../../../../../metadata-utils/src/types.js";
 
-import { getContainersAndMetadata } from "../../../../../tailwind-components/app/gql/cmsPages.js";
-
-interface ICmsPage extends IContainers {
-  mg_tableclass: string;
-}
+import fetchTableMetadata from "../../../../../tailwind-components/app/composables/fetchTableMetadata";
+import fetchTableData from "../../../../../tailwind-components/app/composables/fetchTableData";
 
 const route = useRoute();
 const schema = Array.isArray(route.params.schema)
-  ? route.params.schema[0]
+  ? (route.params.schema[0] as string)
   : route.params.schema ?? "";
 
 useHead({ title: `Pages - ${schema} - Molgenis` });
-
-interface PagesResponse {
-  data: { Containers: ICmsPage[]; _schema?: ISchemaMetaData };
-  error: Record<string, any>[];
-}
-
-const error = ref<string>("");
-const { data } = await $fetch<PagesResponse>(`/${schema}/graphql`, {
-  method: "POST",
-  body: {
-    query: getContainersAndMetadata,
-  },
-}).catch((err) => {
-  error.value = err;
-  throw new Error(err);
-});
-
-const configurablePageTableMetadata = ref<ITableMetaData>();
-const developerPageTableMetadata = ref<ITableMetaData>();
-const formMetadata = ref();
-const showFormModal = ref<boolean>(false);
-const search = ref<string>();
-
-developerPageTableMetadata.value = data._schema?.tables.filter(
-  (row: ITableMetaData) => {
-    return row.id === "DeveloperPages";
-  }
-)[0];
-
-configurablePageTableMetadata.value = data._schema?.tables.filter(
-  (row: ITableMetaData) => {
-    return row.id === "ConfigurablePages";
-  }
-)[0];
-
-function onAddNewPageClick(type: string) {
-  if (type === "ConfigurablePage") {
-    formMetadata.value = configurablePageTableMetadata.value;
-  } else {
-    formMetadata.value = developerPageTableMetadata.value;
-  }
-  showFormModal.value = true;
-}
 
 const crumbs: Crumb[] = [
   { label: schema as string, url: `/${schema}` },
   { label: "Pages", url: "" },
 ];
 
-function setNuxtLink(value: string, page: string): string | undefined {
+const formMetadata = ref();
+const showFormModal = ref<boolean>(false);
+
+const { data, refresh } = useAsyncData(`containers-${schema}`, async () => {
+  const configurablePageMetadata = await fetchTableMetadata(
+    schema,
+    "ConfigurablePages"
+  );
+  const developerPageMetadata = await fetchTableMetadata(
+    schema,
+    "DeveloperPages"
+  );
+  const containers = await fetchTableData(schema, "Containers", {
+    orderby: { name: "ASC" },
+  });
+
+  return {
+    configurablePageMetadata,
+    developerPageMetadata,
+    containers,
+  };
+});
+
+function onAddNewPageClick(type: string) {
+  if (type === "ConfigurablePage") {
+    formMetadata.value = data.value?.configurablePageMetadata;
+  } else {
+    formMetadata.value = data.value?.developerPageMetadata;
+  }
+  showFormModal.value = true;
+}
+
+async function onClose() {
+  await refresh();
+}
+
+function setNuxtLink(value: string, page: string): string {
   if (value.endsWith(".Developer pages")) {
     return `/${schema}/pages/${page}/editor`;
   } else {
@@ -115,19 +99,19 @@ function setNuxtLink(value: string, page: string): string | undefined {
       </div>
     </div>
     <div
-      class="flex flew-wrap justify-start items-center gap-7.5"
-      v-if="data && data.Containers"
+      class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 flew-wrap justify-start items-center gap-7.5"
+      v-if="data && data.containers"
     >
       <div
-        v-for="container in data.Containers"
-        class="relative group border rounded-3px w-1/3 h-48 p-7.5 hover:shadow-md transition-shadow flex justify-center items-center bg-form-legend"
+        v-for="container in data.containers.rows"
+        class="relative group border rounded-3px w-full h-48 p-7.5 hover:shadow-md transition-shadow flex justify-center items-center bg-form-legend"
       >
         <div
           class="absolute top-2.5 right-2.5 p-[5px] h-10 w-10 flex justify-center items-center border border-transparent rounded-full text-button-text hover:bg-button-primary-hover hover:text-button-primary-hover hover:border-button-primary-hover"
           v-tooltip.bottom="`Edit`"
         >
           <NuxtLink
-            :to="setNuxtLink(container.mg_tableclass, container.name)"
+            :to="setNuxtLink((container.mg_tableclass as string), (container.name as string))"
             class="font-display tracking-widest uppercase text-heading-lg hover:underline cursor-pointer"
           >
             <BaseIcon name="Edit" :width="18" />
@@ -142,11 +126,6 @@ function setNuxtLink(value: string, page: string): string | undefined {
         </NuxtLink>
       </div>
     </div>
-    <div v-else>
-      <Message id="page-index-error" :invalid="true">
-        <span>{{ error }}</span>
-      </Message>
-    </div>
   </Container>
   <EditModal
     v-if="formMetadata"
@@ -156,5 +135,6 @@ function setNuxtLink(value: string, page: string): string | undefined {
     :metadata="formMetadata"
     :isInsert="true"
     v-model:visible="showFormModal"
+    @update:cancelled="onClose"
   />
 </template>

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -98,15 +98,7 @@ function setNuxtLink(value: string, page: string): string | undefined {
       </template>
     </PageHeader>
     <div class="flex pb-7.5 justify-between">
-      <div class="w-3/5 xl:w-2/5 2xl:w-1/5">
-        <label for="page-search" class="sr-only"> Search for pages </label>
-        <InputSearch
-          id="page-search"
-          size="medium"
-          v-model="search"
-          placeholder="Search for pages"
-        />
-      </div>
+      <div class="w-3/5 xl:w-2/5 2xl:w-1/5" />
       <div class="flex gap-2.5">
         <ButtonDropdown label="Add new page">
           <Button


### PR DESCRIPTION
### What are the main changes you did

This PR closes molgenis/GCC#3206

- [x] Create button that allows users to create a new page (either a configurable page or a developer page)
- [x] Connect buttons to the right form
- [x] Gallery is refreshed when a new page is created
- [x] Add generic message if no pages are found

### How to test

#### Creating a new page

1. Go to the preview and sign in as admin. Create a new schema using the `MG_CMS` template and include the demo data.
2. In the new UI, go to the new schema and navigate to the page gallery: `/apps/ui/<schema>/pages`
3. Have a look at the demo pages if you would like
4. Click the "Add new page" button. Choose a page type, enter the required fields, and save. The new page is now in the gallery. 

#### Catching the "new pages found error"

1. Create a new schema using the `MG_CMS` template and **do not** include the demo data
2. Go back the page gallery in the UI: `/apps/ui/<schema>/pages`
3. A message should be displayed that informs users that no pages are available.
4. Add a page

#### Catching other errors

For now, the page editor is fully available when using the `MG_CMS` template. If a user were to access the page gallery, they should see an error.

1. In the new UI, go to the page gallery in the pet store: `/apps/ui/pet store/pages`
2. See error message

### Checklist

- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
