### PR TITLE
fix: Change the group concat separator in sparql queries to prevent collisions

### DIFF
--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerDataTypeMappingTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerDataTypeMappingTest.java
@@ -104,7 +104,7 @@ class SparqlSelectRdfTransformerDataTypeMappingTest {
         transformAndGetFirstRow(
             schema, repositoryWithMultiple(predicate, literal("alpha"), literal("beta")));
 
-    List<String> parts = Arrays.asList(row.getString("tags").split(","));
+    List<String> parts = Arrays.asList(row.getString("tags").split("\\|"));
     assertEquals(2, parts.size());
     assertTrue(parts.contains("alpha"));
     assertTrue(parts.contains("beta"));
@@ -124,7 +124,7 @@ class SparqlSelectRdfTransformerDataTypeMappingTest {
             schema, repositoryWithMultiple(predicate, literal(10), literal(20)));
 
     // STR() in GROUP_CONCAT strips the XSD type annotation, leaving just the lexical value
-    List<String> parts = Arrays.asList(row.getString("scores").split(","));
+    List<String> parts = Arrays.asList(row.getString("scores").split("\\|"));
     assertEquals(2, parts.size());
     assertTrue(parts.contains("10"));
     assertTrue(parts.contains("20"));

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/generators/query/SparqlVariableUtil.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/generators/query/SparqlVariableUtil.java
@@ -8,7 +8,8 @@ import org.eclipse.rdf4j.sparqlbuilder.graphpattern.GraphPattern;
 
 public class SparqlVariableUtil {
 
-  public static final String SINGLE = "_single";
+  private static final String CONCAT_ARG = "'|'";
+  private static final String SINGLE = "_single";
 
   private SparqlVariableUtil() {
     // Utility class
@@ -27,7 +28,7 @@ public class SparqlVariableUtil {
   }
 
   public static Projectable concatAs(Variable toConcat, Variable as) {
-    return Expressions.group_concat("','", Expressions.str(toConcat)).distinct().as(as);
+    return Expressions.group_concat(CONCAT_ARG, Expressions.str(toConcat)).distinct().as(as);
   }
 
   public static GraphPattern bindAs(Variable toBind, Variable as) {

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlVariableUtilTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlVariableUtilTest.java
@@ -31,7 +31,7 @@ class SparqlVariableUtilTest {
     Variable toConcat = SparqlBuilder.var("foo");
     Variable as = SparqlBuilder.var("bar");
     assertEquals(
-        "( GROUP_CONCAT( DISTINCT STR( ?foo ) ; SEPARATOR = ',' ) AS ?bar )",
+        "( GROUP_CONCAT( DISTINCT STR( ?foo ) ; SEPARATOR = '|' ) AS ?bar )",
         SparqlVariableUtil.concatAs(toConcat, as).getQueryString());
   }
 

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/TableQueryGeneratorTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/TableQueryGeneratorTest.java
@@ -194,7 +194,7 @@ class TableQueryGeneratorTest {
     String query = new TableQueryGenerator().generate(table);
     assertEquals(
         """
-          SELECT ?_subject_ ( GROUP_CONCAT( DISTINCT STR( ?names_single ) ; SEPARATOR = ',' ) AS ?names )
+          SELECT ?_subject_ ( GROUP_CONCAT( DISTINCT STR( ?names_single ) ; SEPARATOR = '|' ) AS ?names )
           WHERE { ?_subject_ ?anyPredicate ?anyObject .
           OPTIONAL { ?_subject_ xsd:name ?names_single . } }
           GROUP BY ?_subject_

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/generators/ArrayLiteralColumnSparqlQueryGeneratorTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/generators/ArrayLiteralColumnSparqlQueryGeneratorTest.java
@@ -43,7 +43,7 @@ class ArrayLiteralColumnSparqlQueryGeneratorTest {
     ColumnSparqlQueryGenerator mapper = new ArrayColumnSparqlQueryGenerator(START, column);
     assertHasPatterns(mapper, "?start foaf:test ?foo_single .");
     assertHasSelectors(
-        mapper, "( GROUP_CONCAT( DISTINCT STR( ?foo_single ) ; SEPARATOR = ',' ) AS ?foo )");
+        mapper, "( GROUP_CONCAT( DISTINCT STR( ?foo_single ) ; SEPARATOR = '|' ) AS ?foo )");
     assertHasGroupBy(mapper);
   }
 
@@ -53,7 +53,7 @@ class ArrayLiteralColumnSparqlQueryGeneratorTest {
     ColumnSparqlQueryGenerator mapper = new ArrayColumnSparqlQueryGenerator(START, column);
     assertTrue(mapper.getPatterns().isEmpty());
     assertHasSelectors(
-        mapper, "( GROUP_CONCAT( DISTINCT STR( ?foo_single ) ; SEPARATOR = ',' ) AS ?foo )");
+        mapper, "( GROUP_CONCAT( DISTINCT STR( ?foo_single ) ; SEPARATOR = '|' ) AS ?foo )");
     assertHasGroupBy(mapper);
   }
 
@@ -78,7 +78,7 @@ class ArrayLiteralColumnSparqlQueryGeneratorTest {
         BIND( COALESCE( ?foo_single0, ?foo_single1, ?foo_single2 ) AS ?foo_single ) }""",
         "FILTER ( BOUND( ?foo_single ) )");
     assertHasSelectors(
-        mapper, "( GROUP_CONCAT( DISTINCT STR( ?foo_single ) ; SEPARATOR = ',' ) AS ?foo )");
+        mapper, "( GROUP_CONCAT( DISTINCT STR( ?foo_single ) ; SEPARATOR = '|' ) AS ?foo )");
     assertHasGroupBy(mapper);
   }
 
@@ -111,8 +111,8 @@ class ArrayLiteralColumnSparqlQueryGeneratorTest {
       try (TupleQueryResult queryResult =
           connection.prepareTupleQuery(QueryLanguage.SPARQL, query.getQueryString()).evaluate()) {
         BindingSet binding = queryResult.next();
-        assertEquals(literal("foo1,foo2"), binding.getValue("foo"));
-        assertEquals(literal("bar1,bar2"), binding.getValue("bar"));
+        assertEquals(literal("foo1|foo2"), binding.getValue("foo"));
+        assertEquals(literal("bar1|bar2"), binding.getValue("bar"));
         assertFalse(queryResult.hasNext());
       }
     }

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/generators/ReferenceColumnSparqlQueryGeneratorTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/generators/ReferenceColumnSparqlQueryGeneratorTest.java
@@ -174,7 +174,7 @@ class ReferenceColumnSparqlQueryGeneratorTest {
       assertTrue(mapper.getGroupBy().isEmpty());
       assertHasSelectors(
           mapper,
-          "( GROUP_CONCAT( DISTINCT STR( ?product ) ; SEPARATOR = ',' ) AS ?_subject_product )");
+          "( GROUP_CONCAT( DISTINCT STR( ?product ) ; SEPARATOR = '|' ) AS ?_subject_product )");
     }
 
     @Test
@@ -203,8 +203,8 @@ class ReferenceColumnSparqlQueryGeneratorTest {
           "?product schema:name ?product__name_single .");
       assertHasSelectors(
           mapper,
-          "( GROUP_CONCAT( DISTINCT STR( ?product ) ; SEPARATOR = ',' ) AS ?_subject_product )",
-          "( GROUP_CONCAT( DISTINCT STR( ?product__name_single ) ; SEPARATOR = ',' ) AS ?product__name )");
+          "( GROUP_CONCAT( DISTINCT STR( ?product ) ; SEPARATOR = '|' ) AS ?_subject_product )",
+          "( GROUP_CONCAT( DISTINCT STR( ?product__name_single ) ; SEPARATOR = '|' ) AS ?product__name )");
       assertHasGroupBy(mapper);
     }
 
