### PR TITLE
fix: fixes a bug where splitting the sparql array results are not split

### DIFF
--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformer.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformer.java
@@ -2,6 +2,7 @@ package org.molgenis.emx2.fairmapper.transform;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.eclipse.rdf4j.query.*;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -10,10 +11,13 @@ import org.molgenis.emx2.io.tablestore.InMemoryTableStore;
 import org.molgenis.emx2.io.tablestore.TableStore;
 import org.molgenis.emx2.rdf.generators.query.ColumnNameSparqlEncoder;
 import org.molgenis.emx2.rdf.generators.query.QueryGenerator;
+import org.molgenis.emx2.rdf.generators.query.TableQueryGenerator;
 
 public class SparqlSelectRdfTransformer implements RdfTransformer {
 
   private static final String ARRAY_SEPARATOR_REGEX = "\\|";
+  private static final String SUBJECT_COLUMN_PREFIX =
+      TableQueryGenerator.SUBJECT_VARIABLE.getVarName();
 
   private final QueryGenerator queryGenerator;
   private final SchemaMetadata schema;
@@ -75,18 +79,42 @@ public class SparqlSelectRdfTransformer implements RdfTransformer {
    * a set separator.
    */
   private void mapRowArrays(List<Row> rows, TableMetadata tableMetadata) {
-    List<String> arrayColumnNames =
-        tableMetadata.getDownloadColumnNames().stream()
-            .filter(Column::isArray)
-            .map(Column::getName)
+    List<String> columnsToSplit =
+        Stream.concat(
+                arrayValueColumnNames(tableMetadata).stream(),
+                refArraySubjectColumnNames(tableMetadata).stream())
             .toList();
 
     for (Row row : rows) {
-      for (String name : arrayColumnNames) {
-        if (row.notNull(name)) {
-          String[] split = row.getString(name).split(ARRAY_SEPARATOR_REGEX);
-          row.set(name, split);
-        }
+      splitArrayColumns(row, columnsToSplit);
+    }
+  }
+
+  private List<String> arrayValueColumnNames(TableMetadata tableMetadata) {
+    return tableMetadata.getDownloadColumnNames().stream()
+        .filter(Column::isArray)
+        .map(Column::getName)
+        .toList();
+  }
+
+  /**
+   * Reference array columns (e.g. REF_ARRAY) get a "_subject_&lt;column&gt;" binding holding the
+   * IRIs of the referenced rows, aggregated the same way as array values and thus also needing to
+   * be split. Ontology (array) columns are excluded since their value already is the subject IRI,
+   * so they don't get a separate "_subject_" binding.
+   */
+  private List<String> refArraySubjectColumnNames(TableMetadata tableMetadata) {
+    return tableMetadata.getColumns().stream()
+        .filter(column -> column.isReference() && column.isArray() && !column.isOntology())
+        .map(column -> SUBJECT_COLUMN_PREFIX + column.getName())
+        .toList();
+  }
+
+  private void splitArrayColumns(Row row, List<String> columnNames) {
+    for (String name : columnNames) {
+      if (row.notNull(name)) {
+        String[] split = row.getString(name).split(ARRAY_SEPARATOR_REGEX);
+        row.set(name, split);
       }
     }
   }

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformer.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformer.java
@@ -5,15 +5,15 @@ import java.util.stream.Collectors;
 import org.eclipse.rdf4j.query.*;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
-import org.molgenis.emx2.MolgenisException;
-import org.molgenis.emx2.Row;
-import org.molgenis.emx2.SchemaMetadata;
+import org.molgenis.emx2.*;
 import org.molgenis.emx2.io.tablestore.InMemoryTableStore;
 import org.molgenis.emx2.io.tablestore.TableStore;
 import org.molgenis.emx2.rdf.generators.query.ColumnNameSparqlEncoder;
 import org.molgenis.emx2.rdf.generators.query.QueryGenerator;
 
 public class SparqlSelectRdfTransformer implements RdfTransformer {
+
+  private static final String ARRAY_SEPARATOR_REGEX = "\\|";
 
   private final QueryGenerator queryGenerator;
   private final SchemaMetadata schema;
@@ -53,7 +53,8 @@ public class SparqlSelectRdfTransformer implements RdfTransformer {
 
   private void addTableDataToStore(
       String table, SailRepositoryConnection conn, InMemoryTableStore tableStore) {
-    String query = queryGenerator.generate(schema.getTableMetadata(table));
+    TableMetadata tableMetadata = schema.getTableMetadata(table);
+    String query = queryGenerator.generate(tableMetadata);
     TupleQuery prepared = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);
 
     try (TupleQueryResult evaluate = prepared.evaluate()) {
@@ -62,7 +63,31 @@ public class SparqlSelectRdfTransformer implements RdfTransformer {
               .map(ColumnNameSparqlEncoder::decodeSparqlVariable)
               .toList();
 
-      tableStore.writeTable(table, columnNames, evaluate.stream().map(this::mapToRow).toList());
+      List<Row> rows = evaluate.stream().map(this::mapToRow).toList();
+      mapRowArrays(rows, tableMetadata);
+
+      tableStore.writeTable(table, columnNames, rows);
+    }
+  }
+
+  /**
+   * Sparql doesn't support array types out of the box. Thus, we expect to split array columns with
+   * a set separator.
+   */
+  private void mapRowArrays(List<Row> rows, TableMetadata tableMetadata) {
+    List<String> arrayColumnNames =
+        tableMetadata.getDownloadColumnNames().stream()
+            .filter(Column::isArray)
+            .map(Column::getName)
+            .toList();
+
+    for (Row row : rows) {
+      for (String name : arrayColumnNames) {
+        if (row.notNull(name)) {
+          String[] split = row.getString(name).split(ARRAY_SEPARATOR_REGEX);
+          row.set(name, split);
+        }
+      }
     }
   }
 

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerDataTypeMappingTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerDataTypeMappingTest.java
@@ -3,10 +3,9 @@ package org.molgenis.emx2.fairmapper.transform;
 import static org.eclipse.rdf4j.model.util.Statements.statement;
 import static org.eclipse.rdf4j.model.util.Values.iri;
 import static org.eclipse.rdf4j.model.util.Values.literal;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import java.util.Arrays;
 import java.util.List;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Value;
@@ -92,7 +91,7 @@ class SparqlSelectRdfTransformerDataTypeMappingTest {
   }
 
   @Test
-  void shouldMapStringArrayValuesAsCommaSeparated() {
+  void shouldMapStringArrayValuesAsArrays() {
     IRI predicate = iri(PREDICATE_BASE + "tags");
     SchemaMetadata schema =
         setupSchema(
@@ -104,10 +103,7 @@ class SparqlSelectRdfTransformerDataTypeMappingTest {
         transformAndGetFirstRow(
             schema, repositoryWithMultiple(predicate, literal("alpha"), literal("beta")));
 
-    List<String> parts = Arrays.asList(row.getString("tags").split("\\|"));
-    assertEquals(2, parts.size());
-    assertTrue(parts.contains("alpha"));
-    assertTrue(parts.contains("beta"));
+    assertArrayEquals(new String[] {"alpha", "beta"}, row.getStringArray("tags"));
   }
 
   @Test
@@ -124,10 +120,7 @@ class SparqlSelectRdfTransformerDataTypeMappingTest {
             schema, repositoryWithMultiple(predicate, literal(10), literal(20)));
 
     // STR() in GROUP_CONCAT strips the XSD type annotation, leaving just the lexical value
-    List<String> parts = Arrays.asList(row.getString("scores").split("\\|"));
-    assertEquals(2, parts.size());
-    assertTrue(parts.contains("10"));
-    assertTrue(parts.contains("20"));
+    assertArrayEquals(new Integer[] {10, 20}, row.getIntegerArray("scores"));
   }
 
   private SailRepository repositoryWith(IRI predicate, Value object) {

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerTest.java
@@ -8,12 +8,11 @@ import static org.junit.jupiter.api.Assertions.*;
 import java.io.IOException;
 import java.io.StringWriter;
 import java.net.URL;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Objects;
 import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.model.vocabulary.FOAF;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
 import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
@@ -22,25 +21,27 @@ import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.jupiter.api.*;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.datamodels.DataModels;
+import org.molgenis.emx2.datamodels.util.CompareTools;
 import org.molgenis.emx2.io.readers.CsvTableWriter;
 import org.molgenis.emx2.io.tablestore.TableStore;
-import org.molgenis.emx2.rdf.generators.query.FileBasedQueryGenerator;
 import org.molgenis.emx2.rdf.generators.query.TableQueryGenerator;
 import org.molgenis.emx2.sql.TestDatabaseFactory;
 
 class SparqlSelectRdfTransformerTest {
 
+  public static final IRI SUBJECT = iri("https://example.com/bob");
   private Database database;
+  private SchemaMetadata schema;
 
   @BeforeEach
   void setUp() {
     database = TestDatabaseFactory.getTestDatabase();
+    String schemaName = SparqlSelectRdfTransformerTest.class.getSimpleName();
+    schema = database.dropCreateSchema(schemaName).getMetadata();
   }
 
   @Test
   void givenUnknownTable_thenThrow() {
-    String schemaName = SparqlSelectRdfTransformerTest.class.getSimpleName() + "_unknowntable";
-    SchemaMetadata schema = database.dropCreateSchema(schemaName).getMetadata();
     TableQueryGenerator generator = new TableQueryGenerator();
     List<String> tables = List.of("unknown-1", "unknown-2");
     MolgenisException exception =
@@ -48,12 +49,67 @@ class SparqlSelectRdfTransformerTest {
             MolgenisException.class,
             () -> new SparqlSelectRdfTransformer(generator, schema, tables));
     assertEquals(
-        "Unknown table(s) provided to transformer: unknown-1, unknown-2 for schema: SparqlSelectRdfTransformerTest_unknowntable",
+        "Unknown table(s) provided to transformer: unknown-1, unknown-2 for schema: SparqlSelectRdfTransformerTest",
         exception.getMessage());
   }
 
   @Test
-  void givenData_thenQueryTable() throws IOException {
+  void shouldSplitArrayValues() {
+    schema.create(
+        TableMetadata.table("splitArrays_string")
+            .add(
+                Column.column("id").setType(ColumnType.INT).setPkey(),
+                Column.column("names")
+                    .setType(ColumnType.STRING_ARRAY)
+                    .setSemantics(FOAF.FIRST_NAME.stringValue())));
+
+    SailRepository repository =
+        createRepositoryWithStatements(
+            statement(SUBJECT, FOAF.FIRST_NAME, literal("foo"), null),
+            statement(SUBJECT, FOAF.FIRST_NAME, literal("bar"), null));
+
+    TableStore transform =
+        new SparqlSelectRdfTransformer(
+                new TableQueryGenerator(), schema, List.of("splitArrays_string"))
+            .transform(repository);
+
+    Iterator<Row> iterator = transform.readTable("splitArrays_string").iterator();
+    CompareTools.assertEquals(
+        iterator.next(),
+        Row.row("_subject_", SUBJECT.stringValue(), "names", new String[] {"foo", "bar"}));
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void shouldHandleNonStringValues() {
+    schema.create(
+        TableMetadata.table("splitArrays_integer")
+            .add(
+                Column.column("id").setType(ColumnType.INT).setPkey(),
+                Column.column("numbers")
+                    .setType(ColumnType.INT_ARRAY)
+                    .setSemantics(FOAF.FIRST_NAME.stringValue())));
+
+    SailRepository repository =
+        createRepositoryWithStatements(
+            statement(SUBJECT, FOAF.FIRST_NAME, literal(1), null),
+            statement(SUBJECT, FOAF.FIRST_NAME, literal(2), null));
+
+    TableStore transform =
+        new SparqlSelectRdfTransformer(
+                new TableQueryGenerator(), schema, List.of("splitArrays_integer"))
+            .transform(repository);
+
+    Iterator<Row> iterator = transform.readTable("splitArrays_integer").iterator();
+    Row next = iterator.next();
+    CompareTools.assertEquals(
+        next, Row.row("_subject_", SUBJECT.stringValue(), "numbers", new String[] {"1", "2"}));
+    assertArrayEquals(new Integer[] {1, 2}, next.getIntegerArray("numbers"));
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
+  void givenTtlData_thenQueryTable() throws IOException {
     String schemaName = SparqlSelectRdfTransformerTest.class.getSimpleName() + "_petstore";
     database.dropSchemaIfExists(schemaName);
     DataModels.Profile.PET_STORE
@@ -62,7 +118,7 @@ class SparqlSelectRdfTransformerTest {
 
     SparqlSelectRdfTransformer transformer =
         new SparqlSelectRdfTransformer(
-            new FileBasedQueryGenerator(Map.of("Pet", getQueryFilePath())),
+            new TableQueryGenerator(),
             database.getSchema(schemaName).getMetadata(),
             List.of("Pet"));
 
@@ -71,10 +127,23 @@ class SparqlSelectRdfTransformerTest {
 
     StringWriter writer = new StringWriter();
     CsvTableWriter.write(
-        store.readTable("Pet"), List.of("Pet", "name", "status", "weight", "tags"), writer, ',');
+        store.readTable("Pet"), List.of("name", "status", "weight", "tags"), writer, ',');
 
     String expected = readPetsCsv();
     assertEquals(expected, writer.toString());
+  }
+
+  private SailRepository createRepositoryWithStatements(Statement... statements) {
+    SailRepository repository = new SailRepository(new MemoryStore());
+
+    try (SailRepositoryConnection connection = repository.getConnection()) {
+      for (Statement statement : statements) {
+        connection.add(statement);
+      }
+      connection.commit();
+    }
+
+    return repository;
   }
 
   private SailRepository readPetStoreTtl() {
@@ -103,25 +172,23 @@ class SparqlSelectRdfTransformerTest {
 
     @BeforeAll
     void queryTestData() {
-
       // Set up a SailRepository with a single statement to test against
       SailRepository repository = setupRepository();
-      SchemaMetadata schema = setupSchema();
-
       SparqlSelectRdfTransformer transformer =
-          new SparqlSelectRdfTransformer(new TableQueryGenerator(), schema, List.of("testTable"));
+          new SparqlSelectRdfTransformer(
+              new TableQueryGenerator(), setupSchema(), List.of("testTable"));
       TableStore transform = transformer.transform(repository);
       testData = transform.readTable("testTable").iterator().next();
     }
 
     private SchemaMetadata setupSchema() {
-      SchemaMetadata schema = new SchemaMetadata(getClass().getSimpleName() + "_mapColumnNames");
-      schema.create(
-          TableMetadata.table(
-              "testTable",
-              Column.column("first name").setSemantics(FIRST_NAME_SEMANTIC.toString()),
-              Column.column("last_name").setSemantics(LAST_NAME_SEMANTIC.toString())));
-      return schema;
+      return new SchemaMetadata(getClass().getSimpleName() + "_mapColumnNames")
+          .create(
+              TableMetadata.table(
+                  "testTable",
+                  Column.column("first name").setSemantics(FIRST_NAME_SEMANTIC.toString()),
+                  Column.column("last_name").setSemantics(LAST_NAME_SEMANTIC.toString())))
+          .getSchema();
     }
 
     private SailRepository setupRepository() {
@@ -155,11 +222,5 @@ class SparqlSelectRdfTransformerTest {
     return new String(
         Objects.requireNonNull(SparqlSelectRdfTransformerTest.class.getResourceAsStream("pets.csv"))
             .readAllBytes());
-  }
-
-  private static Path getQueryFilePath() {
-    return Paths.get(
-        Objects.requireNonNull(SparqlSelectRdfTransformerTest.class.getResource("query.rq"))
-            .getPath());
   }
 }

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerTest.java
@@ -109,6 +109,37 @@ class SparqlSelectRdfTransformerTest {
   }
 
   @Test
+  void shouldSplitRefArraySubjects() {
+    schema.create(TableMetadata.table("splitRefArrays_tag").add(Column.column("name").setPkey()));
+    schema.create(
+        TableMetadata.table("splitRefArrays_owner")
+            .add(
+                Column.column("id").setType(ColumnType.INT).setPkey(),
+                Column.column("tags")
+                    .setType(ColumnType.REF_ARRAY)
+                    .setRefTable("splitRefArrays_tag")
+                    .setSemantics(FOAF.KNOWS.stringValue())));
+
+    IRI tag1 = iri("https://example.com/tag/1");
+    IRI tag2 = iri("https://example.com/tag/2");
+
+    SailRepository repository =
+        createRepositoryWithStatements(
+            statement(SUBJECT, FOAF.KNOWS, tag1, null), statement(SUBJECT, FOAF.KNOWS, tag2, null));
+
+    TableStore transform =
+        new SparqlSelectRdfTransformer(
+                new TableQueryGenerator(), schema, List.of("splitRefArrays_owner"))
+            .transform(repository);
+
+    Iterator<Row> iterator = transform.readTable("splitRefArrays_owner").iterator();
+    Row row = iterator.next();
+    assertArrayEquals(
+        new String[] {tag1.stringValue(), tag2.stringValue()}, row.getStringArray("_subject_tags"));
+    assertFalse(iterator.hasNext());
+  }
+
+  @Test
   void givenTtlData_thenQueryTable() throws IOException {
     String schemaName = SparqlSelectRdfTransformerTest.class.getSimpleName() + "_petstore";
     database.dropSchemaIfExists(schemaName);

--- a/backend/molgenis-emx2-fairmapper/src/test/resources/org/molgenis/emx2/fairmapper/transform/pets.csv
+++ b/backend/molgenis-emx2-fairmapper/src/test/resources/org/molgenis/emx2/fairmapper/transform/pets.csv
@@ -1,9 +1,9 @@
-Pet,name,status,weight,tags
-http://localhost:8080/pet%20store/api/rdf/Pet/name=pooky,pooky,available,9.4,
-http://localhost:8080/pet%20store/api/rdf/Pet/name=fire%20ant,fire ant,available,0.01,"http://localhost:8080/pet%20store/api/rdf/Tag/name=purple,https://dbpedia.org/page/Green,https://dbpedia.org/page/Red"
-http://localhost:8080/pet%20store/api/rdf/Pet/name=jerry,jerry,available,0.18,http://localhost:8080/pet%20store/api/rdf/Tag/name=blue
-http://localhost:8080/pet%20store/api/rdf/Pet/name=the%20very%20hungry%20caterpillar,the very hungry caterpillar,available,0.5,https://dbpedia.org/page/Green
-http://localhost:8080/pet%20store/api/rdf/Pet/name=tom,tom,available,3.14,https://dbpedia.org/page/Red
-http://localhost:8080/pet%20store/api/rdf/Pet/name=spike,spike,sold,15.7,"https://dbpedia.org/page/Green,https://dbpedia.org/page/Red"
-http://localhost:8080/pet%20store/api/rdf/Pet/name=sylvester,sylvester,available,1.337,http://localhost:8080/pet%20store/api/rdf/Tag/name=purple
-http://localhost:8080/pet%20store/api/rdf/Pet/name=tweety,tweety,available,0.1,https://dbpedia.org/page/Red
+name,status,weight,tags
+the very hungry caterpillar,available,0.5,https://dbpedia.org/page/Green
+sylvester,available,1.337,http://localhost:8080/pet%20store/api/rdf/Tag/name=purple
+tom,available,3.14,https://dbpedia.org/page/Red
+tweety,available,0.1,https://dbpedia.org/page/Red
+fire ant,available,0.01,"http://localhost:8080/pet%20store/api/rdf/Tag/name=purple,https://dbpedia.org/page/Green,https://dbpedia.org/page/Red"
+pooky,available,9.4,
+spike,sold,15.7,"https://dbpedia.org/page/Green,https://dbpedia.org/page/Red"
+jerry,available,0.18,http://localhost:8080/pet%20store/api/rdf/Tag/name=blue


### PR DESCRIPTION
### What are the main changes you did

When doing a sparql query, arrays are represented as a single string where all values are concatenated with a pipe ('|') character. As part of the transform step in the DCAT harvesting pipeline, we now map these to actual arrays.
Splitting is done within transformation, to prevent a dependency on post-processing, as it's part of mapping to natively supported data types.

I'm still not 100% sure about whether it should be done within the transformation step or separately in the post-processing. But for now I chose this setup because we don't have a concrete use case for a different one.

### How to test

- `SparqlSelectRdfTransformerTest#givenTtlData_thenQueryTable` queries a pet store ttl and makes sure that the tags are properly mapped.
- `shouldSplitArrayValues` checks splitting string arrays
- `shouldHandleNonStringValues` checks whether we can still interact with non-string arrays line int arrays.

### Checklist

- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
