### PR TITLE
chore: refactor use of gql dataFetcher to non deprecated api style

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlAdminFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlAdminFieldFactory.java
@@ -53,7 +53,8 @@ public class GraphqlAdminFieldFactory {
           .build();
 
   // retrieve user list, user count
-  public static GraphQLFieldDefinition queryAdminField(Database db) {
+  public static GraphQLFieldDefinition queryAdminField(
+      Database db, GraphQLCodeRegistry.Builder codeRegistry) {
     String userCount = "userCount";
     GraphQLOutputType adminType =
         GraphQLObjectType.newObject()
@@ -73,9 +74,9 @@ public class GraphqlAdminFieldFactory {
                     .build())
             .build();
 
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("_admin")
-        .dataFetcher(
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_admin"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               Map<String, Object> result = new LinkedHashMap<>();
               // check for parameters
@@ -89,9 +90,8 @@ public class GraphqlAdminFieldFactory {
                 }
               }
               return result;
-            })
-        .type(adminType)
-        .build();
+            });
+    return GraphQLFieldDefinition.newFieldDefinition().name("_admin").type(adminType).build();
   }
 
   private static Object getUsers(SelectedField selectedField, Database db) {
@@ -108,34 +108,40 @@ public class GraphqlAdminFieldFactory {
     }
   }
 
-  public static GraphQLFieldDefinition removeUser(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("removeUser")
-        .type(typeForMutationResult)
-        .argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public static GraphQLFieldDefinition removeUser(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "removeUser"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String email = dataFetchingEnvironment.getArgument(EMAIL);
               database.removeUser(email);
               return new GraphqlApiMutationResult(SUCCESS, "User %s removed", email);
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("removeUser")
+        .type(typeForMutationResult)
+        .argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString))
         .build();
   }
 
-  public static GraphQLFieldDefinition setEnabledUser(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("setEnabledUser")
-        .type(typeForMutationResult)
-        .argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString))
-        .argument(GraphQLArgument.newArgument().name(ENABLED).type(Scalars.GraphQLBoolean))
-        .dataFetcher(
+  public static GraphQLFieldDefinition setEnabledUser(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "setEnabledUser"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String email = dataFetchingEnvironment.getArgument(EMAIL);
               boolean enabled = dataFetchingEnvironment.getArgument(ENABLED);
               database.setEnabledUser(email, enabled);
               return new GraphqlApiMutationResult(
                   SUCCESS, "User %s %s ", email, enabled ? "Enabled" : "Disabled");
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("setEnabledUser")
+        .type(typeForMutationResult)
+        .argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString))
+        .argument(GraphQLArgument.newArgument().name(ENABLED).type(Scalars.GraphQLBoolean))
         .build();
   }
 
@@ -174,13 +180,16 @@ public class GraphqlAdminFieldFactory {
         .toList();
   }
 
-  public static GraphQLFieldDefinition updateUser(Database database) {
+  public static GraphQLFieldDefinition updateUser(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", UPDATE_USER),
+        (DataFetcher<?>)
+            dataFetchingEnvironment -> executeUpdateUser(database, dataFetchingEnvironment));
     return GraphQLFieldDefinition.newFieldDefinition()
         .name(UPDATE_USER)
         .type(typeForMutationResult)
         .argument(GraphQLArgument.newArgument().name(UPDATE_USER).type(updateUserType))
-        .dataFetcher(
-            dataFetchingEnvironment -> executeUpdateUser(database, dataFetchingEnvironment))
         .build();
   }
 

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlDatabaseFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlDatabaseFieldFactory.java
@@ -57,35 +57,27 @@ public class GraphqlDatabaseFieldFactory {
     // no instances
   }
 
-  public GraphQLFieldDefinition.Builder deleteMutation(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("deleteSchema")
-        .type(typeForMutationResult)
-        .argument(GraphQLArgument.newArgument().name(ID).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public GraphQLFieldDefinition.Builder deleteMutation(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "deleteSchema"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String id = dataFetchingEnvironment.getArgument(ID);
               database.dropSchema(id); // id and name are still equal, might change in future
               return new GraphqlApiMutationResult(SUCCESS, "Schema %s dropped", id);
             });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("deleteSchema")
+        .type(typeForMutationResult)
+        .argument(GraphQLArgument.newArgument().name(ID).type(Scalars.GraphQLString));
   }
 
-  public GraphQLFieldDefinition.Builder createMutation(Database database, TaskService taskService) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("createSchema")
-        .type(typeForMutationResult)
-        .argument(
-            GraphQLArgument.newArgument().name(GraphqlConstants.NAME).type(Scalars.GraphQLString))
-        .argument(GraphQLArgument.newArgument().name(DESCRIPTION).type(Scalars.GraphQLString))
-        .argument(
-            GraphQLArgument.newArgument().name(Constants.TEMPLATE).type(Scalars.GraphQLString))
-        .argument(
-            GraphQLArgument.newArgument()
-                .name(Constants.INCLUDE_DEMO_DATA)
-                .type(Scalars.GraphQLBoolean))
-        .argument(
-            GraphQLArgument.newArgument().name(Constants.PARENT_JOB).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public GraphQLFieldDefinition.Builder createMutation(
+      Database database, TaskService taskService, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "createSchema"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String name = dataFetchingEnvironment.getArgument(NAME);
               String description = dataFetchingEnvironment.getArgument(DESCRIPTION);
@@ -114,32 +106,45 @@ public class GraphqlDatabaseFieldFactory {
 
               return result;
             });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("createSchema")
+        .type(typeForMutationResult)
+        .argument(
+            GraphQLArgument.newArgument().name(GraphqlConstants.NAME).type(Scalars.GraphQLString))
+        .argument(GraphQLArgument.newArgument().name(DESCRIPTION).type(Scalars.GraphQLString))
+        .argument(
+            GraphQLArgument.newArgument().name(Constants.TEMPLATE).type(Scalars.GraphQLString))
+        .argument(
+            GraphQLArgument.newArgument()
+                .name(Constants.INCLUDE_DEMO_DATA)
+                .type(Scalars.GraphQLBoolean))
+        .argument(
+            GraphQLArgument.newArgument().name(Constants.PARENT_JOB).type(Scalars.GraphQLString));
   }
 
