### PR TITLE
fix(tasks-api): use POST for tasks/clear in TaskApiTest

### DIFF
--- a/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/TaskApiTest.java
+++ b/backend/molgenis-emx2-webapi/src/test/java/org/molgenis/emx2/web/TaskApiTest.java
@@ -35,7 +35,7 @@ class TaskApiTest extends ApiTestBase {
     return Stream.of(
         Arguments.of(Method.GET, "/api/tasks", "Unable to list tasks: can only be done by admin"),
         Arguments.of(
-            Method.GET, "/api/tasks/clear", "Unable to clear tasks: can only be done by admin"),
+            Method.POST, "/api/tasks/clear", "Unable to clear tasks: can only be done by admin"),
         Arguments.of(
             Method.GET,
             "/api/tasks/scheduled",
@@ -62,7 +62,7 @@ class TaskApiTest extends ApiTestBase {
         Arguments.of(
             Method.GET, "/my-schema/api/tasks", "Unable to list tasks: can only be done by admin"),
         Arguments.of(
-            Method.GET,
+            Method.POST,
             "/my-schema/api/tasks/clear",
             "Unable to clear tasks: can only be done by admin"),
         Arguments.of(
@@ -98,7 +98,7 @@ class TaskApiTest extends ApiTestBase {
             "/my-schema/my-app/api/tasks",
             "Unable to list tasks: can only be done by admin"),
         Arguments.of(
-            Method.GET,
+            Method.POST,
             "/my-schema/my-app/api/tasks/clear",
             "Unable to clear tasks: can only be done by admin"),
         Arguments.of(


### PR DESCRIPTION
## What
Fixes the CI failure on master introduced by #6146 (2cff017).

## Why
#6146 changed `/api/tasks/clear` from GET to POST and updated `WebApiSmokeTests`, but missed `TaskApiTest`. Its `unauthorizedPaths()` test still sent GET to the three `tasks/clear` routes.

The requests did not 404: with the literal GET route removed, `GET /api/tasks/clear` now matches the more general `GET /api/tasks/{id}` route with `id="clear"`. The tests still got the expected 400 status, but failed on the message assertion ("Unable to get task" instead of "Unable to clear tasks").

## How
Changed the three `tasks/clear` entries in `unauthorizedPaths()` from `Method.GET` to `Method.POST`.

Verified locally: all 51 `TaskApiTest` cases pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)