### PR TITLE
feat: add TypicalAgeRdfPreProcessor to normalise Health-DCAT-AP typical age predicates

### DIFF
--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/preprocessing/TypicalAgeRdfPreProcessor.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/preprocessing/TypicalAgeRdfPreProcessor.java
@@ -1,0 +1,52 @@
+package org.molgenis.emx2.fairmapper.preprocessing;
+
+import org.eclipse.rdf4j.model.Model;
+import org.eclipse.rdf4j.query.GraphQuery;
+import org.eclipse.rdf4j.query.QueryLanguage;
+import org.eclipse.rdf4j.query.QueryResults;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+
+/**
+ * Normalises abbreviated typical age predicates on {@code dcat:Dataset} resources to the expected
+ * version in the EMX2 catalog model, which is not abbreviated.
+ *
+ * <p>According to the Health-DCAT-AP spec, datasets emit {@code healthdcatap:minTypicalAge} and
+ * instead of {@code healthdcatap:minimumTypicalAge} and {@code healthdcatap:maximumTypicalAge} (see
+ * the <a
+ * href='https://healthdataeu.pages.code.europa.eu/healthdcat-ap/releases/release-7/#healthdcatapmaxTypicalAge'>docs</a>)
+ * which is used in EMX2. This pre-processor reads the abbreviated forms and writes the fully
+ * written ones, so downstream SPARQL queries only need to handle a single predicate name.
+ *
+ * <p>Each age is handled independently: a resource that carries only one of the two abbreviated
+ * predicates will receive only the corresponding canonical predicate.
+ */
+public class TypicalAgeRdfPreProcessor implements RdfPreProcessor {
+
+  private static final String CONSTRUCT =
+      """
+          PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+          PREFIX healthdcatap: <http://healthdataportal.eu/ns/health#>
+          PREFIX dcat: <http://www.w3.org/ns/dcat#>
+
+          CONSTRUCT {
+              ?Resources healthdcatap:maximumTypicalAge ?maxAge .
+              ?Resources healthdcatap:minimumTypicalAge ?minAge .
+          }
+          WHERE {
+              ?Resources rdf:type dcat:Dataset .
+              OPTIONAL { ?Resources healthdcatap:maxTypicalAge ?maxAge . }
+              OPTIONAL { ?Resources healthdcatap:minTypicalAge ?minAge . }
+          }
+          """;
+
+  @Override
+  public void process(SailRepository repository) {
+    try (SailRepositoryConnection conn = repository.getConnection()) {
+      GraphQuery graphQuery = conn.prepareGraphQuery(QueryLanguage.SPARQL, CONSTRUCT);
+      Model result = QueryResults.asModel(graphQuery.evaluate());
+      result.forEach(conn::add);
+      conn.commit();
+    }
+  }
+}

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/preprocessing/TypicalAgeRdfPreProcessorTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/preprocessing/TypicalAgeRdfPreProcessorTest.java
@@ -1,0 +1,178 @@
+package org.molgenis.emx2.fairmapper.preprocessing;
+
+import static org.eclipse.rdf4j.model.util.Statements.statement;
+import static org.eclipse.rdf4j.model.util.Values.*;
+import static org.eclipse.rdf4j.model.util.Values.iri;
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Value;
+import org.eclipse.rdf4j.model.vocabulary.DCAT;
+import org.eclipse.rdf4j.model.vocabulary.RDF;
+import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
+import org.eclipse.rdf4j.sail.memory.MemoryStore;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.rdf.DefaultNamespace;
+
+class TypicalAgeRdfPreProcessorTest {
+
+  private static final IRI DATASET_SUBJECT = iri("https://example.com/dataset/1");
+  private static final IRI CATALOG_SUBJECT = iri("https://example.com/catalog/1");
+
+  private static SailRepository repository;
+
+  @BeforeEach
+  void setUp() {
+    repository = new SailRepository(new MemoryStore());
+  }
+
+  @Test
+  void givenDataset_whenOnlyMinAge_thenAddMinimumAge() {
+    try (SailRepositoryConnection conn = repository.getConnection()) {
+      addSubjectType(conn, DATASET_SUBJECT, DCAT.DATASET);
+      addMinAge(conn, DATASET_SUBJECT, 1);
+      conn.commit();
+    }
+
+    new TypicalAgeRdfPreProcessor().process(repository);
+    assertMinTypicalAgeEquals(DATASET_SUBJECT, 1);
+    assertMaxTypicalAgeEquals(DATASET_SUBJECT, null);
+  }
+
+  @Test
+  void givenDataset_whenOnlyMaxAge_thenAddMaximumAge() {
+    try (SailRepositoryConnection conn = repository.getConnection()) {
+      addSubjectType(conn, DATASET_SUBJECT, DCAT.DATASET);
+      addMaxAge(conn, DATASET_SUBJECT, 1);
+      conn.commit();
+    }
+
+    new TypicalAgeRdfPreProcessor().process(repository);
+    assertMinTypicalAgeEquals(DATASET_SUBJECT, null);
+    assertMaxTypicalAgeEquals(DATASET_SUBJECT, 1);
+  }
+
+  @Test
+  void givenDataset_whenBothMinAndMax_thenAddAgeBothTriplets() {
+    try (SailRepositoryConnection conn = repository.getConnection()) {
+      addSubjectType(conn, DATASET_SUBJECT, DCAT.DATASET);
+      addMinAge(conn, DATASET_SUBJECT, 1);
+      addMaxAge(conn, DATASET_SUBJECT, 10);
+      conn.commit();
+    }
+
+    new TypicalAgeRdfPreProcessor().process(repository);
+    assertMinTypicalAgeEquals(DATASET_SUBJECT, 1);
+    assertMaxTypicalAgeEquals(DATASET_SUBJECT, 10);
+  }
+
+  @Test
+  void givenCatalog_thenDontAddNewTriplets() {
+    try (SailRepositoryConnection conn = repository.getConnection()) {
+      addSubjectType(conn, CATALOG_SUBJECT, DCAT.CATALOG);
+      addMinAge(conn, CATALOG_SUBJECT, 1);
+      addMaxAge(conn, CATALOG_SUBJECT, 10);
+      conn.commit();
+    }
+
+    new TypicalAgeRdfPreProcessor().process(repository);
+    assertMinTypicalAgeEquals(CATALOG_SUBJECT, null);
+    assertMaxTypicalAgeEquals(CATALOG_SUBJECT, null);
+  }
+
+  @Test
+  void givenDataset_whenNoMinOrMax_thenDontAdd() {
+    try (SailRepositoryConnection conn = repository.getConnection()) {
+      addSubjectType(conn, DATASET_SUBJECT, DCAT.DATASET);
+      conn.commit();
+    }
+
+    new TypicalAgeRdfPreProcessor().process(repository);
+    assertMinTypicalAgeEquals(DATASET_SUBJECT, null);
+    assertMaxTypicalAgeEquals(DATASET_SUBJECT, null);
+  }
+
+  @Test
+  void processingShouldBeIdempotent() {
+    try (SailRepositoryConnection conn = repository.getConnection()) {
+      addSubjectType(conn, DATASET_SUBJECT, DCAT.DATASET);
+      addMinAge(conn, DATASET_SUBJECT, 1);
+      addMaxAge(conn, DATASET_SUBJECT, 10);
+      conn.commit();
+    }
+
+    new TypicalAgeRdfPreProcessor().process(repository);
+    long countAfterFirstRun = countAllStatements();
+    new TypicalAgeRdfPreProcessor().process(repository);
+    assertEquals(countAfterFirstRun, countAllStatements());
+  }
+
+  private static void addSubjectType(SailRepositoryConnection conn, IRI subject, IRI type) {
+    addTriplet(conn, subject, RDF.TYPE, type);
+  }
+
+  private static void addMaxAge(SailRepositoryConnection conn, IRI subject, int maxAge) {
+    addTriplet(conn, subject, iriFromHealthDCATAP("maxTypicalAge"), literal(maxAge));
+  }
+
+  private static void addMinAge(SailRepositoryConnection conn, IRI subject, int minAge) {
+    addTriplet(conn, subject, iriFromHealthDCATAP("minTypicalAge"), literal(minAge));
+  }
+
+  private static void addTriplet(
+      SailRepositoryConnection conn, IRI subject, IRI predicate, Value value) {
+    conn.add(statement(subject, predicate, value, null));
+  }
+
+  /**
+   * @param expectedAge null if no age is expected
+   */
+  private void assertMinTypicalAgeEquals(IRI subject, Integer expectedAge) {
+    assertEquals(getAge(subject, iriFromHealthDCATAP("minimumTypicalAge")), expectedAge);
+  }
+
+  /**
+   * @param expectedAge null if no age is expected
+   */
+  private void assertMaxTypicalAgeEquals(IRI subject, Integer expectedAge) {
+    assertEquals(getAge(subject, iriFromHealthDCATAP("maximumTypicalAge")), expectedAge);
+  }
+
+  private Integer getAge(IRI subject, IRI predicate) {
+    String query = "SELECT ?age WHERE { <%s> <%s> ?age }".formatted(subject, predicate);
+    try (SailRepositoryConnection conn = repository.getConnection();
+        TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
+
+      if (!result.hasNext()) {
+        return null;
+      }
+
+      Integer year =
+          Optional.of(result.next().getValue("age").stringValue())
+              .map(Integer::parseInt)
+              .orElse(null);
+
+      if (result.hasNext()) {
+        fail("Multiple years found for subject: " + subject);
+      }
+
+      return year;
+    }
+  }
+
+  private static long countAllStatements() {
+    String query = "SELECT (COUNT(*) AS ?count) WHERE { ?s ?p ?o }";
+    try (SailRepositoryConnection conn = repository.getConnection();
+        TupleQueryResult result = conn.prepareTupleQuery(query).evaluate()) {
+      return Long.parseLong(result.next().getValue("count").stringValue());
+    }
+  }
+
+  private static IRI iriFromHealthDCATAP(String localName) {
+    return iri(DefaultNamespace.HEALTHDCAT_AP.getNamespace().getName() + localName);
+  }
+}


### PR DESCRIPTION
Health-DCAT-AP emits the abbreviated healthdcatap:minTypicalAge / maxTypicalAge predicates, while EMX2's catalog model expects the fully written minimumTypicalAge / maximumTypicalAge forms. 

This pre-processor rewrites the abbreviated predicates to their canonical equivalents so downstream SPARQL queries only need to handle one predicate name per age.

This is the same strategy as were using for the temporal (see `TemporalRdfPreProcessor`). We add additional RDF triplets to the data that we derive from `healthdcatap:minTypicalAge` and `healthdcatap:maxTypicalAge`. In EMX2 we use `healthdcatap:minimumTypicalAge` and `healthdcatap:maximumTypicalAge`.

### What are the main changes you did
- explain what you changed and essential considerations.

### How to test
- explain here what to do to test this (or point to unit tests)

### Checklist
- [ ] updated docs in case of new feature
- [X] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
