### PR TITLE
fix(backend): normalize and validate file paths in static file serving and script task setup

### DIFF
--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
@@ -178,6 +178,7 @@ public class ScriptTask extends Task {
       byte[] extraFileContent = (byte[]) this.extraFile.get(EXTRA_FILE_CONTENTS);
       Object extraFileExtension = this.extraFile.get(EXTRA_FILE_EXTENSION);
       Path extraFilePath = tempDir.resolve(extraFileName);
+      checkForZipSlip(tempDir, extraFilePath.toFile());
 
       try (FileOutputStream fos = new FileOutputStream(extraFilePath.toFile())) {
         fos.write(extraFileContent);

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptFilePathSanity.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptFilePathSanity.java
@@ -1,0 +1,39 @@
+package org.molgenis.emx2.tasks;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.molgenis.emx2.tasks.ScriptType.PYTHON;
+import static org.molgenis.emx2.tasks.TaskStatus.ERROR;
+
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.MolgenisException;
+import org.molgenis.emx2.Row;
+
+class TestScriptFilePathSanity {
+  private static Row extraFile(String filename) {
+    return new Row(
+        "extraFile",
+        "attachment",
+        "extraFile_filename",
+        filename,
+        "extraFile_extension",
+        "csv",
+        "extraFile_contents",
+        new byte[] {1, 2, 3});
+  }
+
+  @Test
+  void rejectsExtraFileResolvingOutsideTempDir() {
+    ScriptTask task =
+        new ScriptTask("extra file outside temp dir")
+            .type(PYTHON)
+            .extraFile(extraFile("../attachment.csv"))
+            .script("print('never runs')");
+
+    // setup fails before the script is executed, so run() reports the error and re-throws
+    assertThrows(MolgenisException.class, task::run);
+    assertEquals(ERROR, task.getStatus());
+    assertTrue(task.getDescription().contains("illegal path"));
+  }
+}

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptFilePathSanity.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptFilePathSanity.java
@@ -13,15 +13,16 @@ import org.molgenis.emx2.Row;
 class TestScriptFilePathSanity {
   @Test
   void rejectsExtraFileResolvingOutsideTempDir() {
-    Row scriptMetadata = new Row(
-        "extraFile",
-        "attachment",
-        "extraFile_filename",
-        "../attachment.csv",
-        "extraFile_extension",
-        "csv",
-        "extraFile_contents",
-        new byte[] {1, 2, 3});
+    Row scriptMetadata =
+        new Row(
+            "extraFile",
+            "attachment",
+            "extraFile_filename",
+            "../attachment.csv",
+            "extraFile_extension",
+            "csv",
+            "extraFile_contents",
+            new byte[] {1, 2, 3});
 
     ScriptTask task =
         new ScriptTask("extra file outside temp dir")

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptFilePathSanity.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptFilePathSanity.java
@@ -11,24 +11,22 @@ import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Row;
 
 class TestScriptFilePathSanity {
-  private static Row extraFile(String filename) {
-    return new Row(
+  @Test
+  void rejectsExtraFileResolvingOutsideTempDir() {
+    Row scriptMetadata = new Row(
         "extraFile",
         "attachment",
         "extraFile_filename",
-        filename,
+        "../attachment.csv",
         "extraFile_extension",
         "csv",
         "extraFile_contents",
         new byte[] {1, 2, 3});
-  }
 
-  @Test
-  void rejectsExtraFileResolvingOutsideTempDir() {
     ScriptTask task =
         new ScriptTask("extra file outside temp dir")
             .type(PYTHON)
-            .extraFile(extraFile("../attachment.csv"))
+            .extraFile(scriptMetadata)
             .script("print('never runs')");
 
     // setup fails before the script is executed, so run() reports the error and re-throws

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ServeStaticFile.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ServeStaticFile.java
@@ -4,6 +4,8 @@ import static org.molgenis.emx2.ColumnType.STRING;
 
 import com.google.common.io.ByteStreams;
 import io.javalin.http.Context;
+import io.javalin.http.HttpStatus;
+
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URLConnection;
@@ -18,8 +20,6 @@ import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.utils.EnvironmentProperty;
 
 public class ServeStaticFile {
-
-  private static final String FORBIDDEN = "Forbidden";
 
   private record AppsPath(boolean isFile, boolean isUi, String mimeType, String path) {
 
@@ -120,7 +120,7 @@ public class ServeStaticFile {
     Path internalRoot = Path.of(INTERNAL_APP_FOLDER).normalize();
     Path resolved = Path.of(path).normalize();
     if (!resolved.startsWith(internalRoot)) {
-      ctx.status(403).result(FORBIDDEN);
+      ctx.status(HttpStatus.FORBIDDEN).result(HttpStatus.FORBIDDEN.getMessage());
       return;
     }
     String resourcePath = convertWindowsPathToJarPath(resolved.toString());
@@ -153,7 +153,7 @@ public class ServeStaticFile {
         internalAppsDirectory.resolve(fallbackFileBase).normalize().toString();
 
     if (!requestedInternalFilePath.startsWith(internalAppsDirectory.toString())) {
-      ctx.status(403).result(FORBIDDEN);
+      ctx.status(HttpStatus.FORBIDDEN).result(HttpStatus.FORBIDDEN.getMessage());
       return;
     }
 
@@ -184,7 +184,7 @@ public class ServeStaticFile {
 
     if (!requestedExternalFilePath.startsWith(externalAppsDirectory)) {
       // Suspected path traversal: reject the request
-      ctx.status(403).result(FORBIDDEN);
+      ctx.status(HttpStatus.FORBIDDEN).result(HttpStatus.FORBIDDEN.getMessage());
       return;
     }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ServeStaticFile.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ServeStaticFile.java
@@ -5,7 +5,6 @@ import static org.molgenis.emx2.ColumnType.STRING;
 import com.google.common.io.ByteStreams;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
-
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.net.URLConnection;

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ServeStaticFile.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ServeStaticFile.java
@@ -19,6 +19,8 @@ import org.molgenis.emx2.utils.EnvironmentProperty;
 
 public class ServeStaticFile {
 
+  private static final String FORBIDDEN = "Forbidden";
+
   private record AppsPath(boolean isFile, boolean isUi, String mimeType, String path) {
 
     public static AppsPath fromContext(Context ctx) {
@@ -118,7 +120,7 @@ public class ServeStaticFile {
     Path internalRoot = Path.of(INTERNAL_APP_FOLDER).normalize();
     Path resolved = Path.of(path).normalize();
     if (!resolved.startsWith(internalRoot)) {
-      ctx.status(403).result("Forbidden");
+      ctx.status(403).result(FORBIDDEN);
       return;
     }
     String resourcePath = convertWindowsPathToJarPath(resolved.toString());
@@ -151,7 +153,7 @@ public class ServeStaticFile {
         internalAppsDirectory.resolve(fallbackFileBase).normalize().toString();
 
     if (!requestedInternalFilePath.startsWith(internalAppsDirectory.toString())) {
-      ctx.status(403).result("Forbidden");
+      ctx.status(403).result(FORBIDDEN);
       return;
     }
 
@@ -182,7 +184,7 @@ public class ServeStaticFile {
 
     if (!requestedExternalFilePath.startsWith(externalAppsDirectory)) {
       // Suspected path traversal: reject the request
-      ctx.status(403).result("Forbidden");
+      ctx.status(403).result(FORBIDDEN);
       return;
     }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ServeStaticFile.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ServeStaticFile.java
@@ -113,14 +113,21 @@ public class ServeStaticFile {
     return false;
   }
 
-  // Serve internal file
+  // Serve internal file (classpath resource under the internal apps root)
   public static void serve(Context ctx, String path) {
+    Path internalRoot = Path.of(INTERNAL_APP_FOLDER).normalize();
+    Path resolved = Path.of(path).normalize();
+    if (!resolved.startsWith(internalRoot)) {
+      ctx.status(403).result("Forbidden");
+      return;
+    }
+    String resourcePath = convertWindowsPathToJarPath(resolved.toString());
 
-    try (InputStream in = ServeStaticFile.class.getResourceAsStream(path)) {
-      String mimeType = URLConnection.guessContentTypeFromName(path);
+    try (InputStream in = ServeStaticFile.class.getResourceAsStream(resourcePath)) {
+      String mimeType = URLConnection.guessContentTypeFromName(resourcePath);
 
       if (mimeType == null) {
-        mimeType = Files.probeContentType(Path.of(path));
+        mimeType = Files.probeContentType(resolved);
       }
       send(ctx, in, mimeType);
     } catch (Exception e) {

--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/ServeStaticFileTest.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/ServeStaticFileTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.*;
 
 import io.javalin.http.Context;
+import io.javalin.http.HttpStatus;
 import java.nio.charset.StandardCharsets;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
@@ -43,26 +44,26 @@ class ServeStaticFileTest {
   @Test
   void testServe_RejectsPathResolvingOutsideRoot() {
     Context ctx = mock(Context.class);
-    when(ctx.status(anyInt())).thenReturn(ctx);
+    when(ctx.status(HttpStatus.FORBIDDEN)).thenReturn(ctx);
     // normalizes to /test.txt, which resolves outside the internal apps root
     String path = "/public_html/apps/../../test.txt";
 
     ServeStaticFile.serve(ctx, path);
 
-    verify(ctx).status(403);
+    verify(ctx).status(HttpStatus.FORBIDDEN);
     verify(ctx).result("Forbidden");
   }
 
   @Test
   void testServe_RejectsPathOutsideRoot() {
     Context ctx = mock(Context.class);
-    when(ctx.status(anyInt())).thenReturn(ctx);
+    when(ctx.status(HttpStatus.FORBIDDEN)).thenReturn(ctx);
     // this resource exists on the classpath, but is not under the internal root
     String path = "/test.txt";
 
     ServeStaticFile.serve(ctx, path);
 
-    verify(ctx).status(403);
+    verify(ctx).status(HttpStatus.FORBIDDEN);
     verify(ctx).result("Forbidden");
   }
 
@@ -116,13 +117,13 @@ class ServeStaticFileTest {
   }
 
   @Test
-  void testServeOnlyContext_NotFoundOnPathTraversalAttempt() {
+  void testServeOnlyContext_ForbiddenOnPathTraversalAttempt() {
     Context ctx = mock(Context.class);
-    when(ctx.status(anyInt())).thenReturn(ctx);
+    when(ctx.status(HttpStatus.FORBIDDEN)).thenReturn(ctx);
     when(ctx.path()).thenReturn("/apps/../../example-app");
 
     ServeStaticFile.serve(ctx);
-    verify(ctx).status(403);
+    verify(ctx).status(HttpStatus.FORBIDDEN);
   }
 
   @Test

--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/ServeStaticFileTest.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/ServeStaticFileTest.java
@@ -14,24 +14,56 @@ class ServeStaticFileTest {
   @Test
   void testServe_FileExists() {
     Context ctx = mock(Context.class);
-    String path = "/test.txt";
+    // serve(ctx, path) only serves resources under the internal apps root
+    String path = "/public_html/apps/test-app/test-assets/styling.css";
 
     ServeStaticFile.serve(ctx, path);
 
-    verify(ctx).header("Content-Type", "text/plain");
-    verify(ctx).result("test".getBytes());
+    verify(ctx).header("Content-Type", "text/css");
+
+    ArgumentCaptor<byte[]> captor = ArgumentCaptor.forClass(byte[].class);
+    verify(ctx).result(captor.capture());
+    String served = new String(captor.getValue(), StandardCharsets.UTF_8);
+    assertTrue(served.contains("color:red"));
   }
 
   @Test
   void testServe_FileNotFound() {
     Context ctx = mock(Context.class);
-    String path = "/non-existent-file.css";
+    // in-contract path (under the internal root) but no such resource
+    String path = "/public_html/apps/non-existent-file.css";
     when(ctx.status(404)).thenReturn(ctx);
 
     ServeStaticFile.serve(ctx, path);
 
     verify(ctx).status(404);
     verify(ctx).result(NOT_FOUND + ctx.path());
+  }
+
+  @Test
+  void testServe_RejectsPathResolvingOutsideRoot() {
+    Context ctx = mock(Context.class);
+    when(ctx.status(anyInt())).thenReturn(ctx);
+    // normalizes to /test.txt, which resolves outside the internal apps root
+    String path = "/public_html/apps/../../test.txt";
+
+    ServeStaticFile.serve(ctx, path);
+
+    verify(ctx).status(403);
+    verify(ctx).result("Forbidden");
+  }
+
+  @Test
+  void testServe_RejectsPathOutsideRoot() {
+    Context ctx = mock(Context.class);
+    when(ctx.status(anyInt())).thenReturn(ctx);
+    // this resource exists on the classpath, but is not under the internal root
+    String path = "/test.txt";
+
+    ServeStaticFile.serve(ctx, path);
+
+    verify(ctx).status(403);
+    verify(ctx).result("Forbidden");
   }
 
   @Test


### PR DESCRIPTION
### What are the main changes you did

Made file path resolution more robust in two places:
- `ServeStaticFile.serve` now normalizes the requested path and only serves classpath resources under the internal apps root, returning 403 otherwise. Mimetype probing now uses the normalized path.
- `ScriptTask` applies the same path containment check to the extra-file write that the extraction loop already uses, so both write paths go through identical validation.