-  public GraphQLFieldDefinition.Builder updateMutation(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("updateSchema")
-        .type(typeForMutationResult)
-        .argument(GraphQLArgument.newArgument().name(NAME).type(Scalars.GraphQLString))
-        .argument(GraphQLArgument.newArgument().name(DESCRIPTION).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public GraphQLFieldDefinition.Builder updateMutation(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "updateSchema"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String name = dataFetchingEnvironment.getArgument(NAME);
               String description = dataFetchingEnvironment.getArgument(Constants.DESCRIPTION);
               database.updateSchema(name, description);
               return new GraphqlApiMutationResult(SUCCESS, "Schema %s updated", name);
             });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("updateSchema")
+        .type(typeForMutationResult)
+        .argument(GraphQLArgument.newArgument().name(NAME).type(Scalars.GraphQLString))
+        .argument(GraphQLArgument.newArgument().name(DESCRIPTION).type(Scalars.GraphQLString));
   }
 
-  public GraphQLFieldDefinition.Builder settingsQueryField(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("_settings")
-        .argument(
-            GraphQLArgument.newArgument()
-                .name(GraphqlConstants.KEYS)
-                .type(GraphQLList.list(Scalars.GraphQLString)))
-        .type(GraphQLList.list(outputSettingsType))
-        .dataFetcher(
+  public GraphQLFieldDefinition.Builder settingsQueryField(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_settings"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               final List<String> selectedKeys =
                   dataFetchingEnvironment.getArgumentOrDefault(KEYS, new ArrayList<>());
@@ -154,12 +159,20 @@ public class GraphqlDatabaseFieldFactory {
 
               return mapSettingsToGraphql(filtered);
             });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("_settings")
+        .argument(
+            GraphQLArgument.newArgument()
+                .name(GraphqlConstants.KEYS)
+                .type(GraphQLList.list(Scalars.GraphQLString)))
+        .type(GraphQLList.list(outputSettingsType));
   }
 
-  public GraphQLFieldDefinition.Builder schemasQuery(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("_schemas")
-        .dataFetcher(
+  public GraphQLFieldDefinition.Builder schemasQuery(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_schemas"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               List<Map<String, String>> result = new ArrayList<>();
               for (SchemaInfo schemaInfo : database.getSchemaInfos()) {
@@ -174,7 +187,9 @@ public class GraphqlDatabaseFieldFactory {
                 result.add(fields);
               }
               return result;
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("_schemas")
         .type(GraphQLList.list(outputSchemasType));
   }
 
@@ -197,12 +212,11 @@ public class GraphqlDatabaseFieldFactory {
                   .type(GraphQLList.list(GraphQLTypeReference.typeRef("MolgenisTask"))))
           .build();
 
-  public GraphQLFieldDefinition tasksQueryField(TaskService taskService, Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("_tasks")
-        .type(GraphQLList.list(outputTaskType))
-        .argument(GraphQLArgument.newArgument().name(TASK_ID).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public GraphQLFieldDefinition tasksQueryField(
+      TaskService taskService, Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_tasks"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String id = dataFetchingEnvironment.getArgument(TASK_ID);
               if (id != null) {
@@ -223,7 +237,11 @@ public class GraphqlDatabaseFieldFactory {
               }
 
               throw new MolgenisException("Listing all tasks is only allowed for admin users");
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("_tasks")
+        .type(GraphQLList.list(outputTaskType))
+        .argument(GraphQLArgument.newArgument().name(TASK_ID).type(Scalars.GraphQLString))
         .build();
   }
 
@@ -239,16 +257,11 @@ public class GraphqlDatabaseFieldFactory {
                   .build())
           .build();
 
-  public GraphQLFieldDefinition changeMutation(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("change")
-        .type(typeForMutationResult)
-        .argument(GraphQLArgument.newArgument().name(USERS).type(GraphQLList.list(inputUserType)))
-        .argument(
-            GraphQLArgument.newArgument()
-                .name(SETTINGS)
-                .type(GraphQLList.list(inputSettingsMetadataType)))
-        .dataFetcher(
+  public GraphQLFieldDefinition changeMutation(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "change"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               StringBuilder messageBuilder = new StringBuilder();
               database.tx(
@@ -262,20 +275,23 @@ public class GraphqlDatabaseFieldFactory {
                     }
                   });
               return new GraphqlApiMutationResult(SUCCESS, messageBuilder.toString().trim());
-            })
-        .build();
-  }
-
-  public GraphQLFieldDefinition dropMutation(Database database) {
+            });
     return GraphQLFieldDefinition.newFieldDefinition()
-        .name("drop")
+        .name("change")
         .type(typeForMutationResult)
         .argument(GraphQLArgument.newArgument().name(USERS).type(GraphQLList.list(inputUserType)))
         .argument(
             GraphQLArgument.newArgument()
                 .name(SETTINGS)
-                .type(GraphQLList.list(inputDropSettingType)))
-        .dataFetcher(
+                .type(GraphQLList.list(inputSettingsMetadataType)))
+        .build();
+  }
+
+  public GraphQLFieldDefinition dropMutation(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "drop"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               StringBuilder messageBuilder = new StringBuilder();
               database.tx(
@@ -289,15 +305,26 @@ public class GraphqlDatabaseFieldFactory {
                     }
                   });
               return new GraphqlApiMutationResult(SUCCESS, messageBuilder.toString().trim());
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("drop")
+        .type(typeForMutationResult)
+        .argument(GraphQLArgument.newArgument().name(USERS).type(GraphQLList.list(inputUserType)))
+        .argument(
+            GraphQLArgument.newArgument()
+                .name(SETTINGS)
+                .type(GraphQLList.list(inputDropSettingType)))
         .build();
   }
 
-  public GraphQLFieldDefinition.Builder lastUpdateQuery(Database database) {
+  public GraphQLFieldDefinition.Builder lastUpdateQuery(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_lastUpdate"),
+        (DataFetcher<?>) dataFetchingEnvironment -> database.getLastUpdated());
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("_lastUpdate")
-        .type(GraphQLList.list(lastUpdateMetadataType))
-        .dataFetcher(dataFetchingEnvironment -> database.getLastUpdated());
+        .type(GraphQLList.list(lastUpdateMetadataType));
   }
 
   private static void dropUsers(

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlFactory.java
@@ -2,6 +2,7 @@ package org.molgenis.emx2.graphql;
 
 import graphql.GraphQL;
 import graphql.execution.AsyncExecutionStrategy;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLObjectType;
 import graphql.schema.GraphQLSchema;
 import org.molgenis.emx2.*;
@@ -16,45 +17,50 @@ public class GraphqlFactory {
 
   public static GraphQL forDatabase(Database database, TaskService taskService) {
 
+    GraphQLCodeRegistry.Builder codeRegistry = GraphQLCodeRegistry.newCodeRegistry();
     GraphQLObjectType.Builder queryBuilder = GraphQLObjectType.newObject().name("Query");
     GraphQLObjectType.Builder mutationBuilder = GraphQLObjectType.newObject().name("Save");
 
-    queryBuilder.field(new GraphqlManifesFieldFactory().queryVersionField(database));
+    queryBuilder.field(new GraphqlManifesFieldFactory().queryVersionField(database, codeRegistry));
 
     if (database.isAdmin()) {
-      queryBuilder.field(GraphqlAdminFieldFactory.queryAdminField(database));
-      mutationBuilder.field(GraphqlAdminFieldFactory.removeUser(database));
-      mutationBuilder.field(GraphqlAdminFieldFactory.setEnabledUser(database));
-      mutationBuilder.field(GraphqlAdminFieldFactory.updateUser(database));
+      queryBuilder.field(GraphqlAdminFieldFactory.queryAdminField(database, codeRegistry));
+      mutationBuilder.field(GraphqlAdminFieldFactory.removeUser(database, codeRegistry));
+      mutationBuilder.field(GraphqlAdminFieldFactory.setEnabledUser(database, codeRegistry));
+      mutationBuilder.field(GraphqlAdminFieldFactory.updateUser(database, codeRegistry));
     }
 
     GraphqlDatabaseFieldFactory db = new GraphqlDatabaseFieldFactory();
-    queryBuilder.field(db.schemasQuery(database));
-    queryBuilder.field(db.settingsQueryField(database));
-    queryBuilder.field(db.tasksQueryField(taskService, database));
+    queryBuilder.field(db.schemasQuery(database, codeRegistry));
+    queryBuilder.field(db.settingsQueryField(database, codeRegistry));
+    queryBuilder.field(db.tasksQueryField(taskService, database, codeRegistry));
     if (database.isAdmin()) {
-      queryBuilder.field(db.lastUpdateQuery(database));
+      queryBuilder.field(db.lastUpdateQuery(database, codeRegistry));
     }
 
-    mutationBuilder.field(db.createMutation(database, taskService));
-    mutationBuilder.field(db.deleteMutation(database));
-    mutationBuilder.field(db.updateMutation(database));
-    mutationBuilder.field(db.dropMutation(database));
-    mutationBuilder.field(db.changeMutation(database));
+    mutationBuilder.field(db.createMutation(database, taskService, codeRegistry));
+    mutationBuilder.field(db.deleteMutation(database, codeRegistry));
+    mutationBuilder.field(db.updateMutation(database, codeRegistry));
+    mutationBuilder.field(db.dropMutation(database, codeRegistry));
+    mutationBuilder.field(db.changeMutation(database, codeRegistry));
 
     GraphqlSessionFieldFactory session = new GraphqlSessionFieldFactory();
-    queryBuilder.field(session.sessionQueryField(database, null));
-    mutationBuilder.field(session.signinField(database));
-    mutationBuilder.field(session.signupField(database));
+    queryBuilder.field(session.sessionQueryField(database, null, codeRegistry));
+    mutationBuilder.field(session.signinField(database, codeRegistry));
+    mutationBuilder.field(session.signupField(database, codeRegistry));
     if (!database.isAnonymous()) {
-      mutationBuilder.field(session.signoutField(database));
-      mutationBuilder.field(session.changePasswordField(database));
-      mutationBuilder.field(session.createTokenField(database));
+      mutationBuilder.field(session.signoutField(database, codeRegistry));
+      mutationBuilder.field(session.changePasswordField(database, codeRegistry));
+      mutationBuilder.field(session.createTokenField(database, codeRegistry));
     }
 
     GraphQL graphql =
         GraphQL.newGraphQL(
-                GraphQLSchema.newSchema().query(queryBuilder).mutation(mutationBuilder).build())
+                GraphQLSchema.newSchema()
+                    .query(queryBuilder)
+                    .mutation(mutationBuilder)
+                    .codeRegistry(codeRegistry.build())
+                    .build())
             .mutationExecutionStrategy(
                 new AsyncExecutionStrategy(new GraphqlCustomExceptionHandler()))
             .build();
@@ -66,57 +72,66 @@ public class GraphqlFactory {
     long start = System.currentTimeMillis();
     logger.info("creating graphql for schema: {}", schema.getMetadata().getName());
 
+    GraphQLCodeRegistry.Builder codeRegistry = GraphQLCodeRegistry.newCodeRegistry();
     GraphQLObjectType.Builder queryBuilder = GraphQLObjectType.newObject().name("Query");
     GraphQLObjectType.Builder mutationBuilder = GraphQLObjectType.newObject().name("Save");
 
-    queryBuilder.field(new GraphqlManifesFieldFactory().queryVersionField(schema.getDatabase()));
+    queryBuilder.field(
+        new GraphqlManifesFieldFactory().queryVersionField(schema.getDatabase(), codeRegistry));
 
     GraphqlSchemaFieldFactory schemaFields = new GraphqlSchemaFieldFactory();
-    queryBuilder.field(schemaFields.schemaQuery(schema));
-    queryBuilder.field(schemaFields.settingsQuery(schema));
-    queryBuilder.field(schemaFields.schemaReportsField(schema));
+    queryBuilder.field(schemaFields.schemaQuery(schema, codeRegistry));
+    queryBuilder.field(schemaFields.settingsQuery(schema, codeRegistry));
+    queryBuilder.field(schemaFields.schemaReportsField(schema, codeRegistry));
 
     GraphqlDatabaseFieldFactory db = new GraphqlDatabaseFieldFactory();
-    queryBuilder.field(db.tasksQueryField(taskService, schema.getDatabase()));
+    queryBuilder.field(db.tasksQueryField(taskService, schema.getDatabase(), codeRegistry));
 
     GraphqlSessionFieldFactory sessionFieldFactory = new GraphqlSessionFieldFactory();
-    queryBuilder.field(sessionFieldFactory.sessionQueryField(schema.getDatabase(), schema));
-    mutationBuilder.field(sessionFieldFactory.signinField(schema.getDatabase()));
-    mutationBuilder.field(sessionFieldFactory.signupField(schema.getDatabase()));
+    queryBuilder.field(
+        sessionFieldFactory.sessionQueryField(schema.getDatabase(), schema, codeRegistry));
+    mutationBuilder.field(sessionFieldFactory.signinField(schema.getDatabase(), codeRegistry));
+    mutationBuilder.field(sessionFieldFactory.signupField(schema.getDatabase(), codeRegistry));
 
     if (!schema.getDatabase().isAnonymous()) {
-      mutationBuilder.field(sessionFieldFactory.signoutField(schema.getDatabase()));
-      mutationBuilder.field(sessionFieldFactory.changePasswordField(schema.getDatabase()));
-      mutationBuilder.field(sessionFieldFactory.createTokenField(schema.getDatabase()));
+      mutationBuilder.field(sessionFieldFactory.signoutField(schema.getDatabase(), codeRegistry));
+      mutationBuilder.field(
+          sessionFieldFactory.changePasswordField(schema.getDatabase(), codeRegistry));
+      mutationBuilder.field(
+          sessionFieldFactory.createTokenField(schema.getDatabase(), codeRegistry));
     }
 
-    mutationBuilder.field(schemaFields.changeMutation(schema));
-    mutationBuilder.field(schemaFields.dropMutation(schema));
-    mutationBuilder.field(schemaFields.truncateMutation(schema, taskService));
+    mutationBuilder.field(schemaFields.changeMutation(schema, codeRegistry));
+    mutationBuilder.field(schemaFields.dropMutation(schema, codeRegistry));
+    mutationBuilder.field(schemaFields.truncateMutation(schema, taskService, codeRegistry));
 
     if (PermissionEvaluator.canManage(schema)) {
-      queryBuilder.field(schemaFields.changeLogQuery(schema));
-      queryBuilder.field(schemaFields.changeLogCountQuery(schema));
+      queryBuilder.field(schemaFields.changeLogQuery(schema, codeRegistry));
+      queryBuilder.field(schemaFields.changeLogCountQuery(schema, codeRegistry));
     }
 
     GraphqlTableFieldFactory tableField = new GraphqlTableFieldFactory(schema);
     for (TableMetadata table : schema.getMetadata().getTables()) {
       if (table.getColumns().size() > 0) {
         if (tableField.hasViewPermission(table)) {
-          queryBuilder.field(tableField.tableQueryField(table));
+          queryBuilder.field(tableField.tableQueryField(table, codeRegistry));
         }
-        queryBuilder.field(tableField.tableAggField(table));
-        queryBuilder.field(tableField.tableGroupByField(table));
+        queryBuilder.field(tableField.tableAggField(table, codeRegistry));
+        queryBuilder.field(tableField.tableGroupByField(table, codeRegistry));
       }
     }
-    mutationBuilder.field(tableField.insertMutation(schema));
-    mutationBuilder.field(tableField.updateMutation(schema));
-    mutationBuilder.field(tableField.upsertMutation(schema));
-    mutationBuilder.field(tableField.deleteMutation(schema));
+    mutationBuilder.field(tableField.insertMutation(schema, codeRegistry));
+    mutationBuilder.field(tableField.updateMutation(schema, codeRegistry));
+    mutationBuilder.field(tableField.upsertMutation(schema, codeRegistry));
+    mutationBuilder.field(tableField.deleteMutation(schema, codeRegistry));
 
     GraphQL graphql =
         GraphQL.newGraphQL(
-                GraphQLSchema.newSchema().query(queryBuilder).mutation(mutationBuilder).build())
+                GraphQLSchema.newSchema()
+                    .query(queryBuilder)
+                    .mutation(mutationBuilder)
+                    .codeRegistry(codeRegistry.build())
+                    .build())
             .mutationExecutionStrategy(
                 new AsyncExecutionStrategy(new GraphqlCustomExceptionHandler()))
             .build();

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlManifesFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlManifesFieldFactory.java
@@ -1,6 +1,9 @@
 package org.molgenis.emx2.graphql;
 
 import graphql.Scalars;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLObjectType;
 import java.util.HashMap;
@@ -14,17 +17,20 @@ public class GraphqlManifesFieldFactory {
   public static final String SPECIFICATION_VERSION = "SpecificationVersion";
   public static final String DATABASE_VERSION = "DatabaseVersion";
 
-  public GraphQLFieldDefinition queryVersionField(Database db) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("_manifest")
-        .dataFetcher(
+  public GraphQLFieldDefinition queryVersionField(
+      Database db, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_manifest"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               Map<String, Object> result = new HashMap<>();
               result.put(IMPLEMENTATION_VERSION, Version.getImplementationVersion());
               result.put(SPECIFICATION_VERSION, Version.getSpecificationVersion());
               result.put(DATABASE_VERSION, db.getDatabaseVersion());
               return result;
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("_manifest")
         .type(
             GraphQLObjectType.newObject()
                 .name("MolgenisManifest")

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlSchemaFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlSchemaFieldFactory.java
@@ -778,7 +778,8 @@ public class GraphqlSchemaFieldFactory {
     }
   }
 
-  public GraphQLFieldDefinition.Builder schemaQuery(Schema schema) {
+  public GraphQLFieldDefinition.Builder schemaQuery(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
     GraphQLObjectType.Builder builder =
         new GraphQLObjectType.Builder()
             .name("MolgenisSchema")
@@ -807,42 +808,44 @@ public class GraphqlSchemaFieldFactory {
               .type(GraphQLList.list(outputMembersMetadataType)));
     }
 
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("_schema")
-        .type(builder)
-        .dataFetcher(GraphqlSchemaFieldFactory.queryFetcher(schema));
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_schema"),
+        GraphqlSchemaFieldFactory.queryFetcher(schema));
+    return GraphQLFieldDefinition.newFieldDefinition().name("_schema").type(builder);
   }
 
-  public GraphQLFieldDefinition.Builder changeLogQuery(Schema schema) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("_changes")
-        .type(GraphQLList.list(changesMetadataType))
-        .dataFetcher(
+  public GraphQLFieldDefinition.Builder changeLogQuery(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_changes"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               int limit = dataFetchingEnvironment.getArgumentOrDefault("limit", 100);
               int offset = dataFetchingEnvironment.getArgumentOrDefault("offset", 0);
               return schema.getChanges(limit, offset);
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("_changes")
+        .type(GraphQLList.list(changesMetadataType))
         .argument(GraphQLArgument.newArgument().name(LIMIT).type(Scalars.GraphQLInt))
         .argument(GraphQLArgument.newArgument().name(OFFSET).type(Scalars.GraphQLInt));
   }
 
-  public GraphQLFieldDefinition.Builder changeLogCountQuery(Schema schema) {
+  public GraphQLFieldDefinition.Builder changeLogCountQuery(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_changesCount"),
+        (DataFetcher<?>) dataFetchingEnvironment -> schema.getChangesCount());
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("_changesCount")
-        .type(Scalars.GraphQLInt)
-        .dataFetcher(dataFetchingEnvironment -> schema.getChangesCount());
+        .type(Scalars.GraphQLInt);
   }
 
-  public GraphQLFieldDefinition.Builder settingsQuery(Schema schema) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("_settings")
-        .argument(
-            GraphQLArgument.newArgument()
-                .name(GraphqlConstants.KEYS)
-                .type(GraphQLList.list(Scalars.GraphQLString)))
-        .type(GraphQLList.list(outputSettingsType))
-        .dataFetcher(
+  public GraphQLFieldDefinition.Builder settingsQuery(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_settings"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               final List<String> selectedKeys =
                   dataFetchingEnvironment.getArgumentOrDefault(KEYS, new ArrayList<>());
@@ -865,13 +868,21 @@ public class GraphqlSchemaFieldFactory {
                               String.valueOf(schema.getDatabase().isOidcEnabled()))))
                   .toList();
             });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("_settings")
+        .argument(
+            GraphQLArgument.newArgument()
+                .name(GraphqlConstants.KEYS)
+                .type(GraphQLList.list(Scalars.GraphQLString)))
+        .type(GraphQLList.list(outputSettingsType));
   }
 
-  public GraphQLFieldDefinition changeMutation(Schema schema) {
+  public GraphQLFieldDefinition changeMutation(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(FieldCoordinates.coordinates("Save", "change"), changeFetcher(schema));
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("change")
         .type(typeForMutationResult)
-        .dataFetcher(changeFetcher(schema))
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.TABLES)
@@ -996,11 +1007,12 @@ public class GraphqlSchemaFieldFactory {
     return keyValueMap;
   }
 
-  public GraphQLFieldDefinition dropMutation(Schema schema) {
+  public GraphQLFieldDefinition dropMutation(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(FieldCoordinates.coordinates("Save", "drop"), dropFetcher(schema));
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("drop")
         .type(typeForMutationResult)
-        .dataFetcher(dropFetcher(schema))
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.TABLES)
@@ -1024,10 +1036,12 @@ public class GraphqlSchemaFieldFactory {
         .build();
   }
 
-  public GraphQLFieldDefinition.Builder truncateMutation(Schema schema, TaskService taskService) {
+  public GraphQLFieldDefinition.Builder truncateMutation(
+      Schema schema, TaskService taskService, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "truncate"), truncateFetcher(schema, taskService));
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("truncate")
-        .dataFetcher(truncateFetcher(schema, taskService))
         .type(typeForMutationResult)
         .argument(
             GraphQLArgument.newArgument()
@@ -1039,7 +1053,22 @@ public class GraphqlSchemaFieldFactory {
                 .type(Scalars.GraphQLBoolean));
   }
 
-  public GraphQLFieldDefinition schemaReportsField(Schema schema) {
+  public GraphQLFieldDefinition schemaReportsField(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_reports"),
+        (DataFetcher<?>)
+            dataFetchingEnvironment -> {
+              Map<String, Object> result = new LinkedHashMap<>();
+              final String id = dataFetchingEnvironment.getArgument(ID);
+              Integer offset = dataFetchingEnvironment.getArgumentOrDefault(OFFSET, 0);
+              Integer limit = dataFetchingEnvironment.getArgumentOrDefault(LIMIT, 10);
+              Map<String, String> parameters =
+                  convertKeyValueListToMap(dataFetchingEnvironment.getArgument(PARAMETERS));
+              result.put(DATA, getReportAsJson(id, schema, parameters, limit, offset));
+              result.put(COUNT, getReportCount(id, schema, parameters));
+              return result;
+            });
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("_reports")
         .type(
@@ -1060,18 +1089,6 @@ public class GraphqlSchemaFieldFactory {
                 .type(GraphQLList.list(inputSettingsMetadataType)))
         .argument(GraphQLArgument.newArgument().name(LIMIT).type(Scalars.GraphQLInt))
         .argument(GraphQLArgument.newArgument().name(OFFSET).type(Scalars.GraphQLInt))
-        .dataFetcher(
-            dataFetchingEnvironment -> {
-              Map<String, Object> result = new LinkedHashMap<>();
-              final String id = dataFetchingEnvironment.getArgument(ID);
-              Integer offset = dataFetchingEnvironment.getArgumentOrDefault(OFFSET, 0);
-              Integer limit = dataFetchingEnvironment.getArgumentOrDefault(LIMIT, 10);
-              Map<String, String> parameters =
-                  convertKeyValueListToMap(dataFetchingEnvironment.getArgument(PARAMETERS));
-              result.put(DATA, getReportAsJson(id, schema, parameters, limit, offset));
-              result.put(COUNT, getReportCount(id, schema, parameters));
-              return result;
-            })
         .build();
   }
 }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlSessionFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlSessionFieldFactory.java
@@ -10,7 +10,10 @@ import static org.molgenis.emx2.graphql.GraphqlSchemaFieldFactory.outputSettings
 import static org.molgenis.emx2.utils.TypeUtils.convertToPascalCase;
 
 import graphql.Scalars;
+import graphql.schema.DataFetcher;
+import graphql.schema.FieldCoordinates;
 import graphql.schema.GraphQLArgument;
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
 import graphql.schema.GraphQLList;
 import graphql.schema.GraphQLObjectType;
@@ -54,11 +57,11 @@ public class GraphqlSessionFieldFactory {
     // no instance
   }
 
-  public GraphQLFieldDefinition signoutField(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("signout")
-        .type(GraphqlApiMutationResult.typeForMutationResult)
-        .dataFetcher(
+  public GraphQLFieldDefinition signoutField(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "signout"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               GraphqlSessionHandlerInterface sessionHandler =
                   dataFetchingEnvironment
@@ -69,17 +72,18 @@ public class GraphqlSessionFieldFactory {
                   GraphqlApiMutationResult.Status.SUCCESS,
                   "User '%s' has signed out",
                   database.getActiveUser());
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("signout")
+        .type(GraphqlApiMutationResult.typeForMutationResult)
         .build();
   }
 
-  public GraphQLFieldDefinition signupField(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("signup")
-        .type(GraphqlApiMutationResult.typeForMutationResult)
-        .argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString))
-        .argument(GraphQLArgument.newArgument().name(PASSWORD).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public GraphQLFieldDefinition signupField(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "signup"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String userName = dataFetchingEnvironment.getArgument(EMAIL);
               String passWord = dataFetchingEnvironment.getArgument(PASSWORD);
@@ -107,17 +111,20 @@ public class GraphqlSessionFieldFactory {
                   });
               return new GraphqlApiMutationResult(
                   GraphqlApiMutationResult.Status.SUCCESS, "User '%s' added", userName);
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("signup")
+        .type(GraphqlApiMutationResult.typeForMutationResult)
+        .argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString))
+        .argument(GraphQLArgument.newArgument().name(PASSWORD).type(Scalars.GraphQLString))
         .build();
   }
 
-  public GraphQLFieldDefinition signinField(Database database) {
-    return GraphQLFieldDefinition.newFieldDefinition()
-        .name("signin")
-        .type(GraphqlApiMutationResultWithToken.typeForSignResult)
-        .argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString))
-        .argument(GraphQLArgument.newArgument().name(PASSWORD).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public GraphQLFieldDefinition signinField(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "signin"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String userName = dataFetchingEnvironment.getArgument(EMAIL);
               String passWord = dataFetchingEnvironment.getArgument(PASSWORD);
@@ -145,11 +152,37 @@ public class GraphqlSessionFieldFactory {
                 return new GraphqlApiMutationResult(
                     FAILED, "Sign in as '%s' failed: user or password unknown", userName);
               }
-            })
+            });
+    return GraphQLFieldDefinition.newFieldDefinition()
+        .name("signin")
+        .type(GraphqlApiMutationResultWithToken.typeForSignResult)
+        .argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString))
+        .argument(GraphQLArgument.newArgument().name(PASSWORD).type(Scalars.GraphQLString))
         .build();
   }
 
