### PR TITLE
feat(tw): propagate http status code in fetch error handling

### DIFF
--- a/apps/tailwind-components/app/composables/fetchGraphql.ts
+++ b/apps/tailwind-components/app/composables/fetchGraphql.ts
@@ -1,5 +1,5 @@
-import { createError } from "nuxt/app";
 import { DATA_NOT_FOUND_ERROR } from "../utils/constants";
+import { fetchErrorToNuxtError } from "../utils/fetchErrorToNuxtError";
 
 export default async (
   schemaId: string,
@@ -17,10 +17,7 @@ export default async (
   }).catch((error) => {
     const message = `Could not fetch graphql for schema ${schemaId}. ${DATA_NOT_FOUND_ERROR}`;
     console.error(message, error);
-    throw createError({
-      ...error,
-      message,
-    });
+    throw fetchErrorToNuxtError(error, message);
   });
 
   return data;

--- a/apps/tailwind-components/app/composables/fetchMetadata.ts
+++ b/apps/tailwind-components/app/composables/fetchMetadata.ts
@@ -1,7 +1,7 @@
-import { createError } from "nuxt/app";
 import { type ISchemaMetaData } from "../../../metadata-utils/src/types";
 import metadataGql from "../../../tailwind-components/app/gql/metadata";
 import { DATA_NOT_FOUND_ERROR } from "../utils/constants";
+import { fetchErrorToNuxtError } from "../utils/fetchErrorToNuxtError";
 import { moduleToString } from "../utils/moduleToString";
 
 const query = moduleToString(metadataGql);
@@ -18,10 +18,10 @@ export default async (schemaId: string): Promise<ISchemaMetaData> => {
     },
   }).catch((error) => {
     console.error(`Could not fetch metadata for schema ${schemaId}, `, error);
-    throw createError({
-      ...error,
-      message: `Could not fetch schema: ${schemaId}. ${DATA_NOT_FOUND_ERROR}`,
-    });
+    throw fetchErrorToNuxtError(
+      error,
+      `Could not fetch schema: ${schemaId}. ${DATA_NOT_FOUND_ERROR}`
+    );
   });
 
   cache.set(schemaId, data._schema);

--- a/apps/tailwind-components/app/composables/fetchTableData.ts
+++ b/apps/tailwind-components/app/composables/fetchTableData.ts
@@ -1,7 +1,7 @@
-import { createError } from "nuxt/app";
 import type { IQueryMetaData } from "../../../metadata-utils/src/IQueryMetaData";
 import type { columnValue, IColumn } from "../../../metadata-utils/src/types";
 import { DATA_NOT_FOUND_ERROR } from "../utils/constants";
+import { fetchErrorToNuxtError } from "../utils/fetchErrorToNuxtError";
 import fetchMetadata from "./fetchMetadata";
 
 export interface ITableDataResponse {
@@ -57,10 +57,7 @@ export default async (
   }).catch((error) => {
     const message = `Could not fetch data for table: ${tableId} in schema: ${schemaId}. ${DATA_NOT_FOUND_ERROR}`;
     console.error(message, error);
-    throw createError({
-      ...error,
-      message,
-    });
+    throw fetchErrorToNuxtError(error, message);
   });
 
   return { rows: data[tableId], count: data[`${tableId}_agg`].count };

