### PR TITLE
fix: Input Ontology breaks form when ontology is empty

### DIFF
--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -7,6 +7,7 @@
     :errorMessage="errorMessage"
   >
     <MessageError v-if="error">{{ error }}</MessageError>
+    <MessageWarning v-if="warning">{{ warning }}</MessageWarning>
     <div
       class="p-0 m-0"
       :class="{ dropdown: !showExpanded, 'border rounded': !showExpanded }"
@@ -168,6 +169,7 @@ export default {
   data() {
     return {
       error: null,
+      warning: null,
       // used for drop down focus state
       focus: false,
       //huge object with all the terms, flattened
@@ -474,7 +476,11 @@ export default {
       },
     },
     data() {
-      if (this.data) {
+      if (!this.data) {
+        this.loading = false;
+        this.warning = `Ontology '${this.tableId}' in schema '${this.schemaId}' is empty`;
+      } else {
+        this.warning = null;
         this.searchResultCount = 0;
 
         //convert to tree of terms

--- a/apps/molgenis-components/src/components/forms/InputOntology.vue
+++ b/apps/molgenis-components/src/components/forms/InputOntology.vue
@@ -116,6 +116,7 @@ import BaseInput from "./baseInputs/BaseInput.vue";
 import FormGroup from "./FormGroup.vue";
 import InputOntologySubtree from "./InputOntologySubtree.vue";
 import MessageError from "./MessageError.vue";
+import MessageWarning from "./MessageWarning.vue";
 //@ts-ignore
 import vClickOutside from "click-outside-vue3";
 import Spinner from "../layout/Spinner.vue";
@@ -476,7 +477,7 @@ export default {
       },
     },
     data() {
-      if (!this.data) {
+      if (!this.data || !this.data.length) {
         this.loading = false;
         this.warning = `Ontology '${this.tableId}' in schema '${this.schemaId}' is empty`;
       } else {


### PR DESCRIPTION


Closes #2712

### What are the main changes you did
- Show warning in case ontology options are empty

### How to test
- see issue 

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