-  public GraphQLFieldDefinition sessionQueryField(Database database, Schema schema) {
+  public GraphQLFieldDefinition sessionQueryField(
+      Database database, Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", "_session"),
+        (DataFetcher<?>)
+            dataFetchingEnvironment -> {
+              Map<String, Object> result = new LinkedHashMap<>();
+              result.put(
+                  EMAIL, database.getActiveUser() != null ? database.getActiveUser() : "anonymous");
+              result.put(ADMIN, database.isAdmin());
+              if (schema != null) {
+                result.put(ROLES, schema.getInheritedRolesForActiveUser());
+                result.put(TABLE_PERMISSIONS, buildTablePermissions(schema));
+              }
+              result.put(SCHEMAS, database.getSchemaNames());
+              User user = database.getUser(database.getActiveUser());
+              result.put(
+                  SETTINGS, user != null ? mapSettingsToGraphql(user.getSettings()) : Map.of());
+              result.put(
+                  TOKEN, JWTgenerator.createTemporaryToken(database, database.getActiveUser()));
+              return result;
+            });
     return GraphQLFieldDefinition.newFieldDefinition()
         .name("_session")
         .type(
@@ -183,24 +216,6 @@ public class GraphqlSessionFieldFactory {
                     GraphQLFieldDefinition.newFieldDefinition()
                         .name(TOKEN)
                         .type(Scalars.GraphQLString)))
-        .dataFetcher(
-            dataFetchingEnvironment -> {
-              Map<String, Object> result = new LinkedHashMap<>();
-              result.put(
-                  EMAIL, database.getActiveUser() != null ? database.getActiveUser() : "anonymous");
-              result.put(ADMIN, database.isAdmin());
-              if (schema != null) {
-                result.put(ROLES, schema.getInheritedRolesForActiveUser());
-                result.put(TABLE_PERMISSIONS, buildTablePermissions(schema));
-              }
-              result.put(SCHEMAS, database.getSchemaNames());
-              User user = database.getUser(database.getActiveUser());
-              result.put(
-                  SETTINGS, user != null ? mapSettingsToGraphql(user.getSettings()) : Map.of());
-              result.put(
-                  TOKEN, JWTgenerator.createTemporaryToken(database, database.getActiveUser()));
-              return result;
-            })
         .build();
   }
 
