### PR TITLE
fix(cms): images are saved when header components are updated

### DIFF
--- a/apps/tailwind-components/app/components/pages/Banner.vue
+++ b/apps/tailwind-components/app/components/pages/Banner.vue
@@ -1,11 +1,14 @@
 <script setup lang="ts">
-import type { IHeaders } from "../../../types/cms";
+import type { IHeaders, IFile } from "../../../types/cms";
 import Button from "../Button.vue";
 
-withDefaults(defineProps<IHeaders & { isEditable?: boolean }>(), {
-  enableFullScreenWidth: false,
-  isEditable: false,
-});
+const props = withDefaults(
+  defineProps<IHeaders & { image?: IFile; isEditable?: boolean }>(),
+  {
+    enableFullScreenWidth: false,
+    isEditable: false,
+  }
+);
 
 const emit = defineEmits<{
   (e: "edit"): void;
@@ -17,10 +20,10 @@ const emit = defineEmits<{
     :id="id"
     class="group relative flex justify-center items-center h-72"
     :class="{
-      'text-gray-100 bg-cover bg-center': backgroundImage,
-      'text-title': !backgroundImage,
+      'text-gray-100 bg-cover bg-center': image?.url,
+      'text-title': !image?.url,
     }"
-    :style="backgroundImage ? `background-image: url(${backgroundImage})` : ''"
+    :style="image?.url ? `background-image: url(${image.url})` : ''"
   >
     <div
       class="m-auto mx-12.5 z-10"
@@ -34,7 +37,7 @@ const emit = defineEmits<{
       <p class="text-body-lg">{{ subtitle }}</p>
     </div>
     <div
-      v-if="backgroundImage"
+      v-if="image?.url"
       class="absolute top-0 left-0 w-full h-full bg-black bg-opacity-60"
     />
     <div v-if="isEditable" class="absolute top-5 right-5">

--- a/apps/tailwind-components/app/components/pages/PageComponent.vue
+++ b/apps/tailwind-components/app/components/pages/PageComponent.vue
@@ -11,6 +11,7 @@ import NavigationGroups from "./Navigation/NavigationGroups.vue";
 import EditModal from "../form/EditModal.vue";
 
 import { parsePageText } from "../../utils/cms";
+import type { IFile } from "../../../types/cms";
 import type { IPageComponent } from "../../../types/CmsComponents";
 import type { ITableMetaData } from "../../../../metadata-utils/src";
 
@@ -38,13 +39,16 @@ const schemaTableName = ref<string>(
 );
 
 const componentData = ref<IPageComponent>(props.component);
+const headerComponentImage = ref<IFile>();
 
-// temporary workaround for graphql bug #2706
 if (
-  !props.mg_tableclass.endsWith(".Images") &&
-  Object.keys(componentData.value).includes("image")
+  props.mg_tableclass.endsWith(".Headers") &&
+  Object.keys(componentData.value).includes("backgroundImage")
 ) {
-  delete componentData.value["image" as keyof IPageComponent];
+  headerComponentImage.value = componentData.value.backgroundImage.image;
+  componentData.value.backgroundImage = {
+    id: componentData.value.backgroundImage.id,
+  };
 }
 
 const componentMetadata = computed<ITableMetaData | undefined>(() => {
@@ -75,7 +79,8 @@ function onEdit(component?: string, value?: IPageComponent) {
     :id="component.id"
     :title="component.title"
     :subtitle="component.subtitle"
-    :background-image="component.backgroundImage?.image?.url"
+    :background-image="component.backgroundImage"
+    :image="headerComponentImage"
     :enable-full-screen-width="component.enableFullScreenWidth"
     :title-is-centered="component.titleIsCentered"
     :is-editable="editingIsEnabled"

--- a/apps/tailwind-components/app/gql/cmsPages.ts
+++ b/apps/tailwind-components/app/gql/cmsPages.ts
@@ -37,10 +37,16 @@ export const getContainersQuery = `query getContainers($filter:ContainersFilter)
                 title
                 subtitle
                 backgroundImage {
+                    displayName
                     image {
                         id
                         url
                     }
+                    alt
+                    width
+                    height
+                    imageIsCentered
+                    id
                 }
                 titleIsCentered
                 

--- a/apps/tailwind-components/tests/vitest/components/pages/Banner.test.ts
+++ b/apps/tailwind-components/tests/vitest/components/pages/Banner.test.ts
@@ -30,8 +30,6 @@ describe("Custom Pages: banner", () => {
   });
 
   test("when an image is defined, the image filter and colors are applied", async () => {
-    console.log(bannerWithImage.html());
-
     expect(bannerWithImage.find("h1").exists()).toBeTruthy();
     expect(bannerWithImage.find("p").exists()).toBeTruthy();
     expect(bannerWithImage.classes()).toContain("text-gray-100");

--- a/apps/tailwind-components/tests/vitest/components/pages/Banner.test.ts
+++ b/apps/tailwind-components/tests/vitest/components/pages/Banner.test.ts
@@ -11,12 +11,15 @@ const defaultBanner = mount(PageBanner, {
   },
 });
 
+const demoImage = "/path/to/some/image.jpg";
+
 const bannerWithImage = mount(PageBanner, {
   props: {
     id: "vitest-page-banner",
     title: "My Page Banner",
     subtitle: "this is an example",
-    backgroundImage: "/page/to/some/image.jpg",
+    backgroundImage: { id: demoImage },
+    image: { id: demoImage, url: demoImage },
   },
 });
 
@@ -27,6 +30,8 @@ describe("Custom Pages: banner", () => {
   });
 
   test("when an image is defined, the image filter and colors are applied", async () => {
+    console.log(bannerWithImage.html());
+
     expect(bannerWithImage.find("h1").exists()).toBeTruthy();
     expect(bannerWithImage.find("p").exists()).toBeTruthy();
     expect(bannerWithImage.classes()).toContain("text-gray-100");

--- a/apps/tailwind-components/types/CmsComponents.ts
+++ b/apps/tailwind-components/types/CmsComponents.ts
@@ -7,12 +7,17 @@ import type {
   INavigationGroups,
   IDeveloperPages,
   IConfigurablePages,
+  IFile,
 } from "./cms.ts";
 
 import type { ITableMetaData } from "../../metadata-utils/src/types.js";
 
+export interface IHeadersExtended extends IHeaders {
+  image?: IFile;
+}
+
 export interface IPageComponent
-  extends IHeaders,
+  extends IHeadersExtended,
     ISections,
     IHeadings,
     IParagraphs,


### PR DESCRIPTION
### What are the main changes you did

The purpose of this PR is to fix an issue in the Header component where images were lost if the content was edited.

- [x] Updated GraphQL query: now retrieves required image attributes (`id`) for saving images
- [x] Added step in PageComponent that transforms the data for Header.backgroundImage value to `{id: "<image-id>"}` instead of an `IFile` object. By adding the missing attributes, we can now simplify this process.
- [x] Updated interfaces in the Header and PageComponent files
- [x] Removed an workaround for bug that has since been resolved (molgenis/GCC#2706) 

This PR is part of molgenis/GCC#1143

### How to test

- Go to the preview and sign in as admin
- In the new UI, go to the `cms` schema. (This is now generated by default.)
- Go to the page gallery: `/cms/pages/` and click on edit icon for the home page.
- Edit the page header; changed the title, subtitle, etc., but leave the image. Save the changes
- Refresh the page. The image should still be present.
- Compare this with master

### Checklist

- [x] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [x] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
