### PR TITLE
fix(nestor): set font size

### DIFF
--- a/apps/nestor-public/public/css/index.css
+++ b/apps/nestor-public/public/css/index.css
@@ -9,7 +9,6 @@
   --max-width: 60vw;
   --viz-chart-title-font-size: 1.1rem;
 
-  font-size: 14pt;
   font-family: Helvetica, sans-serif;
 }
 
@@ -142,6 +141,10 @@
 #nestorPublicDashboard .dashboard-content,
 #nestorPublicDashboard .dashboard-content .dashboard-chart-layout {
   gap: 1em;
+}
+
+#page-home {
+  font-size: 14pt;
 }
 
 @media screen and (min-width: 1800px) {

--- a/apps/nestor-public/public/css/index.css
+++ b/apps/nestor-public/public/css/index.css
@@ -12,6 +12,10 @@
   font-family: Helvetica, sans-serif;
 }
 
+.app-page.nestor-page {
+  font-size: 14pt;
+}
+
 .app-page .page-header {
   background-color: var(--nestor-green-050);
 }
@@ -141,10 +145,6 @@
 #nestorPublicDashboard .dashboard-content,
 #nestorPublicDashboard .dashboard-content .dashboard-chart-layout {
   gap: 1em;
-}
-
-#page-home {
-  font-size: 14pt;
 }
 
 @media screen and (min-width: 1800px) {

--- a/apps/nestor-public/src/pages/view-about.vue
+++ b/apps/nestor-public/src/pages/view-about.vue
@@ -4,7 +4,7 @@ import { Page, PageHeader, PageSection, MessageBox } from "molgenis-viz";
 </script>
 
 <template>
-  <Page>
+  <Page class="nestor-page">
     <PageHeader
       title="NESTOR Registry"
       subtitle="About the NESTOR Registry"

--- a/apps/nestor-public/src/pages/view-contact.vue
+++ b/apps/nestor-public/src/pages/view-contact.vue
@@ -5,7 +5,7 @@ import Address from "../components/Address.vue";
 </script>
 
 <template>
-  <Page>
+  <Page class="nestor-page">
     <PageHeader
       title="NESTOR Registry"
       subtitle="Contact Us"

--- a/apps/nestor-public/src/pages/view-disclaimer.vue
+++ b/apps/nestor-public/src/pages/view-disclaimer.vue
@@ -4,7 +4,7 @@ import { Page, PageHeader, PageSection, MessageBox } from "molgenis-viz";
 </script>
 
 <template>
-  <Page>
+  <Page class="nestor-page">
     <PageHeader
       title="NESTOR Registry"
       subtitle="Disclaimer Statement"

--- a/apps/nestor-public/src/pages/view-documents.vue
+++ b/apps/nestor-public/src/pages/view-documents.vue
@@ -4,7 +4,7 @@ import { Page, PageHeader, PageSection, FileList } from "molgenis-viz";
 </script>
 
 <template>
-  <Page>
+  <Page class="nestor-page">
     <PageHeader
       title="NESTOR Registry"
       subtitle="Download documents"

--- a/apps/nestor-public/src/pages/view-governance.vue
+++ b/apps/nestor-public/src/pages/view-governance.vue
@@ -4,7 +4,7 @@ import { Page, PageHeader, PageSection, MessageBox } from "molgenis-viz";
 </script>
 
 <template>
-  <Page>
+  <Page class="nestor-page">
     <PageHeader
       title="NESTOR Registry"
       subtitle="Governance"

--- a/apps/nestor-public/src/pages/view-home.vue
+++ b/apps/nestor-public/src/pages/view-home.vue
@@ -5,7 +5,7 @@ import Address from "../components/Address.vue";
 </script>
 
 <template>
-  <Page id="page-home">
+  <Page class="nestor-page">
     <PageHeader
       title="NESTOR Registry"
       subtitle="The Netherlands Genetic Tumour Risk Registry"

--- a/apps/nestor-public/src/pages/view-privacy.vue
+++ b/apps/nestor-public/src/pages/view-privacy.vue
@@ -4,7 +4,7 @@ import { Page, PageHeader, PageSection, MessageBox } from "molgenis-viz";
 </script>
 
 <template>
-  <Page>
+  <Page class="nestor-page">
     <PageHeader
       title="NESTOR Registry"
       subtitle="Privacy Policy"


### PR DESCRIPTION
### What are the main changes you did

This PR fixes a small issue where the font size was inconsistent with the previous version of the `nestor-public` vue application, which was adjusted during the refactoring story. 

- [x] fix: enforced font size to `14pt` that was overridden when deployed

### How to test

- Go to the preview and click on the `Nestor public` schema
- View home page. Font page is now 14pt and should match the production server (nestor-registry)

### Checklist

- [x] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [x] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