@@ -219,15 +234,11 @@ public class GraphqlSessionFieldFactory {
         .toList();
   }
 
-  public GraphQLFieldDefinition createTokenField(Database database) {
-    GraphQLFieldDefinition.Builder builder =
-        GraphQLFieldDefinition.newFieldDefinition()
-            .name("createToken")
-            .type(GraphqlApiMutationResultWithToken.typeForSignResult);
-    builder.argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString));
-    return builder
-        .argument(GraphQLArgument.newArgument().name(TOKEN_NAME).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public GraphQLFieldDefinition createTokenField(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "createToken"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String tokenId = dataFetchingEnvironment.getArgument(TOKEN_NAME);
               String userName = dataFetchingEnvironment.getArgument(EMAIL);
@@ -241,21 +252,22 @@ public class GraphqlSessionFieldFactory {
                   "Token '%s' created for user '%s'",
                   tokenId,
                   userName);
-            })
+            });
+    GraphQLFieldDefinition.Builder builder =
+        GraphQLFieldDefinition.newFieldDefinition()
+            .name("createToken")
+            .type(GraphqlApiMutationResultWithToken.typeForSignResult);
+    builder.argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString));
+    return builder
+        .argument(GraphQLArgument.newArgument().name(TOKEN_NAME).type(Scalars.GraphQLString))
         .build();
   }
 
