### PR TITLE
chore(settings): Enable changelog for catalogue templates cohort, network and RWE

### DIFF
--- a/data/_profiles/CohortsStaging.yaml
+++ b/data/_profiles/CohortsStaging.yaml
@@ -6,6 +6,8 @@ profileTags: CohortsStaging
 
 demoData: _demodata/applications/datacatalogue_cohortstaging
 
+settings: _settings/datacatalogue_cohortstaging
+
 # settings:
 
 # special options

--- a/data/_profiles/NetworksStaging.yaml
+++ b/data/_profiles/NetworksStaging.yaml
@@ -6,7 +6,7 @@ profileTags: NetworksStaging
 
 # demoData: _demodata/applications/datacatalogue_networkstaging
 
-# settings: _settings/datacatalogue
+settings: _settings/datacatalogue_networkstaging
 
 # special options
 ontologiesToFixedSchema: CatalogueOntologies

--- a/data/_profiles/RWEStaging.yaml
+++ b/data/_profiles/RWEStaging.yaml
@@ -4,6 +4,8 @@ description: "This catalogue contains metadata on data banks and the variables t
 
 profileTags: RWEStaging
 
+settings: _settings/datacatalogue_rwestaging
+
 # special options
 setViewPermission: anonymous
 ontologiesToFixedSchema: CatalogueOntologies

--- a/data/_settings/datacatalogue_cohortstaging/molgenis_settings.csv
+++ b/data/_settings/datacatalogue_cohortstaging/molgenis_settings.csv
@@ -1,0 +1,2 @@
+table,key,value
+,isChangelogEnabled,true

--- a/data/_settings/datacatalogue_networkstaging/molgenis_settings.csv
+++ b/data/_settings/datacatalogue_networkstaging/molgenis_settings.csv
@@ -1,0 +1,2 @@
+table,key,value
+,isChangelogEnabled,true

--- a/data/_settings/datacatalogue_rwestaging/molgenis_settings.csv
+++ b/data/_settings/datacatalogue_rwestaging/molgenis_settings.csv
@@ -1,0 +1,2 @@
+table,key,value
+,isChangelogEnabled,true


### PR DESCRIPTION
### What are the main changes you did
Fix issue: https://github.com/molgenis/GCC/issues/3098

Templates may contain a ref to a settings file. For staging areas in catalogue this settings file should include isChangelogEnabled = true

### How to test
- Open the preview server and login as admin
- Create a schema `catalogue` with the template DATA_CATALOGUE and select the option to load example data.
- Create a new schema and select the template DATA_CATALOGUE_COHORT_STAGING. Navigate to`Settings` and open the `Advanced settings` this should have the following key, value pair:

**isChangelogEnabled, true**

Repeat the steps for the templates DATA_CATALOGUE_NETWORK_STAGING and DATA_CATALOGUE_RWE_STAGING

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
