### PR TITLE
fix: simplify radius styling and theming

### DIFF
--- a/apps/catalogue/app/app.vue
+++ b/apps/catalogue/app/app.vue
@@ -105,7 +105,7 @@ useHead({
           button-alignment="right"
         >
           <section
-            class="bg-white py-9 lg:px-12.5 px-4 text-gray-900 xl:rounded-3px"
+            class="bg-white py-9 lg:px-12.5 px-4 text-gray-900 xl:rounded-base"
           >
             <h2 class="mb-5 uppercase text-heading-4xl font-display">
               Cookies 🍪🍪🍪

--- a/apps/catalogue/app/components/BottomModal.vue
+++ b/apps/catalogue/app/components/BottomModal.vue
@@ -45,7 +45,7 @@ const emit = defineEmits(["close"]);
     <template #popper="{ hide }">
       <div class="flex justify-center">
         <div
-          class="fixed bottom-0 bg-white overflow-hidden rounded-t-50px w-[95vw]"
+          class="fixed bottom-0 bg-white overflow-hidden rounded-t-alt w-[95vw]"
         >
           <div class="w-full overflow-auto">
             <button @click="hide()" class="absolute top-7 right-8">

--- a/apps/catalogue/app/components/FilterWell.vue
+++ b/apps/catalogue/app/components/FilterWell.vue
@@ -61,7 +61,7 @@ function isAFilterSet(filters: IFilter[]) {
 <template>
   <div
     v-if="isAFilterSet(filters)"
-    class="bg-search-results-view-tabs text-white flex items-center rounded-t-3px"
+    class="bg-search-results-view-tabs text-white flex items-center rounded-t-base"
   >
     <div class="p-4 whitespace-nowrap justify-self-start self-start">
       Active filters

--- a/apps/catalogue/app/components/MainNavigation.vue
+++ b/apps/catalogue/app/components/MainNavigation.vue
@@ -43,7 +43,7 @@ const active = "underline";
       v-if="subButtons.length > 0 && showMoreButton"
     >
       <button
-        class="flex items-center gap-1 pt-3 pb-2 pl-4 pr-2 -mt-3 -ml-4 tracking-widest transition-colors duration-300 translate-y-1 border border-b-0 border-transparent rounded-t-3px font-display text-heading-xl hover:border-white"
+        class="flex items-center gap-1 pt-3 pb-2 pl-4 pr-2 -mt-3 -ml-4 tracking-widest transition-colors duration-300 translate-y-1 border border-b-0 border-transparent rounded-t-base font-display text-heading-xl hover:border-white"
         :class="invert ? 'text-sub-menu' : 'text-menu'"
       >
         More
@@ -52,7 +52,7 @@ const active = "underline";
 
       <template #popper>
         <ol
-          class="flex flex-col gap-1.5 bg-white text-body-base rounded-3px rounded-tr-none shadow-xl p-6"
+          class="flex flex-col gap-1.5 bg-white text-body-base rounded-base rounded-tr-none shadow-xl p-6"
         >
           <li v-for="button in subButtons">
             <a

--- a/apps/catalogue/app/components/SearchBar.vue
+++ b/apps/catalogue/app/components/SearchBar.vue
@@ -10,11 +10,11 @@ function submitSearch(event) {
   <form class="relative" @submit.prevent="submitSearch">
     <input
       type="search"
-      class="w-full pr-32 font-sans text-gray-900 bg-white outline-none rounded-search-input h-15 ring-red-500 pl-7 border-search-input focus:border-white shadow-search-input focus:shadow-search-input hover:shadow-search-input"
+      class="w-full pr-32 font-sans text-gray-900 bg-white outline-none rounded-alt h-15 ring-red-500 pl-7 border-search-input focus:border-white shadow-search-input focus:shadow-search-input hover:shadow-search-input"
       placeholder="Search variable. cohort etc"
     />
     <button
-      class="rounded-search-button absolute top-0 right-0 flex items-center pl-8 pr-6 tracking-wider text-search-button border-search-button border-[1px] transition-colors bg-search-button h-15 font-display text-heading-2xl hover:text-search-button-hover"
+      class="rounded-alt absolute top-0 right-0 flex items-center pl-8 pr-6 tracking-wider text-search-button border-search-button border-[1px] transition-colors bg-search-button h-15 font-display text-heading-2xl hover:text-search-button-hover"
     >
       Search
     </button>

--- a/apps/catalogue/app/components/SearchResultsList.vue
+++ b/apps/catalogue/app/components/SearchResultsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="bg-white rounded-t-3px rounded-b-50px shadow-primary pb-5">
+  <div class="bg-white rounded-t-base rounded-b-alt shadow-primary pb-5">
     <slot></slot>
   </div>
 </template>

--- a/apps/catalogue/app/components/SideNavigation.vue
+++ b/apps/catalogue/app/components/SideNavigation.vue
@@ -17,7 +17,7 @@ function setSideMenuStyle(hash: string) {
 
 <template>
   <nav
-    class="text-body-base bg-white rounded-t-3px rounded-b-50px px-12 py-16 shadow-primary mb-18"
+    class="text-body-base bg-white rounded-t-base rounded-b-alt px-12 py-16 shadow-primary mb-18"
   >
     <div v-if="title || image" class="mb-6 font-display text-heading-4xl">
       <NuxtLink

--- a/apps/catalogue/app/components/content/ContentBlockIntro.vue
+++ b/apps/catalogue/app/components/content/ContentBlockIntro.vue
@@ -161,7 +161,7 @@ const submitForm = async () => {
 
 <template>
   <section
-    class="bg-white py-9 lg:px-12.5 px-5 text-gray-900 xl:rounded-3px shadow-primary xl:border-b-0 border-b-[1px]"
+    class="bg-white py-9 lg:px-12.5 px-5 text-gray-900 xl:rounded-base shadow-primary xl:border-b-0 border-b-[1px]"
   >
     <div class="flex flex-col items-center justify-center gap-11 md:flex-row">
       <img v-if="image" class="max-h-11" :src="image" />

--- a/apps/catalogue/app/components/filter/Sidebar.vue
+++ b/apps/catalogue/app/components/filter/Sidebar.vue
@@ -32,7 +32,7 @@ function handleFilerUpdate(filter: IFilter) {
 
 <template>
   <div
-    class="mt-7.5 rounded-t-3px rounded-b-50px"
+    class="mt-7.5 rounded-t-base rounded-b-alt"
     :class="{ 'bg-sidebar-gradient': !mobileDisplay }"
   >
     <h2

--- a/apps/catalogue/app/components/landing/CohortsOnly.vue
+++ b/apps/catalogue/app/components/landing/CohortsOnly.vue
@@ -95,7 +95,7 @@ function getSettingValue(settingKey: string, settings: ISetting[]) {
     ></PageHeader>
 
     <div
-      class="bg-white relative justify-around flex flex-col md:flex-row px-5 pt-5 pb-6 antialiased lg:pb-10 lg:px-0 rounded-t-3px rounded-b-landing shadow-primary"
+      class="bg-white relative justify-around flex flex-col md:flex-row px-5 pt-5 pb-6 antialiased lg:pb-10 lg:px-0 rounded-t-base rounded-b-alt shadow-primary"
     >
       <LandingCardPrimary
         image="image-link"

--- a/apps/catalogue/app/components/landing/Primary.vue
+++ b/apps/catalogue/app/components/landing/Primary.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="bg-white relative justify-around flex flex-col md:flex-row px-5 pt-5 pb-6 antialiased lg:pb-10 lg:px-0 rounded-t-3px rounded-b-landing shadow-primary"
+    class="bg-white relative justify-around flex flex-col md:flex-row px-5 pt-5 pb-6 antialiased lg:pb-10 lg:px-0 rounded-t-base rounded-b-alt shadow-primary"
   >
     <slot></slot>
   </div>

--- a/apps/catalogue/app/components/store/CartButton.vue
+++ b/apps/catalogue/app/components/store/CartButton.vue
@@ -44,7 +44,7 @@ function onInput() {
   <label
     v-else
     :for="`${resource.id}-shopping-cart-input`"
-    class="xl:flex xl:justify-end px-2 py-1 rounded-3px cursor-pointer items-baseline xl:items-center mt-0.5 xl:mt-0"
+    class="xl:flex xl:justify-end px-2 py-1 rounded-base cursor-pointer items-baseline xl:items-center mt-0.5 xl:mt-0"
     :class="{
       'text-button-cart-add hover:text-button-cart-add-hover':
         !isInShoppingCart,

--- a/apps/catalogue/app/pages/about.vue
+++ b/apps/catalogue/app/pages/about.vue
@@ -57,7 +57,7 @@
               frameborder="0"
               allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
               allowfullscreen
-              class="w-full h-full rounded-lg"
+              class="w-full h-full rounded-alt"
             ></iframe>
           </div>
         </ContentBlock>

--- a/apps/tailwind-components/app/assets/css/main.css
+++ b/apps/tailwind-components/app/assets/css/main.css
@@ -67,6 +67,9 @@
     --box-shadow-pagination-gray: 0px 10px 20px rgba(0, 0, 0, 0.1);
     --box-shadow-no-background-modal: 0.1rem 0.1rem 6px rgba(0, 0, 0, 0.1);
 
+    --radius-base: 3px;
+    --radius-alt: 50px;
+
     --background-image-sidebar-gradient: linear-gradient(
       180deg,
       var(--color-gray-50) -24.76%,
@@ -241,15 +244,8 @@
     --border-width-theme: 1px;
     --border-width-form-required: 1px;
 
-    --border-radius-theme: 3px;
-    --border-radius-3px: 3px;
-    --border-radius-50px: 50px;
-    --border-radius-input: 3px;
-    --border-radius-textarea-input: var(--border-radius-input);
-    --border-radius-search-input: 9999px;
-    --border-radius-search-button: 9999px;
-    --border-radius-pagination: 9999px;
-    --border-radius-landing: 50px;
+    --border-radius-base: var(--radius-base);
+    --border-radius-alt: var(--border-radius-base);
 
     --outline-color-select: var(--color-gray-200);
 

--- a/apps/tailwind-components/app/assets/css/plugins/datepicker.css
+++ b/apps/tailwind-components/app/assets/css/plugins/datepicker.css
@@ -13,7 +13,7 @@
 /* override input styles */
 
 .dp__main .dp__input_wrap .dp__input {
-  @apply h-input bg-input text-input border rounded-input;
+  @apply h-input bg-input text-input border rounded-base;
 }
 
 .dp__main .dp__input_wrap .dp__input_icon {

--- a/apps/tailwind-components/app/assets/css/theme/aumc.css
+++ b/apps/tailwind-components/app/assets/css/theme/aumc.css
@@ -56,13 +56,7 @@
   --text-color-pagination: var(--text-color-title);
   --text-color-pagination-input: var(--color-blue-800);
 
-  --border-radius-3px: 3px;
-  --border-radius-50px: 50px;
-  --border-radius-input: 28px;
-  --border-radius-textarea-input: 20px;
-  --border-radius-search-input: 9999px;
-  --border-radius-search-button: 9999px;
-  --border-radius-landing: 50px;
+  --border-radius-alt: var(--radius-alt);
 
   --border-width-theme: 0px;
 

--- a/apps/tailwind-components/app/assets/css/theme/molgenis.css
+++ b/apps/tailwind-components/app/assets/css/theme/molgenis.css
@@ -130,15 +130,7 @@
   --border-color-pagination: var(--color-transparent);
   --border-color-input-inverted: var(--color-gray-600);
 
-  --border-radius-theme: 50px;
-  --border-radius-3px: 3px;
-  --border-radius-50px: 50px;
-  --border-radius-input: 28px;
-  --border-radius-textarea-input: 20px;
-  --border-radius-search-input: 9999px;
-  --border-radius-search-button: 9999px;
-  --border-radius-pagination: 9999px;
-  --border-radius-landing: 50px;
+  --border-radius-alt: var(--radius-alt);
 
   --border-width-theme: 0px;
   --border-color-footer: var(--background-color-footer);

--- a/apps/tailwind-components/app/assets/css/theme/umcg.css
+++ b/apps/tailwind-components/app/assets/css/theme/umcg.css
@@ -109,14 +109,7 @@
   --border-color-checkbox: #cccccc;
   --border-color-footer: var(--background-color-footer);
 
-  --border-radius-3px: 3px;
-  --border-radius-50px: 50px;
-  --border-radius-input: 28px;
-  --border-radius-textarea-input: 20px;
-  --border-radius-search-input: 3px;
-  --border-radius-search-button: 0px 3px 3px 0px;
-  --border-radius-pagination: 3px;
-  --border-radius-landing: 3px;
+  --border-radius-alt: var(--radius-alt);
 
   --border-width-theme: 0px;
 

--- a/apps/tailwind-components/app/components/AccountMenu.vue
+++ b/apps/tailwind-components/app/components/AccountMenu.vue
@@ -9,7 +9,7 @@
     <HeaderButton label="Account" icon="user" />
     <template #popper>
       <div
-        class="px-[10px] py-[5px] border-theme border-color-theme rounded-theme bg-form"
+        class="px-[10px] py-[5px] border-theme border-color-theme rounded-base bg-form"
       >
         <slot v-if="hasCustomContent" />
         <template v-else>

--- a/apps/tailwind-components/app/components/Button.vue
+++ b/apps/tailwind-components/app/components/Button.vue
@@ -40,18 +40,18 @@ watchEffect(() => {
 
 const COLOR_MAPPING = {
   primary:
-    "tracking-widest uppercase rounded-input font-display bg-button-primary text-button-primary border-button-primary hover:bg-button-primary-hover hover:text-button-primary-hover hover:border-button-primary-hover",
+    "tracking-widest uppercase rounded-alt font-display bg-button-primary text-button-primary border-button-primary hover:bg-button-primary-hover hover:text-button-primary-hover hover:border-button-primary-hover",
   secondary:
-    "tracking-widest uppercase rounded-input font-display bg-button-secondary text-button-secondary border-button-secondary hover:bg-button-secondary-hover hover:text-button-secondary-hover hover:border-button-secondary-hover",
+    "tracking-widest uppercase rounded-alt font-display bg-button-secondary text-button-secondary border-button-secondary hover:bg-button-secondary-hover hover:text-button-secondary-hover hover:border-button-secondary-hover",
   tertiary:
-    "tracking-widest uppercase rounded-input font-display bg-button-tertiary text-button-tertiary border-button-tertiary hover:bg-button-tertiary-hover hover:text-button-tertiary-hover hover:border-button-tertiary-hover",
+    "tracking-widest uppercase rounded-alt font-display bg-button-tertiary text-button-tertiary border-button-tertiary hover:bg-button-tertiary-hover hover:text-button-tertiary-hover hover:border-button-tertiary-hover",
   text: "group pl-0 pr-0 flex items-center text-button-text hover:bg-hover hover:text-link-hover cursor-pointer disabled:cursor-not-allowed disabled:text-disabled border-none h-auto",
   outline:
-    "tracking-widest uppercase rounded-input font-display bg-button-outline text-button-outline border-button-outline hover:bg-button-outline-hover hover:text-button-outline-hover hover:border-button-outline-hover",
+    "tracking-widest uppercase rounded-alt font-display bg-button-outline text-button-outline border-button-outline hover:bg-button-outline-hover hover:text-button-outline-hover hover:border-button-outline-hover",
   disabled:
-    "tracking-widest uppercase rounded-input font-display bg-button-disabled text-button-disabled border-button-disabled cursor-not-allowed hover:bg-button-disabled-hover hover:text-button-disabled-hover hover:border-button-disabled-hover",
+    "tracking-widest uppercase rounded-alt font-display bg-button-disabled text-button-disabled border-button-disabled cursor-not-allowed hover:bg-button-disabled-hover hover:text-button-disabled-hover hover:border-button-disabled-hover",
   filterWell:
-    "whitespace-nowrap bg-button-filter rounded-input text-button-filter border-button-filter hover:bg-button-filter-hover hover:border-button-filter-hover focus:bg-button-filter-hover focus:border-button-filter-hover",
+    "whitespace-nowrap bg-button-filter rounded-alt text-button-filter border-button-filter hover:bg-button-filter-hover hover:border-button-filter-hover focus:bg-button-filter-hover focus:border-button-filter-hover",
   inline:
     "tracking-widest bg-none text-button-inline border-none hover:text-button-secondary rounded-full hover:bg-button-inline-hover",
 };
@@ -114,7 +114,7 @@ const tag = computed(() => (props.href ? "a" : "button"));
     :is="tag"
     :href="props.href"
     v-tooltip.bottom="tooltipText"
-    class="flex items-center justify-center border group-[.button-bar]:rounded-none group-[.button-bar]:first:rounded-l-input group-[.button-bar]:last:rounded-r-input duration-default ease-in-out"
+    class="flex items-center justify-center border group-[.button-bar]:rounded-none group-[.button-bar]:first:rounded-l-alt group-[.button-bar]:last:rounded-r-alt duration-default ease-in-out"
     :class="`${colorClasses} ${sizeClasses} ${iconPositionClass} transition-colors`"
   >
     <BaseIcon v-if="icon" :name="icon" :width="iconSize" />

--- a/apps/tailwind-components/app/components/Message.vue
+++ b/apps/tailwind-components/app/components/Message.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     :aria-labelledby="`${id}-state-context`"
-    class="p-3 font-bold flex items-center rounded-input"
+    class="p-3 font-bold flex items-center rounded-alt"
     :class="{
       'bg-invalid text-invalid fill-invalid': invalid,
       'bg-valid text-valid fill-valid': valid,

--- a/apps/tailwind-components/app/components/Modal.vue
+++ b/apps/tailwind-components/app/components/Modal.vue
@@ -88,7 +88,7 @@ function hide() {
               />
 
               <div
-                class="bg-modal w-3/4 relative rounded-theme h-[95vh] flex flex-col pointer-events-auto"
+                class="bg-modal w-3/4 relative rounded-alt h-[95vh] flex flex-col pointer-events-auto"
                 :class="[
                   {
                     'm-auto': type === 'center',
@@ -131,7 +131,7 @@ function hide() {
                 </div>
 
                 <footer
-                  class="bg-modal-footer px-8 rounded-b-theme border-t border-divider flex-none z-50"
+                  class="bg-modal-footer px-8 rounded-b-alt border-t border-divider flex-none z-50"
                   :class="[
                     {
                       'rounded-r-none': type === 'right',

--- a/apps/tailwind-components/app/components/Navigation.vue
+++ b/apps/tailwind-components/app/components/Navigation.vue
@@ -34,7 +34,7 @@ const linkClass =
   "flex items-center gap-1 tracking-widest transition-colors border border-b-0 border-transparent font-display text-heading-xl hover:underline whitespace-nowrap";
 
 const moreButtonClass =
-  "flex items-center gap-1 pt-3 pb-2 pl-4 pr-2 -mt-3 -ml-4 tracking-widest transition-colors duration-300 translate-y-1 border border-b-0 border-transparent rounded-t-3px font-display text-heading-xl hover:border-white";
+  "flex items-center gap-1 pt-3 pb-2 pl-4 pr-2 -mt-3 -ml-4 tracking-widest transition-colors duration-300 translate-y-1 border border-b-0 border-transparent rounded-t-base font-display text-heading-xl hover:border-white";
 </script>
 
 <template>

--- a/apps/tailwind-components/app/components/NavigationMenuItems.vue
+++ b/apps/tailwind-components/app/components/NavigationMenuItems.vue
@@ -14,7 +14,7 @@ defineProps<{
 }>();
 
 const submenuListClass =
-  "flex flex-col gap-1.5 rounded-3px rounded-tr-none bg-form p-6 shadow-xl text-body-base";
+  "flex flex-col gap-1.5 rounded-base rounded-tr-none bg-form p-6 shadow-xl text-body-base";
 const submenuLinkClass =
   "font-display text-heading-xl whitespace-nowrap transition-colors hover:underline tracking-widest text-sub-menu hover:text-sub-menu-hover";
 const submenuButtonClass =

--- a/apps/tailwind-components/app/components/Pagination.vue
+++ b/apps/tailwind-components/app/components/Pagination.vue
@@ -99,7 +99,7 @@ function changeCurrentPage(event: Event) {
         <a
           href="#"
           @click.prevent="onFirstClick"
-          class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default"
+          class="flex justify-center border border-pagination rounded-alt bg-pagination text-pagination-button h-15 w-15 cursor-default"
           :class="{
             'cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover':
               currentPage > 1,
@@ -113,7 +113,7 @@ function changeCurrentPage(event: Event) {
         <a
           href="#"
           @click.prevent="onPrevClick"
-          class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default"
+          class="flex justify-center border border-pagination rounded-alt bg-pagination text-pagination-button h-15 w-15 cursor-default"
           :class="{
             'cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover':
               currentPage > 1,
@@ -137,7 +137,7 @@ function changeCurrentPage(event: Event) {
         </div>
         <input
           :id="pageInputId"
-          class="sm:px-12 px-7.5 w-32 text-center border border-input rounded-theme bg-input text-pagination-input hover:text-pagination-hover hover:border-pagination-hover hover:bg-pagination-hover h-15 flex items-center tracking-widest"
+          class="sm:px-12 px-7.5 w-32 text-center border border-input rounded-alt bg-input text-pagination-input hover:text-pagination-hover hover:border-pagination-hover hover:bg-pagination-hover h-15 flex items-center tracking-widest"
           :value="currentPage"
           @change="changeCurrentPage"
         />
@@ -156,7 +156,7 @@ function changeCurrentPage(event: Event) {
         <a
           href="#"
           @click.prevent="onNextClick"
-          class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default"
+          class="flex justify-center border border-pagination rounded-alt bg-pagination text-pagination-button h-15 w-15 cursor-default"
           :class="{
             'cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover':
               currentPage < totalPages,
@@ -170,7 +170,7 @@ function changeCurrentPage(event: Event) {
         <a
           href="#"
           @click.prevent="onLastClick"
-          class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default"
+          class="flex justify-center border border-pagination rounded-alt bg-pagination text-pagination-button h-15 w-15 cursor-default"
           :class="{
             'cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover':
               currentPage < totalPages,
@@ -207,7 +207,7 @@ function changeCurrentPage(event: Event) {
               :options="constants.PAGE_SIZE_OPTIONS"
               @update:modelValue="(value) => emit('update:pageSize', value)"
               :modelValue="pageSize"
-              class="!p-0 text-center border border-input rounded-theme !bg-input text-pagination-input !hover:text-pagination-hover hover:outline-pagination-hover hover:bg-pagination-hover h-15 flex items-center tracking-widest"
+              class="!p-0 text-center border border-input rounded-alt !bg-input text-pagination-input !hover:text-pagination-hover hover:outline-pagination-hover hover:bg-pagination-hover h-15 flex items-center tracking-widest"
               :required="true"
             />
           </span>

--- a/apps/tailwind-components/app/components/SideModal.vue
+++ b/apps/tailwind-components/app/components/SideModal.vue
@@ -63,8 +63,8 @@ watch(
 );
 
 const roundedClass = props.slideInRight
-  ? "rounded-l-theme right-0"
-  : "rounded-r-theme";
+  ? "rounded-l-alt right-0"
+  : "rounded-r-alt";
 
 const fullScreenClass = computed(() =>
   props.fullScreen ? "w-[95vw]" : "lg:w-[33vw] md:w-[50vw] w-[95vw]"

--- a/apps/tailwind-components/app/components/Sidebar.vue
+++ b/apps/tailwind-components/app/components/Sidebar.vue
@@ -1,7 +1,7 @@
 <template>
   <div
     ref="panelRef"
-    class="relative shrink-0 w-80 xl:w-96 bg-sidebar-gradient rounded-t-3px rounded-b-theme transition-[margin-left] duration-default motion-reduce:transition-none"
+    class="relative shrink-0 w-80 xl:w-96 bg-sidebar-gradient rounded-t-base rounded-b-alt transition-[margin-left] duration-default motion-reduce:transition-none"
     :class="[
       collapsed ? 'panel-slide-collapsed' : 'panel-expanded',
       { 'cursor-pointer': collapsed },

--- a/apps/tailwind-components/app/components/Well.vue
+++ b/apps/tailwind-components/app/components/Well.vue
@@ -1,6 +1,6 @@
 <template>
   <span
-    class="inline-flex items-center gap-1.5 px-2 py-0.5 text-body-sm whitespace-nowrap bg-button-filter text-button-filter rounded-input border border-button-filter"
+    class="inline-flex items-center gap-1.5 px-2 py-0.5 text-body-sm whitespace-nowrap bg-button-filter text-button-filter rounded-alt border border-button-filter"
   >
     <slot />
   </span>

--- a/apps/tailwind-components/app/components/content/ContentBlock.vue
+++ b/apps/tailwind-components/app/components/content/ContentBlock.vue
@@ -8,7 +8,7 @@ defineProps<{
 
 <template>
   <section
-    class="bg-content py-18 lg:px-12.5 px-5 text-title-contrast xl:rounded-3px last:rounded-b-theme shadow-primary xl:border-b-0 border-b-[1px] overflow-hidden"
+    class="bg-content py-18 lg:px-12.5 px-5 text-title-contrast xl:rounded-base last:rounded-b-alt shadow-primary xl:border-b-0 border-b-[1px] overflow-hidden"
   >
     <h2 class="mb-5 uppercase text-heading-4xl font-display" v-if="title">
       {{ title }}

--- a/apps/tailwind-components/app/components/content/FileDocumentCard.vue
+++ b/apps/tailwind-components/app/components/content/FileDocumentCard.vue
@@ -14,7 +14,7 @@ withDefaults(
 
 <template>
   <a
-    class="border rounded-3px p-5 flex items-center hover:shadow-md transition-shadow"
+    class="border rounded-base p-5 flex items-center hover:shadow-md transition-shadow"
     :href="url"
     :target="isExternal ? '_blank' : '_self'"
   >

--- a/apps/tailwind-components/app/components/content/FileImageCard.vue
+++ b/apps/tailwind-components/app/components/content/FileImageCard.vue
@@ -13,13 +13,13 @@ defineProps({
   <a
     :href="url"
     target="_blank"
-    class="hover:shadow-md transition-shadow border rounded-3px"
+    class="hover:shadow-md transition-shadow border rounded-base"
   >
     <figure class="p-3.5">
       <img
         :src="url"
         :alt="title"
-        class="rounded-3px h-56 bg-contain bg-center"
+        class="rounded-base h-56 bg-contain bg-center"
       />
       <figcaption class="mt-3.5 text-body-base text-link">
         {{ title }}

--- a/apps/tailwind-components/app/components/editor/HtmlPreview.vue
+++ b/apps/tailwind-components/app/components/editor/HtmlPreview.vue
@@ -105,10 +105,10 @@ watch(
 }
 
 .emx2__page_preview.enabled.enabled__button_styles button {
-  @apply h-14 px-7.5 text-heading-xl gap-4 tracking-widest uppercase rounded-input font-display bg-button-outline text-button-outline border border-button-outline hover:bg-button-outline-hover hover:text-button-outline-hover hover:border-button-outline-hover;
+  @apply h-14 px-7.5 text-heading-xl gap-4 tracking-widest uppercase rounded-alt font-display bg-button-outline text-button-outline border border-button-outline hover:bg-button-outline-hover hover:text-button-outline-hover hover:border-button-outline-hover;
 }
 
 .emx2__page_preview.enabled.enabled__button_styles button[type="submit"] {
-  @apply tracking-widest uppercase rounded-input font-display bg-button-primary text-button-primary border-button-primary hover:bg-button-primary-hover hover:text-button-primary-hover hover:border-button-primary-hover;
+  @apply tracking-widest uppercase rounded-alt font-display bg-button-primary text-button-primary border-button-primary hover:bg-button-primary-hover hover:text-button-primary-hover hover:border-button-primary-hover;
 }
 </style>

--- a/apps/tailwind-components/app/components/filter/ActiveFilters.vue
+++ b/apps/tailwind-components/app/components/filter/ActiveFilters.vue
@@ -24,7 +24,7 @@ const hasAnyContent = computed(
 <template>
   <div
     v-if="hasAnyContent"
-    class="flex flex-wrap items-center gap-3 bg-sidebar-gradient rounded-input px-3 py-2 mb-2"
+    class="flex flex-wrap items-center gap-3 bg-sidebar-gradient rounded-alt px-3 py-2 mb-2"
   >
     <span
       class="text-search-filter-group-title text-body-sm whitespace-nowrap mr-1"

--- a/apps/tailwind-components/app/components/filter/Picker.vue
+++ b/apps/tailwind-components/app/components/filter/Picker.vue
@@ -299,7 +299,7 @@ function updateVisibility(value: boolean) {
             <div
               v-if="node.selectable && node.expandable"
               :data-column-id="node.id"
-              class="flex items-center gap-2 py-1.5 px-2 text-body-sm text-title-contrast hover:bg-hover rounded-input"
+              class="flex items-center gap-2 py-1.5 px-2 text-body-sm text-title-contrast hover:bg-hover rounded-alt"
             >
               <label class="flex items-center gap-2 cursor-pointer min-w-0">
                 <input
@@ -386,7 +386,7 @@ function updateVisibility(value: boolean) {
 
             <label
               v-else
-              class="flex items-center gap-2 py-1.5 px-2 text-body-sm text-title-contrast cursor-pointer hover:bg-hover rounded-input"
+              class="flex items-center gap-2 py-1.5 px-2 text-body-sm text-title-contrast cursor-pointer hover:bg-hover rounded-alt"
             >
               <input
                 type="checkbox"

--- a/apps/tailwind-components/app/components/filter/Search.vue
+++ b/apps/tailwind-components/app/components/filter/Search.vue
@@ -39,7 +39,7 @@ const inputId = useId();
       type="search"
       :value="modelValue"
       @input="(event) => handleInput((event.target as HTMLInputElement).value)"
-      class="w-full pr-16 font-sans text-black text-gray-300 bg-white outline-none rounded-theme h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input"
+      class="w-full pr-16 font-sans text-black text-gray-300 bg-white outline-none rounded-alt h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input"
       :class="[
         inverted
           ? 'border-search-input-mobile border'
@@ -48,7 +48,7 @@ const inputId = useId();
       :placeholder="placeholder"
     />
     <button
-      class="rounded-theme absolute top-0 right-0 flex items-center pl-8 pr-6 tracking-wider text-search-button border-search-button border-[1px] transition-colors bg-search-button h-10 font-display text-heading-xl hover:text-search-button-hover"
+      class="rounded-alt absolute top-0 right-0 flex items-center pl-8 pr-6 tracking-wider text-search-button border-search-button border-[1px] transition-colors bg-search-button h-10 font-display text-heading-xl hover:text-search-button-hover"
     >
       {{ label }}
     </button>

--- a/apps/tailwind-components/app/components/form/RequiredInfoSection.vue
+++ b/apps/tailwind-components/app/components/form/RequiredInfoSection.vue
@@ -1,10 +1,10 @@
 <template>
   <span
-    class="flex justify-between min-w-80 h-11 pl-2 border-form-required bg-form-required rounded-form-required"
+    class="flex justify-between min-w-80 h-11 pl-2 border-form-required bg-form-required rounded-base"
   >
     <span class="my-auto py-1 px-3 text-title">{{ message }}</span>
 
-    <ButtonBar class="rounded-input">
+    <ButtonBar class="rounded-alt">
       <button
         v-tooltip.bottom="'previous required field'"
         class="flex items-center border-l border-collapse tracking-widest bg-form-required hover:bg-form-required-btn-hover text-link p-[8px] transition-colors border-l-form-required v-popper--has-tooltip"
@@ -15,7 +15,7 @@
       </button>
       <button
         v-tooltip.bottom="'next required field'"
-        class="flex items-center border-l border-collapse tracking-widest bg-form-required hover:bg-form-required-btn-hover text-link p-[8px] transition-colors border-l-form-required rounded-r-form-required v-popper--has-tooltip"
+        class="flex items-center border-l border-collapse tracking-widest bg-form-required hover:bg-form-required-btn-hover text-link p-[8px] transition-colors border-l-form-required rounded-r-base v-popper--has-tooltip"
         @click="$emit('required-next')"
       >
         <BaseIcon name="arrow-down" :width="24" />

--- a/apps/tailwind-components/app/components/input/File.vue
+++ b/apps/tailwind-components/app/components/input/File.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="flex items-center border rounded-input px-2 h-input"
+    class="flex items-center border rounded-alt px-2 h-input"
     data-elem="container"
     :class="{
       'cursor-pointer duration-default ease-in-out hover:border-input-hover focus-within:border-input-focused':
@@ -18,7 +18,7 @@
         :id="`${id}-current-file`"
         data-elem="current-value-btn"
         ref="selectedFileButton"
-        class="flex justify-center items-center h-10.5 px-5 text-heading-lg gap-3 tracking-widest uppercase font-display duration-default ease-in-out border rounded-input"
+        class="flex justify-center items-center h-10.5 px-5 text-heading-lg gap-3 tracking-widest uppercase font-display duration-default ease-in-out border rounded-alt"
         :class="{
           'text-disabled bg-disabled hover:text-disabled cursor-not-allowed':
             disabled,
@@ -38,7 +38,7 @@
     <div class="flex-none">
       <button
         :id="`${id}-file-open-btn`"
-        class="flex justify-center items-center h-10 px-5 text-heading-xl tracking-widest uppercase font-display duration-default ease-in-out border rounded-input bg-button-filter text-button-filter border-button-filter"
+        class="flex justify-center items-center h-10 px-5 text-heading-xl tracking-widest uppercase font-display duration-default ease-in-out border rounded-alt bg-button-filter text-button-filter border-button-filter"
         :class="{
           'border-invalid text-invalid bg-invalid hover:bg-invalid hover:text-invalid':
             invalid,

--- a/apps/tailwind-components/app/components/input/List.vue
+++ b/apps/tailwind-components/app/components/input/List.vue
@@ -46,7 +46,7 @@ function toggleSelect(node: INode) {
             :name="node.name"
             :checked="modelValue.includes(node.name)"
             @click.stop="toggleSelect(node)"
-            class="w-5 h-5 rounded-3px ml-[6px] mr-2.5 mt-0.5 accent-yellow-500 indeterminate:accent-yellow-500 border border-checkbox hover:cursor-pointer"
+            class="w-5 h-5 rounded-base ml-[6px] mr-2.5 mt-0.5 accent-yellow-500 indeterminate:accent-yellow-500 border border-checkbox hover:cursor-pointer"
           />
         </div>
         <label :for="node.name" class="hover:cursor-pointer text-body-sm group">

--- a/apps/tailwind-components/app/components/input/Ontology.vue
+++ b/apps/tailwind-components/app/components/input/Ontology.vue
@@ -613,7 +613,7 @@ function toStringArray(value: string | string[]): string[] {
   <div
     v-else-if="!initLoading && totalCount"
     :class="{
-      'flex flex-col items-start border outline-none rounded-input':
+      'flex flex-col items-start border outline-none rounded-base':
         displayAsSelect,
       'bg-input ': displayAsSelect && !disabled,
       'border-disabled': displayAsSelect && disabled,

--- a/apps/tailwind-components/app/components/input/Ref.vue
+++ b/apps/tailwind-components/app/components/input/Ref.vue
@@ -297,7 +297,7 @@ const onBlur = useDebounceFn(() => {
   <div
     v-show="!isInitLoading && initialCount"
     :class="{
-      'flex items-center border outline-none rounded-input cursor-pointer':
+      'flex items-center border outline-none rounded-base cursor-pointer':
         displayAsSelect,
       'bg-input ': displayAsSelect && !disabled,
       'border-disabled': displayAsSelect && disabled,
@@ -392,7 +392,7 @@ const onBlur = useDebounceFn(() => {
       <div
         ref="wrapperRef"
         :class="{
-          'max-h-[50vh] top-4 rounded-theme bg-input overflow-y-auto w-full pt-2 pb-6 pl-4 ':
+          'max-h-[50vh] top-4 rounded-alt bg-input overflow-y-auto w-full pt-2 pb-6 pl-4 ':
             displayAsSelect,
         }"
         v-show="(showSelect && !disabled) || !displayAsSelect"

--- a/apps/tailwind-components/app/components/input/RefSelect/Toggle.vue
+++ b/apps/tailwind-components/app/components/input/RefSelect/Toggle.vue
@@ -30,7 +30,7 @@ defineExpose({
     role="combobox"
     ref="combobox"
     :aria-required="required"
-    class="flex justify-between items-center h-input w-full text-left pl-11 border rounded-input cursor-pointer"
+    class="flex justify-between items-center h-input w-full text-left pl-11 border rounded-alt cursor-pointer"
     :class="{
       'bg-input border-invalid text-invalid': invalid && !disabled,
       'bg-input border-valid text-valid': valid && !disabled,

--- a/apps/tailwind-components/app/components/input/Search.vue
+++ b/apps/tailwind-components/app/components/input/Search.vue
@@ -28,7 +28,7 @@ defineEmits<{
 </script>
 <template>
   <div
-    class="relative flex items-center border outline-none rounded-input"
+    class="relative flex items-center border outline-none rounded-alt"
     :class="{
       'bg-input border-valid text-valid': valid && !disabled,
       'bg-input border-invalid text-invalid': invalid && !disabled,

--- a/apps/tailwind-components/app/components/input/Select.vue
+++ b/apps/tailwind-components/app/components/input/Select.vue
@@ -24,7 +24,7 @@ const emit = defineEmits(["update:modelValue", "focus"]);
         $emit('update:modelValue', ($event.target as HTMLSelectElement).value)
     "
     :id="id"
-    class="w-full pr-16 text-black text-gray-300 bg-white rounded-search-input h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input search-input-mobile border border-transparent border-r-8 outline outline-1 outline-select"
+    class="w-full pr-16 text-black text-gray-300 bg-white rounded-alt h-10 ring-red-500 pl-3 shadow-search-input focus:shadow-search-input hover:shadow-search-input search-input-mobile border border-transparent border-r-8 outline outline-1 outline-select"
     :class="{ 'border-red-500 text-red-500': invalid }"
   >
     <option disabled value="" :selected="modelValue === ''">

--- a/apps/tailwind-components/app/components/input/String.vue
+++ b/apps/tailwind-components/app/components/input/String.vue
@@ -20,7 +20,7 @@ const emit = defineEmits(["focus", "blur"]);
     :type="type || 'text'"
     :placeholder="placeholder"
     :disabled="disabled"
-    class="w-full h-input pr-4 pl-3 border outline-none rounded-input"
+    class="w-full h-input pr-4 pl-3 border outline-none rounded-alt"
     :class="{
       'bg-input border-valid text-valid': valid && !disabled,
       'bg-input border-invalid text-invalid': invalid && !disabled,

--- a/apps/tailwind-components/app/components/input/Switch.vue
+++ b/apps/tailwind-components/app/components/input/Switch.vue
@@ -20,7 +20,7 @@ const modelValue = defineModel<IInputValue>();
 
 <template>
   <div
-    class="relative flex items-center border rounded-input w-fit group bg-button-switch"
+    class="relative flex items-center border rounded-alt w-fit group bg-button-switch"
   >
     <div
       v-for="option in options"
@@ -38,7 +38,7 @@ const modelValue = defineModel<IInputValue>();
       <label
         :for="`${id}-switch-${option.value}`"
         v-tooltip.top="option.label || option.value"
-        class="cursor-pointer block transition-all duration-default ease-in-out motion-reduce:transition-none motion-reduce:duration-0 bg-button-switch text-button-switch border border-transparent rounded-input hover:bg-button-switch-hover hover:text-button-switch-hover hover:border-button-switch-hover group-hover:peer-checked:border-transparent group-hover:peer-checked:hover:border-button-switch-hover peer-checked:bg-button-switch-selected peer-checked:text-button-switch-selected peer-checked:border-button-switch-selected peer-checked:hover:bg-button-switch-hover peer-checked:hover:text-button-switch-hover peer-checked:hover:border-button-switch-hover"
+        class="cursor-pointer block transition-all duration-default ease-in-out motion-reduce:transition-none motion-reduce:duration-0 bg-button-switch text-button-switch border border-transparent rounded-alt hover:bg-button-switch-hover hover:text-button-switch-hover hover:border-button-switch-hover group-hover:peer-checked:border-transparent group-hover:peer-checked:hover:border-button-switch-hover peer-checked:bg-button-switch-selected peer-checked:text-button-switch-selected peer-checked:border-button-switch-selected peer-checked:hover:bg-button-switch-hover peer-checked:hover:text-button-switch-hover peer-checked:hover:border-button-switch-hover"
       >
         <span class="sr-only">{{ option.label || option.value }}</span>
         <BaseIcon :name="option.icon" :width="36" class="p-2 text-current" />

--- a/apps/tailwind-components/app/components/input/TextArea.vue
+++ b/apps/tailwind-components/app/components/input/TextArea.vue
@@ -16,7 +16,7 @@ const emit = defineEmits([
     :id="id"
     :placeholder="placeholder"
     :disabled="disabled"
-    class="w-full h-[112px] pl-3 pr-16 py-2 border outline-none rounded-textarea-input"
+    class="w-full h-[112px] pl-3 pr-16 py-2 border outline-none rounded-alt"
     :class="{
       'bg-input border-valid text-valid': valid && !disabled,
       'bg-input border-invalid text-invalid': invalid && !disabled,

--- a/apps/tailwind-components/app/components/input/listbox/Toggle.vue
+++ b/apps/tailwind-components/app/components/input/listbox/Toggle.vue
@@ -6,7 +6,7 @@
     :aria-required="required"
     :aria-expanded="isExpanded"
     :aria-activedescendant="selectedElementId"
-    class="flex justify-start items-center h-input w-full text-left pl-4 border rounded-input"
+    class="flex justify-start items-center h-input w-full text-left pl-4 border rounded-alt"
     :class="{
       'bg-input border-invalid text-invalid': invalid && !disabled,
       'bg-input border-valid text-valid': valid && !disabled,

--- a/apps/tailwind-components/app/components/pages/Navigation/NavigationCards.vue
+++ b/apps/tailwind-components/app/components/pages/Navigation/NavigationCards.vue
@@ -18,7 +18,7 @@ withDefaults(defineProps<INavigationCards>(), {
     <p v-if="description" class="text-body-base">{{ description }}</p>
     <a
       :href="url"
-      class="flex justify-center items-center gap-1.5 p-2 border rounded-input bg-button-outline text-button-outline border-button-outline hover:bg-button-outline-hover hover:text-button-outline-hover hover:border-button-outline-hover duration-default ease-in-out"
+      class="flex justify-center items-center gap-1.5 p-2 border rounded-alt bg-button-outline text-button-outline border-button-outline hover:bg-button-outline-hover hover:text-button-outline-hover hover:border-button-outline-hover duration-default ease-in-out"
       :rel="urlIsExternal ? 'noopener noreferrer' : undefined"
       :target="urlIsExternal ? '_blank' : undefined"
     >

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -83,7 +83,7 @@
 
         <div
           ref="tableContainer"
-          class="relative overflow-auto overflow-y-hidden rounded-b-theme border border-theme border-color-theme"
+          class="relative overflow-auto overflow-y-hidden rounded-base rounded-b-alt border border-theme border-color-theme"
         >
           <div
             v-if="guideX !== null"
@@ -92,7 +92,7 @@
           />
 
           <div
-            class="overflow-x-auto overscroll-x-contain bg-table rounded-t-3px"
+            class="overflow-x-auto overscroll-x-contain bg-table rounded-t-base"
             v-on:scroll.native="handleStickyHeaderOffset"
           >
             <div

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -83,7 +83,7 @@
 
         <div
           ref="tableContainer"
-          class="relative overflow-auto overflow-y-hidden rounded-base rounded-b-alt border border-theme border-color-theme"
+          class="relative overflow-auto overflow-y-hidden rounded-t-base rounded-b-alt border border-theme border-color-theme"
         >
           <div
             v-if="guideX !== null"

--- a/apps/tailwind-components/app/pages/Icons.story.vue
+++ b/apps/tailwind-components/app/pages/Icons.story.vue
@@ -24,7 +24,7 @@
           <select
             id="animation-select"
             v-model="selectedAnimationClass"
-            class="h-full rounded-md border-1 bg-transparent py-0 pl-2 pr-7 text-gray-500 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm"
+            class="h-full rounded-base border-1 bg-transparent py-0 pl-2 pr-7 text-gray-500 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm"
           >
             <option value="null">None</option>
             <option value="animate-spin">animate-spin</option>

--- a/apps/tailwind-components/app/pages/Well.story.vue
+++ b/apps/tailwind-components/app/pages/Well.story.vue
@@ -15,7 +15,7 @@ import Well from "../components/Well.vue";
 const spec = `
 ## Features
 - Presentational pill/badge component for labels and tags
-- Uses theme-aware filter tokens (bg-button-filter, text-button-filter, rounded-input)
+- Uses theme-aware filter tokens (bg-button-filter, text-button-filter, rounded-base, rounded-alt)
 - Non-interactive — wrap in Button for click behavior
 - Slot-based content
 
@@ -25,7 +25,7 @@ None — pure slot component
 ## Test Checklist
 - [ ] Renders across all 5 themes (Light, Dark, Molgenis, UMCG, AUMC)
 - [ ] Text content displays correctly
-- [ ] Rounded-input applies theme-specific border radius
+- [ ] Rounded-base applies theme-specific border radius
 - [ ] Colors match filterWell button variant
 `;
 </script>

--- a/apps/tailwind-components/tailwind.config.js
+++ b/apps/tailwind-components/tailwind.config.js
@@ -427,16 +427,8 @@ module.exports = {
         "chart-paths": "var(--chart-paths)",
       }),
       borderRadius: {
-        theme: "var(--border-radius-theme)",
-        "3px": "var(--border-radius-3px)",
-        "50px": "var(--border-radius-50px)",
-        input: "var(--border-radius-input)",
-        "textarea-input": "var(--border-radius-textarea-input)",
-        "search-input": "var(--border-radius-search-input)",
-        "search-button": "var(--border-radius-search-button)",
-        pagination: "var(--border-radius-pagination)",
-        landing: "var(--border-radius-landing)",
-        "form-required": "var(--border-radius-form-required)",
+        base: "var(--border-radius-base)",
+        alt: "var(--border-radius-alt)",
       },
       borderWidth: {
         "form-required": "var(--border-width-form-required)",

--- a/apps/tailwind-components/tests/vitest/components/__snapshots__/Navigation.spec.ts.snap
+++ b/apps/tailwind-components/tests/vitest/components/__snapshots__/Navigation.spec.ts.snap
@@ -3,10 +3,10 @@
 exports[`Navigation > renders menu html with submenu and sub-submenu items 1`] = `
 "<nav class="flex items-center justify-between gap-6 xl:justify-center"><a href="/#" class="flex items-center gap-1 tracking-widest transition-colors border border-b-0 border-transparent font-display text-heading-xl hover:underline whitespace-nowrap text-menu">Home</a>
   <div class="vmenu-stub" placement="bottom-end" distance="-1"><button class="flex items-center gap-1 tracking-widest transition-colors border border-b-0 border-transparent font-display text-heading-xl hover:underline whitespace-nowrap text-menu" data-test="main-submenu-Data">Data <base-icon-stub name="caret-down" width="24"></base-icon-stub></button>
-    <ol class="flex flex-col gap-1.5 rounded-3px rounded-tr-none bg-form p-6 shadow-xl text-body-base">
+    <ol class="flex flex-col gap-1.5 rounded-base rounded-tr-none bg-form p-6 shadow-xl text-body-base">
       <li>
         <div class="vmenu-stub" placement="right-start" distance="-1"><button class="font-display text-heading-xl whitespace-nowrap transition-colors hover:underline tracking-widest text-sub-menu flex items-center gap-1 border border-b-0 border-transparent text-menu" type="button">Catalog <base-icon-stub name="caret-right" width="24"></base-icon-stub></button>
-          <ol class="flex flex-col gap-1.5 rounded-3px rounded-tr-none bg-form p-6 shadow-xl text-body-base">
+          <ol class="flex flex-col gap-1.5 rounded-base rounded-tr-none bg-form p-6 shadow-xl text-body-base">
             <li><a href="/#entities" class="font-display text-heading-xl whitespace-nowrap transition-colors hover:underline tracking-widest text-sub-menu hover:text-sub-menu-hover">Entities</a></li>
           </ol>
         </div>

--- a/apps/tailwind-components/tests/vitest/components/__snapshots__/Pagination.spec.ts.snap
+++ b/apps/tailwind-components/tests/vitest/components/__snapshots__/Pagination.spec.ts.snap
@@ -3,20 +3,20 @@
 exports[`should render the pagination component with jump to edge 1`] = `
 "<nav role="navigation" class="pt-12.5 font-display text-heading-xl -mx-2.5" aria-labelledby="v-0Label"><span id="v-0Label" class="sr-only"> pagination navigation </span>
   <ul class="flex items-center justify-center list-none gap-2.5">
-    <li><a href="#" class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to page first</span>
+    <li><a href="#" class="flex justify-center border border-pagination rounded-alt bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to page first</span>
         <!---->
       </a></li>
-    <li><a href="#" class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to page 2</span>
+    <li><a href="#" class="flex justify-center border border-pagination rounded-alt bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to page 2</span>
         <!---->
       </a></li>
     <li class="flex justify-center items-center">
-      <div class="px-4 tracking-widest sm:px-5"><label for="v-0" class="sr-only">go to specific page</label><span class="text-pagination"> Page </span></div><input id="v-0" class="sm:px-12 px-7.5 w-32 text-center border border-input rounded-theme bg-input text-pagination-input hover:text-pagination-hover hover:border-pagination-hover hover:bg-pagination-hover h-15 flex items-center tracking-widest" value="3">
+      <div class="px-4 tracking-widest sm:px-5"><label for="v-0" class="sr-only">go to specific page</label><span class="text-pagination"> Page </span></div><input id="v-0" class="sm:px-12 px-7.5 w-32 text-center border border-input rounded-alt bg-input text-pagination-input hover:text-pagination-hover hover:border-pagination-hover hover:bg-pagination-hover h-15 flex items-center tracking-widest" value="3">
       <div class="px-4 tracking-widest sm:px-5 whitespace-nowrap"><span class="text-pagination"> OF 34</span></div>
     </li>
-    <li><a href="#" class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to page 4</span>
+    <li><a href="#" class="flex justify-center border border-pagination rounded-alt bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to page 4</span>
         <!---->
       </a></li>
-    <li><a href="#" class="flex justify-center border border-pagination rounded-theme bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to last page</span>
+    <li><a href="#" class="flex justify-center border border-pagination rounded-alt bg-pagination text-pagination-button h-15 w-15 cursor-default cursor-pointer hover:bg-pagination-hover hover:text-pagination-hover hover:border-pagination-hover focus:bg-pagination-hover focus:text-pagination-hover"><span class="sr-only">Go to last page</span>
         <!---->
       </a></li>
     <!--v-if-->

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -106,7 +106,7 @@ function setNuxtLink(value: string, page: string): string {
           <div
             id="addNewPageDropdown"
             aria-labelledby="openAddNewPageDropdown"
-            class="absolute z-10 w-full shadow-md rounded-sm"
+            class="absolute z-10 w-full shadow-md rounded-base"
             :class="{
               block: showPageDropdown,
               hidden: !showPageDropdown,
@@ -138,7 +138,7 @@ function setNuxtLink(value: string, page: string): string {
     >
       <div
         v-for="container in data.containers.rows"
-        class="relative group border rounded-3px w-full h-48 p-7.5 hover:shadow-md transition-shadow flex justify-center items-center bg-form-legend"
+        class="relative group border rounded-base w-full h-48 p-7.5 hover:shadow-md transition-shadow flex justify-center items-center bg-form-legend"
       >
         <div
           class="absolute top-2.5 right-2.5 p-[5px] h-10 w-10 flex justify-center items-center border border-transparent rounded-full text-button-text hover:bg-button-primary-hover hover:text-button-primary-hover hover:border-button-primary-hover"


### PR DESCRIPTION
Simplify and standardize border radius styling to make it more consistent and easier to theme.


Closes #https://github.com/molgenis/molgenis-emx2/issues/6300

### What are the main changes you did
- Define radius tokens in the Tailwind configuration
- Refactor and remove overlapping radius configuration
- Define default radius values in `main.css`
- Override default values in theme files where required
- Update components and pages to use the shared base and alternative radius tokens
- Use Tailwind's generated radius utilities (`rounded-t-*`, `rounded-b-*`, `rounded-full`, `rounded-none`, etc.) where appropriate

This results in a simpler ( 2 instead of 10 tokens), more consistent, and theme-able ( within our bounds) radius system.


### How to test
- see issue, compare page and components with design ( as indication ) and master branch ( minus the inconsistencies )

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
