### PR TITLE
ci: comment PR preview link via sticky comment

### DIFF
--- a/.github/workflows/pr-preview-comment.yml
+++ b/.github/workflows/pr-preview-comment.yml
@@ -23,4 +23,5 @@ jobs:
             **Preview:** https://preview-emx2-pr-${{ github.event.number }}.dev.molgenis.org/
 
             The preview is deployed by CircleCI and may take a while to become available after each push.
+            Preview servers don't exist indefinitely. If the preview server is unavailable, then either push a new commit, or contact ops.
             Build progress: [CircleCI pipeline for this branch](https://app.circleci.com/pipelines/github/molgenis/molgenis-emx2?branch=${{ steps.branch.outputs.encoded }})

--- a/.github/workflows/pr-preview-comment.yml
+++ b/.github/workflows/pr-preview-comment.yml
@@ -1,0 +1,20 @@
+name: PR preview link
+on:
+  pull_request:
+    types: [ opened, reopened ]
+jobs:
+  preview-comment:
+    # previews are only deployed for branches in this repo, not for forks
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Comment preview link on PR
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: pr-preview
+          message: |
+            **Preview:** https://preview-emx2-pr-${{ github.event.number }}.dev.molgenis.org/
+
+            The preview is deployed by CircleCI and may take a while to become available after each push.

--- a/.github/workflows/pr-preview-comment.yml
+++ b/.github/workflows/pr-preview-comment.yml
@@ -10,6 +10,11 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: URL-encode branch name
+        id: branch
+        env:
+          BRANCH: ${{ github.event.pull_request.head.ref }}
+        run: echo "encoded=$(jq -rn --arg b "$BRANCH" '$b|@uri')" >> "$GITHUB_OUTPUT"
       - name: Comment preview link on PR
         uses: marocchino/sticky-pull-request-comment@v2
         with:
@@ -18,3 +23,4 @@ jobs:
             **Preview:** https://preview-emx2-pr-${{ github.event.number }}.dev.molgenis.org/
 
             The preview is deployed by CircleCI and may take a while to become available after each push.
+            Build progress: [CircleCI pipeline for this branch](https://app.circleci.com/pipelines/github/molgenis/molgenis-emx2?branch=${{ steps.branch.outputs.encoded }})

--- a/.github/workflows/pr-preview-comment.yml
+++ b/.github/workflows/pr-preview-comment.yml
@@ -6,7 +6,7 @@ jobs:
   preview-comment:
     # previews are only deployed for branches in this repo, not for forks
     if: github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-slim
     permissions:
       pull-requests: write
     steps:
@@ -16,7 +16,7 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: echo "encoded=$(jq -rn --arg b "$BRANCH" '$b|@uri')" >> "$GITHUB_OUTPUT"
       - name: Comment preview link on PR
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        uses: marocchino/sticky-pull-request-comment@5770ad5eb8f42dd2c4f34da00c94c5381e49af88 # v3.0.5
         with:
           header: pr-preview
           message: |

--- a/.github/workflows/pr-preview-comment.yml
+++ b/.github/workflows/pr-preview-comment.yml
@@ -16,7 +16,7 @@ jobs:
           BRANCH: ${{ github.event.pull_request.head.ref }}
         run: echo "encoded=$(jq -rn --arg b "$BRANCH" '$b|@uri')" >> "$GITHUB_OUTPUT"
       - name: Comment preview link on PR
-        uses: marocchino/sticky-pull-request-comment@v2
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: pr-preview
           message: |


### PR DESCRIPTION
## What
Adds a GitHub Actions workflow that posts a sticky comment when a PR is opened or reopened, containing:
- the PR preview URL (`https://preview-emx2-pr-<number>.dev.molgenis.org/`)
- a link to the CircleCI pipeline for the PR branch, to follow build progress

## Why
The preview URL is currently only announced on Slack by the CircleCI `pr-preview` job. Since the URL is fully determined by the PR number, we can post it on the PR itself right away, without waiting for CircleCI.

## How
- Uses [`marocchino/sticky-pull-request-comment`](https://github.com/marocchino/sticky-pull-request-comment), so re-runs update the existing comment instead of adding new ones.
- Skips fork PRs, because CircleCI only deploys previews for branches in this repo (the link would be dead).
- The comment notes that the preview may take a while to become available, since the link is posted before the CircleCI deploy finishes.
- The branch name is URL-encoded for the CircleCI link (branch names often contain `/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)