### PR TITLE
fix: search box height

### DIFF
--- a/apps/tailwind-components/app/components/input/Search.vue
+++ b/apps/tailwind-components/app/components/input/Search.vue
@@ -41,7 +41,7 @@ defineEmits<{
         !disabled && !invalid && !valid,
       'h-input-tiny pl-5 pr-5 text-heading-sm gap-2': size === 'tiny',
       'h-input-small pl-5 pr-5 text-heading-sm gap-3': size === 'small',
-      'h-input pl-5 pr-7.5 text-heading-md gap-4': size === 'medium',
+      'h-input-medium pl-5 pr-7.5 text-heading-md gap-4': size === 'medium',
       'h-input-large pl-5 pr-8.75 text-heading-lg gap-5': size === 'large',
     }"
   >


### PR DESCRIPTION
Use consistent height (50px)  for all action bar items

### What are the main changes you did

- update the search input (medium) style class to be consistent with other items in action-bar
- 
### How to test

- compare pr output with master, notice in the pr the height of all the action bar items is equal, notice on master the search input height is not equal to the height of the other items in the same action bar  

### Checklist

- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
