### PR TITLE
feat(apps/molgenis-components): Support cross-schema table-permissions

### DIFF
--- a/apps/molgenis-components/src/client/client.ts
+++ b/apps/molgenis-components/src/client/client.ts
@@ -7,6 +7,7 @@ import type {
   ITableMetaData,
 } from "../../../metadata-utils/src/types";
 import type { IRow } from "../Interfaces/IRow";
+import type { ITablePermission } from "../components/account/Interfaces";
 import { deepClone, getKeyValue } from "../components/utils";
 import type { AggFunction } from "./IClient";
 import type { IClient, INewClient } from "./IClient";
@@ -17,7 +18,13 @@ import { toFormData } from "../../../metadata-utils/src/toFormData";
 // application wide cache for schema meta data
 const schemaCache = new Map<string, Promise<ISchemaMetaData>>();
 
-export { request, fetchSchemaMetaData, convertRowToPrimaryKey };
+export {
+  request,
+  fetchSchemaMetaData,
+  convertRowToPrimaryKey,
+  fetchTablePermissions,
+  resolveTablePermission,
+};
 const client: IClient = {
   newClient: (schemaId?: string): INewClient => {
     return {
@@ -350,6 +357,40 @@ const fetchOntologyOptions = async (
 const fetchSettings = async (schemaId?: string) => {
   return (await request(graphqlURL(schemaId), "{_settings{key, value}}"))
     ._settings;
+};
+
+// session scoped cache of table permissions per schema, so a form referencing
+// another schema can resolve insert/update/delete rights without refetching
+const tablePermissionsCache = new Map<string, Promise<ITablePermission[]>>();
+
+const fetchTablePermissions = (
+  schemaId: string
+): Promise<ITablePermission[]> => {
+  if (!tablePermissionsCache.has(schemaId)) {
+    tablePermissionsCache.set(
+      schemaId,
+      request(
+        graphqlURL(schemaId),
+        "{_session{tablePermissions{id,name,canView,canInsert,canUpdate,canDelete,isRowLevel}}}"
+      ).then((response) => response?._session?.tablePermissions ?? [])
+    );
+  }
+  return tablePermissionsCache.get(schemaId)!;
+};
+
+// resolve the permission of a referenced table: same-schema references are
+// already in the seed (the current session), a reference to another schema is
+// fetched (and cached) from that schema
+const resolveTablePermission = async (
+  schemaId: string,
+  tableId: string,
+  seed: ITablePermission[] = []
+): Promise<ITablePermission | undefined> => {
+  const match = (p: ITablePermission) => p.id === tableId || p.name === tableId;
+  return (
+    seed.find(match) ??
+    (schemaId ? (await fetchTablePermissions(schemaId)).find(match) : undefined)
+  );
 };
 
 const request = async (url: string, graphql: string, variables?: any) => {

--- a/apps/molgenis-components/src/client/fetchTablePermissions.test.ts
+++ b/apps/molgenis-components/src/client/fetchTablePermissions.test.ts
@@ -1,0 +1,97 @@
+import axios from "axios";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { fetchTablePermissions, resolveTablePermission } from "./client";
+
+vi.mock("axios");
+
+const permissions = [
+  { id: "Pet", name: "Pet", canInsert: true, canUpdate: false },
+];
+
+describe("fetchTablePermissions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (axios.post as any).mockResolvedValue({
+      data: { data: { _session: { tablePermissions: permissions } } },
+    });
+  });
+
+  test("returns the table permissions of the requested schema", async () => {
+    const result = await fetchTablePermissions("schema-returns");
+    expect(result).toEqual(permissions);
+    expect(axios.post).toHaveBeenCalledWith(
+      "/schema-returns/graphql",
+      expect.objectContaining({ query: expect.stringContaining("_session") })
+    );
+  });
+
+  test("caches per schema so repeated calls hit the network once", async () => {
+    await fetchTablePermissions("schema-cache");
+    await fetchTablePermissions("schema-cache");
+    expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+
+  test("fetches separately for different schemas", async () => {
+    await fetchTablePermissions("schema-a");
+    await fetchTablePermissions("schema-b");
+    expect(axios.post).toHaveBeenCalledTimes(2);
+  });
+
+  test("returns an empty list when the session has no permissions", async () => {
+    (axios.post as any).mockResolvedValue({
+      data: { data: { _session: {} } },
+    });
+    const result = await fetchTablePermissions("schema-empty");
+    expect(result).toEqual([]);
+  });
+});
+
+describe("resolveTablePermission", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (axios.post as any).mockResolvedValue({
+      data: { data: { _session: { tablePermissions: permissions } } },
+    });
+  });
+
+  test("resolves from the seed (current schema) without fetching", async () => {
+    const result = await resolveTablePermission("pet store", "Pet", [
+      { id: "Pet", name: "Pet", canInsert: true } as any,
+    ]);
+    expect(result?.canInsert).toBe(true);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  test("fetches the referenced schema when the table is not in the seed", async () => {
+    const result = await resolveTablePermission("resolve-other", "Pet", [
+      { id: "Order", name: "Order", canInsert: true } as any,
+    ]);
+    expect(axios.post).toHaveBeenCalledWith(
+      "/resolve-other/graphql",
+      expect.anything()
+    );
+    expect(result?.canInsert).toBe(true);
+  });
+
+  test("matches on table name when the id is pascal-cased", async () => {
+    const result = await resolveTablePermission("pet store", "my table", [
+      { id: "MyTable", name: "my table", canInsert: true } as any,
+    ]);
+    expect(result?.canInsert).toBe(true);
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+
+  test("returns undefined when the referenced table has no permission", async () => {
+    (axios.post as any).mockResolvedValue({
+      data: { data: { _session: { tablePermissions: [] } } },
+    });
+    const result = await resolveTablePermission("resolve-missing", "Pet", []);
+    expect(result).toBeUndefined();
+  });
+
+  test("does not fetch when no schema is given and the seed misses", async () => {
+    const result = await resolveTablePermission("", "Pet", []);
+    expect(result).toBeUndefined();
+    expect(axios.post).not.toHaveBeenCalled();
+  });
+});

--- a/apps/molgenis-components/src/components/account/Interfaces.ts
+++ b/apps/molgenis-components/src/components/account/Interfaces.ts
@@ -1,4 +1,4 @@
-import { ISetting } from "metadata-utils";
+import type { ISetting } from "../../../../metadata-utils/src/types";
 
 export interface ITablePermission {
   name: string;

--- a/apps/molgenis-components/src/components/forms/InputRefBack.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefBack.vue
@@ -102,6 +102,7 @@ import FormGroup from "./FormGroup.vue";
 import MessageError from "./MessageError.vue";
 import MessageWarning from "./MessageWarning.vue";
 import BaseInput from "./baseInputs/BaseInput.vue";
+import { resolveTablePermission } from "../../client/client.ts";
 
 export default {
   name: "InputRefBack",
@@ -159,6 +160,7 @@ export default {
   data() {
     return {
       client: null,
+      tablePermission: undefined,
       tableMetadata: null,
       data: null,
       isLoading: false,
@@ -171,9 +173,6 @@ export default {
     };
   },
   computed: {
-    tablePermission() {
-      return this.tablePermissions?.find((p) => p.name === this.tableId);
-    },
     canInsert() {
       return this.tablePermission?.canInsert ?? this.canEdit;
     },
@@ -247,8 +246,20 @@ export default {
       }
       this.loading = false;
     },
+    async loadPermission() {
+      this.tablePermission = await resolveTablePermission(
+        this.schemaId,
+        this.tableId,
+        this.tablePermissions
+      );
+    },
+  },
+  watch: {
+    schemaId: "loadPermission",
+    tableId: "loadPermission",
   },
   mounted: async function () {
+    this.loadPermission();
     this.client = Client.newClient(this.schemaId);
     this.isLoading = true;
     this.tableMetadata = await this.client

--- a/apps/molgenis-components/src/components/forms/InputRefList.test.ts
+++ b/apps/molgenis-components/src/components/forms/InputRefList.test.ts
@@ -1,0 +1,95 @@
+import axios from "axios";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import InputRefList from "./InputRefList.vue";
+import RowButtonAdd from "../tables/RowButtonAdd.vue";
+
+// Keep the real permission logic (resolveTablePermission / fetchTablePermissions,
+// which is the fix under test) but stub the data-loading client so the mount does
+// not need a real schema behind it.
+vi.mock("../../client/client", async (importActual) => {
+  const actual = await importActual<typeof import("../../client/client")>();
+  return {
+    ...actual,
+    default: {
+      newClient: () => ({
+        fetchTableMetaData: vi
+          .fn()
+          .mockResolvedValue({ id: "Pet", label: "Pet", columns: [] }),
+        fetchTableData: vi
+          .fn()
+          .mockResolvedValue({ Pet: [], Pet_agg: { count: 0 } }),
+      }),
+    },
+  };
+});
+
+vi.mock("axios");
+
+function permissionResponse(canInsert: boolean) {
+  return {
+    data: {
+      data: {
+        _session: {
+          tablePermissions: [{ id: "Pet", name: "Pet", canInsert }],
+        },
+      },
+    },
+  };
+}
+
+function mountRefList(props: Record<string, unknown>) {
+  return mount(InputRefList, {
+    props: { id: "pets", label: "Pet", refLabel: "${name}", ...props },
+  });
+}
+
+describe("InputRefList add button for cross-schema references", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // distinct schema ids per test: the client caches permissions per schema
+  test("shows the add button when the referenced (other) schema grants insert", async () => {
+    (axios.post as any).mockResolvedValue(permissionResponse(true));
+    const wrapper = mountRefList({
+      tableId: "Pet",
+      schemaId: "ref-grant",
+      tablePermissions: [{ id: "Order", name: "Order", canInsert: true }],
+    });
+    await flushPromises();
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "/ref-grant/graphql",
+      expect.anything()
+    );
+    expect(wrapper.findComponent(RowButtonAdd).exists()).toBe(true);
+    expect(wrapper.getComponent(RowButtonAdd).props("schemaId")).toBe(
+      "ref-grant"
+    );
+  });
+
+  test("hides the add button when the referenced schema denies insert", async () => {
+    (axios.post as any).mockResolvedValue(permissionResponse(false));
+    const wrapper = mountRefList({
+      tableId: "Pet",
+      schemaId: "ref-deny",
+      tablePermissions: [{ id: "Order", name: "Order", canInsert: true }],
+    });
+    await flushPromises();
+
+    expect(wrapper.findComponent(RowButtonAdd).exists()).toBe(false);
+  });
+
+  test("uses the current-schema seed without a permission fetch", async () => {
+    const wrapper = mountRefList({
+      tableId: "Pet",
+      schemaId: "pet store",
+      tablePermissions: [{ id: "Pet", name: "Pet", canInsert: true }],
+    });
+    await flushPromises();
+
+    expect(axios.post).not.toHaveBeenCalled();
+    expect(wrapper.findComponent(RowButtonAdd).exists()).toBe(true);
+  });
+});

--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -105,6 +105,7 @@
 </template>
 
 <script lang="ts">
+import type { PropType } from "vue";
 import type { IQueryMetaData } from "../../../../metadata-utils/src/IQueryMetaData";
 import {
   ITableMetaData,
@@ -140,7 +141,7 @@ export default {
       selection: deepClone(this.modelValue),
       count: 0,
       tableMetadata: null as null | ITableMetaData,
-      tablePermission: undefined as undefined | ITablePermission,
+      tablePermission: undefined as ITablePermission | undefined,
       loading: false,
     };
   },
@@ -177,7 +178,7 @@ export default {
       default: () => false,
     },
     tablePermissions: {
-      type: Array,
+      type: Array as PropType<ITablePermission[]>,
       required: false,
       default: () => [],
     },
@@ -278,7 +279,7 @@ export default {
       this.tablePermission = await resolveTablePermission(
         this.schemaId,
         this.tableId,
-        this.tablePermissions as ITablePermission[]
+        this.tablePermissions
       );
     },
   },

--- a/apps/molgenis-components/src/components/forms/InputRefList.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefList.vue
@@ -61,7 +61,7 @@
       <div class="m-1">
         <RowButtonAdd
           id="add-entry"
-          v-if="canEdit"
+          v-if="canInsert"
           :label="`Add new ${label}`"
           :tableId="tableId"
           :schemaId="schemaId"
@@ -87,6 +87,7 @@
             :schemaId="schemaId"
             :tableId="tableId"
             :canEdit="canEdit"
+            :canInsert="canInsert"
             :showSelect="true"
             :filter="filter"
             :limit="10"
@@ -111,7 +112,8 @@ import {
 } from "../../../../metadata-utils/src/types";
 import { IRow } from "../../Interfaces/IRow";
 import { INewClient } from "../../client/IClient";
-import Client from "../../client/client";
+import type { ITablePermission } from "../account/Interfaces";
+import Client, { resolveTablePermission } from "../../client/client";
 import FilterWell from "../filters/FilterWell.vue";
 import LayoutModal from "../layout/LayoutModal.vue";
 import Spinner from "../layout/Spinner.vue";
@@ -138,6 +140,7 @@ export default {
       selection: deepClone(this.modelValue),
       count: 0,
       tableMetadata: null as null | ITableMetaData,
+      tablePermission: undefined as undefined | ITablePermission,
       loading: false,
     };
   },
@@ -173,8 +176,16 @@ export default {
       type: Boolean,
       default: () => false,
     },
+    tablePermissions: {
+      type: Array,
+      required: false,
+      default: () => [],
+    },
   },
   computed: {
+    canInsert() {
+      return this.tablePermission?.canInsert ?? this.canEdit;
+    },
     title() {
       const label = this.tableMetadata?.label || this.tableId;
       return "Select " + label;
@@ -263,8 +274,17 @@ export default {
       this.loading = false;
       this.$emit("optionsLoaded", this.data);
     },
+    async loadPermission() {
+      this.tablePermission = await resolveTablePermission(
+        this.schemaId,
+        this.tableId,
+        this.tablePermissions as ITablePermission[]
+      );
+    },
   },
   watch: {
+    schemaId: "loadPermission",
+    tableId: "loadPermission",
     async modelValue() {
       if (!this.modelValue) {
         this.selection = [];
@@ -282,6 +302,7 @@ export default {
     },
   },
   async created() {
+    this.loadPermission();
     this.loading = true;
     this.client = Client.newClient(this.schemaId);
     this.tableMetadata = await this.client.fetchTableMetaData(this.tableId);

--- a/apps/molgenis-components/src/components/forms/InputRefSelect.test.ts
+++ b/apps/molgenis-components/src/components/forms/InputRefSelect.test.ts
@@ -1,0 +1,82 @@
+import axios from "axios";
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import InputRefSelect from "./InputRefSelect.vue";
+import TableSearch from "../tables/TableSearch.vue";
+
+// resolveTablePermission (the fix under test) runs for real; only the network is
+// mocked. TableSearch is stubbed so opening the picker does not load real data.
+vi.mock("axios");
+
+function permissionResponse(canInsert: boolean) {
+  return {
+    data: {
+      data: {
+        _session: {
+          tablePermissions: [{ id: "Pet", name: "Pet", canInsert }],
+        },
+      },
+    },
+  };
+}
+
+function mountRefSelect(props: Record<string, unknown>) {
+  return mount(InputRefSelect, {
+    props: { id: "pet", refLabel: "${name}", ...props },
+    global: { stubs: { TableSearch: true } },
+  });
+}
+
+async function openPicker(wrapper: ReturnType<typeof mountRefSelect>) {
+  await wrapper.find("input").trigger("click");
+  await flushPromises();
+}
+
+describe("InputRefSelect add button for cross-schema references", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  test("passes insert permission of the referenced schema to the picker", async () => {
+    (axios.post as any).mockResolvedValue(permissionResponse(true));
+    const wrapper = mountRefSelect({
+      tableId: "Pet",
+      schemaId: "ref-select-grant",
+      tablePermissions: [{ id: "Order", name: "Order", canInsert: true }],
+    });
+    await flushPromises();
+    await openPicker(wrapper);
+
+    expect(axios.post).toHaveBeenCalledWith(
+      "/ref-select-grant/graphql",
+      expect.anything()
+    );
+    expect(wrapper.getComponent(TableSearch).props("canInsert")).toBe(true);
+  });
+
+  test("does not grant insert when the referenced schema denies it", async () => {
+    (axios.post as any).mockResolvedValue(permissionResponse(false));
+    const wrapper = mountRefSelect({
+      tableId: "Pet",
+      schemaId: "ref-select-deny",
+      tablePermissions: [{ id: "Order", name: "Order", canInsert: true }],
+    });
+    await flushPromises();
+    await openPicker(wrapper);
+
+    expect(wrapper.getComponent(TableSearch).props("canInsert")).toBe(false);
+  });
+
+  test("uses the current-schema seed without a permission fetch", async () => {
+    const wrapper = mountRefSelect({
+      tableId: "Pet",
+      schemaId: "pet store",
+      tablePermissions: [{ id: "Pet", name: "Pet", canInsert: true }],
+    });
+    await flushPromises();
+    await openPicker(wrapper);
+
+    expect(axios.post).not.toHaveBeenCalled();
+    expect(wrapper.getComponent(TableSearch).props("canInsert")).toBe(true);
+  });
+});

--- a/apps/molgenis-components/src/components/forms/InputRefSelect.vue
+++ b/apps/molgenis-components/src/components/forms/InputRefSelect.vue
@@ -62,6 +62,7 @@ import FormGroup from "./FormGroup.vue";
 import ButtonAlt from "./ButtonAlt.vue";
 import ButtonAction from "./ButtonAction.vue";
 import { applyJsTemplate } from "../utils";
+import { resolveTablePermission } from "../../client/client";
 
 export default {
   name: "InputRefSelect",
@@ -69,6 +70,7 @@ export default {
   data: function () {
     return {
       showSelect: false,
+      tablePermission: undefined,
     };
   },
   components: {
@@ -100,12 +102,23 @@ export default {
     title() {
       return "Select " + this.tableId; //todo need a label
     },
-    tablePermission() {
-      return this.tablePermissions?.find((p) => p.id === this.tableId);
-    },
+  },
+  watch: {
+    schemaId: "loadPermission",
+    tableId: "loadPermission",
+  },
+  created() {
+    this.loadPermission();
   },
   methods: {
     applyJsTemplate,
+    async loadPermission() {
+      this.tablePermission = await resolveTablePermission(
+        this.schemaId,
+        this.tableId,
+        this.tablePermissions
+      );
+    },
     async select(event) {
       this.showSelect = false;
       this.$emit("update:modelValue", await event);


### PR DESCRIPTION
Fixes #6491 

### Problem
The current tablePermissions prop passed to components only knows the current schema's tablePermissions (fetched by MolgenisSession.vue). This poses a problem when components need to know cross-schema access, such as Ref inputs. 

### Solution
This change adds support for fetching cross-schema table-permissions on demand, with a caching mechanism in client.ts to reduce duplicate/repeated network calls.

### Alternative solutions
* I considered altering the graphql request in MolgenisSession L70 (and the response in the backend) to eagerly fetch all tablePermissions for all schema's at once. But the payload quickly explodes when the user has access to many schema's and tables (scales baldy for a per-page request), and this also has a wider impact (requires changing prop type in TableExplorer, RoutedtableExplorer, EditModal, RowEdit, FomInput)
* A hotfix would be to assume 'can edit' for all out-of-schema table permissions, but that only moves the issue instead of solving it

### What are the main changes you did
- add `fetchTablePermissions, resolveTablePermissions` to `molgenis-components/client.ts`
- update `InputRefList`, `InputRefBack` and `InputRefSelect` to fetch external-schema tablePermissions if necessary

### How to test
- See #6491 for issue reproduction steps
- See added unit test

### Checklist
- [ ] updated docs in case of new feature
- [X] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
