### PR TITLE
fix: added a workaround for a bug where SFM CSV writer would skip all fields that have a name, prefixed with '_'.

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableWriter.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/readers/CsvTableWriter.java
@@ -24,7 +24,10 @@ public class CsvTableWriter {
       // fromReader all values into strings first
       Map<String, String> values = new LinkedHashMap<>();
       for (String columnName : r.getColumnNames()) {
-        values.put(columnName, r.getString(columnName));
+        // We remove all prefixing _ characters of column names because SFM csv writer has a bug
+        // that prevents values with a key that start with a _ are skipped. Because of the ordering,
+        // they appear under the correct header column.
+        values.put(columnName.replaceFirst("^_+", ""), r.getString(columnName));
       }
       csvWriter.append(values);
     }

--- a/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/readers/CsvTableWriterTest.java
+++ b/backend/molgenis-emx2-io/src/test/java/org/molgenis/emx2/io/readers/CsvTableWriterTest.java
@@ -1,0 +1,104 @@
+package org.molgenis.emx2.io.readers;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.io.IOException;
+import java.io.StringWriter;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.Row;
+
+class CsvTableWriterTest {
+
+  @Test
+  void shouldRemovePrefixingUnderscores() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    CsvTableWriter.write(
+        List.of(Row.row("_subject_", "foo", "___multiple", "bar")),
+        List.of("_subject_", "___multiple"),
+        stringWriter,
+        ',');
+    assertEquals(
+        """
+        _subject_,___multiple
+        foo,bar
+        """,
+        stringWriter.toString());
+  }
+
+  @Test
+  void shouldWriteHeaderOnlyWhenNoRows() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    CsvTableWriter.write(List.of(), List.of("col1", "col2"), stringWriter, ',');
+    assertEquals(
+        """
+        col1,col2
+        """,
+        stringWriter.toString());
+  }
+
+  @Test
+  void shouldWriteMultipleColumnsInOrder() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    CsvTableWriter.write(
+        List.of(Row.row("col1", "a", "col2", "b")), List.of("col1", "col2"), stringWriter, ',');
+    assertEquals(
+        """
+        col1,col2
+        a,b
+        """,
+        stringWriter.toString());
+  }
+
+  @Test
+  void shouldWriteMultipleRows() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    CsvTableWriter.write(
+        List.of(Row.row("col1", "a"), Row.row("col1", "b")), List.of("col1"), stringWriter, ',');
+    assertEquals(
+        """
+        col1
+        a
+        b
+        """,
+        stringWriter.toString());
+  }
+
+  @Test
+  void shouldUseProvidedSeparator() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    CsvTableWriter.write(
+        List.of(Row.row("col1", "a", "col2", "b")), List.of("col1", "col2"), stringWriter, ';');
+    assertEquals(
+        """
+        col1;col2
+        a;b
+        """,
+        stringWriter.toString());
+  }
+
+  @Test
+  void shouldQuoteValuesContainingSeparator() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    CsvTableWriter.write(List.of(Row.row("col1", "a,b")), List.of("col1"), stringWriter, ',');
+    assertEquals(
+        """
+        col1
+        "a,b"
+        """,
+        stringWriter.toString());
+  }
+
+  @Test
+  void shouldWriteEmptyStringForNullValue() throws IOException {
+    StringWriter stringWriter = new StringWriter();
+    Row row = Row.row("col1", null, "col2", "2");
+    CsvTableWriter.write(List.of(row), List.of("col1", "col2"), stringWriter, ',');
+    assertEquals(
+        """
+        col1,col2
+        ,2
+        """,
+        stringWriter.toString());
+  }
+}


### PR DESCRIPTION
### What are the main changes you did

SFM CSV has a bug that fields with names that start with one or more _ characters are skipped.
As a workaround, we now remove the prefixing _ characters of the values field name. But the headers keep the prefixed names. Using a LinkedHashMap, which retains the sorting, tricks the CSV writer into writing everything correctly.

Example:
Given the following row:
```
_subject_ -> foo
```
We expect the following CSV:
```csv
_subject_
foo
```
The bug would cause the CSV to become the following:
```csv
_subject_

```
The value `foo` is dropped because `_subject` is prefixed with an _.

### How to test

- Unit tests.
- Export CSV tables from the pet store, play around with changing column names and adding/removing _ characters

### Checklist

- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