-  public GraphQLFieldDefinition changePasswordField(Database database) {
-    GraphQLFieldDefinition.Builder builder =
-        GraphQLFieldDefinition.newFieldDefinition()
-            .name("changePassword")
-            .type(typeForMutationResult);
-    if (database.isAdmin()) {
-      builder.argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString));
-    }
-    return builder
-        .argument(GraphQLArgument.newArgument().name(PASSWORD).type(Scalars.GraphQLString))
-        .dataFetcher(
+  public GraphQLFieldDefinition changePasswordField(
+      Database database, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "changePassword"),
+        (DataFetcher<?>)
             dataFetchingEnvironment -> {
               String password = dataFetchingEnvironment.getArgument(PASSWORD);
               String username = dataFetchingEnvironment.getArgument(EMAIL);
@@ -268,7 +280,16 @@ public class GraphqlSessionFieldFactory {
               } else {
                 return new GraphqlApiMutationResult(FAILED, "Password not changed: empty");
               }
-            })
+            });
+    GraphQLFieldDefinition.Builder builder =
+        GraphQLFieldDefinition.newFieldDefinition()
+            .name("changePassword")
+            .type(typeForMutationResult);
+    if (database.isAdmin()) {
+      builder.argument(GraphQLArgument.newArgument().name(EMAIL).type(Scalars.GraphQLString));
+    }
+    return builder
+        .argument(GraphQLArgument.newArgument().name(PASSWORD).type(Scalars.GraphQLString))
         .build();
   }
 }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -75,8 +75,12 @@ public class GraphqlTableFieldFactory {
   }
 
   // schema specific types
