### PR TITLE
docs(catalogue): fix setup instructions in README

### DIFF
--- a/apps/catalogue/README.md
+++ b/apps/catalogue/README.md
@@ -25,7 +25,7 @@ pnpm dev
 Set a non-default (api)proxy target with `NUXT_PUBLIC_API_BASE`, for example:
 
 ```bash
-NUXT_PUBLIC_API_BASE=https://emx2.dev.molgenis.org pnpm dev
+NUXT_PUBLIC_API_BASE=http://localhost:8080 pnpm dev
 ```
 
 ## Production

--- a/apps/catalogue/README.md
+++ b/apps/catalogue/README.md
@@ -1,25 +1,31 @@
-# Nuxt 3 Minimal Starter
+# Catalogue
 
-Look at the [nuxt 3 documentation](https://v3.nuxtjs.org) to learn more.
+The MOLGENIS EMX2 data catalogue app, built with [Nuxt](https://nuxt.com/docs).
 
 ## Setup
 
-Make sure to install the dependencies:
+Install the dependencies from the `apps/` workspace root (this installs all
+frontend apps, including this one):
 
 ```bash
-# pnpm
+cd apps
 pnpm install
 ```
 
 ## Development Server
 
-Start the development server on http://localhost:3000
-
-set non default (api)proxy target with
-`NUXT_PUBLIC_API_BASE`
+Start the development server from the app directory. The app runs on
+http://localhost:3000.
 
 ```bash
+cd apps/catalogue
 pnpm dev
+```
+
+Set a non-default (api)proxy target with `NUXT_PUBLIC_API_BASE`, for example:
+
+```bash
+NUXT_PUBLIC_API_BASE=https://emx2.dev.molgenis.org pnpm dev
 ```
 
 ## Production
@@ -39,7 +45,7 @@ Locally preview production build:
 pnpm preview
 ```
 
-Checkout the [deployment documentation](https://v3.nuxtjs.org/guide/deploy/presets) for more information.
+Checkout the [deployment documentation](https://nuxt.com/docs/getting-started/deployment) for more information.
 
 #### Running the styles
 


### PR DESCRIPTION
## What
The catalogue README still carried the "Nuxt 3 Minimal Starter" template title, linked to the outdated `v3.nuxtjs.org` docs, and its setup instructions did not explain the pnpm workspace layout.

## Changes
- Title and intro now describe the app itself, linking to current Nuxt docs.
- Setup: document that `pnpm install` runs once from the `apps/` workspace root (installing all frontend apps), instead of suggesting a per-app install.
- Development server: instructions are copy-pasteable from the repo root, state the default port (3000), and include a concrete `NUXT_PUBLIC_API_BASE` example.
- Updated the deployment docs link to `nuxt.com`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)