--- a/apps/tailwind-components/app/composables/fetchTableMetadata.ts
+++ b/apps/tailwind-components/app/composables/fetchTableMetadata.ts
@@ -17,7 +17,7 @@ export default async (
     console.error(message);
     throw createError({
       message,
-      status: 404,
+      statusCode: 404,
     });
   } else {
     return tableMetadata;

--- a/apps/tailwind-components/app/composables/useSchemaSettings.ts
+++ b/apps/tailwind-components/app/composables/useSchemaSettings.ts
@@ -1,4 +1,5 @@
-import { createError, useRoute } from "nuxt/app";
+import { useRoute } from "nuxt/app";
+import { fetchErrorToNuxtError } from "../utils/fetchErrorToNuxtError";
 import { computed, ref } from "vue";
 import type { RouteLocationNormalizedGeneric } from "vue-router";
 import type { Resp, Settings } from "../../types/types";
@@ -26,10 +27,10 @@ export const useSchemaSettings = async (
       }),
     }).catch((error) => {
       console.error("Error fetching schema settings", error);
-      throw createError({
-        ...error,
-        message: `Could not fetch schema settings for schema ${schema.value}.`,
-      });
+      throw fetchErrorToNuxtError(
+        error,
+        `Could not fetch schema settings for schema ${schema.value}.`
+      );
     });
 
     if (response) {

--- a/apps/tailwind-components/app/utils/fetchErrorToNuxtError.ts
+++ b/apps/tailwind-components/app/utils/fetchErrorToNuxtError.ts
@@ -1,0 +1,11 @@
+import { createError } from "nuxt/app";
+import { FetchError } from "ofetch";
+import { errorToMessage } from "./errorToMessage";
+
+export function fetchErrorToNuxtError(error: unknown, fallbackMessage: string) {
+  return createError({
+    statusCode: error instanceof FetchError ? (error.statusCode ?? 500) : 500,
+    message: errorToMessage(error, fallbackMessage),
+    cause: error,
+  });
+}

--- a/apps/tailwind-components/tests/vitest/utils/fetchErrorToNuxtError.spec.ts
+++ b/apps/tailwind-components/tests/vitest/utils/fetchErrorToNuxtError.spec.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "vitest";
+import { FetchError } from "ofetch";
+import { fetchErrorToNuxtError } from "../../../app/utils/fetchErrorToNuxtError";
+
+function fetchError(statusCode: number, backendMessage?: string): FetchError {
+  const error = new FetchError("request failed");
+  error.statusCode = statusCode;
+  if (backendMessage) {
+    error.response = {
+      _data: { errors: [{ message: backendMessage }] },
+    } as unknown as FetchError["response"];
+  }
+  return error;
+}
+
+describe("fetchErrorToNuxtError", () => {
+  test("propagates the http status code of a FetchError", () => {
+    const result = fetchErrorToNuxtError(fetchError(404), "fallback");
+    expect(result.statusCode).toBe(404);
+  });
+
+  test("uses the backend error message when present", () => {
+    const result = fetchErrorToNuxtError(
+      fetchError(404, "Schema 'foo' unknown. Might you need to sign in?"),
+      "fallback"
+    );
+    expect(result.message).toBe(
+      "Schema 'foo' unknown. Might you need to sign in?"
+    );
+  });
+
+  test("falls back to the given message without a backend message", () => {
+    const result = fetchErrorToNuxtError(fetchError(400), "fallback message");
+    expect(result.message).toBe("fallback message");
+  });
+
+  test("defaults to 500 for non-fetch errors", () => {
+    const result = fetchErrorToNuxtError(new Error("boom"), "fallback");
+    expect(result.statusCode).toBe(500);
+    expect(result.message).toBe("fallback");
+  });
+});


### PR DESCRIPTION
Improves the error message (and statuscode) when the schema is not found (or not accessible).

Follow-up on #6455, builds on #6478 (base branch of this PR).

### What are the main changes you did
- Added `fetchErrorToNuxtError` util: converts a caught fetch error into a Nuxt error, keeping the real HTTP status code and using the backend's graphql error message when available.
- Used it in the catch blocks of `useSchemaSettings`, `fetchGraphql`, `fetchMetadata` and `fetchTableData`. Spreading a `FetchError` into `createError` dropped the `statusCode` (ofetch defines it as a non-enumerable getter), so every fetch failure rendered as a generic 500.
- Normalized `status: 404` to `statusCode: 404` in `fetchTableMetadata`.

Before (non-existing schema): "An internal server error occurred. Could not fetch schema settings for schema NonExistent. Status code: 500"

After: "The requested page could not be found. Schema 'NonExistent' unknown. Might you need to sign in or ask permission? Status code: 404"

See screenshots below.

### How to test
- Unit tests: `apps/tailwind-components` → `pnpm vitest run tests/vitest/utils/fetchErrorToNuxtError.spec.ts`
- Manual: open `/apps/ui/NonExistent` on the preview deployment; the error page should show 404 with the backend message instead of a generic 500.

### Checklist
- [ ] updated docs in case of new feature
- [X] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)



**Before**
https://emx2.dev.molgenis.org/apps/ui/Nonexistent

<img width="582" height="490" alt="image" src="https://github.com/user-attachments/assets/01f56612-9b65-4714-afff-e5fdd084e2b4" />

**After**
https://preview-emx2-pr-6515.dev.molgenis.org/apps/ui/Nonexistent

<img width="677" height="506" alt="image" src="https://github.com/user-attachments/assets/d8dea8b5-2f68-4404-aad7-4159b95f900c" />