-  public GraphQLFieldDefinition tableQueryField(TableMetadata table) {
+  public GraphQLFieldDefinition tableQueryField(
+      TableMetadata table, GraphQLCodeRegistry.Builder codeRegistry) {
     GraphQLNamedOutputType tableType = createTableObjectType(table);
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", table.getIdentifier()),
+        fetcherForTableQueryField(table));
     return GraphQLFieldDefinition.newFieldDefinition()
         .name(table.getIdentifier())
         .type(GraphQLList.list(tableType))
@@ -84,7 +88,6 @@ public class GraphqlTableFieldFactory {
             String.format(
                 "Retrieve from table '%s'. Use {%s{...All%sFields}} to select all fields including foreign key nested queries",
                 table.getTableName(), table.getIdentifier(), table.getIdentifier()))
-        .dataFetcher(fetcherForTableQueryField(table))
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.FILTER_ARGUMENT)
@@ -113,11 +116,14 @@ public class GraphqlTableFieldFactory {
         .build();
   }
 
-  public GraphQLFieldDefinition tableGroupByField(TableMetadata table) {
+  public GraphQLFieldDefinition tableGroupByField(
+      TableMetadata table, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", table.getIdentifier() + "_groupBy"),
+        fetcherForTableQueryField(table));
     return GraphQLFieldDefinition.newFieldDefinition()
         .name(table.getIdentifier() + "_groupBy")
         .type(GraphQLList.list(createTableGroupByType(table)))
-        .dataFetcher(fetcherForTableQueryField(table))
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.FILTER_ARGUMENT)
@@ -131,11 +137,14 @@ public class GraphqlTableFieldFactory {
         .build();
   }
 
