### PR TITLE
refactor(beacon): Cleanup QueryEntryType state overhead and prevent repeated Templates fetch

### DIFF
--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/QueryEntryType.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/QueryEntryType.java
@@ -58,9 +58,7 @@ public class QueryEntryType {
     if (table == null) {
       throw new MolgenisException("Table " + tableId + " does not exist");
     }
-    if (hasPermissionForGranularity(schema, table.getMetadata())) {
-      numTotalResults = queryTable(table, filterParser, resultSets);
-    }
+    numTotalResults = queryTable(table, filterParser, resultSets);
 
     if (!granularity.equals(Granularity.BOOLEAN)) {
       response.put("numTotalResults", numTotalResults);

--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/QueryEntryType.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/QueryEntryType.java
@@ -31,8 +31,6 @@ public class QueryEntryType {
   private final IncludedResultsetResponses includeStrategy;
 
   private static final ObjectMapper mapper = new ObjectMapper();
-  private Database database;
-  private Schema schema;
 
   public QueryEntryType(BeaconRequestBody request) {
     this.request = request;
@@ -43,17 +41,14 @@ public class QueryEntryType {
   }
 
   public JsonNode query(Schema schema) {
-    if (schema != null) {
-      this.database = schema.getDatabase();
-      this.schema = schema;
-    }
+    Database database = schema.getDatabase();
     ObjectNode response = mapper.createObjectNode();
     response.set("requestBody", mapper.valueToTree(request));
     FilterParser filterParser = parseFilters(response);
 
     int numTotalResults = 0;
     ArrayNode resultSets = mapper.createArrayNode();
-    String tableId = resolveTableId(schema.getName());
+    String tableId = resolveTableId(database, schema.getName());
     Table table = schema.getTable(tableId);
     if (table == null) {
       throw new MolgenisException("Table " + tableId + " does not exist");
@@ -64,11 +59,10 @@ public class QueryEntryType {
       response.put("numTotalResults", numTotalResults);
     }
     response.set("resultSets", resultSets);
-    return getJsltResponse(response);
+    return getJsltResponse(database, schema, response);
   }
 
   public JsonNode query(Database database) throws JsltException {
-    this.database = database;
     ObjectNode response = mapper.createObjectNode();
     response.set("requestBody", mapper.valueToTree(request));
     FilterParser filterParser = parseFilters(response);
@@ -79,7 +73,7 @@ public class QueryEntryType {
     for (String schemaName : database.getSchemaNames()) {
       Schema entrySchema = database.getSchema(schemaName);
       if (entrySchema == null) continue;
-      Table table = entrySchema.getTable(resolveTableId(schemaName));
+      Table table = entrySchema.getTable(resolveTableId(database, schemaName));
       if (table != null) {
         numTotalResults += queryTable(table, filterParser, resultSets);
       }
@@ -88,7 +82,7 @@ public class QueryEntryType {
       response.put("numTotalResults", numTotalResults);
     }
     response.set("resultSets", resultSets);
-    return getJsltResponse(response);
+    return getJsltResponse(database, null, response);
   }
 
   private int queryTable(Table table, FilterParser filterParser, ArrayNode resultSets) {
@@ -136,12 +130,12 @@ public class QueryEntryType {
     return numTotalResults;
   }
 
-  private ObjectNode getJsltResponse(ObjectNode response) {
+  private ObjectNode getJsltResponse(Database database, Schema schema, ObjectNode response) {
     ArrayNode resultSets = response.withArray("resultSets");
 
     String template = null;
     if (schema != null) {
-      Row templateRow = getTemplateRow(schema.getName());
+      Row templateRow = getTemplateRow(database, schema.getName());
       template = templateRow != null ? templateRow.get("template", String.class) : null;
     }
 
@@ -162,13 +156,13 @@ public class QueryEntryType {
     return jsltResponse;
   }
 
-  private String resolveTableId(String schemaName) {
-    Row templateRow = getTemplateRow(schemaName);
+  private String resolveTableId(Database database, String schemaName) {
+    Row templateRow = getTemplateRow(database, schemaName);
     String configuredTable = templateRow != null ? templateRow.getString("tableName") : null;
     return configuredTable != null ? configuredTable : entryType.getId();
   }
 
-  private Row getTemplateRow(String schemaName) {
+  private Row getTemplateRow(Database database, String schemaName) {
     if (database == null) {
       return null;
     }

--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/QueryEntryType.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/QueryEntryType.java
@@ -11,6 +11,7 @@ import com.schibsted.spt.data.jslt.JsltException;
 import com.schibsted.spt.data.jslt.Parser;
 import graphql.ExecutionResult;
 import java.util.List;
+import java.util.Objects;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.beaconv2.common.misc.Granularity;
 import org.molgenis.emx2.beaconv2.common.misc.IncludedResultsetResponses;
@@ -42,16 +43,16 @@ public class QueryEntryType {
 
   public JsonNode query(Schema schema) {
     Database database = schema.getDatabase();
+    ResolvedTemplate template = resolveTemplate(database, schema.getName());
     ObjectNode response = mapper.createObjectNode();
     response.set("requestBody", mapper.valueToTree(request));
     FilterParser filterParser = parseFilters(response);
 
     int numTotalResults = 0;
     ArrayNode resultSets = mapper.createArrayNode();
-    String tableId = resolveTableId(database, schema.getName());
-    Table table = schema.getTable(tableId);
+    Table table = schema.getTable(template.tableId());
     if (table == null) {
-      throw new MolgenisException("Table " + tableId + " does not exist");
+      throw new MolgenisException("Table " + template.tableId() + " does not exist");
     }
     numTotalResults = queryTable(table, filterParser, resultSets);
 
@@ -59,7 +60,7 @@ public class QueryEntryType {
       response.put("numTotalResults", numTotalResults);
     }
     response.set("resultSets", resultSets);
-    return getJsltResponse(database, schema, response);
+    return getJsltResponse(template.jslt(), response);
   }
 
   public JsonNode query(Database database) throws JsltException {
@@ -73,7 +74,8 @@ public class QueryEntryType {
     for (String schemaName : database.getSchemaNames()) {
       Schema entrySchema = database.getSchema(schemaName);
       if (entrySchema == null) continue;
-      Table table = entrySchema.getTable(resolveTableId(database, schemaName));
+      ResolvedTemplate template = resolveTemplate(database, schemaName);
+      Table table = entrySchema.getTable(template.tableId());
       if (table != null) {
         numTotalResults += queryTable(table, filterParser, resultSets);
       }
@@ -82,7 +84,7 @@ public class QueryEntryType {
       response.put("numTotalResults", numTotalResults);
     }
     response.set("resultSets", resultSets);
-    return getJsltResponse(database, null, response);
+    return getJsltResponse(null, response);
   }
 
   private int queryTable(Table table, FilterParser filterParser, ArrayNode resultSets) {
@@ -130,18 +132,12 @@ public class QueryEntryType {
     return numTotalResults;
   }
 
-  private ObjectNode getJsltResponse(Database database, Schema schema, ObjectNode response) {
+  private ObjectNode getJsltResponse(String jsltOverride, ObjectNode response) {
     ArrayNode resultSets = response.withArray("resultSets");
 
-    String template = null;
-    if (schema != null) {
-      Row templateRow = getTemplateRow(database, schema.getName());
-      template = templateRow != null ? templateRow.get("template", String.class) : null;
-    }
-
     Expression jslt;
-    if (template != null) {
-      jslt = Parser.compileString(template);
+    if (jsltOverride != null) {
+      jslt = Parser.compileString(jsltOverride);
     } else {
       String jsltPath = "entry-types/" + entryType.getName().toLowerCase() + ".jslt";
       jslt = Parser.compileResource(jsltPath);
@@ -156,10 +152,17 @@ public class QueryEntryType {
     return jsltResponse;
   }
 
-  private String resolveTableId(Database database, String schemaName) {
-    Row templateRow = getTemplateRow(database, schemaName);
-    String configuredTable = templateRow != null ? templateRow.getString("tableName") : null;
-    return configuredTable != null ? configuredTable : entryType.getId();
+  /* Resolved template for a (schema, entry type): tableId always set; null jslt means use the packaged template. */
+  private record ResolvedTemplate(String tableId, String jslt) {}
+
+  private ResolvedTemplate resolveTemplate(Database database, String schemaName) {
+    Row row = getTemplateRow(database, schemaName);
+    if (row == null) {
+      return new ResolvedTemplate(entryType.getId(), null);
+    }
+    String tableId = Objects.requireNonNullElse(row.getString("tableName"), entryType.getId());
+    String jslt = row.getString("template");
+    return new ResolvedTemplate(tableId, jslt);
   }
 
   private Row getTemplateRow(Database database, String schemaName) {

--- a/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/beacon/BeaconConfigurableTableTest.java
+++ b/backend/molgenis-emx2-datamodels/src/test/java/org/molgenis/emx2/datamodels/beacon/BeaconConfigurableTableTest.java
@@ -9,12 +9,17 @@ import static org.molgenis.emx2.TableMetadata.table;
 import com.fasterxml.jackson.databind.JsonNode;
 import io.javalin.http.Context;
 import java.util.HashMap;
+import java.util.List;
 import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.molgenis.emx2.Database;
+import org.molgenis.emx2.MolgenisException;
+import org.molgenis.emx2.Row;
 import org.molgenis.emx2.Schema;
+import org.molgenis.emx2.Table;
 import org.molgenis.emx2.beaconv2.EntryType;
 import org.molgenis.emx2.beaconv2.QueryEntryType;
 import org.molgenis.emx2.beaconv2.requests.BeaconRequestBody;
@@ -30,6 +35,9 @@ public class BeaconConfigurableTableTest {
 
   private static final String SCHEMA_NAME = "BeaconConfigurableTableTest";
   private static final String CUSTOM_TABLE = "Subjects";
+  private static final String ENDPOINT = "beacon_" + EntryType.INDIVIDUALS.getName();
+  private static final String MARKER_TEMPLATE = "{ \"marker\": \"custom-template\" }";
+
   private static Database database;
   private static Schema schema;
 
@@ -43,34 +51,101 @@ public class BeaconConfigurableTableTest {
     schema.getTable(CUSTOM_TABLE).insert(row("id", "S1"), row("id", "S2"), row("id", "S3"));
   }
 
+  @AfterEach
+  void removeTemplateRows() {
+    database.becomeAdmin();
+    Table templates = database.getSchema(SYSTEM_SCHEMA).getTable("Templates");
+    List<Row> rows =
+        templates.retrieveRows().stream()
+            .filter(r -> SCHEMA_NAME.equals(r.getString("schema")))
+            .toList();
+    if (!rows.isEmpty()) {
+      templates.delete(rows);
+    }
+  }
+
   @AfterAll
   void cleanup() {
     database.becomeAdmin();
-    // dropping the schema cascades through the foreign key and removes the Templates row
+    // dropping the schema cascades through the foreign key and removes any Templates rows
     database.dropSchemaIfExists(SCHEMA_NAME);
   }
 
   @Test
   void queriesConfiguredTableInsteadOfEnumDefault() {
-    database.becomeAdmin();
-    Schema systemSchema = database.getSchema(SYSTEM_SCHEMA);
-    systemSchema
-        .getTable("Templates")
-        .insert(
-            row(
-                "endpoint", "beacon_" + EntryType.INDIVIDUALS.getName(),
-                "schema", SCHEMA_NAME,
-                "tableName", CUSTOM_TABLE));
+    insertTemplate(row("endpoint", ENDPOINT, "schema", SCHEMA_NAME, "tableName", CUSTOM_TABLE));
 
-    Context request =
-        BeaconTestUtil.mockEntryTypeRequestRegular(EntryType.INDIVIDUALS.getId(), new HashMap<>());
-    QueryEntryType queryEntryType = new QueryEntryType(new BeaconRequestBody(request));
-    JsonNode json = queryEntryType.query(database.getSchema(SCHEMA_NAME));
-
+    JsonNode json = newQuery().query(schema);
     JsonNode resultSet = json.get("response").get("resultSets").get(0);
     // proves the query targeted the configured "Subjects" table (3 rows) and not the
     // non-existent "Individuals" table that the enum would otherwise resolve to
     assertEquals(3, resultSet.get("resultsCount").intValue());
     assertEquals(3, resultSet.get("results").size());
+  }
+
+  @Test
+  void appliesConfiguredJsltTemplate_singleSchema() {
+    insertTemplate(
+        row(
+            "endpoint", ENDPOINT,
+            "schema", SCHEMA_NAME,
+            "tableName", CUSTOM_TABLE,
+            "template", MARKER_TEMPLATE));
+
+    JsonNode json = newQuery().query(schema);
+    assertEquals("custom-template", json.path("marker").asText());
+    assertFalse(json.has("response"));
+  }
+
+  @Test
+  void crossSchemaHonorsConfiguredTableName() {
+    insertTemplate(row("endpoint", ENDPOINT, "schema", SCHEMA_NAME, "tableName", CUSTOM_TABLE));
+
+    JsonNode json = newQuery().query(database);
+    JsonNode resultSet = resultSetFor(json, SCHEMA_NAME);
+    assertNotNull(resultSet, "cross-schema query should include the configured schema");
+    assertEquals(3, resultSet.get("resultsCount").intValue());
+  }
+
+  @Test
+  void crossSchemaIgnoresConfiguredJsltTemplate() {
+    insertTemplate(
+        row(
+            "endpoint", ENDPOINT,
+            "schema", SCHEMA_NAME,
+            "tableName", CUSTOM_TABLE,
+            "template", MARKER_TEMPLATE));
+
+    JsonNode json = newQuery().query(database);
+    assertFalse(json.has("marker"));
+    assertTrue(json.has("response"));
+  }
+
+  @Test
+  void missingTableThrowsForSingleSchemaButIsSkippedCrossSchema() {
+    assertThrows(MolgenisException.class, () -> newQuery().query(schema));
+
+    JsonNode json = assertDoesNotThrow(() -> newQuery().query(database));
+    assertNull(resultSetFor(json, SCHEMA_NAME));
+  }
+
+  private void insertTemplate(Row row) {
+    database.becomeAdmin();
+    database.getSchema(SYSTEM_SCHEMA).getTable("Templates").insert(row);
+  }
+
+  private QueryEntryType newQuery() {
+    Context request =
+        BeaconTestUtil.mockEntryTypeRequestRegular(EntryType.INDIVIDUALS.getId(), new HashMap<>());
+    return new QueryEntryType(new BeaconRequestBody(request));
+  }
+
+  private static JsonNode resultSetFor(JsonNode response, String schemaId) {
+    for (JsonNode resultSet : response.get("response").get("resultSets")) {
+      if (schemaId.equals(resultSet.path("id").asText())) {
+        return resultSet;
+      }
+    }
+    return null;
   }
 }


### PR DESCRIPTION
Cleanup of `QueryEntryType` alongside the configurable-`tableId` work — no behavioural change.

### Changes
- Remove the mutable `database`/`schema` fields; the two `query()` overloads no longer doubled as initializers. Values are threaded as parameters instead, removing an instance-reuse hazard.
- Fetch the `Templates` row once per schema (was twice in the single-schema path, each a `becomeAdmin` + full scan) and resolve it into a small `ResolvedTemplate(tableId, jslt)` record, so callers read named fields instead of null-checking a `Row` and its columns.
- `tableId` default is applied in one place via `requireNonNullElse`, so it's always populated.
- `getJsltResponse` takes the nullable `jsltOverride` string; `null` = use the packaged template (making the cross-schema path's behaviour explicit at the call site).

### Testing
Beacon datamodels tests pass (`:backend:molgenis-emx2-datamodels:test --tests "...beacon.*"`): 65 run, 0 failures.

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