@@ -235,8 +235,8 @@ class ReferenceColumnSparqlQueryGeneratorTest {
           ?product schema:name ?product__name_single . }""");
       assertHasSelectors(
           mapper,
-          "( GROUP_CONCAT( DISTINCT STR( ?product ) ; SEPARATOR = ',' ) AS ?_subject_product )",
-          "( GROUP_CONCAT( DISTINCT STR( ?product__name_single ) ; SEPARATOR = ',' ) AS ?product__name )");
+          "( GROUP_CONCAT( DISTINCT STR( ?product ) ; SEPARATOR = '|' ) AS ?_subject_product )",
+          "( GROUP_CONCAT( DISTINCT STR( ?product__name_single ) ; SEPARATOR = '|' ) AS ?product__name )");
       assertHasGroupBy(mapper);
     }
   }
@@ -406,7 +406,7 @@ class ReferenceColumnSparqlQueryGeneratorTest {
           new ReferenceColumnSparqlQueryGenerator(productVar, column);
       assertHasPatterns(mapper, "OPTIONAL { ?product schema:tag ?tag_single . }");
       assertHasSelectors(
-          mapper, "( GROUP_CONCAT( DISTINCT STR( ?tag_single ) ; SEPARATOR = ',' ) AS ?tag )");
+          mapper, "( GROUP_CONCAT( DISTINCT STR( ?tag_single ) ; SEPARATOR = '|' ) AS ?tag )");
       assertHasGroupBy(mapper);
     }
   }

--- a/backend/molgenis-emx2-rdf/src/test/resources/queries/expected_pets.csv
+++ b/backend/molgenis-emx2-rdf/src/test/resources/queries/expected_pets.csv
@@ -1,9 +1,9 @@
 _subject_,name,status,tags,weight
 http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=the%20very%20hungry%20caterpillar,the very hungry caterpillar,available,https://dbpedia.org/page/Green,5.0E-1
-http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=fire%20ant,fire ant,available,"http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=purple,https://dbpedia.org/page/Green,https://dbpedia.org/page/Red",1.0E-2
 http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=jerry,jerry,available,http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=blue,1.8E-1
 http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=tweety,tweety,available,https://dbpedia.org/page/Red,1.0E-1
 http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=tom,tom,available,https://dbpedia.org/page/Red,3.14E0
 http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=sylvester,sylvester,available,http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=purple,1.337E0
 http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=spike,spike,sold,,1.57E1
-http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=pooky,pooky,available,"http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=blue,https://dbpedia.org/page/Red,http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=colors,https://dbpedia.org/page/Green,http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=purple",9.4E0
+http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=fire%20ant,fire ant,available,http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=purple|https://dbpedia.org/page/Green|https://dbpedia.org/page/Red,1.0E-2
+http://emx2.dev.molgenis.org/pet%20store/api/rdf/Pet/name=pooky,pooky,available,http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=blue|https://dbpedia.org/page/Red|http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=colors|https://dbpedia.org/page/Green|http://emx2.dev.molgenis.org/pet%20store/api/rdf/Tag/name=purple,9.4E0


### PR DESCRIPTION
### What are the main changes you did
Change the group concat separator in sparql queries to use a pipe character '|' to prevent collisions with keys that contain a ','.

### How to test
- unit tests

### Checklist
- [ ] updated docs in case of new feature
- [X] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