-  public GraphQLFieldDefinition tableAggField(TableMetadata table) {
+  public GraphQLFieldDefinition tableAggField(
+      TableMetadata table, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Query", table.getIdentifier() + "_agg"),
+        fetcherForTableQueryField(table));
     return GraphQLFieldDefinition.newFieldDefinition()
         .name(table.getIdentifier() + "_agg")
         .type(createTableAggregationType(table))
-        .dataFetcher(fetcherForTableQueryField(table))
         .argument(
             GraphQLArgument.newArgument()
                 .name(GraphqlConstants.FILTER_ARGUMENT)
@@ -912,12 +921,14 @@ public class GraphqlTableFieldFactory {
         .orElseThrow(() -> new MolgenisException("Unknown order by column id: " + id));
   }
 
-  private GraphQLFieldDefinition getMutationDefinition(Schema schema, MutationType type) {
+  private GraphQLFieldDefinition getMutationDefinition(
+      Schema schema, MutationType type, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", type.name().toLowerCase()), fetcher(schema, type));
     GraphQLFieldDefinition.Builder fieldBuilder =
         GraphQLFieldDefinition.newFieldDefinition()
             .name(type.name().toLowerCase())
-            .type(typeForMutationResult)
-            .dataFetcher(fetcher(schema, type));
+            .type(typeForMutationResult);
     for (TableMetadata table : schema.getMetadata().getTables()) {
       if (!table.getColumnsIncludingSubclassesExcludingHeadings().isEmpty()) {
         fieldBuilder.argument(
@@ -929,24 +940,27 @@ public class GraphqlTableFieldFactory {
     return fieldBuilder.build();
   }
 
-  public GraphQLFieldDefinition insertMutation(Schema schema) {
-    return getMutationDefinition(schema, MutationType.INSERT);
+  public GraphQLFieldDefinition insertMutation(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    return getMutationDefinition(schema, MutationType.INSERT, codeRegistry);
   }
 
-  public GraphQLFieldDefinition updateMutation(Schema schema) {
-    return getMutationDefinition(schema, MutationType.UPDATE);
+  public GraphQLFieldDefinition updateMutation(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    return getMutationDefinition(schema, MutationType.UPDATE, codeRegistry);
   }
 
-  public GraphQLFieldDefinition upsertMutation(Schema schema) {
-    return getMutationDefinition(schema, MutationType.SAVE);
+  public GraphQLFieldDefinition upsertMutation(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    return getMutationDefinition(schema, MutationType.SAVE, codeRegistry);
   }
 
-  public GraphQLFieldDefinition deleteMutation(Schema schema) {
+  public GraphQLFieldDefinition deleteMutation(
+      Schema schema, GraphQLCodeRegistry.Builder codeRegistry) {
+    codeRegistry.dataFetcher(
+        FieldCoordinates.coordinates("Save", "delete"), fetcher(schema, MutationType.DELETE));
     GraphQLFieldDefinition.Builder fieldBuilder =
-        GraphQLFieldDefinition.newFieldDefinition()
-            .name("delete")
-            .type(typeForMutationResult)
-            .dataFetcher(fetcher(schema, MutationType.DELETE));
+        GraphQLFieldDefinition.newFieldDefinition().name("delete").type(typeForMutationResult);
 
     fieldBuilder.argument(
         GraphQLArgument.newArgument().name("strict").type(Scalars.GraphQLBoolean).build());

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/GraphqlSchemaFieldFactoryTest.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/GraphqlSchemaFieldFactoryTest.java
@@ -3,6 +3,7 @@ package org.molgenis.emx2.graphql;
 import static java.util.function.Predicate.*;
 import static org.junit.jupiter.api.Assertions.*;
 
+import graphql.schema.GraphQLCodeRegistry;
 import graphql.schema.GraphQLFieldDefinition;
 import java.util.Arrays;
 import java.util.List;
@@ -34,7 +35,9 @@ class GraphqlSchemaFieldFactoryTest {
       schema.addMember("test-user", privilege.toString());
       schema.getDatabase().setActiveUser("test-user");
 
-      GraphQLFieldDefinition.Builder builder = new GraphqlSchemaFieldFactory().schemaQuery(schema);
+      GraphQLFieldDefinition.Builder builder =
+          new GraphqlSchemaFieldFactory()
+              .schemaQuery(schema, GraphQLCodeRegistry.newCodeRegistry());
       GraphQLFieldDefinition definition = builder.build();
       assertTrue(
           definitionContainsMembersField(definition),
@@ -50,7 +53,9 @@ class GraphqlSchemaFieldFactoryTest {
       schema.addMember("test-user", privilege.toString());
       schema.getDatabase().setActiveUser("test-user");
 
-      GraphQLFieldDefinition.Builder builder = new GraphqlSchemaFieldFactory().schemaQuery(schema);
+      GraphQLFieldDefinition.Builder builder =
+          new GraphqlSchemaFieldFactory()
+              .schemaQuery(schema, GraphQLCodeRegistry.newCodeRegistry());
       GraphQLFieldDefinition definition = builder.build();
       assertFalse(
           definitionContainsMembersField(definition),


### PR DESCRIPTION
### What are the main changes you did
- refactor use of gql data fetch build to use non depreciated api style
- switch to using codeRegistry to pass around gql builder context
### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
