### PR TITLE
feat(tw): add truncation action to EMX2 table

### DIFF
--- a/apps/metadata-utils/src/types.ts
+++ b/apps/metadata-utils/src/types.ts
@@ -208,7 +208,7 @@ export type TaskStatus =
   | "WARNING"
   | "ERROR"
   | "UNKNOWN"
-  | "CANCELED";
+  | "CANCELLED";
 
 export interface TaskResponse {
   data: {

--- a/apps/metadata-utils/src/types.ts
+++ b/apps/metadata-utils/src/types.ts
@@ -199,3 +199,29 @@ export type IInputValueLabel = {
 export type IRow = Record<columnId, columnValue>;
 
 export type DateValue = Date | string | undefined | null;
+
+export type TaskStatus =
+  | "WAITING"
+  | "RUNNING"
+  | "COMPLETED"
+  | "SKIPPED"
+  | "WARNING"
+  | "ERROR"
+  | "UNKNOWN"
+  | "CANCELED";
+
+export interface TaskResponse {
+  data: {
+    _tasks: {
+      id: string;
+      description: string;
+      status: TaskStatus;
+    }[];
+  };
+}
+
+export type TruncateStatus =
+  | "REQUEST_CONFIRMATION"
+  | "RUNNING"
+  | "COMPLETED"
+  | "FAILED";

--- a/apps/tailwind-components/app/components/Modal.vue
+++ b/apps/tailwind-components/app/components/Modal.vue
@@ -12,11 +12,13 @@ withDefaults(
     maxWidth?: string;
     type?: "center" | "left" | "right";
     backgroundAccessible?: boolean;
+    size?: "small" | "medium" | "large";
   }>(),
   {
     type: "center",
     maxWidth: "max-w-xl",
     backgroundAccessible: false,
+    size: "large",
   }
 );
 
@@ -88,9 +90,12 @@ function hide() {
               />
 
               <div
-                class="bg-modal w-3/4 relative rounded-alt h-[95vh] flex flex-col pointer-events-auto"
+                class="bg-modal w-3/4 relative rounded-alt max-h-[95dvh] min-h-[18.75rem] flex flex-col pointer-events-auto"
                 :class="[
                   {
+                    'h-[95vh]': size === 'large',
+                    'h-[50vh]': size === 'medium',
+                    'h-[33vh]': size === 'small',
                     'm-auto': type === 'center',
                     'ml-auto rounded-r-none': type === 'right',
                     'mr-auto rounded-l-none': type === 'left',

--- a/apps/tailwind-components/app/components/ModalContentContainer.vue
+++ b/apps/tailwind-components/app/components/ModalContentContainer.vue
@@ -1,0 +1,5 @@
+<template>
+  <div class="p-12.5">
+    <slot />
+  </div>
+</template>

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -52,6 +52,22 @@
           :tableId="tableId"
         />
 
+        <Truncate
+          v-if="props.isEditable && data?.tableMetadata"
+          v-slot="{ showConfirmationModal }"
+          :metadata="data.tableMetadata"
+          @update:truncated="afterRowDeleted"
+        >
+          <Button
+            type="outline"
+            size="medium"
+            @click="showConfirmationModal"
+            :disabled="!rows.length"
+          >
+            Truncate
+          </Button>
+        </Truncate>
+
         <slot name="toolbar-end" />
       </div>
     </div>
@@ -362,6 +378,7 @@ import DeleteRows from "./control/DeleteRows.vue";
 import TableControlColumns from "./control/Columns.vue";
 import TableEMX2Head from "./TableEMX2Head.vue";
 import DownloadButton from "./control/DownloadButton.vue";
+import Truncate from "./control/Truncate.vue";
 
 const props = withDefaults(
   defineProps<{
@@ -481,20 +498,22 @@ const { data, refresh, status } = useAsyncData(
     });
 
     // add unique row identifier for selection purposes
-    const rows: TableRow[] = await Promise.all(
-      tableData.rows.map(async (row) => {
-        const primaryKey = await getPrimaryKey(
-          row,
-          props.tableId,
-          props.schemaId
-        );
-        return {
-          ...row,
-          _rowId: primaryKey,
-          _rowIdString: JSON.stringify(primaryKey),
-        };
-      })
-    );
+    const rows: TableRow[] = tableData.rows?.length
+      ? await Promise.all(
+          tableData.rows.map(async (row) => {
+            const primaryKey = await getPrimaryKey(
+              row,
+              props.tableId,
+              props.schemaId
+            );
+            return {
+              ...row,
+              _rowId: primaryKey,
+              _rowIdString: JSON.stringify(primaryKey),
+            };
+          })
+        )
+      : [];
 
     return {
       tableMetadata,

--- a/apps/tailwind-components/app/components/table/control/DeleteRows.vue
+++ b/apps/tailwind-components/app/components/table/control/DeleteRows.vue
@@ -14,7 +14,6 @@ import Modal from "../../Modal.vue";
 import { isMgError } from "../../../utils/typeUtils";
 
 const session = await useSession();
-const table = useTable();
 
 const props = defineProps<{
   schemaId: string;
@@ -26,6 +25,8 @@ const emit = defineEmits<{
   (e: "update:deleted", deleted: boolean): void;
   (e: "update:cancelled", cancelled: boolean): void;
 }>();
+
+const table = useTable(props.schemaId, props.metadata.id);
 
 const visible = defineModel("visible", {
   type: Boolean,
@@ -42,7 +43,7 @@ function reAuthenticate() {
 
 async function onDeleteConfirm() {
   try {
-    await table.deleteRecords(props.schemaId, props.metadata.id, props.keys);
+    await table.deleteRecords(props.keys);
     emit("update:deleted", true);
     visible.value = false;
   } catch (error: unknown) {
@@ -60,7 +61,7 @@ async function onDeleteConfirm() {
 </script>
 
 <template>
-  <Modal v-model:visible="visible" max-width="max-w-9/10">
+  <Modal v-model:visible="visible" size="small">
     <template #header>
       <header class="pt-[36px] px-8 overflow-y-auto border-b border-divider">
         <div class="mb-5 relative flex items-center">
@@ -83,12 +84,10 @@ async function onDeleteConfirm() {
 
     <section class="grid grid-cols-4 gap-1"></section>
 
-    <div class="w-[90%] mx-8 my-auto py-4">
-      <p class="text-body-lg text-center text-title-contrast">
-        Are you sure you want to delete the {{ keys.size }} selected rows.
-      </p>
-      <p class="text-body-lg text-center text-title-contrast">
-        This action cannot be undone.
+    <div class="mx-8 my-auto py-4">
+      <p class="text-sm">
+        Are you sure you want to delete the {{ keys.size }} selected rows. This
+        action cannot be undone.
       </p>
     </div>
 

--- a/apps/tailwind-components/app/components/table/control/RowControls.vue
+++ b/apps/tailwind-components/app/components/table/control/RowControls.vue
@@ -34,7 +34,7 @@ const singleRowSelected = computed(() => props.numberOfSelectedRows === 1);
       >
         <div class="flex items-center pl-2 pr-2 gap-2">
           <Checkbox
-            :model-value="allRowsSelected"
+            :model-value="allRowsSelected && numberOfSelectedRows > 0"
             :indeterminate="!allRowsSelected && numberOfSelectedRows > 0"
             :prevent-click="true"
           >

--- a/apps/tailwind-components/app/components/table/control/Truncate.vue
+++ b/apps/tailwind-components/app/components/table/control/Truncate.vue
@@ -1,0 +1,153 @@
+<script setup lang="ts">
+import { computed, ref, watch } from "vue";
+import type {
+  ITableMetaData,
+  TruncateStatus,
+} from "../../../../../metadata-utils/src/types";
+import Button from "../../Button.vue";
+import Modal from "../../Modal.vue";
+import ModalContentContainer from "../../ModalContentContainer.vue";
+import BaseIcon from "../../BaseIcon.vue";
+import { useTable } from "../../../composables/useTable";
+
+const props = defineProps<{
+  metadata: ITableMetaData;
+}>();
+
+const emit = defineEmits<{
+  (e: "update:truncated", truncated: boolean): void;
+}>();
+
+const isModalOpen = ref(false);
+const truncateStatus = ref<TruncateStatus>("REQUEST_CONFIRMATION");
+const truncateResultMessage = ref<string | null>(null);
+const showResultDetails = ref(false);
+const modalSize = computed(() =>
+  truncateResultMessage.value ? "medium" : "small"
+);
+
+async function handleTruncate() {
+  const table = useTable(props.metadata.schemaId, props.metadata.id);
+  const truncateResult = await table.truncate(truncateStatus);
+  if (truncateResult.status === "FAILED") {
+    truncateResultMessage.value =
+      truncateResult.description || "An unknown error occurred.";
+  }
+}
+
+function showConfirmationModal() {
+  isModalOpen.value = true;
+}
+
+watch(isModalOpen, (newStatus) => {
+  if (!newStatus) {
+    resetModal();
+  }
+});
+
+function resetModal() {
+  if (truncateStatus.value === "COMPLETED") {
+    emit("update:truncated", true);
+  }
+  isModalOpen.value = false;
+  truncateStatus.value = "REQUEST_CONFIRMATION";
+  truncateResultMessage.value = null;
+  showResultDetails.value = false;
+}
+</script>
+
+<template>
+  <slot :showConfirmationModal="showConfirmationModal">
+    <Button type="outline" size="medium" @click="isModalOpen = true">
+      Truncate
+    </Button>
+  </slot>
+
+  <Modal
+    v-model:visible="isModalOpen"
+    :title="`Truncate ${metadata.label}`"
+    :size="modalSize"
+  >
+    <ModalContentContainer>
+      <p class="text-sm" v-if="truncateStatus === 'REQUEST_CONFIRMATION'">
+        Are you sure you want to truncate the table
+        <strong>{{ metadata.label }}</strong> ? This removes all data from the
+        table. This action cannot be undone.
+      </p>
+      <div
+        class="text-sm flex flex-row gap-1"
+        v-else-if="truncateStatus === 'RUNNING'"
+      >
+        <span
+          >Truncating the table <strong>{{ metadata.label }}</strong></span
+        >
+        <BaseIcon class="ml-2 animate-spin" name="ProgressActivity" />
+      </div>
+      <p class="text-sm" v-else-if="truncateStatus === 'COMPLETED'">
+        Successfully truncated the table <strong>{{ metadata.label }}</strong
+        >.
+      </p>
+      <div class="text-sm" v-else-if="truncateStatus === 'FAILED'">
+        <div class="flex flex-row gap-2 items-center">
+          <p>
+            Failed to truncate the table <strong>{{ metadata.label }}</strong
+            >.
+          </p>
+
+          <Button
+            v-if="truncateResultMessage"
+            type="text"
+            size="tiny"
+            @click="showResultDetails = !showResultDetails"
+          >
+            {{ showResultDetails ? "Hide" : "Show" }} Details
+          </Button>
+        </div>
+
+        <p
+          v-if="truncateResultMessage && showResultDetails"
+          class="mt-2 italic text-sm"
+        >
+          {{ truncateResultMessage }}
+        </p>
+      </div>
+    </ModalContentContainer>
+
+    <template #footer>
+      <menu class="flex items-center justify-end gap-4 h-modal-footer">
+        <Button
+          type="outline"
+          size="medium"
+          @click="resetModal"
+          :disabled="truncateStatus === 'RUNNING'"
+          v-if="
+            truncateStatus === 'REQUEST_CONFIRMATION' ||
+            truncateStatus === 'RUNNING'
+          "
+        >
+          Cancel
+        </Button>
+        <Button
+          type="primary"
+          size="medium"
+          @click="handleTruncate"
+          v-if="
+            truncateStatus === 'REQUEST_CONFIRMATION' ||
+            truncateStatus === 'RUNNING'
+          "
+          :disabled="truncateStatus === 'RUNNING'"
+        >
+          Truncate
+        </Button>
+        <Button
+          v-if="truncateStatus === 'COMPLETED' || truncateStatus === 'FAILED'"
+          type="primary"
+          size="medium"
+          @click="resetModal"
+        >
+          Close
+        </Button>
+      </menu>
+    </template>
+  </Modal>
+</template>

--- a/apps/tailwind-components/app/composables/useTable.ts
+++ b/apps/tailwind-components/app/composables/useTable.ts
@@ -1,13 +1,24 @@
 import { SessionExpiredError } from "../utils/sessionExpiredError";
-import type { columnValue } from "../../../metadata-utils/src/types";
+import type {
+  columnValue,
+  TaskStatus,
+  TruncateStatus,
+} from "../../../metadata-utils/src/types";
 import { useSession } from "./useSession";
+import { ref, type Ref } from "vue";
+import { useTask } from "./useTask";
 
-export const useTable = () => {
-  const deleteRecords = async (
-    schemaId: string,
-    tableId: string,
-    keys: Set<Record<string, columnValue>>
-  ) => {
+interface TruncateResponse {
+  data: {
+    truncate: {
+      taskId: string;
+      message: string;
+    };
+  };
+}
+
+export const useTable = (schemaId: string, tableId: string) => {
+  const deleteRecords = async (keys: Set<Record<string, columnValue>>) => {
     const query = `mutation delete($pkey:[${tableId}Input]){delete(${tableId}:$pkey){message}}`;
     const variables = { pkey: Array.from(keys) };
 
@@ -20,6 +31,55 @@ export const useTable = () => {
     }).catch((error) =>
       handleFetchError(error, "Error on delete records from table " + tableId)
     );
+  };
+
+  const truncate = async (truncateStatus: Ref<TruncateStatus>) => {
+    truncateStatus.value = "RUNNING";
+    try {
+      const truncateResp = await $fetch<TruncateResponse>(
+        `/${schemaId}/graphql`,
+        {
+          method: "POST",
+          body: {
+            query: `mutation { truncate(tables: "${tableId}", async: true) { taskId, message } }`,
+          },
+        }
+      );
+
+      const truncateTaskId = truncateResp.data.truncate.taskId;
+      if (!truncateTaskId) {
+        throw new Error("No task returned from truncate operation");
+      }
+
+      const taskStatus = ref<TaskStatus>("WAITING");
+
+      const finalStatus = await useTask(schemaId, truncateTaskId)
+        .pollStatus(taskStatus)
+        .catch((error) => {
+          console.error("Error polling task status:", error);
+          throw error; // Rethrow the error to be caught by the outer try-catch
+        });
+
+      if (finalStatus.status === "COMPLETED") {
+        console.log("Truncate operation completed successfully.");
+        truncateStatus.value = "COMPLETED";
+        return { status: truncateStatus.value };
+      } else {
+        console.error("Truncate operation failed.");
+        truncateStatus.value = "FAILED";
+        return {
+          status: truncateStatus.value,
+          description: finalStatus.description,
+        };
+      }
+    } catch (error) {
+      console.error("Error truncating table:", error);
+      truncateStatus.value = "FAILED";
+      return {
+        status: truncateStatus.value,
+        description: (error as Error).message,
+      };
+    }
   };
 
   async function handleFetchError(error: any, message: string) {
@@ -38,5 +98,6 @@ export const useTable = () => {
 
   return {
     deleteRecords,
+    truncate,
   };
 };

--- a/apps/tailwind-components/app/composables/useTask.ts
+++ b/apps/tailwind-components/app/composables/useTask.ts
@@ -1,0 +1,58 @@
+import type { Ref } from "vue";
+import type { TaskStatus } from "../../../metadata-utils/src/types";
+
+const taskPollingFiels =
+  "{ id, description, status, subTasks { id, description, status} }";
+
+interface taskPollingResponse {
+  status: TaskStatus;
+  description?: string;
+  subTasks?: taskPollingResponse[];
+}
+
+export const useTask = (schemaId: string, taskId: string) => {
+  function pollStatus(
+    status: Ref<TaskStatus>,
+    interval: number = 2000
+  ): Promise<taskPollingResponse> {
+    return new Promise((resolve, reject) => {
+      const checkStatus = async () => {
+        try {
+          const response = await $fetch(`/${schemaId}/graphql`, {
+            method: "POST",
+            body: {
+              query: `query { _tasks(id:"${taskId}") ${taskPollingFiels} }`,
+            },
+          });
+
+          if (!response.data._tasks[0]?.status) {
+            status.value = "UNKNOWN";
+            reject(new Error("Task status not found"));
+            return;
+          } else {
+            status.value = response.data._tasks[0].status;
+          }
+
+          if (status.value === "COMPLETED" || status.value === "ERROR") {
+            resolve({
+              status: status.value,
+              description: response.data._tasks[0].description,
+            });
+          } else if (status.value === "RUNNING" || status.value === "WAITING") {
+            setTimeout(checkStatus, interval);
+          } else {
+            reject(new Error(`Task failed with status: ${status.value}`));
+          }
+        } catch (error) {
+          reject(error);
+        }
+      };
+
+      checkStatus();
+    });
+  }
+
+  return {
+    pollStatus,
+  };
+};

--- a/apps/tailwind-components/app/composables/useTask.ts
+++ b/apps/tailwind-components/app/composables/useTask.ts
@@ -1,27 +1,27 @@
 import type { Ref } from "vue";
 import type { TaskStatus } from "../../../metadata-utils/src/types";
 
-const taskPollingFiels =
-  "{ id, description, status, subTasks { id, description, status} }";
+const taskPollingFields =
+  "{ id, description, status, subTasks { id, description, status } }";
 
-interface taskPollingResponse {
+interface TaskPollingResponse {
   status: TaskStatus;
   description?: string;
-  subTasks?: taskPollingResponse[];
+  subTasks?: TaskPollingResponse[];
 }
 
 export const useTask = (schemaId: string, taskId: string) => {
   function pollStatus(
     status: Ref<TaskStatus>,
     interval: number = 2000
-  ): Promise<taskPollingResponse> {
+  ): Promise<TaskPollingResponse> {
     return new Promise((resolve, reject) => {
       const checkStatus = async () => {
         try {
           const response = await $fetch(`/${schemaId}/graphql`, {
             method: "POST",
             body: {
-              query: `query { _tasks(id:"${taskId}") ${taskPollingFiels} }`,
+              query: `query { _tasks(id:"${taskId}") ${taskPollingFields} }`,
             },
           });
 
@@ -33,7 +33,7 @@ export const useTask = (schemaId: string, taskId: string) => {
             status.value = response.data._tasks[0].status;
           }
 
-          if (status.value === "COMPLETED" || status.value === "ERROR") {
+          if (status.value === "COMPLETED" || status.value === "ERROR" || status.value === "CANCELLED") {
             resolve({
               status: status.value,
               description: response.data._tasks[0].description,

--- a/apps/tailwind-components/app/composables/useTask.ts
+++ b/apps/tailwind-components/app/composables/useTask.ts
@@ -33,7 +33,11 @@ export const useTask = (schemaId: string, taskId: string) => {
             status.value = response.data._tasks[0].status;
           }
 
-          if (status.value === "COMPLETED" || status.value === "ERROR" || status.value === "CANCELLED") {
+          if (
+            status.value === "COMPLETED" ||
+            status.value === "ERROR" ||
+            status.value === "CANCELLED"
+          ) {
             resolve({
               status: status.value,
               description: response.data._tasks[0].description,

--- a/apps/tailwind-components/tests/vitest/composables/useTable.test.ts
+++ b/apps/tailwind-components/tests/vitest/composables/useTable.test.ts
@@ -84,8 +84,7 @@ describe("useTable", () => {
     });
 
     const { truncate } = useTable("demo", "Person");
-    const truncateStatus = ref<TruncateStatus>("IDLE");
-
+    const truncateStatus = ref<TruncateStatus>("REQUEST_CONFIRMATION");
     await expect(truncate(truncateStatus)).resolves.toEqual({
       status: "COMPLETED",
     });

--- a/apps/tailwind-components/tests/vitest/composables/useTable.test.ts
+++ b/apps/tailwind-components/tests/vitest/composables/useTable.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { ref } from "vue";
+import { flushPromises } from "@vue/test-utils";
+import type {
+  TaskStatus,
+  TruncateStatus,
+} from "../../../../metadata-utils/src/types";
+import { SessionExpiredError } from "../../../app/utils/sessionExpiredError";
+
+vi.mock("../../../app/composables/useTask", () => ({
+  useTask: vi.fn(),
+}));
+
+vi.mock("../../../app/composables/useSession", () => ({
+  useSession: vi.fn(),
+}));
+
+import { useTask } from "../../../app/composables/useTask";
+import { useSession } from "../../../app/composables/useSession";
+import { useTable } from "../../../app/composables/useTable";
+
+describe("useTable", () => {
+  const fetchMock = vi.fn();
+  const pollStatusMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("$fetch", fetchMock);
+
+    vi.mocked(useTask).mockReturnValue({
+      pollStatus: pollStatusMock,
+    } as unknown as ReturnType<typeof useTask>);
+
+    vi.mocked(useSession).mockResolvedValue({
+      hasSessionTimeout: vi.fn().mockResolvedValue(false),
+    } as unknown as Awaited<ReturnType<typeof useSession>>);
+  });
+
+  test("deleteRecords calls graphql delete mutation with keys", async () => {
+    fetchMock.mockResolvedValueOnce({ data: { delete: { message: "ok" } } });
+
+    const { deleteRecords } = useTable("demo", "Person");
+    const keys = new Set([{ id: "1" }, { id: "2" }]);
+
+    await deleteRecords(keys);
+
+    expect(fetchMock).toHaveBeenCalledWith("/demo/graphql", {
+      method: "POST",
+      body: {
+        query:
+          "mutation delete($pkey:[PersonInput]){delete(Person:$pkey){message}}",
+        variables: { pkey: [{ id: "1" }, { id: "2" }] },
+      },
+    });
+  });
+
+  test("deleteRecords throws SessionExpiredError on timed out session", async () => {
+    const fetchError = { statusCode: 401 };
+    fetchMock.mockRejectedValueOnce(fetchError);
+
+    vi.mocked(useSession).mockResolvedValue({
+      hasSessionTimeout: vi.fn().mockResolvedValue(true),
+    } as unknown as Awaited<ReturnType<typeof useSession>>);
+
+    const { deleteRecords } = useTable("demo", "Person");
+
+    await expect(deleteRecords(new Set([{ id: "1" }]))).rejects.toBeInstanceOf(
+      SessionExpiredError
+    );
+  });
+
+  test("truncate sets status to COMPLETED when task poll succeeds", async () => {
+    fetchMock.mockResolvedValueOnce({
+      data: {
+        truncate: {
+          taskId: "task-1",
+          message: "queued",
+        },
+      },
+    });
+    pollStatusMock.mockResolvedValueOnce({
+      status: "COMPLETED" satisfies TaskStatus,
+      description: "done",
+    });
+
+    const { truncate } = useTable("demo", "Person");
+    const truncateStatus = ref<TruncateStatus>("IDLE");
+
+    await expect(truncate(truncateStatus)).resolves.toEqual({
+      status: "COMPLETED",
+    });
+    await flushPromises();
+
+    expect(vi.mocked(useTask)).toHaveBeenCalledWith("demo", "task-1");
+    expect(pollStatusMock).toHaveBeenCalledTimes(1);
+    expect(truncateStatus.value).toBe("COMPLETED");
+  });
+
+  test("truncate returns FAILED with description when task poll returns ERROR", async () => {
+    fetchMock.mockResolvedValueOnce({
+      data: {
+        truncate: {
+          taskId: "task-2",
+          message: "queued",
+        },
+      },
+    });
+    pollStatusMock.mockResolvedValueOnce({
+      status: "ERROR" satisfies TaskStatus,
+      description: "truncate failed",
+    });
+
+    const { truncate } = useTable("demo", "Person");
+    const truncateStatus = ref<TruncateStatus>("IDLE");
+
+    await expect(truncate(truncateStatus)).resolves.toEqual({
+      status: "FAILED",
+      description: "truncate failed",
+    });
+    await flushPromises();
+
+    expect(truncateStatus.value).toBe("FAILED");
+  });
+
+  test("truncate returns FAILED when task polling rejects", async () => {
+    fetchMock.mockResolvedValueOnce({
+      data: {
+        truncate: {
+          taskId: "task-3",
+          message: "queued",
+        },
+      },
+    });
+    pollStatusMock.mockRejectedValueOnce(new Error("poll failed"));
+
+    const { truncate } = useTable("demo", "Person");
+    const truncateStatus = ref<TruncateStatus>("IDLE");
+
+    await expect(truncate(truncateStatus)).resolves.toEqual({
+      status: "FAILED",
+      description: "poll failed",
+    });
+
+    expect(truncateStatus.value).toBe("FAILED");
+  });
+
+  test("truncate returns FAILED when no task id is returned", async () => {
+    fetchMock.mockResolvedValueOnce({
+      data: {
+        truncate: {
+          taskId: "",
+          message: "queued",
+        },
+      },
+    });
+
+    const { truncate } = useTable("demo", "Person");
+    const truncateStatus = ref<TruncateStatus>("IDLE");
+
+    await expect(truncate(truncateStatus)).resolves.toEqual({
+      status: "FAILED",
+      description: "No task returned from truncate operation",
+    });
+
+    expect(truncateStatus.value).toBe("FAILED");
+  });
+});

--- a/apps/tailwind-components/tests/vitest/composables/useTask.test.ts
+++ b/apps/tailwind-components/tests/vitest/composables/useTask.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, afterEach, describe, expect, test, vi } from "vitest";
+import { ref } from "vue";
+import type { TaskStatus } from "../../../../metadata-utils/src/types";
+import { useTask } from "../../../app/composables/useTask";
+
+describe("useTask", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal("$fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  test("resolves immediately when API returns completed", async () => {
+    fetchMock.mockResolvedValueOnce({
+      data: { _tasks: [{ status: "COMPLETED", description: "done" }] },
+    });
+
+    const status = ref<TaskStatus>("RUNNING");
+    const { pollStatus } = useTask("demo", "task-1");
+
+    await expect(pollStatus(status)).resolves.toEqual({
+      status: "COMPLETED",
+      description: "done",
+    });
+    expect(status.value).toBe("COMPLETED");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(fetchMock).toHaveBeenCalledWith("/demo/graphql", {
+      method: "POST",
+      body: {
+        query:
+          'query { _tasks(id:"task-1") { id, description, status, subTasks { id, description, status} } }',
+      },
+    });
+  });
+
+  test("keeps polling until API returns completed", async () => {
+    vi.useFakeTimers();
+    fetchMock
+      .mockResolvedValueOnce({ data: { _tasks: [{ status: "RUNNING" }] } })
+      .mockResolvedValueOnce({
+        data: { _tasks: [{ status: "COMPLETED", description: "done" }] },
+      });
+
+    const status = ref<TaskStatus>("RUNNING");
+    const { pollStatus } = useTask("demo", "task-2");
+
+    const resultPromise = pollStatus(status, 1000);
+    await Promise.resolve();
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(status.value).toBe("RUNNING");
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    await expect(resultPromise).resolves.toEqual({
+      status: "COMPLETED",
+      description: "done",
+    });
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(status.value).toBe("COMPLETED");
+  });
+
+  test("rejects and sets status to UNKNOWN when response has no task status", async () => {
+    fetchMock.mockResolvedValueOnce({
+      data: { _tasks: [] },
+    });
+
+    const status = ref<TaskStatus>("RUNNING");
+    const { pollStatus } = useTask("demo", "task-3");
+
+    await expect(pollStatus(status)).rejects.toThrow("Task status not found");
+    expect(status.value).toBe("UNKNOWN");
+  });
+
+  test("rejects when API returns terminal error status", async () => {
+    fetchMock.mockResolvedValueOnce({
+      data: { _tasks: [{ status: "ERROR" }] },
+    });
+
+    const status = ref<TaskStatus>("WAITING");
+    const { pollStatus } = useTask("demo", "task-5");
+
+    await expect(pollStatus(status)).resolves.toEqual({
+      status: "ERROR",
+      description: undefined,
+    });
+    expect(status.value).toBe("ERROR");
+  });
+
+  test("rejects when fetch fails", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("network error"));
+
+    const status = ref<TaskStatus>("RUNNING");
+    const { pollStatus } = useTask("demo", "task-4");
+
+    await expect(pollStatus(status)).rejects.toThrow("network error");
+  });
+});

--- a/apps/tailwind-components/tests/vitest/composables/useTask.test.ts
+++ b/apps/tailwind-components/tests/vitest/composables/useTask.test.ts
@@ -78,7 +78,7 @@ describe("useTask", () => {
     expect(status.value).toBe("UNKNOWN");
   });
 
-  test("rejects when API returns terminal error status", async () => {
+  test("resolves when API returns terminal error status", async () => {
     fetchMock.mockResolvedValueOnce({
       data: { _tasks: [{ status: "ERROR" }] },
     });

--- a/apps/tailwind-components/tests/vitest/composables/useTask.test.ts
+++ b/apps/tailwind-components/tests/vitest/composables/useTask.test.ts
@@ -30,13 +30,16 @@ describe("useTask", () => {
     });
     expect(status.value).toBe("COMPLETED");
     expect(fetchMock).toHaveBeenCalledTimes(1);
-    expect(fetchMock).toHaveBeenCalledWith("/demo/graphql", {
+    const fetchArgs = fetchMock.mock.calls[0];
+    expect(fetchArgs?.[0]).toBe("/demo/graphql");
+    expect(fetchArgs?.[1]).toMatchObject({
       method: "POST",
-      body: {
-        query:
-          'query { _tasks(id:"task-1") { id, description, status, subTasks { id, description, status} } }',
-      },
     });
+
+    const query = fetchArgs?.[1]?.body?.query;
+    expect(query).toContain('_tasks(id:"task-1")');
+    expect(query).toContain("id, description, status");
+    expect(query).toContain("subTasks");
   });
 
   test("keeps polling until API returns completed", async () => {


### PR DESCRIPTION
Allows users with edit rights to truncate the table.

* The control is only shown to users with edit permissions.
* The control is disabled when the table is empty.

### What are the main changes you did

- add Truncate component, button, modal
- extend useTable composabe with truncate function
- add useTask composable to monitor task
- extend modal properties to set modal size
- fix issue in TableEMX2 where empty table results error on key resolve

### How to test

- check button is not show if user has no edit permission for the table 
- check button is shown if user has edit permission
- check button is disabled if table has no rows 
- check clicking the button show the truncate confirmation modal 
- check the table is not truncated if the user does not confirm the action 
- check the truncate request is made if the user confirms the action 
- check the user is updated on the action status 
- check that the user is informed if the action is completed 
- check that the table ui is updated if the action was completed successfully and the modal is closed 
- check the user is notified if the action resulted in an error 
- check that the user can inspect the error details 

### Checklist

- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
