### PR TITLE
fix: add missing ?_type_ to group by clause, fixing multiple rows for tables with multiple semantics

### DIFF
--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/generators/query/TableQueryGenerator.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/generators/query/TableQueryGenerator.java
@@ -100,7 +100,8 @@ public class TableQueryGenerator implements QueryGenerator {
 
       select
           .where(SUBJECT_VARIABLE.isA(TYPE_VARIABLE))
-          .values(value -> value.variables(TYPE_VARIABLE).values(semantics));
+          .values(value -> value.variables(TYPE_VARIABLE).values(semantics))
+          .groupBy(TYPE_VARIABLE);
     }
   }
 

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/TableQueryGeneratorTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/TableQueryGeneratorTest.java
@@ -99,7 +99,7 @@ class TableQueryGeneratorTest {
         SELECT ?_subject ?name
         WHERE { ?_subject a ?_type_ .
         ?_subject xsd:name ?name . }
-        GROUP BY ?_subject ?name
+        GROUP BY ?_type_ ?_subject ?name
         VALUES ?_type_ {
           xsd:foo\s
           xsd:bar\s


### PR DESCRIPTION
Addresses: https://github.com/molgenis/molgenis-emx2/issues/6196

### What are the main changes you did
- when using a generated query for a table with multiple semantics, we get a Cartesian product with a row for each semantic bound to the table, meaning multiple rows for the same data. This properly flattens the results

### How to test
- unit tests

### Checklist
- [ ] updated docs in case of new feature
- [X] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
