### PR TITLE
chore: have new PR assigned to current user, set as draft, and assigned to correct team board in 'working'

### DIFF
--- a/.github/pr-triage-teams.yml
+++ b/.github/pr-triage-teams.yml
@@ -1,0 +1,46 @@
+# This file is the mapping of known PR authors to their board Team.
+# Presence of a login here is the ONLY thing that can cause a PR to be
+# assigned, drafted and boarded on open. An author not listed here is
+# "unknown" and is never assigned.
+#
+# No `[bot]` login and neither machine account (`JV-CI-CD`,
+# `molgenis-jenkins`) may ever be added to this file.
+teams:
+  aikevd: Dev
+  aneashodselmans: Onboarding
+  bartcharbon: Analysis
+  Bellaannabinoy: Onboarding
+  BrendaHijmans: Delivery
+  chinook25: Dev
+  connoratrug: Dev
+  davidruvolo51: Dev
+  dennishendriksen: Analysis
+  DickPostma: Ops
+  dtroelofsprins: Delivery
+  EleanorHyde-UMCG: Onboarding
+  erikzwart: Delivery
+  esthervanenckevort: Delivery
+  Fernananas: Delivery
+  Gerbenvandervries: Analysis
+  GeriekeBeen: Onboarding
+  gvdgeijn: Analysis
+  harmbrugge: Dev
+  hslh: Delivery
+  jelmerveen: Dev
+  jhhaanstra: Dev
+  joelkuiper: Dev
+  joerivandervelde: Dev
+  LdeHosson: Onboarding
+  marieke-bijlsma: Infra
+  marijevdgeest: Onboarding
+  marikaris: Armadillo
+  MaxPostema: Dev
+  mswertz: Dev
+  nakikkertumcg: Dev
+  pneerincx: Infra
+  RoanKanninga: Analysis
+  RubenOPS: Ops
+  svandenhoek: Dev
+  timcadman: Armadillo
+  willemijn-oudijk: Delivery
+  YpeZ: Delivery

--- a/.github/pr-triage-teams.yml
+++ b/.github/pr-triage-teams.yml
@@ -5,6 +5,11 @@
 #
 # No `[bot]` login and neither machine account (`JV-CI-CD`,
 # `molgenis-jenkins`) may ever be added to this file.
+#
+# The team below is only ever written to a board item whose Team is EMPTY.
+# Changing someone's team here will not move their existing PRs, and a Team
+# you set by hand on the board is never overwritten. Same for Sprint, which
+# is filled once with the sprint current at the time and then left alone.
 teams:
   aikevd: Dev
   aneashodselmans: Onboarding

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -558,17 +558,14 @@ def apply_redirected_board_write(action, is_draft, mapped_team, pr_item, closing
     least one issue, so it gets no card of its own -- an existing one is
     removed from board 15, unconditionally -- and each linked issue's card
     is written instead, per decide_issue_card_update. synchronize never
-    reaches this function; see apply_board_write."""
-    if decide_remove_pr_card(closing_issues, pr_item):
-        was = f"Status {pr_item['status']!r}, Team {pr_item['team']!r}, Sprint {pr_item['sprint']!r}"
-        # Recorded BEFORE the mutation runs -- this row is the one place a
-        # person can recover the values from, so a timeout after GitHub has
-        # already committed the removal must not lose it.
-        summary_rows.append(("PR card removed", f"{pr_item['id']} (was: {was})"))
-        remove_item_from_board(pr_item["id"], board_token)
-    else:
-        summary_rows.append(("PR card", f"none to add or remove (closes {len(closing_issues)} linked issue(s))"))
+    reaches this function; see apply_board_write.
 
+    Order matters, owner ruling: every linked issue's card is written FIRST,
+    and the PR's own card is removed LAST. If an issue write fails partway
+    (a GraphQL error, a timeout), the PR's card survives -- a transient
+    duplicate, which the spec explicitly prefers over the alternative this
+    ordering rules out: the PR's card gone and no issue card written, i.e.
+    zero cards for the same piece of work."""
     current_iteration = resolve_current_iteration(board_token)
     current_sprint_title = current_iteration["title"] if current_iteration else None
 
@@ -588,6 +585,16 @@ def apply_redirected_board_write(action, is_draft, mapped_team, pr_item, closing
             issue_ref["id"], existing_issue_item, fields, current_values, current_iteration, board_token, summary_rows
         )
         summary_rows.append((f"Issue #{issue_ref['number']}", f"item {item_id}"))
+
+    if decide_remove_pr_card(closing_issues, pr_item):
+        was = f"Status {pr_item['status']!r}, Team {pr_item['team']!r}, Sprint {pr_item['sprint']!r}"
+        # Recorded BEFORE the mutation runs -- this row is the one place a
+        # person can recover the values from, so a timeout after GitHub has
+        # already committed the removal must not lose it.
+        summary_rows.append(("PR card removed", f"{pr_item['id']} (was: {was})"))
+        remove_item_from_board(pr_item["id"], board_token)
+    else:
+        summary_rows.append(("PR card", f"none to add or remove (closes {len(closing_issues)} linked issue(s))"))
 
 
 def apply_board_write(action, pr_node_id, is_draft, mapped_team, board_token, summary_rows, verdict_prefix, insert_verdict_at=None):
@@ -644,10 +651,6 @@ def handle_board_update(action, pull_request):
     pr_node_id = pull_request["node_id"]
     is_draft = pull_request["draft"]
 
-    mapping_path = mapping_file_path(__file__)
-    mapping = load_teams_mapping(mapping_path)
-    mapped_team = team_for(author_login, mapping) or UNKNOWN_AUTHOR_TEAM
-
     print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
 
     summary_rows = [
@@ -657,6 +660,10 @@ def handle_board_update(action, pull_request):
     ]
 
     try:
+        mapping_path = mapping_file_path(__file__)
+        mapping = load_teams_mapping(mapping_path)
+        mapped_team = team_for(author_login, mapping) or UNKNOWN_AUTHOR_TEAM
+
         board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
         apply_board_write(action, pr_node_id, is_draft, mapped_team, board_token, summary_rows, verdict_prefix=action)

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -182,6 +182,16 @@ def graphql_request(query, variables, token):
     return result
 
 
+def require_node(result, resolved_id):
+    node = result["data"]["node"]
+    if node is None:
+        raise GraphqlError(
+            f"GraphQL id '{resolved_id}' resolved to no node (data.node is null). "
+            f"The id is probably stale, e.g. a board field that was deleted and recreated."
+        )
+    return node
+
+
 def assign_author(repo, pr_number, author_login, token):
     return http_request(
         f"{GITHUB_API_URL}/repos/{repo}/issues/{pr_number}/assignees",
@@ -241,7 +251,7 @@ def find_board_item_for_pr(pr_node_id, token):
     }
     """
     result = graphql_request(query, {"contentId": pr_node_id}, token)
-    nodes = result["data"]["node"]["projectItems"]["nodes"]
+    nodes = require_node(result, pr_node_id)["projectItems"]["nodes"]
     for node in nodes:
         if node["project"]["id"] == BOARD_PROJECT_ID:
             status_value = node["status"]
@@ -294,7 +304,7 @@ def fetch_project_field_options(field_id, token):
     }
     """
     result = graphql_request(query, {"fieldId": field_id}, token)
-    return result["data"]["node"]["options"]
+    return require_node(result, field_id)["options"]
 
 
 def set_project_field_iteration(item_id, field_id, iteration_id, token):
@@ -337,7 +347,7 @@ def fetch_project_iterations(field_id, token):
     }
     """
     result = graphql_request(query, {"fieldId": field_id}, token)
-    return result["data"]["node"]["configuration"]["iterations"]
+    return require_node(result, field_id)["configuration"]["iterations"]
 
 
 def write_step_summary(rows):
@@ -351,11 +361,12 @@ def write_step_summary(rows):
 
 
 # One handler for every event whose only job is to move board fields, never the
-# assignee or the draft state: the three transitions (which set Status outright
-# and fill Team/Sprint only if empty) and synchronize (which fills all three
-# only if empty). decide_board_update carries the difference; this function is
-# purely the I/O around it, so a future field slots into SINGLE_SELECT_FIELD_SPECS
-# without touching the fill-vs-overwrite logic.
+# assignee or the draft state: the three transitions and synchronize alike.
+# Status follows decide_status's one rule regardless of action (fill when
+# empty or already Working/Review, leave any other value alone); Team and
+# Sprint always fill only if empty. decide_board_update carries the whole
+# rule; this function is purely the I/O around it, so a future field slots
+# into SINGLE_SELECT_FIELD_SPECS without touching the fill-vs-overwrite logic.
 BOARD_UPDATE_ACTIONS = TRANSITION_ACTIONS + ("synchronize",)
 
 SINGLE_SELECT_FIELD_SPECS = (
@@ -487,11 +498,6 @@ def handle_open_triage(action, pull_request, repo):
     pr_node_id = pull_request["node_id"]
     is_draft = pull_request["draft"]
 
-    mapping_path = mapping_file_path(__file__)
-    mapping = load_teams_mapping(mapping_path)
-
-    decision = decide(author_login=author_login, is_draft=is_draft, mapping=mapping)
-
     print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
 
     summary_rows = [
@@ -501,79 +507,96 @@ def handle_open_triage(action, pull_request, repo):
     ]
     failures = []
 
-    board_token = os.environ["PROJECT_BOARD_TOKEN"]
-
-    assignment_succeeded = True
-    if decision["assign"]:
-        try:
-            github_token = os.environ["GITHUB_TOKEN"]
-            assign_result = assign_author(repo, pr_number, author_login, github_token)
-            check_assignment_succeeded(author_login, assign_result)
-            summary_rows.append(("Assignee set", True))
-        except Exception as error:
-            print(f"ERROR: assignment failed: {error}")
-            summary_rows.append(("Assignee set", f"FAILED: {error}"))
-            failures.append(str(error))
-            assignment_succeeded = False
-    elif decision["known"]:
-        summary_rows.append(("Assignee set", "skipped, not required by decision"))
-    else:
-        summary_rows.append(("Assignee set", "skipped, unknown author is never assigned"))
-
-    # Assign-then-draft is a real dependency, not the chaining we removed elsewhere:
-    # claiming ownership is what force-to-draft means, so a failed assignment must
-    # leave the PR exactly as its author left it, boarded Review, not force-drafted
-    # and unowned. The board write below stays independent of both outcomes.
-    actual_is_draft = is_draft
-    if decision["force_draft"] and assignment_succeeded:
-        try:
-            draft_result = convert_pr_to_draft(pr_node_id, board_token)
-            actual_is_draft = draft_result["data"]["convertPullRequestToDraft"]["pullRequest"]["isDraft"]
-            summary_rows.append(("Converted to draft", actual_is_draft))
-        except Exception as error:
-            print(f"ERROR: convert-to-draft failed: {error}")
-            summary_rows.append(("Converted to draft", f"FAILED: {error}"))
-            failures.append(str(error))
-    elif decision["force_draft"] and not assignment_succeeded:
-        summary_rows.append(("Converted to draft", "skipped, assignment failed"))
-    elif decision["known"]:
-        summary_rows.append(("Converted to draft", "skipped, already draft"))
-    else:
-        summary_rows.append(("Converted to draft", "skipped, draft state left untouched for unknown author"))
-
-    target_status = decide_status(actual_is_draft, current_status=None)
-
-    if decision["known"]:
-        verdict = f"known -> assign+draft+{target_status}/{decision['team']}"
-    else:
-        verdict = (
-            f"unknown (absent from .github/pr-triage-teams.yml) -> "
-            f"no assignee, draft untouched, boarded {target_status}/{decision['team']}"
-        )
-    print(f"verdict: {verdict}")
-    summary_rows.insert(3, ("Verdict", verdict))
-
     try:
-        status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
-        status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
+        mapping_path = mapping_file_path(__file__)
+        mapping = load_teams_mapping(mapping_path)
 
-        team_options = fetch_project_field_options(TEAM_FIELD_ID, board_token)
-        team_option_id = find_option_id_by_name(team_options, decision["team"], strip_emoji=False)
+        decision = decide(author_login=author_login, is_draft=is_draft, mapping=mapping)
 
-        item_id = add_item_to_project(pr_node_id, board_token)
-        summary_rows.append(("Board item id", item_id))
+        board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
-        set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
-        summary_rows.append(("Status option id written", status_option_id))
+        assignment_succeeded = True
+        if decision["assign"]:
+            try:
+                github_token = os.environ["GITHUB_TOKEN"]
+                assign_result = assign_author(repo, pr_number, author_login, github_token)
+                check_assignment_succeeded(author_login, assign_result)
+                summary_rows.append(("Assignee set", True))
+            except Exception as error:
+                print(f"ERROR: assignment failed: {error}")
+                summary_rows.append(("Assignee set", f"FAILED: {error}"))
+                failures.append(str(error))
+                assignment_succeeded = False
+        else:
+            summary_rows.append(("Assignee set", "skipped, unknown author is never assigned"))
 
-        set_project_field_option(item_id, TEAM_FIELD_ID, team_option_id, board_token)
-        summary_rows.append(("Team option id written", team_option_id))
+        # Assign-then-draft is a real dependency, not the chaining we removed elsewhere:
+        # claiming ownership is what force-to-draft means, so a failed assignment must
+        # leave the PR exactly as its author left it, boarded Review, not force-drafted
+        # and unowned. The board write below stays independent of both outcomes.
+        actual_is_draft = is_draft
+        if decision["force_draft"] and assignment_succeeded:
+            try:
+                draft_result = convert_pr_to_draft(pr_node_id, board_token)
+                actual_is_draft = draft_result["data"]["convertPullRequestToDraft"]["pullRequest"]["isDraft"]
+                summary_rows.append(("Converted to draft", actual_is_draft))
+            except Exception as error:
+                print(f"ERROR: convert-to-draft failed: {error}")
+                summary_rows.append(("Converted to draft", f"FAILED: {error}"))
+                failures.append(str(error))
+        elif decision["force_draft"] and not assignment_succeeded:
+            summary_rows.append(("Converted to draft", "skipped, assignment failed"))
+        elif decision["known"]:
+            summary_rows.append(("Converted to draft", "skipped, already draft"))
+        else:
+            summary_rows.append(("Converted to draft", "skipped, draft state left untouched for unknown author"))
+
+        target_status = decide_status(actual_is_draft, current_status=None)
+
+        if decision["known"]:
+            verdict = f"known -> assign+draft+{target_status}/{decision['team']}"
+        else:
+            verdict = (
+                f"unknown (absent from .github/pr-triage-teams.yml) -> "
+                f"no assignee, draft untouched, boarded {target_status}/{decision['team']}"
+            )
+        print(f"verdict: {verdict}")
+        summary_rows.insert(3, ("Verdict", verdict))
+
+        try:
+            status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
+            status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
+
+            team_options = fetch_project_field_options(TEAM_FIELD_ID, board_token)
+            team_option_id = find_option_id_by_name(team_options, decision["team"], strip_emoji=False)
+
+            iterations = fetch_project_iterations(SPRINT_FIELD_ID, board_token)
+            current_iteration = find_current_iteration(iterations, current_date())
+
+            item_id = add_item_to_project(pr_node_id, board_token)
+            summary_rows.append(("Board item id", item_id))
+
+            set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
+            summary_rows.append(("Status option id written", status_option_id))
+
+            set_project_field_option(item_id, TEAM_FIELD_ID, team_option_id, board_token)
+            summary_rows.append(("Team option id written", team_option_id))
+
+            if current_iteration:
+                set_project_field_iteration(item_id, SPRINT_FIELD_ID, current_iteration["id"], board_token)
+                summary_rows.append(("Sprint option id written", current_iteration["id"]))
+            else:
+                summary_rows.append(("Sprint", "not set, no current iteration resolved"))
+        except Exception as error:
+            print(f"ERROR: board write failed: {error}")
+            summary_rows.append(("Board write", f"FAILED: {error}"))
+            failures.append(str(error))
     except Exception as error:
-        print(f"ERROR: board write failed: {error}")
-        summary_rows.append(("Board write", f"FAILED: {error}"))
+        print(f"ERROR: {error}")
+        summary_rows.append(("Failure", str(error)))
         failures.append(str(error))
-
-    write_step_summary(summary_rows)
+    finally:
+        write_step_summary(summary_rows)
 
     if failures:
         print(f"ERROR: {len(failures)} outcome(s) failed: {'; '.join(failures)}")

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -503,6 +503,7 @@ def handle_open_triage(action, pull_request, repo):
 
     board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
+    assignment_succeeded = True
     if decision["assign"]:
         try:
             github_token = os.environ["GITHUB_TOKEN"]
@@ -513,13 +514,18 @@ def handle_open_triage(action, pull_request, repo):
             print(f"ERROR: assignment failed: {error}")
             summary_rows.append(("Assignee set", f"FAILED: {error}"))
             failures.append(str(error))
+            assignment_succeeded = False
     elif decision["known"]:
         summary_rows.append(("Assignee set", "skipped, not required by decision"))
     else:
         summary_rows.append(("Assignee set", "skipped, unknown author is never assigned"))
 
+    # Assign-then-draft is a real dependency, not the chaining we removed elsewhere:
+    # claiming ownership is what force-to-draft means, so a failed assignment must
+    # leave the PR exactly as its author left it, boarded Review, not force-drafted
+    # and unowned. The board write below stays independent of both outcomes.
     actual_is_draft = is_draft
-    if decision["force_draft"]:
+    if decision["force_draft"] and assignment_succeeded:
         try:
             draft_result = convert_pr_to_draft(pr_node_id, board_token)
             actual_is_draft = draft_result["data"]["convertPullRequestToDraft"]["pullRequest"]["isDraft"]
@@ -528,6 +534,8 @@ def handle_open_triage(action, pull_request, repo):
             print(f"ERROR: convert-to-draft failed: {error}")
             summary_rows.append(("Converted to draft", f"FAILED: {error}"))
             failures.append(str(error))
+    elif decision["force_draft"] and not assignment_succeeded:
+        summary_rows.append(("Converted to draft", "skipped, assignment failed"))
     elif decision["known"]:
         summary_rows.append(("Converted to draft", "skipped, already draft"))
     else:

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -43,29 +43,20 @@ def check_assignment_succeeded(author_login, assign_result):
         )
 
 
-def decide(author_login, is_draft, mapping):
-    team = mapping.get(author_login)
-    known = bool(team) and bool(team.strip())
-    if not known:
-        return {
-            "known": False,
-            "assign": False,
-            "force_draft": False,
-            "team": UNKNOWN_AUTHOR_TEAM,
-        }
-    return {
-        "known": True,
-        "assign": True,
-        "force_draft": not is_draft,
-        "team": team,
-    }
-
-
-TRANSITION_ACTIONS = ("ready_for_review", "converted_to_draft", "reopened")
-
-
 def is_blank(value):
     return not value or not value.strip()
+
+
+def team_for(author_login, mapping):
+    team = mapping.get(author_login)
+    return None if is_blank(team) else team
+
+
+def decide(author_login, is_draft, mapping):
+    team = team_for(author_login, mapping)
+    if team is None:
+        return {"known": False, "force_draft": False, "team": UNKNOWN_AUTHOR_TEAM}
+    return {"known": True, "force_draft": not is_draft, "team": team}
 
 
 def target_status_from_draft_state(is_draft):
@@ -89,16 +80,18 @@ STATUS_MANAGED_VALUES = (STATUS_WORKING, STATUS_REVIEW)
 
 
 def decide_status(is_draft, current_status):
-    if is_blank(current_status) or strip_emoji_prefix(current_status) in STATUS_MANAGED_VALUES:
-        return target_status_from_draft_state(is_draft)
+    target = target_status_from_draft_state(is_draft)
+    if is_blank(current_status):
+        return target
+    current = strip_emoji_prefix(current_status)
+    if current == target:
+        return None
+    if current in STATUS_MANAGED_VALUES:
+        return target
     return None
 
 
-def decide_board_update(
-    action, is_draft, current_status, current_team, mapped_team, current_sprint=None, current_sprint_title=None
-):
-    if action not in TRANSITION_ACTIONS and action != "synchronize":
-        return None
+def decide_board_update(is_draft, current_status, current_team, mapped_team, current_sprint=None, current_sprint_title=None):
     return {
         "status": decide_status(is_draft, current_status),
         "team": mapped_team if is_blank(current_team) else None,
@@ -360,19 +353,78 @@ def write_step_summary(rows):
             handle.write(f"| {name} | {value} |\n")
 
 
-# One handler for every event whose only job is to move board fields, never the
-# assignee or the draft state: the three transitions and synchronize alike.
-# Status follows decide_status's one rule regardless of action (fill when
-# empty or already Working/Review, leave any other value alone); Team and
-# Sprint always fill only if empty. decide_board_update carries the whole
-# rule; this function is purely the I/O around it, so a future field slots
-# into SINGLE_SELECT_FIELD_SPECS without touching the fill-vs-overwrite logic.
+# Every event that touches the board (the three transitions, synchronize, and
+# opened) applies the one rule in decide_board_update: Status per decide_status,
+# Team and Sprint fill-only. Sprint's mutation shape differs from a single-select
+# (iterationId, not singleSelectOptionId), which is why it is written separately
+# below rather than through SINGLE_SELECT_FIELD_SPECS; a real fourth field would
+# still touch this table, current_values, FIELD_LABELS, and the write loop below.
+TRANSITION_ACTIONS = ("ready_for_review", "converted_to_draft", "reopened")
 BOARD_UPDATE_ACTIONS = TRANSITION_ACTIONS + ("synchronize",)
 
 SINGLE_SELECT_FIELD_SPECS = (
     ("status", STATUS_FIELD_ID, True, "Status"),
     ("team", TEAM_FIELD_ID, False, "Team"),
 )
+FIELD_LABELS = {"status": "Status", "team": "Team", "sprint": "Sprint"}
+
+
+def resolve_and_apply_board_fields(pr_node_id, existing_item, fields, current_values, current_iteration, board_token, summary_rows):
+    resolved_single_select = {}
+    for key, field_id, strip_emoji, _label in SINGLE_SELECT_FIELD_SPECS:
+        target_value = fields[key]
+        if target_value is not None:
+            options = fetch_project_field_options(field_id, board_token)
+            resolved_single_select[key] = (field_id, find_option_id_by_name(options, target_value, strip_emoji=strip_emoji))
+
+    sprint_iteration_id = current_iteration["id"] if (fields["sprint"] is not None and current_iteration) else None
+
+    if existing_item:
+        item_id = existing_item["id"]
+        summary_rows.append(("Board item", f"found existing item {item_id}"))
+    else:
+        item_id = add_item_to_project(pr_node_id, board_token)
+        summary_rows.append(("Board item", f"no existing item, added {item_id}"))
+
+    for key, label in FIELD_LABELS.items():
+        target_value = fields[key]
+        if target_value is None:
+            summary_rows.append((label, f"left as-is ({current_values[key]!r})"))
+        elif key == "sprint":
+            set_project_field_iteration(item_id, SPRINT_FIELD_ID, sprint_iteration_id, board_token)
+            summary_rows.append((f"{label} set", target_value))
+        else:
+            field_id, option_id = resolved_single_select[key]
+            set_project_field_option(item_id, field_id, option_id, board_token)
+            summary_rows.append((f"{label} set", target_value))
+
+    return item_id
+
+
+def resolve_board_state(pr_node_id, board_token):
+    """Looks up the item and, when needed, the current sprint. Returns
+    (existing_item, current_values, current_iteration)."""
+    existing_item = find_board_item_for_pr(pr_node_id, board_token)
+    current_values = {
+        "status": existing_item["status"] if existing_item else None,
+        "team": existing_item["team"] if existing_item else None,
+        "sprint": existing_item["sprint"] if existing_item else None,
+    }
+
+    current_iteration = None
+    if is_blank(current_values["sprint"]):
+        iterations = fetch_project_iterations(SPRINT_FIELD_ID, board_token)
+        current_iteration = find_current_iteration(iterations, current_date())
+
+    return existing_item, current_values, current_iteration
+
+
+def board_verdict(prefix, fields, current_values):
+    parts = [
+        f"{label} {fields[key] if fields[key] else f'left as {current_values[key]!r}'}"
+        for key, label in FIELD_LABELS.items()
+    ]
+    return f"{prefix} -> " + ", ".join(parts)
 
 
 def handle_board_update(action, pull_request):
@@ -383,7 +435,7 @@ def handle_board_update(action, pull_request):
 
     mapping_path = mapping_file_path(__file__)
     mapping = load_teams_mapping(mapping_path)
-    mapped_team = decide(author_login=author_login, is_draft=is_draft, mapping=mapping)["team"]
+    mapped_team = team_for(author_login, mapping) or UNKNOWN_AUTHOR_TEAM
 
     print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
 
@@ -396,69 +448,25 @@ def handle_board_update(action, pull_request):
     try:
         board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
-        existing_item = find_board_item_for_pr(pr_node_id, board_token)
-        current_status = existing_item["status"] if existing_item else None
-        current_team = existing_item["team"] if existing_item else None
-        current_sprint = existing_item["sprint"] if existing_item else None
-
-        iterations = fetch_project_iterations(SPRINT_FIELD_ID, board_token)
-        current_iteration = find_current_iteration(iterations, current_date())
+        existing_item, current_values, current_iteration = resolve_board_state(pr_node_id, board_token)
         current_sprint_title = current_iteration["title"] if current_iteration else None
 
         fields = decide_board_update(
-            action,
             is_draft,
-            current_status,
-            current_team,
+            current_values["status"],
+            current_values["team"],
             mapped_team,
-            current_sprint=current_sprint,
+            current_sprint=current_values["sprint"],
             current_sprint_title=current_sprint_title,
         )
 
-        verdict = (
-            f"{action} -> Status "
-            f"{fields['status'] if fields['status'] else f'left as {current_status!r}'}, Team "
-            f"{fields['team'] if fields['team'] else f'left as {current_team!r}'}, Sprint "
-            f"{fields['sprint'] if fields['sprint'] else f'left as {current_sprint!r}'}"
-        )
+        verdict = board_verdict(action, fields, current_values)
         print(f"verdict: {verdict}")
         summary_rows.append(("Verdict", verdict))
 
-        resolved_single_select = []
-        for key, field_id, strip_emoji, label in SINGLE_SELECT_FIELD_SPECS:
-            target_value = fields[key]
-            if target_value is None:
-                continue
-            options = fetch_project_field_options(field_id, board_token)
-            option_id = find_option_id_by_name(options, target_value, strip_emoji=strip_emoji)
-            resolved_single_select.append((field_id, option_id, label, target_value))
-
-        sprint_target = fields["sprint"]
-        if sprint_target is not None:
-            sprint_iteration_id = current_iteration["id"]
-
-        if existing_item:
-            item_id = existing_item["id"]
-            summary_rows.append(("Board item", f"found existing item {item_id}"))
-        else:
-            item_id = add_item_to_project(pr_node_id, board_token)
-            summary_rows.append(("Board item", f"no existing item, added {item_id}"))
-
-        for field_id, option_id, label, target_value in resolved_single_select:
-            set_project_field_option(item_id, field_id, option_id, board_token)
-            summary_rows.append((f"{label} set", target_value))
-
-        if sprint_target is not None:
-            set_project_field_iteration(item_id, SPRINT_FIELD_ID, sprint_iteration_id, board_token)
-            summary_rows.append(("Sprint set", sprint_target))
-
-        for key, current_value, label in (
-            ("status", current_status, "Status"),
-            ("team", current_team, "Team"),
-            ("sprint", current_sprint, "Sprint"),
-        ):
-            if fields[key] is None:
-                summary_rows.append((label, f"left as-is ({current_value!r})"))
+        resolve_and_apply_board_fields(
+            pr_node_id, existing_item, fields, current_values, current_iteration, board_token, summary_rows
+        )
 
         summary_rows.append(("Assignee", "not touched, deliberate, including when empty"))
         summary_rows.append(("Draft state", "not touched, deliberate"))
@@ -467,9 +475,6 @@ def handle_board_update(action, pull_request):
         raise
     finally:
         write_step_summary(summary_rows)
-
-
-OPEN_TRIAGE_ACTIONS = ("opened",)
 
 
 def handle_unrecognized_action(action, pull_request):
@@ -516,7 +521,7 @@ def handle_open_triage(action, pull_request, repo):
         board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
         assignment_succeeded = True
-        if decision["assign"]:
+        if decision["known"]:
             try:
                 github_token = os.environ["GITHUB_TOKEN"]
                 assign_result = assign_author(repo, pr_number, author_login, github_token)
@@ -551,42 +556,27 @@ def handle_open_triage(action, pull_request, repo):
         else:
             summary_rows.append(("Converted to draft", "skipped, draft state left untouched for unknown author"))
 
-        target_status = decide_status(actual_is_draft, current_status=None)
-
-        if decision["known"]:
-            verdict = f"known -> assign+draft+{target_status}/{decision['team']}"
-        else:
-            verdict = (
-                f"unknown (absent from .github/pr-triage-teams.yml) -> "
-                f"no assignee, draft untouched, boarded {target_status}/{decision['team']}"
-            )
-        print(f"verdict: {verdict}")
-        summary_rows.insert(3, ("Verdict", verdict))
-
         try:
-            status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
-            status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
+            existing_item, current_values, current_iteration = resolve_board_state(pr_node_id, board_token)
+            current_sprint_title = current_iteration["title"] if current_iteration else None
 
-            team_options = fetch_project_field_options(TEAM_FIELD_ID, board_token)
-            team_option_id = find_option_id_by_name(team_options, decision["team"], strip_emoji=False)
+            fields = decide_board_update(
+                actual_is_draft,
+                current_values["status"],
+                current_values["team"],
+                decision["team"],
+                current_sprint=current_values["sprint"],
+                current_sprint_title=current_sprint_title,
+            )
 
-            iterations = fetch_project_iterations(SPRINT_FIELD_ID, board_token)
-            current_iteration = find_current_iteration(iterations, current_date())
+            verdict_prefix = "known, assign+draft" if decision["known"] else "unknown (absent from .github/pr-triage-teams.yml), no assignee, draft untouched"
+            verdict = board_verdict(verdict_prefix, fields, current_values)
+            print(f"verdict: {verdict}")
+            summary_rows.insert(3, ("Verdict", verdict))
 
-            item_id = add_item_to_project(pr_node_id, board_token)
-            summary_rows.append(("Board item id", item_id))
-
-            set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
-            summary_rows.append(("Status option id written", status_option_id))
-
-            set_project_field_option(item_id, TEAM_FIELD_ID, team_option_id, board_token)
-            summary_rows.append(("Team option id written", team_option_id))
-
-            if current_iteration:
-                set_project_field_iteration(item_id, SPRINT_FIELD_ID, current_iteration["id"], board_token)
-                summary_rows.append(("Sprint option id written", current_iteration["id"]))
-            else:
-                summary_rows.append(("Sprint", "not set, no current iteration resolved"))
+            resolve_and_apply_board_fields(
+                pr_node_id, existing_item, fields, current_values, current_iteration, board_token, summary_rows
+            )
         except Exception as error:
             print(f"ERROR: board write failed: {error}")
             summary_rows.append(("Board write", f"FAILED: {error}"))
@@ -615,7 +605,7 @@ def main():
         handle_board_update(action, pull_request)
         return
 
-    if action not in OPEN_TRIAGE_ACTIONS:
+    if action != "opened":
         handle_unrecognized_action(action, pull_request)
         return
 

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -307,6 +307,56 @@ def handle_transition(action, transition, pull_request):
         write_step_summary(summary_rows)
 
 
+ADD_IF_MISSING_ACTIONS = ("synchronize",)
+
+
+def handle_add_if_missing(action, pull_request):
+    author_login = pull_request["user"]["login"]
+    head_branch = pull_request["head"]["ref"]
+    pr_node_id = pull_request["node_id"]
+    is_draft = pull_request["draft"]
+
+    summary_rows = [
+        ("Event/action", f"pull_request / {action}"),
+        ("Head branch", head_branch),
+        ("Author", author_login),
+    ]
+
+    try:
+        board_token = os.environ["PROJECT_BOARD_TOKEN"]
+
+        existing_item = find_board_item_for_pr(pr_node_id, board_token)
+        if existing_item:
+            verdict = f"already on board (item {existing_item['id']}) -> no action taken"
+            print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
+            print(f"verdict: {verdict}")
+            summary_rows.append(("Verdict", verdict))
+            summary_rows.append(("Board item", f"already exists as {existing_item['id']}, left untouched"))
+        else:
+            target_status = STATUS_WORKING if is_draft else STATUS_REVIEW
+            verdict = f"missing from board -> added, boarded {target_status} (Team, assignee and draft not touched)"
+            print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
+            print(f"verdict: {verdict}")
+            summary_rows.append(("Verdict", verdict))
+
+            status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
+            status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
+
+            item_id = add_item_to_project(pr_node_id, board_token)
+            summary_rows.append(("Board item", f"no existing item, added {item_id}"))
+
+            set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
+            summary_rows.append(("Status set", target_status))
+            summary_rows.append(("Team", "not touched, deliberate"))
+            summary_rows.append(("Assignee", "not touched, deliberate"))
+            summary_rows.append(("Draft state", "not touched, deliberate"))
+    except Exception as error:
+        summary_rows.append(("Failure", str(error)))
+        raise
+    finally:
+        write_step_summary(summary_rows)
+
+
 OPEN_TRIAGE_ACTIONS = ("opened",)
 
 
@@ -329,29 +379,12 @@ def handle_unrecognized_action(action, pull_request):
     )
 
 
-def main():
-    event_path = os.environ["GITHUB_EVENT_PATH"]
-    with open(event_path, encoding="utf-8") as handle:
-        event = json.load(handle)
-
-    action = event["action"]
-    pull_request = event["pull_request"]
-
-    transition = decide_transition(action, is_draft=pull_request.get("draft"))
-    if transition is not None:
-        handle_transition(action, transition, pull_request)
-        return
-
-    if action not in OPEN_TRIAGE_ACTIONS:
-        handle_unrecognized_action(action, pull_request)
-        return
-
+def handle_open_triage(action, pull_request, repo):
     author_login = pull_request["user"]["login"]
     head_branch = pull_request["head"]["ref"]
     pr_number = pull_request["number"]
     pr_node_id = pull_request["node_id"]
     is_draft = pull_request["draft"]
-    repo = event["repository"]["full_name"]
 
     mapping_path = mapping_file_path(__file__)
     mapping = load_teams_mapping(mapping_path)
@@ -375,31 +408,41 @@ def main():
         ("Author", author_login),
         ("Verdict", verdict),
     ]
+    failures = []
 
-    try:
-        board_token = os.environ["PROJECT_BOARD_TOKEN"]
+    board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
-        if decision["assign"]:
+    if decision["assign"]:
+        try:
             github_token = os.environ["GITHUB_TOKEN"]
             assign_result = assign_author(repo, pr_number, author_login, github_token)
             check_assignment_succeeded(author_login, assign_result)
             summary_rows.append(("Assignee set", True))
-        elif decision["known"]:
-            summary_rows.append(("Assignee set", "skipped, not required by decision"))
-        else:
-            summary_rows.append(("Assignee set", "skipped, unknown author is never assigned"))
+        except Exception as error:
+            print(f"ERROR: assignment failed: {error}")
+            summary_rows.append(("Assignee set", f"FAILED: {error}"))
+            failures.append(str(error))
+    elif decision["known"]:
+        summary_rows.append(("Assignee set", "skipped, not required by decision"))
+    else:
+        summary_rows.append(("Assignee set", "skipped, unknown author is never assigned"))
 
-        if decision["force_draft"]:
-            github_token = os.environ["GITHUB_TOKEN"]
-            draft_result = convert_pr_to_draft(pr_node_id, github_token)
+    if decision["force_draft"]:
+        try:
+            draft_result = convert_pr_to_draft(pr_node_id, board_token)
             summary_rows.append(
                 ("Converted to draft", draft_result["data"]["convertPullRequestToDraft"]["pullRequest"]["isDraft"])
             )
-        elif decision["known"]:
-            summary_rows.append(("Converted to draft", "skipped, already draft"))
-        else:
-            summary_rows.append(("Converted to draft", "skipped, draft state left untouched for unknown author"))
+        except Exception as error:
+            print(f"ERROR: convert-to-draft failed: {error}")
+            summary_rows.append(("Converted to draft", f"FAILED: {error}"))
+            failures.append(str(error))
+    elif decision["known"]:
+        summary_rows.append(("Converted to draft", "skipped, already draft"))
+    else:
+        summary_rows.append(("Converted to draft", "skipped, draft state left untouched for unknown author"))
 
+    try:
         status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
         status_option_id = find_option_id_by_name(status_options, decision["status"], strip_emoji=True)
 
@@ -415,10 +458,40 @@ def main():
         set_project_field_option(item_id, TEAM_FIELD_ID, team_option_id, board_token)
         summary_rows.append(("Team option id written", team_option_id))
     except Exception as error:
-        summary_rows.append(("Failure", str(error)))
-        raise
-    finally:
-        write_step_summary(summary_rows)
+        print(f"ERROR: board write failed: {error}")
+        summary_rows.append(("Board write", f"FAILED: {error}"))
+        failures.append(str(error))
+
+    write_step_summary(summary_rows)
+
+    if failures:
+        print(f"ERROR: {len(failures)} outcome(s) failed: {'; '.join(failures)}")
+        sys.exit(1)
+
+
+def main():
+    event_path = os.environ["GITHUB_EVENT_PATH"]
+    with open(event_path, encoding="utf-8") as handle:
+        event = json.load(handle)
+
+    action = event["action"]
+    pull_request = event["pull_request"]
+
+    transition = decide_transition(action, is_draft=pull_request.get("draft"))
+    if transition is not None:
+        handle_transition(action, transition, pull_request)
+        return
+
+    if action in ADD_IF_MISSING_ACTIONS:
+        handle_add_if_missing(action, pull_request)
+        return
+
+    if action not in OPEN_TRIAGE_ACTIONS:
+        handle_unrecognized_action(action, pull_request)
+        return
+
+    repo = event["repository"]["full_name"]
+    handle_open_triage(action, pull_request, repo)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -30,6 +30,19 @@ class GraphqlError(Exception):
     pass
 
 
+class AssignmentDroppedError(Exception):
+    pass
+
+
+def check_assignment_succeeded(author_login, assign_result):
+    assignee_logins = [assignee["login"] for assignee in assign_result.get("assignees", [])]
+    if author_login not in assignee_logins:
+        raise AssignmentDroppedError(
+            f"GitHub did not assign '{author_login}' (assignees after the call: {assignee_logins}). "
+            f"The login is probably no longer valid for assignment; .github/pr-triage-teams.yml is probably stale."
+        )
+
+
 def decide(author_login, is_draft, mapping):
     team = mapping.get(author_login)
     known = bool(team) and bool(team.strip())
@@ -50,11 +63,13 @@ def decide(author_login, is_draft, mapping):
     }
 
 
-def decide_transition(action):
+def decide_transition(action, is_draft=None):
     if action == "ready_for_review":
         return {"status": STATUS_REVIEW}
     if action == "converted_to_draft":
         return {"status": STATUS_WORKING}
+    if action == "reopened":
+        return {"status": STATUS_WORKING if is_draft else STATUS_REVIEW}
     return None
 
 
@@ -73,8 +88,8 @@ def find_option_id_by_name(options, target_name, strip_emoji):
     )
 
 
-def parse_teams_mapping(text):
-    mapping = {}
+def parse_teams_entries(text):
+    entries = []
     in_teams_block = False
     for raw_line in text.splitlines():
         line = raw_line.split("#", 1)[0].rstrip()
@@ -89,13 +104,21 @@ def parse_teams_mapping(text):
             in_teams_block = False
             continue
         key, _, value = line.strip().partition(":")
-        mapping[key.strip()] = value.strip()
-    return mapping
+        entries.append((key.strip(), value.strip()))
+    return entries
+
+
+def parse_teams_mapping(text):
+    return dict(parse_teams_entries(text))
 
 
 def load_teams_mapping(path):
     with open(path, encoding="utf-8") as handle:
         return parse_teams_mapping(handle.read())
+
+
+def mapping_file_path(pr_triage_file):
+    return os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(pr_triage_file))), "pr-triage-teams.yml")
 
 
 def http_request(url, token, method="GET", body=None):
@@ -284,7 +307,7 @@ def handle_transition(action, transition, pull_request):
         write_step_summary(summary_rows)
 
 
-OPEN_TRIAGE_ACTIONS = ("opened", "reopened")
+OPEN_TRIAGE_ACTIONS = ("opened",)
 
 
 def handle_unrecognized_action(action, pull_request):
@@ -314,7 +337,7 @@ def main():
     action = event["action"]
     pull_request = event["pull_request"]
 
-    transition = decide_transition(action)
+    transition = decide_transition(action, is_draft=pull_request.get("draft"))
     if transition is not None:
         handle_transition(action, transition, pull_request)
         return
@@ -330,7 +353,7 @@ def main():
     is_draft = pull_request["draft"]
     repo = event["repository"]["full_name"]
 
-    mapping_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "pr-triage-teams.yml")
+    mapping_path = mapping_file_path(__file__)
     mapping = load_teams_mapping(mapping_path)
 
     decision = decide(author_login=author_login, is_draft=is_draft, mapping=mapping)
@@ -359,9 +382,8 @@ def main():
         if decision["assign"]:
             github_token = os.environ["GITHUB_TOKEN"]
             assign_result = assign_author(repo, pr_number, author_login, github_token)
-            summary_rows.append(
-                ("Assignee set", author_login in [u["login"] for u in assign_result.get("assignees", [])])
-            )
+            check_assignment_succeeded(author_login, assign_result)
+            summary_rows.append(("Assignee set", True))
         elif decision["known"]:
             summary_rows.append(("Assignee set", "skipped, not required by decision"))
         else:

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -5,6 +5,7 @@ teams mapping in, an assign/draft/board verdict out. No network, no GitHub
 API, no environment reads. Everything below main() is I/O built on top of it.
 """
 
+import datetime
 import json
 import os
 import re
@@ -15,6 +16,7 @@ import urllib.request
 BOARD_PROJECT_ID = "PVT_kwDOABnCXs4AgIEx"
 STATUS_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgVUF6A"
 TEAM_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgbkzoM"
+SPRINT_FIELD_ID = "PVTIF_lADOABnCXs4AgIExzgavkek"
 STATUS_WORKING = "Working"
 STATUS_REVIEW = "Review"
 KNOWN_AUTHOR_STATUS = STATUS_WORKING
@@ -63,13 +65,45 @@ def decide(author_login, is_draft, mapping):
     }
 
 
-def decide_transition(action, is_draft=None):
+TRANSITION_ACTIONS = ("ready_for_review", "converted_to_draft", "reopened")
+
+
+def is_blank(value):
+    return not value or not value.strip()
+
+
+def target_status_from_draft_state(is_draft):
+    return STATUS_WORKING if is_draft else STATUS_REVIEW
+
+
+def current_date():
+    return datetime.date.today()
+
+
+def find_current_iteration(iterations, today):
+    for iteration in iterations:
+        start = datetime.date.fromisoformat(iteration["startDate"])
+        end = start + datetime.timedelta(days=iteration["duration"])
+        if start <= today < end:
+            return iteration
+    return None
+
+
+def decide_board_update(
+    action, is_draft, current_status, current_team, mapped_team, current_sprint=None, current_sprint_title=None
+):
+    team_fill = mapped_team if is_blank(current_team) else None
+    sprint_fill = current_sprint_title if (current_sprint_title and is_blank(current_sprint)) else None
+
     if action == "ready_for_review":
-        return {"status": STATUS_REVIEW}
+        return {"status": STATUS_REVIEW, "team": team_fill, "sprint": sprint_fill}
     if action == "converted_to_draft":
-        return {"status": STATUS_WORKING}
+        return {"status": STATUS_WORKING, "team": team_fill, "sprint": sprint_fill}
     if action == "reopened":
-        return {"status": STATUS_WORKING if is_draft else STATUS_REVIEW}
+        return {"status": target_status_from_draft_state(is_draft), "team": team_fill, "sprint": sprint_fill}
+    if action == "synchronize":
+        status_fill = target_status_from_draft_state(is_draft) if is_blank(current_status) else None
+        return {"status": status_fill, "team": team_fill, "sprint": sprint_fill}
     return None
 
 
@@ -192,8 +226,14 @@ def find_board_item_for_pr(pr_node_id, token):
             nodes {
               id
               project { id }
-              fieldValueByName(name: "Status") {
+              status: fieldValueByName(name: "Status") {
                 ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              team: fieldValueByName(name: "Team") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              sprint: fieldValueByName(name: "Sprint") {
+                ... on ProjectV2ItemFieldIterationValue { title }
               }
             }
           }
@@ -205,9 +245,15 @@ def find_board_item_for_pr(pr_node_id, token):
     nodes = result["data"]["node"]["projectItems"]["nodes"]
     for node in nodes:
         if node["project"]["id"] == BOARD_PROJECT_ID:
-            field_value = node["fieldValueByName"]
-            old_status = field_value["name"] if field_value else None
-            return {"id": node["id"], "old_status": old_status}
+            status_value = node["status"]
+            team_value = node["team"]
+            sprint_value = node["sprint"]
+            return {
+                "id": node["id"],
+                "status": status_value["name"] if status_value else None,
+                "team": team_value["name"] if team_value else None,
+                "sprint": sprint_value["title"] if sprint_value else None,
+            }
     return None
 
 
@@ -252,6 +298,49 @@ def fetch_project_field_options(field_id, token):
     return result["data"]["node"]["options"]
 
 
+def set_project_field_iteration(item_id, field_id, iteration_id, token):
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { iterationId: $iterationId }
+        }
+      ) {
+        projectV2Item { id }
+      }
+    }
+    """
+    return graphql_request(
+        query,
+        {
+            "projectId": BOARD_PROJECT_ID,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "iterationId": iteration_id,
+        },
+        token,
+    )
+
+
+def fetch_project_iterations(field_id, token):
+    query = """
+    query($fieldId: ID!) {
+      node(id: $fieldId) {
+        ... on ProjectV2IterationField {
+          configuration {
+            iterations { id title startDate duration }
+          }
+        }
+      }
+    }
+    """
+    result = graphql_request(query, {"fieldId": field_id}, token)
+    return result["data"]["node"]["configuration"]["iterations"]
+
+
 def write_step_summary(rows):
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if not summary_path:
@@ -262,60 +351,32 @@ def write_step_summary(rows):
             handle.write(f"| {name} | {value} |\n")
 
 
-def handle_transition(action, transition, pull_request):
-    author_login = pull_request["user"]["login"]
-    head_branch = pull_request["head"]["ref"]
-    pr_node_id = pull_request["node_id"]
-    target_status = transition["status"]
+# One handler for every event whose only job is to move board fields, never the
+# assignee or the draft state: the three transitions (which set Status outright
+# and fill Team/Sprint only if empty) and synchronize (which fills all three
+# only if empty). decide_board_update carries the difference; this function is
+# purely the I/O around it, so a future field slots into SINGLE_SELECT_FIELD_SPECS
+# without touching the fill-vs-overwrite logic.
+BOARD_UPDATE_ACTIONS = TRANSITION_ACTIONS + ("synchronize",)
 
-    verdict = f"transition -> Status {target_status} only (Team and assignee left untouched)"
-
-    print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
-    print(f"verdict: {verdict}")
-
-    summary_rows = [
-        ("Event/action", f"pull_request / {action}"),
-        ("Head branch", head_branch),
-        ("Author", author_login),
-        ("Verdict", verdict),
-    ]
-
-    try:
-        board_token = os.environ["PROJECT_BOARD_TOKEN"]
-
-        status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
-        status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
-
-        existing_item = find_board_item_for_pr(pr_node_id, board_token)
-        if existing_item:
-            item_id = existing_item["id"]
-            summary_rows.append(("Board item", f"found existing item {item_id}"))
-            summary_rows.append(("Status before", existing_item["old_status"]))
-        else:
-            item_id = add_item_to_project(pr_node_id, board_token)
-            summary_rows.append(("Board item", f"no existing item, added {item_id}"))
-            summary_rows.append(("Status before", "none, item just added"))
-
-        set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
-        summary_rows.append(("Status after", target_status))
-        summary_rows.append(("Team", "not touched, deliberate"))
-        summary_rows.append(("Assignee", "not touched, deliberate, including when empty"))
-    except Exception as error:
-        summary_rows.append(("Failure", str(error)))
-        raise
-    finally:
-        write_step_summary(summary_rows)
+SINGLE_SELECT_FIELD_SPECS = (
+    ("status", STATUS_FIELD_ID, True, "Status"),
+    ("team", TEAM_FIELD_ID, False, "Team"),
+)
 
 
-ADD_IF_MISSING_ACTIONS = ("synchronize",)
-
-
-def handle_add_if_missing(action, pull_request):
+def handle_board_update(action, pull_request):
     author_login = pull_request["user"]["login"]
     head_branch = pull_request["head"]["ref"]
     pr_node_id = pull_request["node_id"]
     is_draft = pull_request["draft"]
 
+    mapping_path = mapping_file_path(__file__)
+    mapping = load_teams_mapping(mapping_path)
+    mapped_team = decide(author_login=author_login, is_draft=is_draft, mapping=mapping)["team"]
+
+    print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
+
     summary_rows = [
         ("Event/action", f"pull_request / {action}"),
         ("Head branch", head_branch),
@@ -326,30 +387,71 @@ def handle_add_if_missing(action, pull_request):
         board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
         existing_item = find_board_item_for_pr(pr_node_id, board_token)
+        current_status = existing_item["status"] if existing_item else None
+        current_team = existing_item["team"] if existing_item else None
+        current_sprint = existing_item["sprint"] if existing_item else None
+
+        iterations = fetch_project_iterations(SPRINT_FIELD_ID, board_token)
+        current_iteration = find_current_iteration(iterations, current_date())
+        current_sprint_title = current_iteration["title"] if current_iteration else None
+
+        fields = decide_board_update(
+            action,
+            is_draft,
+            current_status,
+            current_team,
+            mapped_team,
+            current_sprint=current_sprint,
+            current_sprint_title=current_sprint_title,
+        )
+
+        verdict = (
+            f"{action} -> Status "
+            f"{fields['status'] if fields['status'] else f'left as {current_status!r}'}, Team "
+            f"{fields['team'] if fields['team'] else f'left as {current_team!r}'}, Sprint "
+            f"{fields['sprint'] if fields['sprint'] else f'left as {current_sprint!r}'}"
+        )
+        print(f"verdict: {verdict}")
+        summary_rows.append(("Verdict", verdict))
+
+        resolved_single_select = []
+        for key, field_id, strip_emoji, label in SINGLE_SELECT_FIELD_SPECS:
+            target_value = fields[key]
+            if target_value is None:
+                continue
+            options = fetch_project_field_options(field_id, board_token)
+            option_id = find_option_id_by_name(options, target_value, strip_emoji=strip_emoji)
+            resolved_single_select.append((field_id, option_id, label, target_value))
+
+        sprint_target = fields["sprint"]
+        if sprint_target is not None:
+            sprint_iteration_id = current_iteration["id"]
+
         if existing_item:
-            verdict = f"already on board (item {existing_item['id']}) -> no action taken"
-            print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
-            print(f"verdict: {verdict}")
-            summary_rows.append(("Verdict", verdict))
-            summary_rows.append(("Board item", f"already exists as {existing_item['id']}, left untouched"))
+            item_id = existing_item["id"]
+            summary_rows.append(("Board item", f"found existing item {item_id}"))
         else:
-            target_status = STATUS_WORKING if is_draft else STATUS_REVIEW
-            verdict = f"missing from board -> added, boarded {target_status} (Team, assignee and draft not touched)"
-            print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
-            print(f"verdict: {verdict}")
-            summary_rows.append(("Verdict", verdict))
-
-            status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
-            status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
-
             item_id = add_item_to_project(pr_node_id, board_token)
             summary_rows.append(("Board item", f"no existing item, added {item_id}"))
 
-            set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
-            summary_rows.append(("Status set", target_status))
-            summary_rows.append(("Team", "not touched, deliberate"))
-            summary_rows.append(("Assignee", "not touched, deliberate"))
-            summary_rows.append(("Draft state", "not touched, deliberate"))
+        for field_id, option_id, label, target_value in resolved_single_select:
+            set_project_field_option(item_id, field_id, option_id, board_token)
+            summary_rows.append((f"{label} set", target_value))
+
+        if sprint_target is not None:
+            set_project_field_iteration(item_id, SPRINT_FIELD_ID, sprint_iteration_id, board_token)
+            summary_rows.append(("Sprint set", sprint_target))
+
+        for key, current_value, label in (
+            ("status", current_status, "Status"),
+            ("team", current_team, "Team"),
+            ("sprint", current_sprint, "Sprint"),
+        ):
+            if fields[key] is None:
+                summary_rows.append((label, f"left as-is ({current_value!r})"))
+
+        summary_rows.append(("Assignee", "not touched, deliberate, including when empty"))
+        summary_rows.append(("Draft state", "not touched, deliberate"))
     except Exception as error:
         summary_rows.append(("Failure", str(error)))
         raise
@@ -477,13 +579,8 @@ def main():
     action = event["action"]
     pull_request = event["pull_request"]
 
-    transition = decide_transition(action, is_draft=pull_request.get("draft"))
-    if transition is not None:
-        handle_transition(action, transition, pull_request)
-        return
-
-    if action in ADD_IF_MISSING_ACTIONS:
-        handle_add_if_missing(action, pull_request)
+    if action in BOARD_UPDATE_ACTIONS:
+        handle_board_update(action, pull_request)
         return
 
     if action not in OPEN_TRIAGE_ACTIONS:

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -15,8 +15,10 @@ import urllib.request
 BOARD_PROJECT_ID = "PVT_kwDOABnCXs4AgIEx"
 STATUS_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgVUF6A"
 TEAM_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgbkzoM"
-KNOWN_AUTHOR_STATUS = "Working"
-UNKNOWN_AUTHOR_STATUS = "Review"
+STATUS_WORKING = "Working"
+STATUS_REVIEW = "Review"
+KNOWN_AUTHOR_STATUS = STATUS_WORKING
+UNKNOWN_AUTHOR_STATUS = STATUS_REVIEW
 UNKNOWN_AUTHOR_TEAM = "Dev"
 
 GITHUB_API_URL = "https://api.github.com"
@@ -50,9 +52,9 @@ def decide(author_login, is_draft, mapping):
 
 def decide_transition(action):
     if action == "ready_for_review":
-        return {"status": UNKNOWN_AUTHOR_STATUS}
+        return {"status": STATUS_REVIEW}
     if action == "converted_to_draft":
-        return {"status": KNOWN_AUTHOR_STATUS}
+        return {"status": STATUS_WORKING}
     return None
 
 
@@ -163,7 +165,7 @@ def find_board_item_for_pr(pr_node_id, token):
     query($contentId: ID!) {
       node(id: $contentId) {
         ... on PullRequest {
-          projectItems(first: 20) {
+          projectItems(first: 100) {
             nodes {
               id
               project { id }
@@ -258,6 +260,9 @@ def handle_transition(action, transition, pull_request):
     try:
         board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
+        status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
+        status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
+
         existing_item = find_board_item_for_pr(pr_node_id, board_token)
         if existing_item:
             item_id = existing_item["id"]
@@ -268,8 +273,6 @@ def handle_transition(action, transition, pull_request):
             summary_rows.append(("Board item", f"no existing item, added {item_id}"))
             summary_rows.append(("Status before", "none, item just added"))
 
-        status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
-        status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
         set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
         summary_rows.append(("Status after", target_status))
         summary_rows.append(("Team", "not touched, deliberate"))
@@ -279,6 +282,28 @@ def handle_transition(action, transition, pull_request):
         raise
     finally:
         write_step_summary(summary_rows)
+
+
+OPEN_TRIAGE_ACTIONS = ("opened", "reopened")
+
+
+def handle_unrecognized_action(action, pull_request):
+    author_login = pull_request["user"]["login"]
+    head_branch = pull_request["head"]["ref"]
+
+    verdict = f"unrecognized action '{action}' -> no action taken"
+
+    print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
+    print(f"verdict: {verdict}")
+
+    write_step_summary(
+        [
+            ("Event/action", f"pull_request / {action}"),
+            ("Head branch", head_branch),
+            ("Author", author_login),
+            ("Verdict", verdict),
+        ]
+    )
 
 
 def main():
@@ -292,6 +317,10 @@ def main():
     transition = decide_transition(action)
     if transition is not None:
         handle_transition(action, transition, pull_request)
+        return
+
+    if action not in OPEN_TRIAGE_ACTIONS:
+        handle_unrecognized_action(action, pull_request)
         return
 
     author_login = pull_request["user"]["login"]

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -1,0 +1,374 @@
+"""Decides what to do with a pull request on open/reopen, and does the writes.
+
+The decision (decide) is pure: author login + current draft state + the loaded
+teams mapping in, an assign/draft/board verdict out. No network, no GitHub
+API, no environment reads. Everything below main() is I/O built on top of it.
+"""
+
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+BOARD_PROJECT_ID = "PVT_kwDOABnCXs4AgIEx"
+STATUS_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgVUF6A"
+TEAM_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgbkzoM"
+KNOWN_AUTHOR_STATUS = "Working"
+UNKNOWN_AUTHOR_STATUS = "Review"
+UNKNOWN_AUTHOR_TEAM = "Dev"
+
+GITHUB_API_URL = "https://api.github.com"
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+HTTP_TIMEOUT_SECONDS = 30
+
+
+class GraphqlError(Exception):
+    pass
+
+
+def decide(author_login, is_draft, mapping):
+    team = mapping.get(author_login)
+    known = bool(team) and bool(team.strip())
+    if not known:
+        return {
+            "known": False,
+            "assign": False,
+            "force_draft": False,
+            "status": UNKNOWN_AUTHOR_STATUS,
+            "team": UNKNOWN_AUTHOR_TEAM,
+        }
+    return {
+        "known": True,
+        "assign": True,
+        "force_draft": not is_draft,
+        "status": KNOWN_AUTHOR_STATUS,
+        "team": team,
+    }
+
+
+def decide_transition(action):
+    if action == "ready_for_review":
+        return {"status": UNKNOWN_AUTHOR_STATUS}
+    if action == "converted_to_draft":
+        return {"status": KNOWN_AUTHOR_STATUS}
+    return None
+
+
+def strip_emoji_prefix(name):
+    return re.sub(r"^[^\w]+", "", name).strip()
+
+
+def find_option_id_by_name(options, target_name, strip_emoji):
+    for option in options:
+        candidate = strip_emoji_prefix(option["name"]) if strip_emoji else option["name"]
+        if candidate == target_name:
+            return option["id"]
+    available = ", ".join(f'{o["name"]!r} ({o["id"]})' for o in options)
+    raise ValueError(
+        f"'{target_name}' does not match any live board option. Available options: {available}"
+    )
+
+
+def parse_teams_mapping(text):
+    mapping = {}
+    in_teams_block = False
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if line.strip() == "teams:":
+            in_teams_block = True
+            continue
+        if not in_teams_block:
+            continue
+        if not line.startswith((" ", "\t")):
+            in_teams_block = False
+            continue
+        key, _, value = line.strip().partition(":")
+        mapping[key.strip()] = value.strip()
+    return mapping
+
+
+def load_teams_mapping(path):
+    with open(path, encoding="utf-8") as handle:
+        return parse_teams_mapping(handle.read())
+
+
+def http_request(url, token, method="GET", body=None):
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", "application/vnd.github+json")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        print(f"GitHub API error {error.code} for {method} {url}: {error.read().decode('utf-8')}")
+        raise
+
+
+def graphql_request(query, variables, token):
+    result = http_request(
+        GITHUB_GRAPHQL_URL,
+        token,
+        method="POST",
+        body={"query": query, "variables": variables},
+    )
+    errors = result.get("errors")
+    if errors:
+        raise GraphqlError(f"GraphQL request returned errors: {errors}")
+    return result
+
+
+def assign_author(repo, pr_number, author_login, token):
+    return http_request(
+        f"{GITHUB_API_URL}/repos/{repo}/issues/{pr_number}/assignees",
+        token,
+        method="POST",
+        body={"assignees": [author_login]},
+    )
+
+
+def convert_pr_to_draft(pr_node_id, token):
+    query = """
+    mutation($pullRequestId: ID!) {
+      convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+        pullRequest { id isDraft }
+      }
+    }
+    """
+    return graphql_request(query, {"pullRequestId": pr_node_id}, token)
+
+
+def add_item_to_project(pr_node_id, token):
+    query = """
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }
+    """
+    result = graphql_request(
+        query, {"projectId": BOARD_PROJECT_ID, "contentId": pr_node_id}, token
+    )
+    return result["data"]["addProjectV2ItemById"]["item"]["id"]
+
+
+def find_board_item_for_pr(pr_node_id, token):
+    query = """
+    query($contentId: ID!) {
+      node(id: $contentId) {
+        ... on PullRequest {
+          projectItems(first: 20) {
+            nodes {
+              id
+              project { id }
+              fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    result = graphql_request(query, {"contentId": pr_node_id}, token)
+    nodes = result["data"]["node"]["projectItems"]["nodes"]
+    for node in nodes:
+        if node["project"]["id"] == BOARD_PROJECT_ID:
+            field_value = node["fieldValueByName"]
+            old_status = field_value["name"] if field_value else None
+            return {"id": node["id"], "old_status": old_status}
+    return None
+
+
+def set_project_field_option(item_id, field_id, option_id, token):
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { singleSelectOptionId: $optionId }
+        }
+      ) {
+        projectV2Item { id }
+      }
+    }
+    """
+    return graphql_request(
+        query,
+        {
+            "projectId": BOARD_PROJECT_ID,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+        token,
+    )
+
+
+def fetch_project_field_options(field_id, token):
+    query = """
+    query($fieldId: ID!) {
+      node(id: $fieldId) {
+        ... on ProjectV2SingleSelectField {
+          options { id name }
+        }
+      }
+    }
+    """
+    result = graphql_request(query, {"fieldId": field_id}, token)
+    return result["data"]["node"]["options"]
+
+
+def write_step_summary(rows):
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if not summary_path:
+        return
+    with open(summary_path, "a", encoding="utf-8") as handle:
+        handle.write("### PR triage\n\n| Fact | Value |\n|---|---|\n")
+        for name, value in rows:
+            handle.write(f"| {name} | {value} |\n")
+
+
+def handle_transition(action, transition, pull_request):
+    author_login = pull_request["user"]["login"]
+    head_branch = pull_request["head"]["ref"]
+    pr_node_id = pull_request["node_id"]
+    target_status = transition["status"]
+
+    verdict = f"transition -> Status {target_status} only (Team and assignee left untouched)"
+
+    print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
+    print(f"verdict: {verdict}")
+
+    summary_rows = [
+        ("Event/action", f"pull_request / {action}"),
+        ("Head branch", head_branch),
+        ("Author", author_login),
+        ("Verdict", verdict),
+    ]
+
+    try:
+        board_token = os.environ["PROJECT_BOARD_TOKEN"]
+
+        existing_item = find_board_item_for_pr(pr_node_id, board_token)
+        if existing_item:
+            item_id = existing_item["id"]
+            summary_rows.append(("Board item", f"found existing item {item_id}"))
+            summary_rows.append(("Status before", existing_item["old_status"]))
+        else:
+            item_id = add_item_to_project(pr_node_id, board_token)
+            summary_rows.append(("Board item", f"no existing item, added {item_id}"))
+            summary_rows.append(("Status before", "none, item just added"))
+
+        status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
+        status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
+        set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
+        summary_rows.append(("Status after", target_status))
+        summary_rows.append(("Team", "not touched, deliberate"))
+        summary_rows.append(("Assignee", "not touched, deliberate, including when empty"))
+    except Exception as error:
+        summary_rows.append(("Failure", str(error)))
+        raise
+    finally:
+        write_step_summary(summary_rows)
+
+
+def main():
+    event_path = os.environ["GITHUB_EVENT_PATH"]
+    with open(event_path, encoding="utf-8") as handle:
+        event = json.load(handle)
+
+    action = event["action"]
+    pull_request = event["pull_request"]
+
+    transition = decide_transition(action)
+    if transition is not None:
+        handle_transition(action, transition, pull_request)
+        return
+
+    author_login = pull_request["user"]["login"]
+    head_branch = pull_request["head"]["ref"]
+    pr_number = pull_request["number"]
+    pr_node_id = pull_request["node_id"]
+    is_draft = pull_request["draft"]
+    repo = event["repository"]["full_name"]
+
+    mapping_path = os.path.join(os.path.dirname(os.path.dirname(__file__)), "pr-triage-teams.yml")
+    mapping = load_teams_mapping(mapping_path)
+
+    decision = decide(author_login=author_login, is_draft=is_draft, mapping=mapping)
+
+    if decision["known"]:
+        verdict = f"known -> assign+draft+{decision['status']}/{decision['team']}"
+    else:
+        verdict = (
+            f"unknown (absent from .github/pr-triage-teams.yml) -> "
+            f"no assignee, draft untouched, boarded {decision['status']}/{decision['team']}"
+        )
+
+    print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
+    print(f"verdict: {verdict}")
+
+    summary_rows = [
+        ("Event/action", f"pull_request / {action}"),
+        ("Head branch", head_branch),
+        ("Author", author_login),
+        ("Verdict", verdict),
+    ]
+
+    try:
+        board_token = os.environ["PROJECT_BOARD_TOKEN"]
+
+        if decision["assign"]:
+            github_token = os.environ["GITHUB_TOKEN"]
+            assign_result = assign_author(repo, pr_number, author_login, github_token)
+            summary_rows.append(
+                ("Assignee set", author_login in [u["login"] for u in assign_result.get("assignees", [])])
+            )
+        elif decision["known"]:
+            summary_rows.append(("Assignee set", "skipped, not required by decision"))
+        else:
+            summary_rows.append(("Assignee set", "skipped, unknown author is never assigned"))
+
+        if decision["force_draft"]:
+            github_token = os.environ["GITHUB_TOKEN"]
+            draft_result = convert_pr_to_draft(pr_node_id, github_token)
+            summary_rows.append(
+                ("Converted to draft", draft_result["data"]["convertPullRequestToDraft"]["pullRequest"]["isDraft"])
+            )
+        elif decision["known"]:
+            summary_rows.append(("Converted to draft", "skipped, already draft"))
+        else:
+            summary_rows.append(("Converted to draft", "skipped, draft state left untouched for unknown author"))
+
+        status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
+        status_option_id = find_option_id_by_name(status_options, decision["status"], strip_emoji=True)
+
+        team_options = fetch_project_field_options(TEAM_FIELD_ID, board_token)
+        team_option_id = find_option_id_by_name(team_options, decision["team"], strip_emoji=False)
+
+        item_id = add_item_to_project(pr_node_id, board_token)
+        summary_rows.append(("Board item id", item_id))
+
+        set_project_field_option(item_id, STATUS_FIELD_ID, status_option_id, board_token)
+        summary_rows.append(("Status option id written", status_option_id))
+
+        set_project_field_option(item_id, TEAM_FIELD_ID, team_option_id, board_token)
+        summary_rows.append(("Team option id written", team_option_id))
+    except Exception as error:
+        summary_rows.append(("Failure", str(error)))
+        raise
+    finally:
+        write_step_summary(summary_rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -19,8 +19,6 @@ TEAM_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgbkzoM"
 SPRINT_FIELD_ID = "PVTIF_lADOABnCXs4AgIExzgavkek"
 STATUS_WORKING = "Working"
 STATUS_REVIEW = "Review"
-KNOWN_AUTHOR_STATUS = STATUS_WORKING
-UNKNOWN_AUTHOR_STATUS = STATUS_REVIEW
 UNKNOWN_AUTHOR_TEAM = "Dev"
 
 GITHUB_API_URL = "https://api.github.com"
@@ -53,14 +51,12 @@ def decide(author_login, is_draft, mapping):
             "known": False,
             "assign": False,
             "force_draft": False,
-            "status": UNKNOWN_AUTHOR_STATUS,
             "team": UNKNOWN_AUTHOR_TEAM,
         }
     return {
         "known": True,
         "assign": True,
         "force_draft": not is_draft,
-        "status": KNOWN_AUTHOR_STATUS,
         "team": team,
     }
 
@@ -89,22 +85,25 @@ def find_current_iteration(iterations, today):
     return None
 
 
+STATUS_MANAGED_VALUES = (STATUS_WORKING, STATUS_REVIEW)
+
+
+def decide_status(is_draft, current_status):
+    if is_blank(current_status) or strip_emoji_prefix(current_status) in STATUS_MANAGED_VALUES:
+        return target_status_from_draft_state(is_draft)
+    return None
+
+
 def decide_board_update(
     action, is_draft, current_status, current_team, mapped_team, current_sprint=None, current_sprint_title=None
 ):
-    team_fill = mapped_team if is_blank(current_team) else None
-    sprint_fill = current_sprint_title if (current_sprint_title and is_blank(current_sprint)) else None
-
-    if action == "ready_for_review":
-        return {"status": STATUS_REVIEW, "team": team_fill, "sprint": sprint_fill}
-    if action == "converted_to_draft":
-        return {"status": STATUS_WORKING, "team": team_fill, "sprint": sprint_fill}
-    if action == "reopened":
-        return {"status": target_status_from_draft_state(is_draft), "team": team_fill, "sprint": sprint_fill}
-    if action == "synchronize":
-        status_fill = target_status_from_draft_state(is_draft) if is_blank(current_status) else None
-        return {"status": status_fill, "team": team_fill, "sprint": sprint_fill}
-    return None
+    if action not in TRANSITION_ACTIONS and action != "synchronize":
+        return None
+    return {
+        "status": decide_status(is_draft, current_status),
+        "team": mapped_team if is_blank(current_team) else None,
+        "sprint": current_sprint_title if (current_sprint_title and is_blank(current_sprint)) else None,
+    }
 
 
 def strip_emoji_prefix(name):
@@ -493,22 +492,12 @@ def handle_open_triage(action, pull_request, repo):
 
     decision = decide(author_login=author_login, is_draft=is_draft, mapping=mapping)
 
-    if decision["known"]:
-        verdict = f"known -> assign+draft+{decision['status']}/{decision['team']}"
-    else:
-        verdict = (
-            f"unknown (absent from .github/pr-triage-teams.yml) -> "
-            f"no assignee, draft untouched, boarded {decision['status']}/{decision['team']}"
-        )
-
     print(f"event=pull_request action={action} head_branch={head_branch} author={author_login}")
-    print(f"verdict: {verdict}")
 
     summary_rows = [
         ("Event/action", f"pull_request / {action}"),
         ("Head branch", head_branch),
         ("Author", author_login),
-        ("Verdict", verdict),
     ]
     failures = []
 
@@ -529,12 +518,12 @@ def handle_open_triage(action, pull_request, repo):
     else:
         summary_rows.append(("Assignee set", "skipped, unknown author is never assigned"))
 
+    actual_is_draft = is_draft
     if decision["force_draft"]:
         try:
             draft_result = convert_pr_to_draft(pr_node_id, board_token)
-            summary_rows.append(
-                ("Converted to draft", draft_result["data"]["convertPullRequestToDraft"]["pullRequest"]["isDraft"])
-            )
+            actual_is_draft = draft_result["data"]["convertPullRequestToDraft"]["pullRequest"]["isDraft"]
+            summary_rows.append(("Converted to draft", actual_is_draft))
         except Exception as error:
             print(f"ERROR: convert-to-draft failed: {error}")
             summary_rows.append(("Converted to draft", f"FAILED: {error}"))
@@ -544,9 +533,21 @@ def handle_open_triage(action, pull_request, repo):
     else:
         summary_rows.append(("Converted to draft", "skipped, draft state left untouched for unknown author"))
 
+    target_status = decide_status(actual_is_draft, current_status=None)
+
+    if decision["known"]:
+        verdict = f"known -> assign+draft+{target_status}/{decision['team']}"
+    else:
+        verdict = (
+            f"unknown (absent from .github/pr-triage-teams.yml) -> "
+            f"no assignee, draft untouched, boarded {target_status}/{decision['team']}"
+        )
+    print(f"verdict: {verdict}")
+    summary_rows.insert(3, ("Verdict", verdict))
+
     try:
         status_options = fetch_project_field_options(STATUS_FIELD_ID, board_token)
-        status_option_id = find_option_id_by_name(status_options, decision["status"], strip_emoji=True)
+        status_option_id = find_option_id_by_name(status_options, target_status, strip_emoji=True)
 
         team_options = fetch_project_field_options(TEAM_FIELD_ID, board_token)
         team_option_id = find_option_id_by_name(team_options, decision["team"], strip_emoji=False)

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -99,6 +99,77 @@ def decide_board_update(is_draft, current_status, current_team, mapped_team, cur
     }
 
 
+def keyword_closing_issues(all_closing_issues, user_linked_issues):
+    """Aim 6 redirects only on a KEYWORD-derived closing reference
+    (close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved in the PR
+    body) [owner ruling, narrowing the original "closingIssuesReferences
+    reports it, so it counts" reading]. An issue linked only by hand through
+    GitHub's Development sidebar, with no keyword in the body, does NOT
+    redirect -- `Addresses: <url>` is a real habit in this repo, used
+    deliberately to link without auto-closing.
+
+    GitHub's closingIssuesReferences field reports both kinds together;
+    userLinkedOnly=true reports only the hand-linked ones. Keyword-derived is
+    therefore `all_closing_issues` minus `user_linked_issues`, matched by
+    node id -- verified against two real PRs of each shape, see
+    notes/github-facts.md §8."""
+    user_linked_ids = {issue["id"] for issue in user_linked_issues}
+    return [issue for issue in all_closing_issues if issue["id"] not in user_linked_ids]
+
+
+def decide_redirect_to_issues(closing_issues):
+    """Aim 6: a PR that closes at least one issue gets no card of its own --
+    every linked issue's card is written instead. An empty list changes
+    nothing; the PR is boarded exactly as it always was."""
+    return bool(closing_issues)
+
+
+def decide_remove_pr_card(closing_issues, existing_pr_item):
+    """The story's one removal: unconditional, and narrow. True exactly when
+    the PR closes at least one issue AND the PR already has an item on board
+    15 -- never guarded by that item's Status or fields, and never true for
+    an issue's item, which this is never called with. "Removal" is
+    board-only: the card comes off board 15, nothing about the PR itself
+    changes.
+
+    Deliberately action-blind: this function does not know synchronize is
+    excluded from removal. That exclusion lives in the one call site,
+    apply_board_write's `action not in PR_CARD_REMOVAL_ACTIONS` guard --
+    apply_redirected_board_write (and this function) are never reached for
+    synchronize at all. If a second caller is ever added, that guard has to
+    move or be duplicated; it does not enforce itself here."""
+    return decide_redirect_to_issues(closing_issues) and existing_pr_item is not None
+
+
+def decide_issue_card_update(action, is_draft, existing_issue_item, mapped_team, current_sprint_title):
+    """Pure decision for ONE linked issue's card. existing_issue_item is None
+    when the issue has no item yet on board 15.
+
+    - `synchronize` never touches a linked issue's card at all -- existing or
+      missing, this returns None.
+    - `edited` never touches an EXISTING issue card (Status is not moved by a
+      body edit), but still adds and fills a missing one, because a PR with
+      no card and an issue with no card is the one outcome no aim tolerates.
+      Status is left unwritten on the card it adds -- only opened and the
+      three transitions ever move a linked issue's Status.
+    - `opened` and the three transitions set Status only on an existing card
+      (Team and Sprint stay exactly as a person left them), and fill all
+      three -- Status, Team, Sprint -- on a card they add.
+
+    Returns None for "write nothing", otherwise a fields dict shaped like
+    resolve_and_apply_board_fields expects: {"status", "team", "sprint"},
+    each either a target value or None meaning "leave as-is"."""
+    if existing_issue_item is not None:
+        if action not in ISSUE_STATUS_ACTIONS:
+            return None
+        return {"status": decide_status(is_draft, existing_issue_item["status"]), "team": None, "sprint": None}
+
+    if action not in ISSUE_STATUS_ACTIONS and action not in ISSUE_ADD_ONLY_ACTIONS:
+        return None
+    status = target_status_from_draft_state(is_draft) if action in ISSUE_STATUS_ACTIONS else None
+    return {"status": status, "team": mapped_team, "sprint": current_sprint_title}
+
+
 def strip_emoji_prefix(name):
     return re.sub(r"^[^\w]+", "", name).strip()
 
@@ -219,44 +290,88 @@ def add_item_to_project(pr_node_id, token):
     return result["data"]["addProjectV2ItemById"]["item"]["id"]
 
 
-def find_board_item_for_pr(pr_node_id, token):
+def remove_item_from_board(item_id, token):
+    """The story's one removal (aim 6): a PR's own CARD on board 15, removed
+    unconditionally the moment the PR closes an issue and already has one --
+    no guard on its Status or fields. This removes the board item only,
+    nothing about the pull request itself; the GraphQL mutation is still
+    named deleteProjectV2Item (GitHub's name, not ours). Never call this with
+    an issue's item id; an issue's card is never removed by anything in this
+    workflow."""
+    query = """
+    mutation($projectId: ID!, $itemId: ID!) {
+      deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
+        deletedItemId
+      }
+    }
+    """
+    return graphql_request(query, {"projectId": BOARD_PROJECT_ID, "itemId": item_id}, token)
+
+
+def find_board_item_for_pr(content_id, token):
+    """Resolves a content node's (PullRequest or Issue) item on board 15, plus
+    -- for a PullRequest only -- the issues it closes by a BODY KEYWORD
+    (close/closes/fixes/resolves/... ). Both content kinds share the
+    identical projectItems shape, so the fragment is factored into
+    ProjectItemFields; closingIssuesReferences exists only on PullRequest, and
+    riding both the unfiltered and userLinkedOnly variants on this same query
+    costs no extra round trip. keyword_closing_issues does the split -- see
+    notes/github-facts.md §8. Returns {"item": item-or-None, "closing_issues":
+    [{"id", "number"}, ...]} -- closing_issues is always [] for an Issue node."""
     query = """
     query($contentId: ID!) {
       node(id: $contentId) {
         ... on PullRequest {
-          projectItems(first: 100) {
-            nodes {
-              id
-              project { id }
-              status: fieldValueByName(name: "Status") {
-                ... on ProjectV2ItemFieldSingleSelectValue { name }
-              }
-              team: fieldValueByName(name: "Team") {
-                ... on ProjectV2ItemFieldSingleSelectValue { name }
-              }
-              sprint: fieldValueByName(name: "Sprint") {
-                ... on ProjectV2ItemFieldIterationValue { title }
-              }
-            }
+          projectItems(first: 100) { ...ProjectItemFields }
+          closingIssuesReferences(first: 20) {
+            nodes { id number }
           }
+          userLinkedClosingIssues: closingIssuesReferences(first: 20, userLinkedOnly: true) {
+            nodes { id number }
+          }
+        }
+        ... on Issue {
+          projectItems(first: 100) { ...ProjectItemFields }
+        }
+      }
+    }
+    fragment ProjectItemFields on ProjectV2ItemConnection {
+      nodes {
+        id
+        project { id }
+        status: fieldValueByName(name: "Status") {
+          ... on ProjectV2ItemFieldSingleSelectValue { name }
+        }
+        team: fieldValueByName(name: "Team") {
+          ... on ProjectV2ItemFieldSingleSelectValue { name }
+        }
+        sprint: fieldValueByName(name: "Sprint") {
+          ... on ProjectV2ItemFieldIterationValue { title }
         }
       }
     }
     """
-    result = graphql_request(query, {"contentId": pr_node_id}, token)
-    nodes = require_node(result, pr_node_id)["projectItems"]["nodes"]
-    for node in nodes:
-        if node["project"]["id"] == BOARD_PROJECT_ID:
-            status_value = node["status"]
-            team_value = node["team"]
-            sprint_value = node["sprint"]
-            return {
-                "id": node["id"],
+    result = graphql_request(query, {"contentId": content_id}, token)
+    node = require_node(result, content_id)
+    item = None
+    for candidate in node["projectItems"]["nodes"]:
+        if candidate["project"]["id"] == BOARD_PROJECT_ID:
+            status_value = candidate["status"]
+            team_value = candidate["team"]
+            sprint_value = candidate["sprint"]
+            item = {
+                "id": candidate["id"],
                 "status": status_value["name"] if status_value else None,
                 "team": team_value["name"] if team_value else None,
                 "sprint": sprint_value["title"] if sprint_value else None,
             }
-    return None
+            break
+    closing_issues_field = node.get("closingIssuesReferences")
+    all_closing_issues = closing_issues_field["nodes"] if closing_issues_field else []
+    user_linked_field = node.get("userLinkedClosingIssues")
+    user_linked_issues = user_linked_field["nodes"] if user_linked_field else []
+    closing_issues = keyword_closing_issues(all_closing_issues, user_linked_issues)
+    return {"item": item, "closing_issues": closing_issues}
 
 
 def set_project_field_option(item_id, field_id, option_id, token):
@@ -353,14 +468,29 @@ def write_step_summary(rows):
             handle.write(f"| {name} | {value} |\n")
 
 
-# Every event that touches the board (the three transitions, synchronize, and
-# opened) applies the one rule in decide_board_update: Status per decide_status,
-# Team and Sprint fill-only. Sprint's mutation shape differs from a single-select
+# Every event that touches the board (the three transitions, synchronize,
+# edited, and opened) applies the one rule in decide_board_update -- to the
+# PR's OWN card when it closes no issue: Status per decide_status, Team and
+# Sprint fill-only. Sprint's mutation shape differs from a single-select
 # (iterationId, not singleSelectOptionId), which is why it is written separately
 # below rather than through SINGLE_SELECT_FIELD_SPECS; a real fourth field would
 # still touch this table, current_values, FIELD_LABELS, and the write loop below.
 TRANSITION_ACTIONS = ("ready_for_review", "converted_to_draft", "reopened")
-BOARD_UPDATE_ACTIONS = TRANSITION_ACTIONS + ("synchronize",)
+BOARD_UPDATE_ACTIONS = TRANSITION_ACTIONS + ("synchronize", "edited")
+
+# Aim 6, redirected to a linked issue's card instead of the PR's own: which
+# actions may set that card's Status, and which may only add+fill a missing
+# one without ever moving Status. See decide_issue_card_update.
+ISSUE_STATUS_ACTIONS = TRANSITION_ACTIONS + ("opened",)
+ISSUE_ADD_ONLY_ACTIONS = ("edited",)
+
+# The actions that remove the PR's own card when it closes an issue: opened,
+# edited, and the three transitions. NOT synchronize -- a push that removed
+# the PR's card while never adding the issue's would leave zero cards for
+# the same piece of work (owner ruling, review finding F1). For a closing
+# PR, synchronize therefore writes nothing anywhere: not the PR's card
+# (removal or otherwise), not any issue's.
+PR_CARD_REMOVAL_ACTIONS = ISSUE_STATUS_ACTIONS + ISSUE_ADD_ONLY_ACTIONS
 
 SINGLE_SELECT_FIELD_SPECS = (
     ("status", STATUS_FIELD_ID, True, "Status"),
@@ -401,22 +531,9 @@ def resolve_and_apply_board_fields(pr_node_id, existing_item, fields, current_va
     return item_id
 
 
-def resolve_board_state(pr_node_id, board_token):
-    """Looks up the item and, when needed, the current sprint. Returns
-    (existing_item, current_values, current_iteration)."""
-    existing_item = find_board_item_for_pr(pr_node_id, board_token)
-    current_values = {
-        "status": existing_item["status"] if existing_item else None,
-        "team": existing_item["team"] if existing_item else None,
-        "sprint": existing_item["sprint"] if existing_item else None,
-    }
-
-    current_iteration = None
-    if is_blank(current_values["sprint"]):
-        iterations = fetch_project_iterations(SPRINT_FIELD_ID, board_token)
-        current_iteration = find_current_iteration(iterations, current_date())
-
-    return existing_item, current_values, current_iteration
+def resolve_current_iteration(board_token):
+    iterations = fetch_project_iterations(SPRINT_FIELD_ID, board_token)
+    return find_current_iteration(iterations, current_date())
 
 
 def board_verdict(prefix, fields, current_values):
@@ -425,6 +542,100 @@ def board_verdict(prefix, fields, current_values):
         for key, label in FIELD_LABELS.items()
     ]
     return f"{prefix} -> " + ", ".join(parts)
+
+
+def _record_verdict(summary_rows, insert_at, verdict):
+    print(f"verdict: {verdict}")
+    row = ("Verdict", verdict)
+    if insert_at is None:
+        summary_rows.append(row)
+    else:
+        summary_rows.insert(insert_at, row)
+
+
+def apply_redirected_board_write(action, is_draft, mapped_team, pr_item, closing_issues, board_token, summary_rows):
+    """Aim 6, for an action in PR_CARD_REMOVAL_ACTIONS: the PR closes at
+    least one issue, so it gets no card of its own -- an existing one is
+    removed from board 15, unconditionally -- and each linked issue's card
+    is written instead, per decide_issue_card_update. synchronize never
+    reaches this function; see apply_board_write."""
+    if decide_remove_pr_card(closing_issues, pr_item):
+        was = f"Status {pr_item['status']!r}, Team {pr_item['team']!r}, Sprint {pr_item['sprint']!r}"
+        # Recorded BEFORE the mutation runs -- this row is the one place a
+        # person can recover the values from, so a timeout after GitHub has
+        # already committed the removal must not lose it.
+        summary_rows.append(("PR card removed", f"{pr_item['id']} (was: {was})"))
+        remove_item_from_board(pr_item["id"], board_token)
+    else:
+        summary_rows.append(("PR card", f"none to add or remove (closes {len(closing_issues)} linked issue(s))"))
+
+    current_iteration = resolve_current_iteration(board_token)
+    current_sprint_title = current_iteration["title"] if current_iteration else None
+
+    for issue_ref in closing_issues:
+        issue_lookup = find_board_item_for_pr(issue_ref["id"], board_token)
+        existing_issue_item = issue_lookup["item"]
+        fields = decide_issue_card_update(action, is_draft, existing_issue_item, mapped_team, current_sprint_title)
+        if fields is None:
+            summary_rows.append((f"Issue #{issue_ref['number']}", "left untouched"))
+            continue
+        current_values = {
+            "status": existing_issue_item["status"] if existing_issue_item else None,
+            "team": existing_issue_item["team"] if existing_issue_item else None,
+            "sprint": existing_issue_item["sprint"] if existing_issue_item else None,
+        }
+        item_id = resolve_and_apply_board_fields(
+            issue_ref["id"], existing_issue_item, fields, current_values, current_iteration, board_token, summary_rows
+        )
+        summary_rows.append((f"Issue #{issue_ref['number']}", f"item {item_id}"))
+
+
+def apply_board_write(action, pr_node_id, is_draft, mapped_team, board_token, summary_rows, verdict_prefix, insert_verdict_at=None):
+    """The redirect-aware board write shared by every board-writing action --
+    opened, the three transitions, synchronize, and edited. Reads the PR's
+    own item and the issues it closes in one round trip (find_board_item_for_pr),
+    then either redirects to those issues' cards (aim 6, decide_redirect_to_issues)
+    or writes the PR's own card exactly as before this ticket. For a closing
+    PR, synchronize is a special case: it is not in PR_CARD_REMOVAL_ACTIONS,
+    so it writes nothing anywhere -- not the PR's card, not any issue's."""
+    lookup = find_board_item_for_pr(pr_node_id, board_token)
+    pr_item = lookup["item"]
+    closing_issues = lookup["closing_issues"]
+
+    if decide_redirect_to_issues(closing_issues):
+        if action not in PR_CARD_REMOVAL_ACTIONS:
+            _record_verdict(
+                summary_rows, insert_verdict_at, f"{verdict_prefix} -> closes {len(closing_issues)} issue(s), {action} writes nothing"
+            )
+            return
+        _record_verdict(
+            summary_rows, insert_verdict_at, f"{verdict_prefix} -> closes {len(closing_issues)} issue(s), no PR card"
+        )
+        apply_redirected_board_write(action, is_draft, mapped_team, pr_item, closing_issues, board_token, summary_rows)
+        return
+
+    current_values = {
+        "status": pr_item["status"] if pr_item else None,
+        "team": pr_item["team"] if pr_item else None,
+        "sprint": pr_item["sprint"] if pr_item else None,
+    }
+    current_iteration = None
+    if is_blank(current_values["sprint"]):
+        current_iteration = resolve_current_iteration(board_token)
+    current_sprint_title = current_iteration["title"] if current_iteration else None
+
+    fields = decide_board_update(
+        is_draft,
+        current_values["status"],
+        current_values["team"],
+        mapped_team,
+        current_sprint=current_values["sprint"],
+        current_sprint_title=current_sprint_title,
+    )
+
+    _record_verdict(summary_rows, insert_verdict_at, board_verdict(verdict_prefix, fields, current_values))
+
+    resolve_and_apply_board_fields(pr_node_id, pr_item, fields, current_values, current_iteration, board_token, summary_rows)
 
 
 def handle_board_update(action, pull_request):
@@ -448,25 +659,7 @@ def handle_board_update(action, pull_request):
     try:
         board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
-        existing_item, current_values, current_iteration = resolve_board_state(pr_node_id, board_token)
-        current_sprint_title = current_iteration["title"] if current_iteration else None
-
-        fields = decide_board_update(
-            is_draft,
-            current_values["status"],
-            current_values["team"],
-            mapped_team,
-            current_sprint=current_values["sprint"],
-            current_sprint_title=current_sprint_title,
-        )
-
-        verdict = board_verdict(action, fields, current_values)
-        print(f"verdict: {verdict}")
-        summary_rows.append(("Verdict", verdict))
-
-        resolve_and_apply_board_fields(
-            pr_node_id, existing_item, fields, current_values, current_iteration, board_token, summary_rows
-        )
+        apply_board_write(action, pr_node_id, is_draft, mapped_team, board_token, summary_rows, verdict_prefix=action)
 
         summary_rows.append(("Assignee", "not touched, deliberate, including when empty"))
         summary_rows.append(("Draft state", "not touched, deliberate"))
@@ -557,25 +750,16 @@ def handle_open_triage(action, pull_request, repo):
             summary_rows.append(("Converted to draft", "skipped, draft state left untouched for unknown author"))
 
         try:
-            existing_item, current_values, current_iteration = resolve_board_state(pr_node_id, board_token)
-            current_sprint_title = current_iteration["title"] if current_iteration else None
-
-            fields = decide_board_update(
-                actual_is_draft,
-                current_values["status"],
-                current_values["team"],
-                decision["team"],
-                current_sprint=current_values["sprint"],
-                current_sprint_title=current_sprint_title,
-            )
-
             verdict_prefix = "known, assign+draft" if decision["known"] else "unknown (absent from .github/pr-triage-teams.yml), no assignee, draft untouched"
-            verdict = board_verdict(verdict_prefix, fields, current_values)
-            print(f"verdict: {verdict}")
-            summary_rows.insert(3, ("Verdict", verdict))
-
-            resolve_and_apply_board_fields(
-                pr_node_id, existing_item, fields, current_values, current_iteration, board_token, summary_rows
+            apply_board_write(
+                "opened",
+                pr_node_id,
+                actual_is_draft,
+                decision["team"],
+                board_token,
+                summary_rows,
+                verdict_prefix=verdict_prefix,
+                insert_verdict_at=3,
             )
         except Exception as error:
             print(f"ERROR: board write failed: {error}")

--- a/.github/scripts/pr_triage.py
+++ b/.github/scripts/pr_triage.py
@@ -1,311 +1,35 @@
-"""Decides what to do with a pull request on open/reopen, and does the writes.
+"""Decides what to do with a pull request on open/reopen, and does the
+writes: main(), the event handlers, the apply/orchestration functions that
+mix a decision with I/O, and the step summary.
 
-The decision (decide) is pure: author login + current draft state + the loaded
-teams mapping in, an assign/draft/board verdict out. No network, no GitHub
-API, no environment reads. Everything below main() is I/O built on top of it.
+The pure verdicts live in pr_triage_decide (no network, no GitHub API, no
+environment reads, no clock); every HTTP call lives in pr_triage_github. This
+module wires the two together and is the one the workflow runs directly, so
+the script directory is put on sys.path before either sibling import.
 """
 
 import datetime
 import json
 import os
-import re
 import sys
-import urllib.error
-import urllib.request
 
-BOARD_PROJECT_ID = "PVT_kwDOABnCXs4AgIEx"
-STATUS_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgVUF6A"
-TEAM_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgbkzoM"
-SPRINT_FIELD_ID = "PVTIF_lADOABnCXs4AgIExzgavkek"
-STATUS_WORKING = "Working"
-STATUS_REVIEW = "Review"
-UNKNOWN_AUTHOR_TEAM = "Dev"
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-GITHUB_API_URL = "https://api.github.com"
-GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
-HTTP_TIMEOUT_SECONDS = 30
-
-
-class GraphqlError(Exception):
-    pass
-
-
-class AssignmentDroppedError(Exception):
-    pass
-
-
-def check_assignment_succeeded(author_login, assign_result):
-    assignee_logins = [assignee["login"] for assignee in assign_result.get("assignees", [])]
-    if author_login not in assignee_logins:
-        raise AssignmentDroppedError(
-            f"GitHub did not assign '{author_login}' (assignees after the call: {assignee_logins}). "
-            f"The login is probably no longer valid for assignment; .github/pr-triage-teams.yml is probably stale."
-        )
-
-
-def is_blank(value):
-    return not value or not value.strip()
-
-
-def team_for(author_login, mapping):
-    team = mapping.get(author_login)
-    return None if is_blank(team) else team
-
-
-def decide(author_login, is_draft, mapping):
-    team = team_for(author_login, mapping)
-    if team is None:
-        return {"known": False, "force_draft": False, "team": UNKNOWN_AUTHOR_TEAM}
-    return {"known": True, "force_draft": not is_draft, "team": team}
-
-
-def target_status_from_draft_state(is_draft):
-    return STATUS_WORKING if is_draft else STATUS_REVIEW
+import pr_triage_decide
+import pr_triage_github
 
 
 def current_date():
     return datetime.date.today()
 
 
-def find_current_iteration(iterations, today):
-    for iteration in iterations:
-        start = datetime.date.fromisoformat(iteration["startDate"])
-        end = start + datetime.timedelta(days=iteration["duration"])
-        if start <= today < end:
-            return iteration
-    return None
-
-
-STATUS_MANAGED_VALUES = (STATUS_WORKING, STATUS_REVIEW)
-
-
-def decide_status(is_draft, current_status):
-    target = target_status_from_draft_state(is_draft)
-    if is_blank(current_status):
-        return target
-    current = strip_emoji_prefix(current_status)
-    if current == target:
-        return None
-    if current in STATUS_MANAGED_VALUES:
-        return target
-    return None
-
-
-def decide_board_update(is_draft, current_status, current_team, mapped_team, current_sprint=None, current_sprint_title=None):
-    return {
-        "status": decide_status(is_draft, current_status),
-        "team": mapped_team if is_blank(current_team) else None,
-        "sprint": current_sprint_title if (current_sprint_title and is_blank(current_sprint)) else None,
-    }
-
-
-def keyword_closing_issues(all_closing_issues, user_linked_issues):
-    """Aim 6 redirects only on a KEYWORD-derived closing reference
-    (close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved in the PR
-    body) [owner ruling, narrowing the original "closingIssuesReferences
-    reports it, so it counts" reading]. An issue linked only by hand through
-    GitHub's Development sidebar, with no keyword in the body, does NOT
-    redirect -- `Addresses: <url>` is a real habit in this repo, used
-    deliberately to link without auto-closing.
-
-    GitHub's closingIssuesReferences field reports both kinds together;
-    userLinkedOnly=true reports only the hand-linked ones. Keyword-derived is
-    therefore `all_closing_issues` minus `user_linked_issues`, matched by
-    node id -- verified against two real PRs of each shape, see
-    notes/github-facts.md §8."""
-    user_linked_ids = {issue["id"] for issue in user_linked_issues}
-    return [issue for issue in all_closing_issues if issue["id"] not in user_linked_ids]
-
-
-def decide_redirect_to_issues(closing_issues):
-    """Aim 6: a PR that closes at least one issue gets no card of its own --
-    every linked issue's card is written instead. An empty list changes
-    nothing; the PR is boarded exactly as it always was."""
-    return bool(closing_issues)
-
-
-def decide_remove_pr_card(closing_issues, existing_pr_item):
-    """The story's one removal: unconditional, and narrow. True exactly when
-    the PR closes at least one issue AND the PR already has an item on board
-    15 -- never guarded by that item's Status or fields, and never true for
-    an issue's item, which this is never called with. "Removal" is
-    board-only: the card comes off board 15, nothing about the PR itself
-    changes.
-
-    Deliberately action-blind: this function does not know synchronize is
-    excluded from removal. That exclusion lives in the one call site,
-    apply_board_write's `action not in PR_CARD_REMOVAL_ACTIONS` guard --
-    apply_redirected_board_write (and this function) are never reached for
-    synchronize at all. If a second caller is ever added, that guard has to
-    move or be duplicated; it does not enforce itself here."""
-    return decide_redirect_to_issues(closing_issues) and existing_pr_item is not None
-
-
-def decide_issue_card_update(action, is_draft, existing_issue_item, mapped_team, current_sprint_title):
-    """Pure decision for ONE linked issue's card. existing_issue_item is None
-    when the issue has no item yet on board 15.
-
-    - `synchronize` never touches a linked issue's card at all -- existing or
-      missing, this returns None.
-    - `edited` never touches an EXISTING issue card (Status is not moved by a
-      body edit), but still adds and fills a missing one, because a PR with
-      no card and an issue with no card is the one outcome no aim tolerates.
-      Status is left unwritten on the card it adds -- only opened and the
-      three transitions ever move a linked issue's Status.
-    - `opened` and the three transitions set Status only on an existing card
-      (Team and Sprint stay exactly as a person left them), and fill all
-      three -- Status, Team, Sprint -- on a card they add.
-
-    Returns None for "write nothing", otherwise a fields dict shaped like
-    resolve_and_apply_board_fields expects: {"status", "team", "sprint"},
-    each either a target value or None meaning "leave as-is"."""
-    if existing_issue_item is not None:
-        if action not in ISSUE_STATUS_ACTIONS:
-            return None
-        return {"status": decide_status(is_draft, existing_issue_item["status"]), "team": None, "sprint": None}
-
-    if action not in ISSUE_STATUS_ACTIONS and action not in ISSUE_ADD_ONLY_ACTIONS:
-        return None
-    status = target_status_from_draft_state(is_draft) if action in ISSUE_STATUS_ACTIONS else None
-    return {"status": status, "team": mapped_team, "sprint": current_sprint_title}
-
-
-def strip_emoji_prefix(name):
-    return re.sub(r"^[^\w]+", "", name).strip()
-
-
-def find_option_id_by_name(options, target_name, strip_emoji):
-    for option in options:
-        candidate = strip_emoji_prefix(option["name"]) if strip_emoji else option["name"]
-        if candidate == target_name:
-            return option["id"]
-    available = ", ".join(f'{o["name"]!r} ({o["id"]})' for o in options)
-    raise ValueError(
-        f"'{target_name}' does not match any live board option. Available options: {available}"
-    )
-
-
-def parse_teams_entries(text):
-    entries = []
-    in_teams_block = False
-    for raw_line in text.splitlines():
-        line = raw_line.split("#", 1)[0].rstrip()
-        if not line.strip():
-            continue
-        if line.strip() == "teams:":
-            in_teams_block = True
-            continue
-        if not in_teams_block:
-            continue
-        if not line.startswith((" ", "\t")):
-            in_teams_block = False
-            continue
-        key, _, value = line.strip().partition(":")
-        entries.append((key.strip(), value.strip()))
-    return entries
-
-
-def parse_teams_mapping(text):
-    return dict(parse_teams_entries(text))
-
-
 def load_teams_mapping(path):
     with open(path, encoding="utf-8") as handle:
-        return parse_teams_mapping(handle.read())
+        return pr_triage_decide.parse_teams_mapping(handle.read())
 
 
 def mapping_file_path(pr_triage_file):
     return os.path.join(os.path.dirname(os.path.dirname(os.path.abspath(pr_triage_file))), "pr-triage-teams.yml")
-
-
-def http_request(url, token, method="GET", body=None):
-    data = json.dumps(body).encode("utf-8") if body is not None else None
-    request = urllib.request.Request(url, data=data, method=method)
-    request.add_header("Authorization", f"Bearer {token}")
-    request.add_header("Accept", "application/vnd.github+json")
-    if data is not None:
-        request.add_header("Content-Type", "application/json")
-    try:
-        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
-            return json.loads(response.read().decode("utf-8"))
-    except urllib.error.HTTPError as error:
-        print(f"GitHub API error {error.code} for {method} {url}: {error.read().decode('utf-8')}")
-        raise
-
-
-def graphql_request(query, variables, token):
-    result = http_request(
-        GITHUB_GRAPHQL_URL,
-        token,
-        method="POST",
-        body={"query": query, "variables": variables},
-    )
-    errors = result.get("errors")
-    if errors:
-        raise GraphqlError(f"GraphQL request returned errors: {errors}")
-    return result
-
-
-def require_node(result, resolved_id):
-    node = result["data"]["node"]
-    if node is None:
-        raise GraphqlError(
-            f"GraphQL id '{resolved_id}' resolved to no node (data.node is null). "
-            f"The id is probably stale, e.g. a board field that was deleted and recreated."
-        )
-    return node
-
-
-def assign_author(repo, pr_number, author_login, token):
-    return http_request(
-        f"{GITHUB_API_URL}/repos/{repo}/issues/{pr_number}/assignees",
-        token,
-        method="POST",
-        body={"assignees": [author_login]},
-    )
-
-
-def convert_pr_to_draft(pr_node_id, token):
-    query = """
-    mutation($pullRequestId: ID!) {
-      convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
-        pullRequest { id isDraft }
-      }
-    }
-    """
-    return graphql_request(query, {"pullRequestId": pr_node_id}, token)
-
-
-def add_item_to_project(pr_node_id, token):
-    query = """
-    mutation($projectId: ID!, $contentId: ID!) {
-      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
-        item { id }
-      }
-    }
-    """
-    result = graphql_request(
-        query, {"projectId": BOARD_PROJECT_ID, "contentId": pr_node_id}, token
-    )
-    return result["data"]["addProjectV2ItemById"]["item"]["id"]
-
-
-def remove_item_from_board(item_id, token):
-    """The story's one removal (aim 6): a PR's own CARD on board 15, removed
-    unconditionally the moment the PR closes an issue and already has one --
-    no guard on its Status or fields. This removes the board item only,
-    nothing about the pull request itself; the GraphQL mutation is still
-    named deleteProjectV2Item (GitHub's name, not ours). Never call this with
-    an issue's item id; an issue's card is never removed by anything in this
-    workflow."""
-    query = """
-    mutation($projectId: ID!, $itemId: ID!) {
-      deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
-        deletedItemId
-      }
-    }
-    """
-    return graphql_request(query, {"projectId": BOARD_PROJECT_ID, "itemId": item_id}, token)
 
 
 def find_board_item_for_pr(content_id, token):
@@ -317,7 +41,10 @@ def find_board_item_for_pr(content_id, token):
     riding both the unfiltered and userLinkedOnly variants on this same query
     costs no extra round trip. keyword_closing_issues does the split -- see
     notes/github-facts.md §8. Returns {"item": item-or-None, "closing_issues":
-    [{"id", "number"}, ...]} -- closing_issues is always [] for an Issue node."""
+    [{"id", "number"}, ...]} -- closing_issues is always [] for an Issue node.
+
+    Lives here rather than in pr_triage_github because it needs
+    keyword_closing_issues, and pr_triage_github imports nothing of ours."""
     query = """
     query($contentId: ID!) {
       node(id: $contentId) {
@@ -351,11 +78,11 @@ def find_board_item_for_pr(content_id, token):
       }
     }
     """
-    result = graphql_request(query, {"contentId": content_id}, token)
-    node = require_node(result, content_id)
+    result = pr_triage_github.graphql_request(query, {"contentId": content_id}, token)
+    node = pr_triage_github.require_node(result, content_id)
     item = None
     for candidate in node["projectItems"]["nodes"]:
-        if candidate["project"]["id"] == BOARD_PROJECT_ID:
+        if candidate["project"]["id"] == pr_triage_github.BOARD_PROJECT_ID:
             status_value = candidate["status"]
             team_value = candidate["team"]
             sprint_value = candidate["sprint"]
@@ -370,92 +97,8 @@ def find_board_item_for_pr(content_id, token):
     all_closing_issues = closing_issues_field["nodes"] if closing_issues_field else []
     user_linked_field = node.get("userLinkedClosingIssues")
     user_linked_issues = user_linked_field["nodes"] if user_linked_field else []
-    closing_issues = keyword_closing_issues(all_closing_issues, user_linked_issues)
+    closing_issues = pr_triage_decide.keyword_closing_issues(all_closing_issues, user_linked_issues)
     return {"item": item, "closing_issues": closing_issues}
-
-
-def set_project_field_option(item_id, field_id, option_id, token):
-    query = """
-    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
-      updateProjectV2ItemFieldValue(
-        input: {
-          projectId: $projectId
-          itemId: $itemId
-          fieldId: $fieldId
-          value: { singleSelectOptionId: $optionId }
-        }
-      ) {
-        projectV2Item { id }
-      }
-    }
-    """
-    return graphql_request(
-        query,
-        {
-            "projectId": BOARD_PROJECT_ID,
-            "itemId": item_id,
-            "fieldId": field_id,
-            "optionId": option_id,
-        },
-        token,
-    )
-
-
-def fetch_project_field_options(field_id, token):
-    query = """
-    query($fieldId: ID!) {
-      node(id: $fieldId) {
-        ... on ProjectV2SingleSelectField {
-          options { id name }
-        }
-      }
-    }
-    """
-    result = graphql_request(query, {"fieldId": field_id}, token)
-    return require_node(result, field_id)["options"]
-
-
-def set_project_field_iteration(item_id, field_id, iteration_id, token):
-    query = """
-    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
-      updateProjectV2ItemFieldValue(
-        input: {
-          projectId: $projectId
-          itemId: $itemId
-          fieldId: $fieldId
-          value: { iterationId: $iterationId }
-        }
-      ) {
-        projectV2Item { id }
-      }
-    }
-    """
-    return graphql_request(
-        query,
-        {
-            "projectId": BOARD_PROJECT_ID,
-            "itemId": item_id,
-            "fieldId": field_id,
-            "iterationId": iteration_id,
-        },
-        token,
-    )
-
-
-def fetch_project_iterations(field_id, token):
-    query = """
-    query($fieldId: ID!) {
-      node(id: $fieldId) {
-        ... on ProjectV2IterationField {
-          configuration {
-            iterations { id title startDate duration }
-          }
-        }
-      }
-    }
-    """
-    result = graphql_request(query, {"fieldId": field_id}, token)
-    return require_node(result, field_id)["configuration"]["iterations"]
 
 
 def write_step_summary(rows):
@@ -475,26 +118,9 @@ def write_step_summary(rows):
 # (iterationId, not singleSelectOptionId), which is why it is written separately
 # below rather than through SINGLE_SELECT_FIELD_SPECS; a real fourth field would
 # still touch this table, current_values, FIELD_LABELS, and the write loop below.
-TRANSITION_ACTIONS = ("ready_for_review", "converted_to_draft", "reopened")
-BOARD_UPDATE_ACTIONS = TRANSITION_ACTIONS + ("synchronize", "edited")
-
-# Aim 6, redirected to a linked issue's card instead of the PR's own: which
-# actions may set that card's Status, and which may only add+fill a missing
-# one without ever moving Status. See decide_issue_card_update.
-ISSUE_STATUS_ACTIONS = TRANSITION_ACTIONS + ("opened",)
-ISSUE_ADD_ONLY_ACTIONS = ("edited",)
-
-# The actions that remove the PR's own card when it closes an issue: opened,
-# edited, and the three transitions. NOT synchronize -- a push that removed
-# the PR's card while never adding the issue's would leave zero cards for
-# the same piece of work (owner ruling, review finding F1). For a closing
-# PR, synchronize therefore writes nothing anywhere: not the PR's card
-# (removal or otherwise), not any issue's.
-PR_CARD_REMOVAL_ACTIONS = ISSUE_STATUS_ACTIONS + ISSUE_ADD_ONLY_ACTIONS
-
 SINGLE_SELECT_FIELD_SPECS = (
-    ("status", STATUS_FIELD_ID, True, "Status"),
-    ("team", TEAM_FIELD_ID, False, "Team"),
+    ("status", pr_triage_github.STATUS_FIELD_ID, True, "Status"),
+    ("team", pr_triage_github.TEAM_FIELD_ID, False, "Team"),
 )
 FIELD_LABELS = {"status": "Status", "team": "Team", "sprint": "Sprint"}
 
@@ -504,8 +130,8 @@ def resolve_and_apply_board_fields(pr_node_id, existing_item, fields, current_va
     for key, field_id, strip_emoji, _label in SINGLE_SELECT_FIELD_SPECS:
         target_value = fields[key]
         if target_value is not None:
-            options = fetch_project_field_options(field_id, board_token)
-            resolved_single_select[key] = (field_id, find_option_id_by_name(options, target_value, strip_emoji=strip_emoji))
+            options = pr_triage_github.fetch_project_field_options(field_id, board_token)
+            resolved_single_select[key] = (field_id, pr_triage_decide.find_option_id_by_name(options, target_value, strip_emoji=strip_emoji))
 
     sprint_iteration_id = current_iteration["id"] if (fields["sprint"] is not None and current_iteration) else None
 
@@ -513,7 +139,7 @@ def resolve_and_apply_board_fields(pr_node_id, existing_item, fields, current_va
         item_id = existing_item["id"]
         summary_rows.append(("Board item", f"found existing item {item_id}"))
     else:
-        item_id = add_item_to_project(pr_node_id, board_token)
+        item_id = pr_triage_github.add_item_to_project(pr_node_id, board_token)
         summary_rows.append(("Board item", f"no existing item, added {item_id}"))
 
     for key, label in FIELD_LABELS.items():
@@ -521,19 +147,19 @@ def resolve_and_apply_board_fields(pr_node_id, existing_item, fields, current_va
         if target_value is None:
             summary_rows.append((label, f"left as-is ({current_values[key]!r})"))
         elif key == "sprint":
-            set_project_field_iteration(item_id, SPRINT_FIELD_ID, sprint_iteration_id, board_token)
+            pr_triage_github.set_project_field_iteration(item_id, pr_triage_github.SPRINT_FIELD_ID, sprint_iteration_id, board_token)
             summary_rows.append((f"{label} set", target_value))
         else:
             field_id, option_id = resolved_single_select[key]
-            set_project_field_option(item_id, field_id, option_id, board_token)
+            pr_triage_github.set_project_field_option(item_id, field_id, option_id, board_token)
             summary_rows.append((f"{label} set", target_value))
 
     return item_id
 
 
 def resolve_current_iteration(board_token):
-    iterations = fetch_project_iterations(SPRINT_FIELD_ID, board_token)
-    return find_current_iteration(iterations, current_date())
+    iterations = pr_triage_github.fetch_project_iterations(pr_triage_github.SPRINT_FIELD_ID, board_token)
+    return pr_triage_decide.find_current_iteration(iterations, current_date())
 
 
 def board_verdict(prefix, fields, current_values):
@@ -572,7 +198,7 @@ def apply_redirected_board_write(action, is_draft, mapped_team, pr_item, closing
     for issue_ref in closing_issues:
         issue_lookup = find_board_item_for_pr(issue_ref["id"], board_token)
         existing_issue_item = issue_lookup["item"]
-        fields = decide_issue_card_update(action, is_draft, existing_issue_item, mapped_team, current_sprint_title)
+        fields = pr_triage_decide.decide_issue_card_update(action, is_draft, existing_issue_item, mapped_team, current_sprint_title)
         if fields is None:
             summary_rows.append((f"Issue #{issue_ref['number']}", "left untouched"))
             continue
@@ -586,13 +212,13 @@ def apply_redirected_board_write(action, is_draft, mapped_team, pr_item, closing
         )
         summary_rows.append((f"Issue #{issue_ref['number']}", f"item {item_id}"))
 
-    if decide_remove_pr_card(closing_issues, pr_item):
+    if pr_triage_decide.decide_remove_pr_card(closing_issues, pr_item):
         was = f"Status {pr_item['status']!r}, Team {pr_item['team']!r}, Sprint {pr_item['sprint']!r}"
         # Recorded BEFORE the mutation runs -- this row is the one place a
         # person can recover the values from, so a timeout after GitHub has
         # already committed the removal must not lose it.
         summary_rows.append(("PR card removed", f"{pr_item['id']} (was: {was})"))
-        remove_item_from_board(pr_item["id"], board_token)
+        pr_triage_github.remove_item_from_board(pr_item["id"], board_token)
     else:
         summary_rows.append(("PR card", f"none to add or remove (closes {len(closing_issues)} linked issue(s))"))
 
@@ -609,8 +235,8 @@ def apply_board_write(action, pr_node_id, is_draft, mapped_team, board_token, su
     pr_item = lookup["item"]
     closing_issues = lookup["closing_issues"]
 
-    if decide_redirect_to_issues(closing_issues):
-        if action not in PR_CARD_REMOVAL_ACTIONS:
+    if pr_triage_decide.decide_redirect_to_issues(closing_issues):
+        if action not in pr_triage_decide.PR_CARD_REMOVAL_ACTIONS:
             _record_verdict(
                 summary_rows, insert_verdict_at, f"{verdict_prefix} -> closes {len(closing_issues)} issue(s), {action} writes nothing"
             )
@@ -627,11 +253,11 @@ def apply_board_write(action, pr_node_id, is_draft, mapped_team, board_token, su
         "sprint": pr_item["sprint"] if pr_item else None,
     }
     current_iteration = None
-    if is_blank(current_values["sprint"]):
+    if pr_triage_decide.is_blank(current_values["sprint"]):
         current_iteration = resolve_current_iteration(board_token)
     current_sprint_title = current_iteration["title"] if current_iteration else None
 
-    fields = decide_board_update(
+    fields = pr_triage_decide.decide_board_update(
         is_draft,
         current_values["status"],
         current_values["team"],
@@ -662,7 +288,7 @@ def handle_board_update(action, pull_request):
     try:
         mapping_path = mapping_file_path(__file__)
         mapping = load_teams_mapping(mapping_path)
-        mapped_team = team_for(author_login, mapping) or UNKNOWN_AUTHOR_TEAM
+        mapped_team = pr_triage_decide.team_for(author_login, mapping) or pr_triage_decide.UNKNOWN_AUTHOR_TEAM
 
         board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
@@ -716,7 +342,7 @@ def handle_open_triage(action, pull_request, repo):
         mapping_path = mapping_file_path(__file__)
         mapping = load_teams_mapping(mapping_path)
 
-        decision = decide(author_login=author_login, is_draft=is_draft, mapping=mapping)
+        decision = pr_triage_decide.decide(author_login=author_login, is_draft=is_draft, mapping=mapping)
 
         board_token = os.environ["PROJECT_BOARD_TOKEN"]
 
@@ -724,8 +350,8 @@ def handle_open_triage(action, pull_request, repo):
         if decision["known"]:
             try:
                 github_token = os.environ["GITHUB_TOKEN"]
-                assign_result = assign_author(repo, pr_number, author_login, github_token)
-                check_assignment_succeeded(author_login, assign_result)
+                assign_result = pr_triage_github.assign_author(repo, pr_number, author_login, github_token)
+                pr_triage_decide.check_assignment_succeeded(author_login, assign_result)
                 summary_rows.append(("Assignee set", True))
             except Exception as error:
                 print(f"ERROR: assignment failed: {error}")
@@ -742,7 +368,7 @@ def handle_open_triage(action, pull_request, repo):
         actual_is_draft = is_draft
         if decision["force_draft"] and assignment_succeeded:
             try:
-                draft_result = convert_pr_to_draft(pr_node_id, board_token)
+                draft_result = pr_triage_github.convert_pr_to_draft(pr_node_id, board_token)
                 actual_is_draft = draft_result["data"]["convertPullRequestToDraft"]["pullRequest"]["isDraft"]
                 summary_rows.append(("Converted to draft", actual_is_draft))
             except Exception as error:
@@ -792,7 +418,7 @@ def main():
     action = event["action"]
     pull_request = event["pull_request"]
 
-    if action in BOARD_UPDATE_ACTIONS:
+    if action in pr_triage_decide.BOARD_UPDATE_ACTIONS:
         handle_board_update(action, pull_request)
         return
 

--- a/.github/scripts/pr_triage_decide.py
+++ b/.github/scripts/pr_triage_decide.py
@@ -1,0 +1,207 @@
+"""Every pure verdict PR triage makes, and the vocabulary it compares against.
+
+The decision (decide) is pure: author login + current draft state + the loaded
+teams mapping in, an assign/draft/board verdict out. No network, no GitHub
+API, no environment reads, no clock, and no import of another pr_triage_*
+module -- see pr_triage.current_date for the one place that reads the clock.
+"""
+
+import datetime
+import re
+
+STATUS_WORKING = "Working"
+STATUS_REVIEW = "Review"
+UNKNOWN_AUTHOR_TEAM = "Dev"
+
+
+class AssignmentDroppedError(Exception):
+    pass
+
+
+def check_assignment_succeeded(author_login, assign_result):
+    assignee_logins = [assignee["login"] for assignee in assign_result.get("assignees", [])]
+    if author_login not in assignee_logins:
+        raise AssignmentDroppedError(
+            f"GitHub did not assign '{author_login}' (assignees after the call: {assignee_logins}). "
+            f"The login is probably no longer valid for assignment; .github/pr-triage-teams.yml is probably stale."
+        )
+
+
+def is_blank(value):
+    return not value or not value.strip()
+
+
+def team_for(author_login, mapping):
+    team = mapping.get(author_login)
+    return None if is_blank(team) else team
+
+
+def decide(author_login, is_draft, mapping):
+    team = team_for(author_login, mapping)
+    if team is None:
+        return {"known": False, "force_draft": False, "team": UNKNOWN_AUTHOR_TEAM}
+    return {"known": True, "force_draft": not is_draft, "team": team}
+
+
+def target_status_from_draft_state(is_draft):
+    return STATUS_WORKING if is_draft else STATUS_REVIEW
+
+
+def find_current_iteration(iterations, today):
+    for iteration in iterations:
+        start = datetime.date.fromisoformat(iteration["startDate"])
+        end = start + datetime.timedelta(days=iteration["duration"])
+        if start <= today < end:
+            return iteration
+    return None
+
+
+STATUS_MANAGED_VALUES = (STATUS_WORKING, STATUS_REVIEW)
+
+
+def decide_status(is_draft, current_status):
+    target = target_status_from_draft_state(is_draft)
+    if is_blank(current_status):
+        return target
+    current = strip_emoji_prefix(current_status)
+    if current == target:
+        return None
+    if current in STATUS_MANAGED_VALUES:
+        return target
+    return None
+
+
+def decide_board_update(is_draft, current_status, current_team, mapped_team, current_sprint=None, current_sprint_title=None):
+    return {
+        "status": decide_status(is_draft, current_status),
+        "team": mapped_team if is_blank(current_team) else None,
+        "sprint": current_sprint_title if (current_sprint_title and is_blank(current_sprint)) else None,
+    }
+
+
+def keyword_closing_issues(all_closing_issues, user_linked_issues):
+    """Aim 6 redirects only on a KEYWORD-derived closing reference
+    (close/closes/closed/fix/fixes/fixed/resolve/resolves/resolved in the PR
+    body) [owner ruling, narrowing the original "closingIssuesReferences
+    reports it, so it counts" reading]. An issue linked only by hand through
+    GitHub's Development sidebar, with no keyword in the body, does NOT
+    redirect -- `Addresses: <url>` is a real habit in this repo, used
+    deliberately to link without auto-closing.
+
+    GitHub's closingIssuesReferences field reports both kinds together;
+    userLinkedOnly=true reports only the hand-linked ones. Keyword-derived is
+    therefore `all_closing_issues` minus `user_linked_issues`, matched by
+    node id -- verified against two real PRs of each shape, see
+    notes/github-facts.md §8."""
+    user_linked_ids = {issue["id"] for issue in user_linked_issues}
+    return [issue for issue in all_closing_issues if issue["id"] not in user_linked_ids]
+
+
+def decide_redirect_to_issues(closing_issues):
+    """Aim 6: a PR that closes at least one issue gets no card of its own --
+    every linked issue's card is written instead. An empty list changes
+    nothing; the PR is boarded exactly as it always was."""
+    return bool(closing_issues)
+
+
+def decide_remove_pr_card(closing_issues, existing_pr_item):
+    """The story's one removal: unconditional, and narrow. True exactly when
+    the PR closes at least one issue AND the PR already has an item on board
+    15 -- never guarded by that item's Status or fields, and never true for
+    an issue's item, which this is never called with. "Removal" is
+    board-only: the card comes off board 15, nothing about the PR itself
+    changes.
+
+    Deliberately action-blind: this function does not know synchronize is
+    excluded from removal. That exclusion lives in the one call site,
+    apply_board_write's `action not in PR_CARD_REMOVAL_ACTIONS` guard --
+    apply_redirected_board_write (and this function) are never reached for
+    synchronize at all. If a second caller is ever added, that guard has to
+    move or be duplicated; it does not enforce itself here."""
+    return decide_redirect_to_issues(closing_issues) and existing_pr_item is not None
+
+
+def decide_issue_card_update(action, is_draft, existing_issue_item, mapped_team, current_sprint_title):
+    """Pure decision for ONE linked issue's card. existing_issue_item is None
+    when the issue has no item yet on board 15.
+
+    - `synchronize` never touches a linked issue's card at all -- existing or
+      missing, this returns None.
+    - `edited` never touches an EXISTING issue card (Status is not moved by a
+      body edit), but still adds and fills a missing one, because a PR with
+      no card and an issue with no card is the one outcome no aim tolerates.
+      Status is left unwritten on the card it adds -- only opened and the
+      three transitions ever move a linked issue's Status.
+    - `opened` and the three transitions set Status only on an existing card
+      (Team and Sprint stay exactly as a person left them), and fill all
+      three -- Status, Team, Sprint -- on a card they add.
+
+    Returns None for "write nothing", otherwise a fields dict shaped like
+    resolve_and_apply_board_fields expects: {"status", "team", "sprint"},
+    each either a target value or None meaning "leave as-is"."""
+    if existing_issue_item is not None:
+        if action not in ISSUE_STATUS_ACTIONS:
+            return None
+        return {"status": decide_status(is_draft, existing_issue_item["status"]), "team": None, "sprint": None}
+
+    if action not in ISSUE_STATUS_ACTIONS and action not in ISSUE_ADD_ONLY_ACTIONS:
+        return None
+    status = target_status_from_draft_state(is_draft) if action in ISSUE_STATUS_ACTIONS else None
+    return {"status": status, "team": mapped_team, "sprint": current_sprint_title}
+
+
+def strip_emoji_prefix(name):
+    return re.sub(r"^[^\w]+", "", name).strip()
+
+
+def find_option_id_by_name(options, target_name, strip_emoji):
+    for option in options:
+        candidate = strip_emoji_prefix(option["name"]) if strip_emoji else option["name"]
+        if candidate == target_name:
+            return option["id"]
+    available = ", ".join(f'{o["name"]!r} ({o["id"]})' for o in options)
+    raise ValueError(
+        f"'{target_name}' does not match any live board option. Available options: {available}"
+    )
+
+
+def parse_teams_entries(text):
+    entries = []
+    in_teams_block = False
+    for raw_line in text.splitlines():
+        line = raw_line.split("#", 1)[0].rstrip()
+        if not line.strip():
+            continue
+        if line.strip() == "teams:":
+            in_teams_block = True
+            continue
+        if not in_teams_block:
+            continue
+        if not line.startswith((" ", "\t")):
+            in_teams_block = False
+            continue
+        key, _, value = line.strip().partition(":")
+        entries.append((key.strip(), value.strip()))
+    return entries
+
+
+def parse_teams_mapping(text):
+    return dict(parse_teams_entries(text))
+
+
+TRANSITION_ACTIONS = ("ready_for_review", "converted_to_draft", "reopened")
+BOARD_UPDATE_ACTIONS = TRANSITION_ACTIONS + ("synchronize", "edited")
+
+# Aim 6, redirected to a linked issue's card instead of the PR's own: which
+# actions may set that card's Status, and which may only add+fill a missing
+# one without ever moving Status. See decide_issue_card_update.
+ISSUE_STATUS_ACTIONS = TRANSITION_ACTIONS + ("opened",)
+ISSUE_ADD_ONLY_ACTIONS = ("edited",)
+
+# The actions that remove the PR's own card when it closes an issue: opened,
+# edited, and the three transitions. NOT synchronize -- a push that removed
+# the PR's card while never adding the issue's would leave zero cards for
+# the same piece of work (owner ruling, review finding F1). For a closing
+# PR, synchronize therefore writes nothing anywhere: not the PR's card
+# (removal or otherwise), not any issue's.
+PR_CARD_REMOVAL_ACTIONS = ISSUE_STATUS_ACTIONS + ISSUE_ADD_ONLY_ACTIONS

--- a/.github/scripts/pr_triage_github.py
+++ b/.github/scripts/pr_triage_github.py
@@ -1,0 +1,194 @@
+"""Every HTTP call PR triage makes, and the board and API addresses they
+need. No decision logic and no import of another pr_triage_* module.
+"""
+
+import json
+import urllib.error
+import urllib.request
+
+BOARD_PROJECT_ID = "PVT_kwDOABnCXs4AgIEx"
+STATUS_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgVUF6A"
+TEAM_FIELD_ID = "PVTSSF_lADOABnCXs4AgIExzgbkzoM"
+SPRINT_FIELD_ID = "PVTIF_lADOABnCXs4AgIExzgavkek"
+
+GITHUB_API_URL = "https://api.github.com"
+GITHUB_GRAPHQL_URL = "https://api.github.com/graphql"
+HTTP_TIMEOUT_SECONDS = 30
+
+
+class GraphqlError(Exception):
+    pass
+
+
+def http_request(url, token, method="GET", body=None):
+    data = json.dumps(body).encode("utf-8") if body is not None else None
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Authorization", f"Bearer {token}")
+    request.add_header("Accept", "application/vnd.github+json")
+    if data is not None:
+        request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=HTTP_TIMEOUT_SECONDS) as response:
+            return json.loads(response.read().decode("utf-8"))
+    except urllib.error.HTTPError as error:
+        print(f"GitHub API error {error.code} for {method} {url}: {error.read().decode('utf-8')}")
+        raise
+
+
+def graphql_request(query, variables, token):
+    result = http_request(
+        GITHUB_GRAPHQL_URL,
+        token,
+        method="POST",
+        body={"query": query, "variables": variables},
+    )
+    errors = result.get("errors")
+    if errors:
+        raise GraphqlError(f"GraphQL request returned errors: {errors}")
+    return result
+
+
+def require_node(result, resolved_id):
+    node = result["data"]["node"]
+    if node is None:
+        raise GraphqlError(
+            f"GraphQL id '{resolved_id}' resolved to no node (data.node is null). "
+            f"The id is probably stale, e.g. a board field that was deleted and recreated."
+        )
+    return node
+
+
+def assign_author(repo, pr_number, author_login, token):
+    return http_request(
+        f"{GITHUB_API_URL}/repos/{repo}/issues/{pr_number}/assignees",
+        token,
+        method="POST",
+        body={"assignees": [author_login]},
+    )
+
+
+def convert_pr_to_draft(pr_node_id, token):
+    query = """
+    mutation($pullRequestId: ID!) {
+      convertPullRequestToDraft(input: { pullRequestId: $pullRequestId }) {
+        pullRequest { id isDraft }
+      }
+    }
+    """
+    return graphql_request(query, {"pullRequestId": pr_node_id}, token)
+
+
+def add_item_to_project(pr_node_id, token):
+    query = """
+    mutation($projectId: ID!, $contentId: ID!) {
+      addProjectV2ItemById(input: { projectId: $projectId, contentId: $contentId }) {
+        item { id }
+      }
+    }
+    """
+    result = graphql_request(
+        query, {"projectId": BOARD_PROJECT_ID, "contentId": pr_node_id}, token
+    )
+    return result["data"]["addProjectV2ItemById"]["item"]["id"]
+
+
+def remove_item_from_board(item_id, token):
+    """The story's one removal (aim 6): a PR's own CARD on board 15, removed
+    unconditionally the moment the PR closes an issue and already has one --
+    no guard on its Status or fields. This removes the board item only,
+    nothing about the pull request itself; the GraphQL mutation is still
+    named deleteProjectV2Item (GitHub's name, not ours). Never call this with
+    an issue's item id; an issue's card is never removed by anything in this
+    workflow."""
+    query = """
+    mutation($projectId: ID!, $itemId: ID!) {
+      deleteProjectV2Item(input: { projectId: $projectId, itemId: $itemId }) {
+        deletedItemId
+      }
+    }
+    """
+    return graphql_request(query, {"projectId": BOARD_PROJECT_ID, "itemId": item_id}, token)
+
+
+def set_project_field_option(item_id, field_id, option_id, token):
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $optionId: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { singleSelectOptionId: $optionId }
+        }
+      ) {
+        projectV2Item { id }
+      }
+    }
+    """
+    return graphql_request(
+        query,
+        {
+            "projectId": BOARD_PROJECT_ID,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "optionId": option_id,
+        },
+        token,
+    )
+
+
+def fetch_project_field_options(field_id, token):
+    query = """
+    query($fieldId: ID!) {
+      node(id: $fieldId) {
+        ... on ProjectV2SingleSelectField {
+          options { id name }
+        }
+      }
+    }
+    """
+    result = graphql_request(query, {"fieldId": field_id}, token)
+    return require_node(result, field_id)["options"]
+
+
+def set_project_field_iteration(item_id, field_id, iteration_id, token):
+    query = """
+    mutation($projectId: ID!, $itemId: ID!, $fieldId: ID!, $iterationId: String!) {
+      updateProjectV2ItemFieldValue(
+        input: {
+          projectId: $projectId
+          itemId: $itemId
+          fieldId: $fieldId
+          value: { iterationId: $iterationId }
+        }
+      ) {
+        projectV2Item { id }
+      }
+    }
+    """
+    return graphql_request(
+        query,
+        {
+            "projectId": BOARD_PROJECT_ID,
+            "itemId": item_id,
+            "fieldId": field_id,
+            "iterationId": iteration_id,
+        },
+        token,
+    )
+
+
+def fetch_project_iterations(field_id, token):
+    query = """
+    query($fieldId: ID!) {
+      node(id: $fieldId) {
+        ... on ProjectV2IterationField {
+          configuration {
+            iterations { id title startDate duration }
+          }
+        }
+      }
+    }
+    """
+    result = graphql_request(query, {"fieldId": field_id}, token)
+    return require_node(result, field_id)["configuration"]["iterations"]

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -120,8 +120,15 @@ class DecideTransitionTest(unittest.TestCase):
     def test_opened_is_not_a_transition(self):
         self.assertIsNone(pr_triage.decide_transition("opened"))
 
-    def test_reopened_is_not_a_transition(self):
-        self.assertIsNone(pr_triage.decide_transition("reopened"))
+    def test_reopened_draft_pr_moves_status_to_working(self):
+        transition = pr_triage.decide_transition("reopened", is_draft=True)
+
+        self.assertEqual(transition["status"], "Working")
+
+    def test_reopened_ready_pr_moves_status_to_review(self):
+        transition = pr_triage.decide_transition("reopened", is_draft=False)
+
+        self.assertEqual(transition["status"], "Review")
 
     def test_transition_rule_is_decoupled_from_the_unknown_author_rule(self):
         with mock.patch.object(pr_triage, "UNKNOWN_AUTHOR_STATUS", "SomethingElse"):
@@ -134,6 +141,22 @@ class DecideTransitionTest(unittest.TestCase):
             transition = pr_triage.decide_transition("converted_to_draft")
 
         self.assertEqual(transition["status"], "Working")
+
+
+class CheckAssignmentSucceededTest(unittest.TestCase):
+    def test_raises_when_author_login_is_absent_from_the_assignees_response(self):
+        assign_result = {"assignees": []}
+
+        with self.assertRaises(pr_triage.AssignmentDroppedError) as context:
+            pr_triage.check_assignment_succeeded("someuser", assign_result)
+
+        self.assertIn("someuser", str(context.exception))
+        self.assertIn("pr-triage-teams.yml", str(context.exception))
+
+    def test_does_not_raise_when_author_login_is_present(self):
+        assign_result = {"assignees": [{"login": "someuser"}]}
+
+        pr_triage.check_assignment_succeeded("someuser", assign_result)
 
 
 class StripEmojiPrefixTest(unittest.TestCase):
@@ -234,6 +257,22 @@ class ValidateTeamValuesTest(unittest.TestCase):
         errors = validate_pr_triage_teams.find_unknown_team_values(mapping, valid_team_names={"Dev", "Delivery"})
 
         self.assertEqual(errors, [])
+
+
+class FindDuplicateLoginsTest(unittest.TestCase):
+    def test_flags_a_login_listed_twice(self):
+        text = "teams:\n  mswertz: Dev\n  hslh: Delivery\n  mswertz: Delivery\n"
+
+        duplicates = validate_pr_triage_teams.find_duplicate_logins(text)
+
+        self.assertEqual(duplicates, ["mswertz"])
+
+    def test_passes_when_every_login_appears_once(self):
+        text = "teams:\n  mswertz: Dev\n  hslh: Delivery\n"
+
+        duplicates = validate_pr_triage_teams.find_duplicate_logins(text)
+
+        self.assertEqual(duplicates, [])
 
 
 class ValidateBlankTeamValuesTest(unittest.TestCase):
@@ -429,6 +468,247 @@ class MainWiringTest(unittest.TestCase):
         self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
         self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_OPT")
         self.assertEqual(team_write["token"], "board-token")
+
+
+class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
+    def test_main_raises_and_records_failure_when_github_drops_the_assignment(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        def fake_http_request(url, token, method="GET", body=None):
+            if url.endswith("/assignees"):
+                return {"assignees": []}
+            raise AssertionError(f"unexpected call: {url}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "github-token",
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                with self.assertRaises(pr_triage.AssignmentDroppedError):
+                    pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("Failure", summary_text)
+        self.assertIn("mswertz", summary_text)
+
+
+class MappingFilePathTest(unittest.TestCase):
+    def test_is_absolute_even_when_file_argument_is_relative(self):
+        result = pr_triage.mapping_file_path("some/relative/.github/scripts/pr_triage.py")
+
+        self.assertTrue(os.path.isabs(result))
+
+    def test_resolves_next_to_the_given_file_not_against_cwd(self):
+        result = pr_triage.mapping_file_path("/opt/checkout/.github/scripts/pr_triage.py")
+
+        self.assertEqual(result, "/opt/checkout/.github/pr-triage-teams.yml")
+
+
+class MainWiringReopenedTest(unittest.TestCase):
+    def _run_reopened(self, is_draft, item_exists):
+        import tempfile
+
+        event = {
+            "action": "reopened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": is_draft,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+
+            if url.endswith("/assignees"):
+                raise AssertionError("reopened must never touch the assignee")
+            if "convertPullRequestToDraft" in query:
+                raise AssertionError("reopened must never call convertPullRequestToDraft")
+            if "ReadyForReview" in query:
+                raise AssertionError("reopened must never call a ready-conversion mutation")
+
+            if "projectItems" in query:
+                if item_exists:
+                    nodes = [
+                        {
+                            "id": "EXISTING_ITEM",
+                            "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                            "fieldValueByName": {"name": "Working"},
+                        }
+                    ]
+                else:
+                    nodes = []
+                return {"data": {"node": {"projectItems": {"nodes": nodes}}}}
+
+            if "addProjectV2ItemById" in query:
+                if item_exists:
+                    raise AssertionError("must not add an item that already exists")
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "NEW_ITEM"}}}}
+
+            if "updateProjectV2ItemFieldValue" in query:
+                if variables.get("fieldId") == pr_triage.TEAM_FIELD_ID:
+                    raise AssertionError("reopened must never write the Team field")
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM"}}}}
+
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
+                raise AssertionError("reopened must never fetch Team options")
+
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                pr_triage.main()
+
+        return calls
+
+    def test_reopened_draft_pr_moves_status_to_working(self):
+        calls = self._run_reopened(is_draft=True, item_exists=True)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 1)
+        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
+
+    def test_reopened_ready_pr_moves_status_to_review(self):
+        calls = self._run_reopened(is_draft=False, item_exists=True)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 1)
+        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")
+
+    def test_reopened_with_no_existing_item_is_added_not_skipped(self):
+        calls = self._run_reopened(is_draft=False, item_exists=False)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        add_item_calls = [call for call in calls if "addProjectV2ItemById" in query_of(call)]
+        self.assertEqual(len(add_item_calls), 1)
+
+
+class MainWiringOpenedStillRunsFullOpenPathTest(unittest.TestCase):
+    def test_opened_action_still_assigns_drafts_and_writes_team(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+            if url.endswith("/assignees"):
+                return {"assignees": [{"login": "mswertz"}]}
+            if "convertPullRequestToDraft" in query:
+                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+            if "addProjectV2ItemById" in query:
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "github-token",
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                pr_triage.main()
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        assign_call = next(call for call in calls if call["url"].endswith("/assignees"))
+        self.assertEqual(assign_call["token"], "github-token")
+
+        draft_call = next(call for call in calls if "convertPullRequestToDraft" in query_of(call))
+        self.assertEqual(draft_call["token"], "github-token")
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 2)
+        self.assertEqual(field_writes[1]["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
 
 
 class MainWiringUnknownAuthorTest(unittest.TestCase):
@@ -1255,6 +1535,88 @@ class FindBannedTermsAcrossTriageSourceTest(unittest.TestCase):
         self.assertEqual(findings, [])
 
 
+class ValidateMainExitsNonZeroOnDuplicateLoginTest(unittest.TestCase):
+    def test_main_exits_non_zero_when_a_login_is_listed_twice(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = os.path.join(tmp_dir, "repo")
+            scripts_dir = os.path.join(repo_root, ".github", "scripts")
+            workflows_dir = os.path.join(repo_root, ".github", "workflows")
+            os.makedirs(scripts_dir)
+            os.makedirs(workflows_dir)
+            with open(os.path.join(repo_root, ".github", "pr-triage-teams.yml"), "w", encoding="utf-8") as handle:
+                handle.write("teams:\n  mswertz: Dev\n  mswertz: Delivery\n")
+            with open(os.path.join(workflows_dir, "pr-triage.yml"), "w", encoding="utf-8") as handle:
+                handle.write("on:\n  pull_request:\n    types: [opened]\n")
+            with open(os.path.join(scripts_dir, "pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("def decide():\n    pass\n")
+            with open(os.path.join(scripts_dir, "validate_pr_triage_teams.py"), "w", encoding="utf-8") as handle:
+                handle.write("BANNED = ('author_association',)\n")
+            with open(os.path.join(scripts_dir, "test_pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("workflow_text = 'author_association'\n")
+
+            env = {"PROJECT_BOARD_TOKEN": "board-token"}
+            fake_status_options = [{"id": "s1", "name": "Working"}, {"id": "s2", "name": "Review"}]
+            fake_team_options = [{"id": "t1", "name": "Dev"}, {"id": "t2", "name": "Delivery"}]
+
+            def fake_fetch(field_id, token):
+                if field_id == pr_triage.TEAM_FIELD_ID:
+                    return fake_team_options
+                return fake_status_options
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "fetch_project_field_options", side_effect=fake_fetch
+            ):
+                with self.assertRaises(SystemExit) as context:
+                    validate_pr_triage_teams.main(repo_root=repo_root)
+
+        self.assertNotEqual(context.exception.code, 0)
+
+
+class ValidateMainChecksTransitionStatusConstantsTest(unittest.TestCase):
+    def _write_clean_repo(self, tmp_dir):
+        repo_root = os.path.join(tmp_dir, "repo")
+        scripts_dir = os.path.join(repo_root, ".github", "scripts")
+        workflows_dir = os.path.join(repo_root, ".github", "workflows")
+        os.makedirs(scripts_dir)
+        os.makedirs(workflows_dir)
+        with open(os.path.join(repo_root, ".github", "pr-triage-teams.yml"), "w", encoding="utf-8") as handle:
+            handle.write("teams:\n  mswertz: Dev\n")
+        with open(os.path.join(workflows_dir, "pr-triage.yml"), "w", encoding="utf-8") as handle:
+            handle.write("on:\n  pull_request:\n    types: [opened]\n")
+        with open(os.path.join(scripts_dir, "pr_triage.py"), "w", encoding="utf-8") as handle:
+            handle.write("def decide():\n    pass\n")
+        with open(os.path.join(scripts_dir, "validate_pr_triage_teams.py"), "w", encoding="utf-8") as handle:
+            handle.write("BANNED = ('author_association',)\n")
+        with open(os.path.join(scripts_dir, "test_pr_triage.py"), "w", encoding="utf-8") as handle:
+            handle.write("workflow_text = 'author_association'\n")
+        return repo_root
+
+    def test_validator_flags_a_status_review_that_diverged_from_the_unknown_author_status(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = self._write_clean_repo(tmp_dir)
+
+            env = {"PROJECT_BOARD_TOKEN": "board-token"}
+            fake_status_options = [{"id": "s1", "name": "Working"}, {"id": "s2", "name": "Review"}]
+            fake_team_options = [{"id": "t1", "name": "Dev"}]
+
+            def fake_fetch(field_id, token):
+                if field_id == pr_triage.TEAM_FIELD_ID:
+                    return fake_team_options
+                return fake_status_options
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "fetch_project_field_options", side_effect=fake_fetch
+            ), mock.patch.object(pr_triage, "STATUS_REVIEW", "DivergedFromUnknownAuthorStatus"):
+                with self.assertRaises(SystemExit) as context:
+                    validate_pr_triage_teams.main(repo_root=repo_root)
+
+        self.assertNotEqual(context.exception.code, 0)
+
+
 class ValidateMainExitsNonZeroOnBannedTermTest(unittest.TestCase):
     def test_main_exits_non_zero_when_a_banned_term_is_planted(self):
         import tempfile
@@ -1286,6 +1648,18 @@ class ValidateMainExitsNonZeroOnBannedTermTest(unittest.TestCase):
                     validate_pr_triage_teams.main(repo_root=repo_root)
 
         self.assertNotEqual(context.exception.code, 0)
+
+
+class WorkflowHasAPerPrConcurrencyGroupTest(unittest.TestCase):
+    def test_concurrency_group_is_scoped_per_pr_and_does_not_cancel_in_progress_runs(self):
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
+        with open(workflow_path, encoding="utf-8") as handle:
+            workflow_text = handle.read()
+
+        self.assertIn("concurrency:", workflow_text)
+        self.assertIn("github.event.pull_request.number", workflow_text)
+        self.assertNotIn("cancel-in-progress: true", workflow_text)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -20,7 +20,6 @@ class DecidePrTriageTest(unittest.TestCase):
         self.assertTrue(decision["known"])
         self.assertTrue(decision["assign"])
         self.assertTrue(decision["force_draft"])
-        self.assertEqual(decision["status"], "Working")
         self.assertEqual(decision["team"], "Dev")
 
     def test_known_author_mapped_to_delivery_boards_under_delivery(self):
@@ -39,7 +38,6 @@ class DecidePrTriageTest(unittest.TestCase):
         self.assertFalse(decision["known"])
         self.assertFalse(decision["assign"])
         self.assertFalse(decision["force_draft"])
-        self.assertEqual(decision["status"], "Review")
         self.assertEqual(decision["team"], "Dev")
 
     def test_unknown_author_already_draft_is_still_not_touched(self):
@@ -50,7 +48,6 @@ class DecidePrTriageTest(unittest.TestCase):
         self.assertFalse(decision["known"])
         self.assertFalse(decision["assign"])
         self.assertFalse(decision["force_draft"])
-        self.assertEqual(decision["status"], "Review")
         self.assertEqual(decision["team"], "Dev")
 
     def test_bot_author_is_unknown_regardless_of_login_shape(self):
@@ -60,7 +57,6 @@ class DecidePrTriageTest(unittest.TestCase):
 
         self.assertFalse(decision["known"])
         self.assertFalse(decision["assign"])
-        self.assertEqual(decision["status"], "Review")
         self.assertEqual(decision["team"], "Dev")
 
     def test_known_author_already_draft_is_not_re_converted(self):
@@ -87,7 +83,6 @@ class DecidePrTriageTest(unittest.TestCase):
         self.assertFalse(decision["known"])
         self.assertFalse(decision["assign"])
         self.assertFalse(decision["force_draft"])
-        self.assertEqual(decision["status"], "Review")
         self.assertEqual(decision["team"], "Dev")
 
     def test_whitespace_only_team_value_is_treated_as_unknown(self):
@@ -105,45 +100,89 @@ class DecidePrTriageTest(unittest.TestCase):
         self.assertFalse(decision["known"])
 
 
+class DecideStatusTest(unittest.TestCase):
+    def test_blank_status_fills_from_draft_state(self):
+        self.assertEqual(pr_triage.decide_status(True, None), "Working")
+        self.assertEqual(pr_triage.decide_status(False, None), "Review")
+
+    def test_blank_string_status_counts_as_blank(self):
+        self.assertEqual(pr_triage.decide_status(True, "   "), "Working")
+
+    def test_working_flips_to_review_when_pr_is_ready(self):
+        self.assertEqual(pr_triage.decide_status(False, "Working"), "Review")
+
+    def test_review_flips_to_working_when_pr_is_draft(self):
+        self.assertEqual(pr_triage.decide_status(True, "Review"), "Working")
+
+    def test_working_stays_working_when_pr_is_draft(self):
+        self.assertEqual(pr_triage.decide_status(True, "Working"), "Working")
+
+    def test_review_stays_review_when_pr_is_ready(self):
+        self.assertEqual(pr_triage.decide_status(False, "Review"), "Review")
+
+    def test_non_managed_statuses_are_never_touched_regardless_of_draft_state(self):
+        for status in ("Epic", "Blocked", "Backlog", "Done", "Inbox", "Icebox"):
+            with self.subTest(status=status):
+                self.assertIsNone(pr_triage.decide_status(True, status))
+                self.assertIsNone(pr_triage.decide_status(False, status))
+
+    def test_all_eight_real_board_option_names_behave_correctly_for_both_draft_states(self):
+        expected = {
+            "\U0001f4cb Epic": (None, None),
+            "⛔️ Blocked": (None, None),
+            "\U0001f4da Backlog": (None, None),
+            "\U0001f6e0️ Working": ("Working", "Review"),
+            "\U0001f50d Review": ("Working", "Review"),
+            "✅ Done": (None, None),
+            "\U0001f4e5 Inbox": (None, None),
+            "Icebox": (None, None),
+        }
+
+        for real_name, (expected_draft, expected_ready) in expected.items():
+            with self.subTest(real_name=real_name):
+                self.assertEqual(pr_triage.decide_status(True, real_name), expected_draft)
+                self.assertEqual(pr_triage.decide_status(False, real_name), expected_ready)
+
+
 class DecideBoardUpdateTest(unittest.TestCase):
     def test_ready_for_review_sets_status_review_outright(self):
         fields = pr_triage.decide_board_update(
-            "ready_for_review", is_draft=False, current_status="Working", current_team="Dev", mapped_team="Dev"
+            "ready_for_review", is_draft=False, current_status="🛠️ Working", current_team="Dev", mapped_team="Dev"
         )
 
         self.assertEqual(fields["status"], "Review")
 
     def test_converted_to_draft_sets_status_working_outright(self):
         fields = pr_triage.decide_board_update(
-            "converted_to_draft", is_draft=True, current_status="Review", current_team="Dev", mapped_team="Dev"
+            "converted_to_draft", is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
         )
 
         self.assertEqual(fields["status"], "Working")
 
     def test_reopened_draft_sets_status_working_outright(self):
         fields = pr_triage.decide_board_update(
-            "reopened", is_draft=True, current_status="Review", current_team="Dev", mapped_team="Dev"
+            "reopened", is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
         )
 
         self.assertEqual(fields["status"], "Working")
 
     def test_reopened_ready_sets_status_review_outright(self):
         fields = pr_triage.decide_board_update(
-            "reopened", is_draft=False, current_status="Working", current_team="Dev", mapped_team="Dev"
+            "reopened", is_draft=False, current_status="🛠️ Working", current_team="Dev", mapped_team="Dev"
         )
 
         self.assertEqual(fields["status"], "Review")
 
-    def test_transition_status_overwrites_even_when_status_already_set(self):
+    def test_transition_flips_a_managed_status_to_match_current_draft_state(self):
         fields = pr_triage.decide_board_update(
-            "ready_for_review", is_draft=False, current_status="Review", current_team="Dev", mapped_team="Dev"
+            "reopened", is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
         )
 
-        self.assertEqual(fields["status"], "Review")
+        self.assertEqual(fields["status"], "Working")
 
     def test_transition_fills_team_when_empty(self):
         fields = pr_triage.decide_board_update(
-            "ready_for_review", is_draft=False, current_status="Working", current_team=None, mapped_team="Delivery"
+            "ready_for_review", is_draft=False, current_status="🛠️ Working", current_team=None, mapped_team="Delivery"
         )
 
         self.assertEqual(fields["team"], "Delivery")
@@ -152,7 +191,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
         fields = pr_triage.decide_board_update(
             "ready_for_review",
             is_draft=False,
-            current_status="Working",
+            current_status="🛠️ Working",
             current_team="Analysis",
             mapped_team="Delivery",
         )
@@ -173,38 +212,52 @@ class DecideBoardUpdateTest(unittest.TestCase):
 
         self.assertEqual(fields["status"], "Review")
 
-    def test_synchronize_never_overwrites_a_non_empty_status(self):
+    def test_synchronize_flips_a_managed_status_to_match_current_draft_state(self):
         fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=True, current_status="Review", current_team="Dev", mapped_team="Dev"
+            "synchronize", is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
+        )
+
+        self.assertEqual(fields["status"], "Working")
+
+    def test_synchronize_leaves_a_non_managed_status_alone(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=True, current_status="📋 Epic", current_team="Dev", mapped_team="Dev"
+        )
+
+        self.assertIsNone(fields["status"])
+
+    def test_transition_leaves_a_non_managed_status_alone(self):
+        fields = pr_triage.decide_board_update(
+            "ready_for_review", is_draft=False, current_status="⛔️ Blocked", current_team="Dev", mapped_team="Dev"
         )
 
         self.assertIsNone(fields["status"])
 
     def test_synchronize_fills_team_when_empty(self):
         fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status="Review", current_team=None, mapped_team="Delivery"
+            "synchronize", is_draft=False, current_status="🔍 Review", current_team=None, mapped_team="Delivery"
         )
 
         self.assertEqual(fields["team"], "Delivery")
 
     def test_synchronize_never_overwrites_a_non_empty_team(self):
         fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status="Review", current_team="Analysis", mapped_team="Delivery"
+            "synchronize", is_draft=False, current_status="🔍 Review", current_team="Analysis", mapped_team="Delivery"
         )
 
         self.assertIsNone(fields["team"])
 
-    def test_synchronize_never_overwrites_status_or_team_together(self):
+    def test_synchronize_leaves_non_managed_status_alone_while_still_filling_team(self):
         fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=True, current_status="Review", current_team="Analysis", mapped_team="Delivery"
+            "synchronize", is_draft=True, current_status="📋 Epic", current_team=None, mapped_team="Delivery"
         )
 
         self.assertIsNone(fields["status"])
-        self.assertIsNone(fields["team"])
+        self.assertEqual(fields["team"], "Delivery")
 
     def test_blank_string_team_counts_as_empty(self):
         fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status="Review", current_team="   ", mapped_team="Delivery"
+            "synchronize", is_draft=False, current_status="🔍 Review", current_team="   ", mapped_team="Delivery"
         )
 
         self.assertEqual(fields["team"], "Delivery")
@@ -227,7 +280,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
         fields = pr_triage.decide_board_update(
             "ready_for_review",
             is_draft=False,
-            current_status="Working",
+            current_status="🛠️ Working",
             current_team="Dev",
             mapped_team="Dev",
             current_sprint=None,
@@ -240,7 +293,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
         fields = pr_triage.decide_board_update(
             "converted_to_draft",
             is_draft=True,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             mapped_team="Dev",
             current_sprint="Sprint 259",
@@ -253,7 +306,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
         fields = pr_triage.decide_board_update(
             "reopened",
             is_draft=False,
-            current_status="Working",
+            current_status="🛠️ Working",
             current_team="Dev",
             mapped_team="Dev",
             current_sprint=None,
@@ -266,7 +319,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
         fields = pr_triage.decide_board_update(
             "synchronize",
             is_draft=False,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             mapped_team="Dev",
             current_sprint=None,
@@ -279,7 +332,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
         fields = pr_triage.decide_board_update(
             "synchronize",
             is_draft=False,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             mapped_team="Dev",
             current_sprint="Sprint 259",
@@ -292,7 +345,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
         fields = pr_triage.decide_board_update(
             "synchronize",
             is_draft=False,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             mapped_team="Dev",
             current_sprint="   ",
@@ -305,7 +358,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
         fields = pr_triage.decide_board_update(
             "synchronize",
             is_draft=False,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             mapped_team="Dev",
             current_sprint=None,
@@ -316,7 +369,7 @@ class DecideBoardUpdateTest(unittest.TestCase):
 
     def test_no_field_is_written_by_default_when_sprint_args_are_omitted(self):
         fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status="Review", current_team="Dev", mapped_team="Dev"
+            "synchronize", is_draft=False, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
         )
 
         self.assertIsNone(fields["sprint"])
@@ -613,7 +666,7 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -689,7 +742,7 @@ class MainWiringTest(unittest.TestCase):
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -771,7 +824,7 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -848,7 +901,16 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                    return {
+                        "data": {
+                            "node": {
+                                "options": [
+                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
+                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
+                                ]
+                            }
+                        }
+                    }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -889,6 +951,11 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
 
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
         self.assertEqual(len(field_writes), 2)
+
+        status_write = next(
+            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        )
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_REVIEW_OPT")
 
         self.assertIn("### PR triage", summary_text)
         self.assertIn("| Assignee set | True |", summary_text)
@@ -1049,7 +1116,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
 
     def test_ready_for_review_overwrites_status_even_when_already_set(self):
         calls, _ = self._run_board_update(
-            "ready_for_review", is_draft=False, item_exists=True, current_status="Working", current_team="Dev"
+            "ready_for_review", is_draft=False, item_exists=True, current_status="🛠️ Working", current_team="Dev"
         )
 
         status_writes = [
@@ -1064,7 +1131,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
 
     def test_converted_to_draft_overwrites_status_even_when_already_set(self):
         calls, _ = self._run_board_update(
-            "converted_to_draft", is_draft=True, item_exists=True, current_status="Review", current_team="Dev"
+            "converted_to_draft", is_draft=True, item_exists=True, current_status="🔍 Review", current_team="Dev"
         )
 
         status_writes = [
@@ -1076,7 +1143,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
 
     def test_reopened_draft_overwrites_status_to_working(self):
         calls, _ = self._run_board_update(
-            "reopened", is_draft=True, item_exists=True, current_status="Review", current_team="Dev"
+            "reopened", is_draft=True, item_exists=True, current_status="🔍 Review", current_team="Dev"
         )
 
         status_writes = [
@@ -1088,7 +1155,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
 
     def test_reopened_ready_overwrites_status_to_review(self):
         calls, _ = self._run_board_update(
-            "reopened", is_draft=False, item_exists=True, current_status="Working", current_team="Dev"
+            "reopened", is_draft=False, item_exists=True, current_status="🛠️ Working", current_team="Dev"
         )
 
         status_writes = [
@@ -1105,6 +1172,18 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         self.assertEqual(len(add_item_calls), 1)
         self.assertEqual(add_item_calls[0]["token"], "board-token")
 
+    def test_transition_never_touches_a_non_managed_status(self):
+        calls, _ = self._run_board_update(
+            "ready_for_review", is_draft=False, item_exists=True, current_status="⛔️ Blocked", current_team="Dev"
+        )
+
+        status_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        ]
+        self.assertEqual(status_writes, [])
+
     # --- transitions: Team and Sprint fill only, never overwrite ---
 
     def test_transition_fills_team_when_empty(self):
@@ -1112,7 +1191,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "ready_for_review",
             is_draft=False,
             item_exists=True,
-            current_status="Working",
+            current_status="🛠️ Working",
             current_team=None,
             mapping={"mswertz": "Delivery"},
         )
@@ -1128,7 +1207,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "ready_for_review",
             is_draft=False,
             item_exists=True,
-            current_status="Working",
+            current_status="🛠️ Working",
             current_team="Dev",
             mapping={"mswertz": "Delivery"},
         )
@@ -1143,7 +1222,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "converted_to_draft",
             is_draft=True,
             item_exists=True,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             current_sprint=None,
         )
@@ -1161,7 +1240,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "converted_to_draft",
             is_draft=True,
             item_exists=True,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             current_sprint="Sprint 259",
         )
@@ -1180,7 +1259,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "synchronize",
             is_draft=False,
             item_exists=True,
-            current_status="Review",
+            current_status="📋 Epic",
             current_team="Dev",
             current_sprint="Sprint 260",
         )
@@ -1203,12 +1282,30 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         self.assertEqual(len(status_writes), 1)
         self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
 
-    def test_synchronize_never_overwrites_a_non_empty_status(self):
+    def test_synchronize_flips_a_managed_status_to_match_current_draft_state(self):
         calls, _ = self._run_board_update(
             "synchronize",
             is_draft=True,
             item_exists=True,
-            current_status="Review",
+            current_status="🔍 Review",
+            current_team="Dev",
+            current_sprint="Sprint 260",
+        )
+
+        status_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        ]
+        self.assertEqual(len(status_writes), 1)
+        self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
+
+    def test_synchronize_never_touches_a_non_managed_status(self):
+        calls, _ = self._run_board_update(
+            "synchronize",
+            is_draft=True,
+            item_exists=True,
+            current_status="📋 Epic",
             current_team="Dev",
             current_sprint="Sprint 260",
         )
@@ -1225,7 +1322,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "synchronize",
             is_draft=False,
             item_exists=True,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team=None,
             current_sprint="Sprint 260",
             mapping={"mswertz": "Delivery"},
@@ -1242,7 +1339,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "synchronize",
             is_draft=False,
             item_exists=True,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             current_sprint="Sprint 260",
             mapping={"mswertz": "Delivery"},
@@ -1258,7 +1355,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "synchronize",
             is_draft=False,
             item_exists=True,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             current_sprint=None,
         )
@@ -1276,7 +1373,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             "synchronize",
             is_draft=False,
             item_exists=True,
-            current_status="Review",
+            current_status="🔍 Review",
             current_team="Dev",
             current_sprint="Sprint 259",
         )
@@ -1504,7 +1601,16 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_REVIEW_OPT", "name": "Review"}]}}}
+                    return {
+                        "data": {
+                            "node": {
+                                "options": [
+                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
+                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
+                                ]
+                            }
+                        }
+                    }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_DEV_OPT", "name": "Dev"}]}}}
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -1532,7 +1638,7 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
 
         return calls, summary_text
 
-    def _assert_unknown_author_boarded_correctly(self, calls, summary_text):
+    def _assert_unknown_author_boarded_correctly(self, calls, summary_text, expected_status_option_id):
         def query_of(call):
             return (call["body"] or {}).get("query", "")
 
@@ -1547,7 +1653,7 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
 
         status_write = field_writes[0]
         self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
-        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_REVIEW_OPT")
+        self.assertEqual(status_write["body"]["variables"]["optionId"], expected_status_option_id)
         self.assertEqual(status_write["token"], "board-token")
 
         team_write = field_writes[1]
@@ -1562,13 +1668,13 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
         )
         self.assertIn("absent from .github/pr-triage-teams.yml", summary_text)
 
-    def test_unknown_author_ready_for_review_is_boarded_without_assign_or_draft(self):
+    def test_unknown_author_ready_for_review_is_boarded_review(self):
         calls, summary_text = self._run_main_for(is_draft=False)
-        self._assert_unknown_author_boarded_correctly(calls, summary_text)
+        self._assert_unknown_author_boarded_correctly(calls, summary_text, "STATUS_REVIEW_OPT")
 
-    def test_unknown_author_already_draft_is_boarded_without_assign_or_draft(self):
+    def test_unknown_author_already_draft_is_boarded_working(self):
         calls, summary_text = self._run_main_for(is_draft=True)
-        self._assert_unknown_author_boarded_correctly(calls, summary_text)
+        self._assert_unknown_author_boarded_correctly(calls, summary_text, "STATUS_WORKING_OPT")
 
 
 class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
@@ -1607,7 +1713,7 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
                     call_kinds.append("fetch_status_options")
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     call_kinds.append("fetch_team_options")
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
@@ -1781,7 +1887,16 @@ class MainReadsAssignDecisionTest(unittest.TestCase):
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                    return {
+                        "data": {
+                            "node": {
+                                "options": [
+                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
+                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
+                                ]
+                            }
+                        }
+                    }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -1829,7 +1944,7 @@ class FindBoardItemForPrTest(unittest.TestCase):
                             {
                                 "id": "EXISTING_ITEM",
                                 "project": {"id": pr_triage.BOARD_PROJECT_ID},
-                                "status": {"name": "Working"},
+                                "status": {"name": "🛠️ Working"},
                                 "team": {"name": "Dev"},
                                 "sprint": {"title": "Sprint 260"},
                             },
@@ -1842,7 +1957,7 @@ class FindBoardItemForPrTest(unittest.TestCase):
             item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertEqual(item["id"], "EXISTING_ITEM")
-        self.assertEqual(item["status"], "Working")
+        self.assertEqual(item["status"], "🛠️ Working")
         self.assertEqual(item["team"], "Dev")
         self.assertEqual(item["sprint"], "Sprint 260")
 
@@ -2086,7 +2201,7 @@ class ValidateMainExitsNonZeroOnDuplicateLoginTest(unittest.TestCase):
                 handle.write("workflow_text = 'author_association'\n")
 
             env = {"PROJECT_BOARD_TOKEN": "board-token"}
-            fake_status_options = [{"id": "s1", "name": "Working"}, {"id": "s2", "name": "Review"}]
+            fake_status_options = [{"id": "s1", "name": "🛠️ Working"}, {"id": "s2", "name": "🔍 Review"}]
             fake_team_options = [{"id": "t1", "name": "Dev"}, {"id": "t2", "name": "Delivery"}]
 
             def fake_fetch(field_id, token):
@@ -2129,7 +2244,7 @@ class ValidateMainChecksTransitionStatusConstantsTest(unittest.TestCase):
             repo_root = self._write_clean_repo(tmp_dir)
 
             env = {"PROJECT_BOARD_TOKEN": "board-token"}
-            fake_status_options = [{"id": "s1", "name": "Working"}, {"id": "s2", "name": "Review"}]
+            fake_status_options = [{"id": "s1", "name": "🛠️ Working"}, {"id": "s2", "name": "🔍 Review"}]
             fake_team_options = [{"id": "t1", "name": "Dev"}]
 
             def fake_fetch(field_id, token):

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -388,98 +388,12 @@ class DecideStatusTest(unittest.TestCase):
 
 
 class DecideBoardUpdateTest(unittest.TestCase):
-    """decide_board_update no longer takes an action: main() already filters to
-    BOARD_UPDATE_ACTIONS before calling it, so every action in that tuple (the
-    three transitions and synchronize alike) must obey the identical rule.
-    Every case below runs once per action via subTest to prove that."""
-
-    def test_status_flips_a_managed_status_to_match_current_draft_state(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
-                )
-                self.assertEqual(fields["status"], "Working")
-
-                fields = pr_triage.decide_board_update(
-                    is_draft=False, current_status="🛠️ Working", current_team="Dev", mapped_team="Dev"
-                )
-                self.assertEqual(fields["status"], "Review")
-
-    def test_status_already_matching_current_draft_state_is_not_rewritten(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=True, current_status="🛠️ Working", current_team="Dev", mapped_team="Dev"
-                )
-                self.assertIsNone(fields["status"])
-
-    def test_status_fills_when_empty(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=True, current_status=None, current_team="Dev", mapped_team="Dev"
-                )
-                self.assertEqual(fields["status"], "Working")
-
-                fields = pr_triage.decide_board_update(
-                    is_draft=False, current_status=None, current_team="Dev", mapped_team="Dev"
-                )
-                self.assertEqual(fields["status"], "Review")
-
-    def test_status_leaves_a_non_managed_status_alone(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=True, current_status="📋 Epic", current_team="Dev", mapped_team="Dev"
-                )
-                self.assertIsNone(fields["status"])
-
-    def test_team_fills_when_empty(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=False, current_status="🛠️ Working", current_team=None, mapped_team="Delivery"
-                )
-                self.assertEqual(fields["team"], "Delivery")
-
-    def test_team_never_overwrites_a_non_empty_team(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=False, current_status="🛠️ Working", current_team="Analysis", mapped_team="Delivery"
-                )
-                self.assertIsNone(fields["team"])
-
-    def test_leaves_non_managed_status_alone_while_still_filling_team(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=True, current_status="📋 Epic", current_team=None, mapped_team="Delivery"
-                )
-                self.assertIsNone(fields["status"])
-                self.assertEqual(fields["team"], "Delivery")
-
-    def test_blank_string_team_counts_as_empty(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=False, current_status="🔍 Review", current_team="   ", mapped_team="Delivery"
-                )
-                self.assertEqual(fields["team"], "Delivery")
-
-    def test_sprint_fills_when_empty(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=False,
-                    current_status="🛠️ Working",
-                    current_team="Dev",
-                    mapped_team="Dev",
-                    current_sprint=None,
-                    current_sprint_title="Sprint 260",
-                )
-                self.assertEqual(fields["sprint"], "Sprint 260")
+    """decide_board_update takes no `action` argument, so a subTest loop over
+    BOARD_UPDATE_ACTIONS proved nothing beyond running the same assertion 5
+    times. Every other case this class used to cover that way is provably
+    redundant against MainWiringBoardUpdateTest and DecideStatusTest, per an
+    owner-approved mutation-tested trim. This one survives: without it, a
+    mutant that always overwrites a non-empty Sprint escapes every other test."""
 
     def test_sprint_never_overwrites_a_non_empty_sprint(self):
         for action in pr_triage.BOARD_UPDATE_ACTIONS:
@@ -493,39 +407,6 @@ class DecideBoardUpdateTest(unittest.TestCase):
                     current_sprint_title="Sprint 260",
                 )
                 self.assertIsNone(fields["sprint"])
-
-    def test_blank_string_sprint_counts_as_empty(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=False,
-                    current_status="🔍 Review",
-                    current_team="Dev",
-                    mapped_team="Dev",
-                    current_sprint="   ",
-                    current_sprint_title="Sprint 260",
-                )
-                self.assertEqual(fields["sprint"], "Sprint 260")
-
-    def test_empty_sprint_stays_unwritten_when_no_current_iteration_resolves(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=False,
-                    current_status="🔍 Review",
-                    current_team="Dev",
-                    mapped_team="Dev",
-                    current_sprint=None,
-                    current_sprint_title=None,
-                )
-                self.assertIsNone(fields["sprint"])
-
-    def test_no_field_is_written_by_default_when_sprint_args_are_omitted(self):
-        fields = pr_triage.decide_board_update(
-            is_draft=False, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
-        )
-
-        self.assertIsNone(fields["sprint"])
 
 
 class KeywordClosingIssuesTest(unittest.TestCase):

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -1,7 +1,9 @@
+import contextlib
 import datetime
 import json
 import os
 import sys
+import tempfile
 import unittest
 from unittest import mock
 
@@ -9,6 +11,155 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import pr_triage
 import validate_pr_triage_teams
+
+DEFAULT_ITERATIONS = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
+DEFAULT_STATUS_OPTIONS = [{"id": "STATUS_OPT_WORKING", "name": "🛠️ Working"}, {"id": "STATUS_OPT_REVIEW", "name": "🔍 Review"}]
+DEFAULT_TEAM_OPTIONS = [{"id": "TEAM_OPT_DEV", "name": "Dev"}]
+
+# The board's real Status options, all eight, as returned live -- every option
+# carries an emoji prefix from GitHub except Icebox.
+LIVE_STATUS_OPTIONS = [
+    {"id": "285bb9d7", "name": "\U0001f4cb Epic"},
+    {"id": "ff9f2e2b", "name": "⛔️ Blocked"},
+    {"id": "f75ad846", "name": "\U0001f4da Backlog"},
+    {"id": "47fc9ee4", "name": "\U0001f6e0️ Working"},
+    {"id": "879449e7", "name": "\U0001f50d Review"},
+    {"id": "98236657", "name": "✅ Done"},
+    {"id": "58e93f55", "name": "\U0001f4e5 Inbox"},
+    {"id": "7164e058", "name": "Icebox"},
+]
+
+
+def query_of(call):
+    return (call["body"] or {}).get("query", "")
+
+
+def make_fake_http_request(
+    calls,
+    *,
+    assign_result=None,
+    assign_error=None,
+    draft_result=None,
+    draft_error=None,
+    board_item=None,
+    status_options=None,
+    team_options=None,
+    iterations=None,
+    add_item_id="ITEM_1",
+    extra=None,
+):
+    """One fake GitHub for every pr_triage test: records every call, and answers
+    each request shape pr_triage.http_request can make. `board_item` is what
+    find_board_item_for_pr's query resolves to (None -> no existing item).
+    `extra(url, token, method, body, query, variables)` is consulted first and,
+    if it returns something other than None, that is the response -- the escape
+    hatch for a test that needs one response to differ from these defaults."""
+    if status_options is None:
+        status_options = DEFAULT_STATUS_OPTIONS
+    if team_options is None:
+        team_options = DEFAULT_TEAM_OPTIONS
+    if iterations is None:
+        iterations = DEFAULT_ITERATIONS
+
+    def fake_http_request(url, token, method="GET", body=None):
+        calls.append({"url": url, "token": token, "body": body})
+        query = (body or {}).get("query", "")
+        variables = (body or {}).get("variables", {})
+
+        if extra is not None:
+            result = extra(url, token, method, body, query, variables)
+            if result is not None:
+                return result
+
+        if url.endswith("/assignees"):
+            if assign_error is not None:
+                raise assign_error
+            if assign_result is not None:
+                return assign_result
+            return {"assignees": [{"login": login} for login in (body or {}).get("assignees", [])]}
+
+        if "convertPullRequestToDraft" in query:
+            if draft_error is not None:
+                raise draft_error
+            if draft_result is not None:
+                return draft_result
+            return {
+                "data": {
+                    "convertPullRequestToDraft": {
+                        "pullRequest": {"id": variables.get("pullRequestId"), "isDraft": True}
+                    }
+                }
+            }
+
+        if "projectItems" in query:
+            nodes = []
+            if board_item is not None:
+                nodes = [
+                    {
+                        "id": board_item["id"],
+                        "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                        "status": {"name": board_item["status"]} if board_item.get("status") else None,
+                        "team": {"name": board_item["team"]} if board_item.get("team") else None,
+                        "sprint": {"title": board_item["sprint"]} if board_item.get("sprint") else None,
+                    }
+                ]
+            return {"data": {"node": {"projectItems": {"nodes": nodes}}}}
+
+        if "addProjectV2ItemById" in query:
+            return {"data": {"addProjectV2ItemById": {"item": {"id": add_item_id}}}}
+
+        if "updateProjectV2ItemFieldValue" in query:
+            return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": variables.get("itemId")}}}}
+
+        if "options { id name }" in query:
+            if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                return {"data": {"node": {"options": status_options}}}
+            if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                return {"data": {"node": {"options": team_options}}}
+
+        if "configuration" in query:
+            return {"data": {"node": {"configuration": {"iterations": iterations}}}}
+
+        raise AssertionError(f"unexpected call: {url} {query}")
+
+    return fake_http_request
+
+
+def run_main(event, *, http_request=None, current_date=None, env_extra=None):
+    """The tempdir + event.json + summary file + env + mock.patch scaffold every
+    main() test needs, collapsed to one call. Returns (summary_text, exit_code):
+    exit_code is None when main() returned normally, or sys.exit's code when it
+    didn't -- callers that only care about the happy path can ignore it."""
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        event_path = os.path.join(tmp_dir, "event.json")
+        with open(event_path, "w", encoding="utf-8") as handle:
+            json.dump(event, handle)
+        summary_path = os.path.join(tmp_dir, "summary.md")
+        open(summary_path, "w", encoding="utf-8").close()
+
+        env = {
+            "GITHUB_EVENT_PATH": event_path,
+            "GITHUB_TOKEN": "github-token",
+            "PROJECT_BOARD_TOKEN": "board-token",
+            "GITHUB_STEP_SUMMARY": summary_path,
+        }
+        if env_extra:
+            env.update(env_extra)
+
+        exit_code = None
+        try:
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(mock.patch.dict(os.environ, env, clear=False))
+                if http_request is not None:
+                    stack.enter_context(mock.patch.object(pr_triage, "http_request", side_effect=http_request))
+                if current_date is not None:
+                    stack.enter_context(mock.patch.object(pr_triage, "current_date", return_value=current_date))
+                pr_triage.main()
+        except SystemExit as exit_call:
+            exit_code = exit_call.code
+
+        with open(summary_path, encoding="utf-8") as handle:
+            return handle.read(), exit_code
 
 
 class DecidePrTriageTest(unittest.TestCase):
@@ -18,7 +169,6 @@ class DecidePrTriageTest(unittest.TestCase):
         decision = pr_triage.decide(author_login="mswertz", is_draft=False, mapping=mapping)
 
         self.assertTrue(decision["known"])
-        self.assertTrue(decision["assign"])
         self.assertTrue(decision["force_draft"])
         self.assertEqual(decision["team"], "Dev")
 
@@ -36,7 +186,6 @@ class DecidePrTriageTest(unittest.TestCase):
         decision = pr_triage.decide(author_login="some-outside-contributor", is_draft=False, mapping=mapping)
 
         self.assertFalse(decision["known"])
-        self.assertFalse(decision["assign"])
         self.assertFalse(decision["force_draft"])
         self.assertEqual(decision["team"], "Dev")
 
@@ -46,7 +195,6 @@ class DecidePrTriageTest(unittest.TestCase):
         decision = pr_triage.decide(author_login="some-outside-contributor", is_draft=True, mapping=mapping)
 
         self.assertFalse(decision["known"])
-        self.assertFalse(decision["assign"])
         self.assertFalse(decision["force_draft"])
         self.assertEqual(decision["team"], "Dev")
 
@@ -56,7 +204,6 @@ class DecidePrTriageTest(unittest.TestCase):
         decision = pr_triage.decide(author_login="dependabot[bot]", is_draft=False, mapping=mapping)
 
         self.assertFalse(decision["known"])
-        self.assertFalse(decision["assign"])
         self.assertEqual(decision["team"], "Dev")
 
     def test_known_author_already_draft_is_not_re_converted(self):
@@ -81,7 +228,6 @@ class DecidePrTriageTest(unittest.TestCase):
         decision = pr_triage.decide(author_login="someuser", is_draft=False, mapping=mapping)
 
         self.assertFalse(decision["known"])
-        self.assertFalse(decision["assign"])
         self.assertFalse(decision["force_draft"])
         self.assertEqual(decision["team"], "Dev")
 
@@ -114,11 +260,11 @@ class DecideStatusTest(unittest.TestCase):
     def test_review_flips_to_working_when_pr_is_draft(self):
         self.assertEqual(pr_triage.decide_status(True, "Review"), "Working")
 
-    def test_working_stays_working_when_pr_is_draft(self):
-        self.assertEqual(pr_triage.decide_status(True, "Working"), "Working")
+    def test_working_already_matching_draft_state_is_not_rewritten(self):
+        self.assertIsNone(pr_triage.decide_status(True, "Working"))
 
-    def test_review_stays_review_when_pr_is_ready(self):
-        self.assertEqual(pr_triage.decide_status(False, "Review"), "Review")
+    def test_review_already_matching_ready_state_is_not_rewritten(self):
+        self.assertIsNone(pr_triage.decide_status(False, "Review"))
 
     def test_non_managed_statuses_are_never_touched_regardless_of_draft_state(self):
         for status in ("Epic", "Blocked", "Backlog", "Done", "Inbox", "Icebox"):
@@ -131,8 +277,8 @@ class DecideStatusTest(unittest.TestCase):
             "\U0001f4cb Epic": (None, None),
             "⛔️ Blocked": (None, None),
             "\U0001f4da Backlog": (None, None),
-            "\U0001f6e0️ Working": ("Working", "Review"),
-            "\U0001f50d Review": ("Working", "Review"),
+            "\U0001f6e0️ Working": (None, "Review"),
+            "\U0001f50d Review": ("Working", None),
             "✅ Done": (None, None),
             "\U0001f4e5 Inbox": (None, None),
             "Icebox": (None, None),
@@ -145,231 +291,141 @@ class DecideStatusTest(unittest.TestCase):
 
 
 class DecideBoardUpdateTest(unittest.TestCase):
-    def test_ready_for_review_sets_status_review_outright(self):
-        fields = pr_triage.decide_board_update(
-            "ready_for_review", is_draft=False, current_status="🛠️ Working", current_team="Dev", mapped_team="Dev"
-        )
+    """decide_board_update no longer takes an action: main() already filters to
+    BOARD_UPDATE_ACTIONS before calling it, so every action in that tuple (the
+    three transitions and synchronize alike) must obey the identical rule.
+    Every case below runs once per action via subTest to prove that."""
 
-        self.assertEqual(fields["status"], "Review")
+    def test_status_flips_a_managed_status_to_match_current_draft_state(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
+                )
+                self.assertEqual(fields["status"], "Working")
 
-    def test_converted_to_draft_sets_status_working_outright(self):
-        fields = pr_triage.decide_board_update(
-            "converted_to_draft", is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
-        )
+                fields = pr_triage.decide_board_update(
+                    is_draft=False, current_status="🛠️ Working", current_team="Dev", mapped_team="Dev"
+                )
+                self.assertEqual(fields["status"], "Review")
 
-        self.assertEqual(fields["status"], "Working")
+    def test_status_already_matching_current_draft_state_is_not_rewritten(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=True, current_status="🛠️ Working", current_team="Dev", mapped_team="Dev"
+                )
+                self.assertIsNone(fields["status"])
 
-    def test_reopened_draft_sets_status_working_outright(self):
-        fields = pr_triage.decide_board_update(
-            "reopened", is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
-        )
+    def test_status_fills_when_empty(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=True, current_status=None, current_team="Dev", mapped_team="Dev"
+                )
+                self.assertEqual(fields["status"], "Working")
 
-        self.assertEqual(fields["status"], "Working")
+                fields = pr_triage.decide_board_update(
+                    is_draft=False, current_status=None, current_team="Dev", mapped_team="Dev"
+                )
+                self.assertEqual(fields["status"], "Review")
 
-    def test_reopened_ready_sets_status_review_outright(self):
-        fields = pr_triage.decide_board_update(
-            "reopened", is_draft=False, current_status="🛠️ Working", current_team="Dev", mapped_team="Dev"
-        )
+    def test_status_leaves_a_non_managed_status_alone(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=True, current_status="📋 Epic", current_team="Dev", mapped_team="Dev"
+                )
+                self.assertIsNone(fields["status"])
 
-        self.assertEqual(fields["status"], "Review")
+    def test_team_fills_when_empty(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=False, current_status="🛠️ Working", current_team=None, mapped_team="Delivery"
+                )
+                self.assertEqual(fields["team"], "Delivery")
 
-    def test_transition_flips_a_managed_status_to_match_current_draft_state(self):
-        fields = pr_triage.decide_board_update(
-            "reopened", is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
-        )
+    def test_team_never_overwrites_a_non_empty_team(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=False, current_status="🛠️ Working", current_team="Analysis", mapped_team="Delivery"
+                )
+                self.assertIsNone(fields["team"])
 
-        self.assertEqual(fields["status"], "Working")
-
-    def test_transition_fills_team_when_empty(self):
-        fields = pr_triage.decide_board_update(
-            "ready_for_review", is_draft=False, current_status="🛠️ Working", current_team=None, mapped_team="Delivery"
-        )
-
-        self.assertEqual(fields["team"], "Delivery")
-
-    def test_transition_never_overwrites_a_non_empty_team(self):
-        fields = pr_triage.decide_board_update(
-            "ready_for_review",
-            is_draft=False,
-            current_status="🛠️ Working",
-            current_team="Analysis",
-            mapped_team="Delivery",
-        )
-
-        self.assertIsNone(fields["team"])
-
-    def test_synchronize_fills_status_only_when_empty_and_draft(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=True, current_status=None, current_team="Dev", mapped_team="Dev"
-        )
-
-        self.assertEqual(fields["status"], "Working")
-
-    def test_synchronize_fills_status_only_when_empty_and_ready(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status=None, current_team="Dev", mapped_team="Dev"
-        )
-
-        self.assertEqual(fields["status"], "Review")
-
-    def test_synchronize_flips_a_managed_status_to_match_current_draft_state(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=True, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
-        )
-
-        self.assertEqual(fields["status"], "Working")
-
-    def test_synchronize_leaves_a_non_managed_status_alone(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=True, current_status="📋 Epic", current_team="Dev", mapped_team="Dev"
-        )
-
-        self.assertIsNone(fields["status"])
-
-    def test_transition_leaves_a_non_managed_status_alone(self):
-        fields = pr_triage.decide_board_update(
-            "ready_for_review", is_draft=False, current_status="⛔️ Blocked", current_team="Dev", mapped_team="Dev"
-        )
-
-        self.assertIsNone(fields["status"])
-
-    def test_synchronize_fills_team_when_empty(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status="🔍 Review", current_team=None, mapped_team="Delivery"
-        )
-
-        self.assertEqual(fields["team"], "Delivery")
-
-    def test_synchronize_never_overwrites_a_non_empty_team(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status="🔍 Review", current_team="Analysis", mapped_team="Delivery"
-        )
-
-        self.assertIsNone(fields["team"])
-
-    def test_synchronize_leaves_non_managed_status_alone_while_still_filling_team(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=True, current_status="📋 Epic", current_team=None, mapped_team="Delivery"
-        )
-
-        self.assertIsNone(fields["status"])
-        self.assertEqual(fields["team"], "Delivery")
+    def test_leaves_non_managed_status_alone_while_still_filling_team(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=True, current_status="📋 Epic", current_team=None, mapped_team="Delivery"
+                )
+                self.assertIsNone(fields["status"])
+                self.assertEqual(fields["team"], "Delivery")
 
     def test_blank_string_team_counts_as_empty(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status="🔍 Review", current_team="   ", mapped_team="Delivery"
-        )
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=False, current_status="🔍 Review", current_team="   ", mapped_team="Delivery"
+                )
+                self.assertEqual(fields["team"], "Delivery")
 
-        self.assertEqual(fields["team"], "Delivery")
+    def test_sprint_fills_when_empty(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=False,
+                    current_status="🛠️ Working",
+                    current_team="Dev",
+                    mapped_team="Dev",
+                    current_sprint=None,
+                    current_sprint_title="Sprint 260",
+                )
+                self.assertEqual(fields["sprint"], "Sprint 260")
 
-    def test_opened_is_not_a_board_update_action(self):
-        self.assertIsNone(
-            pr_triage.decide_board_update(
-                "opened", is_draft=False, current_status=None, current_team=None, mapped_team="Dev"
-            )
-        )
-
-    def test_unrecognized_action_is_not_a_board_update_action(self):
-        self.assertIsNone(
-            pr_triage.decide_board_update(
-                "labeled", is_draft=False, current_status=None, current_team=None, mapped_team="Dev"
-            )
-        )
-
-    def test_transition_fills_sprint_when_empty(self):
-        fields = pr_triage.decide_board_update(
-            "ready_for_review",
-            is_draft=False,
-            current_status="🛠️ Working",
-            current_team="Dev",
-            mapped_team="Dev",
-            current_sprint=None,
-            current_sprint_title="Sprint 260",
-        )
-
-        self.assertEqual(fields["sprint"], "Sprint 260")
-
-    def test_transition_never_overwrites_a_non_empty_sprint(self):
-        fields = pr_triage.decide_board_update(
-            "converted_to_draft",
-            is_draft=True,
-            current_status="🔍 Review",
-            current_team="Dev",
-            mapped_team="Dev",
-            current_sprint="Sprint 259",
-            current_sprint_title="Sprint 260",
-        )
-
-        self.assertIsNone(fields["sprint"])
-
-    def test_reopened_fills_sprint_when_empty(self):
-        fields = pr_triage.decide_board_update(
-            "reopened",
-            is_draft=False,
-            current_status="🛠️ Working",
-            current_team="Dev",
-            mapped_team="Dev",
-            current_sprint=None,
-            current_sprint_title="Sprint 260",
-        )
-
-        self.assertEqual(fields["sprint"], "Sprint 260")
-
-    def test_synchronize_fills_sprint_when_empty(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize",
-            is_draft=False,
-            current_status="🔍 Review",
-            current_team="Dev",
-            mapped_team="Dev",
-            current_sprint=None,
-            current_sprint_title="Sprint 260",
-        )
-
-        self.assertEqual(fields["sprint"], "Sprint 260")
-
-    def test_synchronize_never_overwrites_a_non_empty_sprint(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize",
-            is_draft=False,
-            current_status="🔍 Review",
-            current_team="Dev",
-            mapped_team="Dev",
-            current_sprint="Sprint 259",
-            current_sprint_title="Sprint 260",
-        )
-
-        self.assertIsNone(fields["sprint"])
+    def test_sprint_never_overwrites_a_non_empty_sprint(self):
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=True,
+                    current_status="🔍 Review",
+                    current_team="Dev",
+                    mapped_team="Dev",
+                    current_sprint="Sprint 259",
+                    current_sprint_title="Sprint 260",
+                )
+                self.assertIsNone(fields["sprint"])
 
     def test_blank_string_sprint_counts_as_empty(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize",
-            is_draft=False,
-            current_status="🔍 Review",
-            current_team="Dev",
-            mapped_team="Dev",
-            current_sprint="   ",
-            current_sprint_title="Sprint 260",
-        )
-
-        self.assertEqual(fields["sprint"], "Sprint 260")
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=False,
+                    current_status="🔍 Review",
+                    current_team="Dev",
+                    mapped_team="Dev",
+                    current_sprint="   ",
+                    current_sprint_title="Sprint 260",
+                )
+                self.assertEqual(fields["sprint"], "Sprint 260")
 
     def test_empty_sprint_stays_unwritten_when_no_current_iteration_resolves(self):
-        fields = pr_triage.decide_board_update(
-            "synchronize",
-            is_draft=False,
-            current_status="🔍 Review",
-            current_team="Dev",
-            mapped_team="Dev",
-            current_sprint=None,
-            current_sprint_title=None,
-        )
-
-        self.assertIsNone(fields["sprint"])
+        for action in pr_triage.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_board_update(
+                    is_draft=False,
+                    current_status="🔍 Review",
+                    current_team="Dev",
+                    mapped_team="Dev",
+                    current_sprint=None,
+                    current_sprint_title=None,
+                )
+                self.assertIsNone(fields["sprint"])
 
     def test_no_field_is_written_by_default_when_sprint_args_are_omitted(self):
         fields = pr_triage.decide_board_update(
-            "synchronize", is_draft=False, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
+            is_draft=False, current_status="🔍 Review", current_team="Dev", mapped_team="Dev"
         )
 
         self.assertIsNone(fields["sprint"])
@@ -377,7 +433,6 @@ class DecideBoardUpdateTest(unittest.TestCase):
 
 class FindCurrentIterationTest(unittest.TestCase):
     def test_returns_the_iteration_containing_today(self):
-        import datetime
 
         iterations = [
             {"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21},
@@ -390,7 +445,6 @@ class FindCurrentIterationTest(unittest.TestCase):
         self.assertEqual(iteration["title"], "Sprint 260")
 
     def test_start_date_itself_is_inside_the_iteration(self):
-        import datetime
 
         iterations = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
 
@@ -399,7 +453,6 @@ class FindCurrentIterationTest(unittest.TestCase):
         self.assertEqual(iteration["id"], "bd551114")
 
     def test_the_day_after_the_iteration_ends_is_not_inside_it(self):
-        import datetime
 
         iterations = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
 
@@ -409,7 +462,6 @@ class FindCurrentIterationTest(unittest.TestCase):
         self.assertIsNone(iteration)
 
     def test_returns_none_when_no_iteration_contains_the_date(self):
-        import datetime
 
         iterations = [{"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21}]
 
@@ -418,12 +470,10 @@ class FindCurrentIterationTest(unittest.TestCase):
         self.assertIsNone(iteration)
 
     def test_returns_none_for_an_empty_iteration_list(self):
-        import datetime
 
         self.assertIsNone(pr_triage.find_current_iteration([], datetime.date(2026, 8, 8)))
 
     def test_does_not_assume_the_first_entry_is_current(self):
-        import datetime
 
         iterations = [
             {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21},
@@ -591,31 +641,35 @@ class ValidateBlankTeamValuesTest(unittest.TestCase):
 
 
 class ValidateStatusOptionTest(unittest.TestCase):
+    """find_missing_option is built on pr_triage.find_option_id_by_name, the same
+    lookup write time uses -- so a value missing here and a value missing at
+    write time report the identical message."""
+
     def test_passes_when_working_is_a_live_status_option(self):
         status_options = [{"id": "47fc9ee4", "name": "\U0001f6e0️ Working"}]
 
-        error = validate_pr_triage_teams.find_missing_status_option(status_options, "Working")
+        error = validate_pr_triage_teams.find_missing_option(status_options, "Working", strip_emoji=True)
 
         self.assertIsNone(error)
 
     def test_flags_when_working_is_not_a_live_status_option(self):
         status_options = [{"id": "98236657", "name": "✅ Done"}]
 
-        error = validate_pr_triage_teams.find_missing_status_option(status_options, "Working")
+        error = validate_pr_triage_teams.find_missing_option(status_options, "Working", strip_emoji=True)
 
         self.assertIsNotNone(error)
 
     def test_passes_when_review_is_a_live_status_option(self):
         status_options = [{"id": "879449e7", "name": "\U0001f50d Review"}]
 
-        error = validate_pr_triage_teams.find_missing_status_option(status_options, "Review")
+        error = validate_pr_triage_teams.find_missing_option(status_options, "Review", strip_emoji=True)
 
         self.assertIsNone(error)
 
     def test_flags_when_review_is_not_a_live_status_option(self):
         status_options = [{"id": "98236657", "name": "✅ Done"}]
 
-        error = validate_pr_triage_teams.find_missing_status_option(status_options, "Review")
+        error = validate_pr_triage_teams.find_missing_option(status_options, "Review", strip_emoji=True)
 
         self.assertIsNotNone(error)
 
@@ -624,22 +678,20 @@ class ValidateTeamOptionTest(unittest.TestCase):
     def test_passes_when_dev_is_a_live_team_option(self):
         team_options = [{"id": "f2a5529c", "name": "Dev"}]
 
-        error = validate_pr_triage_teams.find_missing_team_option(team_options, "Dev")
+        error = validate_pr_triage_teams.find_missing_option(team_options, "Dev", strip_emoji=False)
 
         self.assertIsNone(error)
 
     def test_flags_when_dev_is_not_a_live_team_option(self):
         team_options = [{"id": "34b176a9", "name": "Delivery"}]
 
-        error = validate_pr_triage_teams.find_missing_team_option(team_options, "Dev")
+        error = validate_pr_triage_teams.find_missing_option(team_options, "Dev", strip_emoji=False)
 
         self.assertIsNotNone(error)
 
 
 class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
     def test_a_missing_mapping_file_still_writes_a_summary_and_exits_non_zero(self):
-        import tempfile
-
         event = {
             "action": "opened",
             "pull_request": {
@@ -652,36 +704,17 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
             "repository": {"full_name": "molgenis/molgenis-emx2"},
         }
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
+        with mock.patch.object(
+            pr_triage, "load_teams_mapping", side_effect=FileNotFoundError("no such file: pr-triage-teams.yml")
+        ):
+            summary_text, exit_code = run_main(event)
 
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "fake-github-token",
-                "PROJECT_BOARD_TOKEN": "fake-board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "load_teams_mapping", side_effect=FileNotFoundError("no such file: pr-triage-teams.yml")
-            ):
-                with self.assertRaises(SystemExit) as context:
-                    pr_triage.main()
-
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
-
-        self.assertNotEqual(context.exception.code, 0)
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsNotNone(exit_code)
         self.assertIn("### PR triage", summary_text)
         self.assertIn("no such file", summary_text)
 
     def test_assign_failure_skips_the_draft_flip_but_still_boards_review_and_exits_non_zero(self):
-        import tempfile
-
         event = {
             "action": "opened",
             "pull_request": {
@@ -696,73 +729,18 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
 
         calls = []
 
-        def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
+        def refuse_draft_flip(url, token, method, body, query, variables):
             if "convertPullRequestToDraft" in query:
                 raise AssertionError("assignment failure must skip the draft flip entirely")
-            if "addProjectV2ItemById" in query:
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
-            if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {
-                        "data": {
-                            "node": {
-                                "options": [
-                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
-                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
-                                ]
-                            }
-                        }
-                    }
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
-            if "configuration" in query:
-                return {
-                    "data": {
-                        "node": {
-                            "configuration": {
-                                "iterations": [
-                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
-                                ]
-                            }
-                        }
-                    }
-                }
-            raise AssertionError(f"unexpected call: {url} {query}")
+            return None
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
+        fake_http_request = make_fake_http_request(calls, extra=refuse_draft_flip)
 
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "fake-github-token",
-                "PROJECT_BOARD_TOKEN": "fake-board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
+        with mock.patch.object(pr_triage, "assign_author", side_effect=pr_triage.GraphqlError("boom")):
+            summary_text, exit_code = run_main(event, http_request=fake_http_request, current_date=datetime.date(2026, 8, 8))
 
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "assign_author", side_effect=pr_triage.GraphqlError("boom")
-            ), mock.patch.object(pr_triage, "http_request", side_effect=fake_http_request), mock.patch.object(
-                pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
-            ):
-                with self.assertRaises(SystemExit) as context:
-                    pr_triage.main()
-
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
-
-        self.assertNotEqual(context.exception.code, 0)
-
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsNotNone(exit_code)
 
         self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
         self.assertTrue(any("addProjectV2ItemById" in query_of(call) for call in calls))
@@ -772,20 +750,18 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
         status_write = next(
             call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
         )
-        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_REVIEW_OPT")
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT_REVIEW")
 
         self.assertIn("### PR triage", summary_text)
         self.assertIn("boom", summary_text)
-        self.assertIn("Board item id", summary_text)
-        self.assertIn("Status option id written", summary_text)
+        self.assertIn("Board item", summary_text)
+        self.assertIn("Status set", summary_text)
         self.assertIn("| Converted to draft | skipped, assignment failed |", summary_text)
-        self.assertIn("Team option id written", summary_text)
+        self.assertIn("Team set", summary_text)
 
 
 class MainWiringTest(unittest.TestCase):
     def test_known_author_writes_go_to_the_right_endpoint_field_and_token(self):
-        import tempfile
-
         event = {
             "action": "opened",
             "pull_request": {
@@ -799,59 +775,7 @@ class MainWiringTest(unittest.TestCase):
         }
 
         calls = []
-
-        def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
-            if url.endswith("/assignees"):
-                return {"assignees": [{"login": "mswertz"}]}
-            if "convertPullRequestToDraft" in query:
-                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
-            if "addProjectV2ItemById" in query:
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
-            if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
-            if "configuration" in query:
-                return {
-                    "data": {
-                        "node": {
-                            "configuration": {
-                                "iterations": [
-                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
-                                ]
-                            }
-                        }
-                    }
-                }
-            raise AssertionError(f"unexpected call: {url} {query}")
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
-
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "github-token",
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
-                pr_triage.main()
-
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+        run_main(event, http_request=make_fake_http_request(calls), current_date=datetime.date(2026, 8, 8))
 
         assign_call = next(call for call in calls if call["url"].endswith("/assignees"))
         self.assertEqual(assign_call["token"], "github-token")
@@ -867,12 +791,12 @@ class MainWiringTest(unittest.TestCase):
 
         status_write = field_writes[0]
         self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
-        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT")
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT_WORKING")
         self.assertEqual(status_write["token"], "board-token")
 
         team_write = field_writes[1]
         self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
-        self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_OPT")
+        self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_OPT_DEV")
         self.assertEqual(team_write["token"], "board-token")
 
         sprint_write = field_writes[2]
@@ -883,8 +807,6 @@ class MainWiringTest(unittest.TestCase):
 
 class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
     def test_dropped_assignment_skips_the_draft_flip_but_still_boards_review_and_exits_non_zero(self):
-        import tempfile
-
         event = {
             "action": "opened",
             "pull_request": {
@@ -899,73 +821,17 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
 
         calls = []
 
-        def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
-            if url.endswith("/assignees"):
-                return {"assignees": []}
+        def refuse_draft_flip(url, token, method, body, query, variables):
             if "convertPullRequestToDraft" in query:
                 raise AssertionError("a dropped assignment must skip the draft flip entirely")
-            if "addProjectV2ItemById" in query:
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
-            if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {
-                        "data": {
-                            "node": {
-                                "options": [
-                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
-                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
-                                ]
-                            }
-                        }
-                    }
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
-            if "configuration" in query:
-                return {
-                    "data": {
-                        "node": {
-                            "configuration": {
-                                "iterations": [
-                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
-                                ]
-                            }
-                        }
-                    }
-                }
-            raise AssertionError(f"unexpected call: {url} {query}")
+            return None
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
+        fake_http_request = make_fake_http_request(calls, assign_result={"assignees": []}, extra=refuse_draft_flip)
 
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "github-token",
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
+        summary_text, exit_code = run_main(event, http_request=fake_http_request, current_date=datetime.date(2026, 8, 8))
 
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
-                with self.assertRaises(SystemExit) as context:
-                    pr_triage.main()
-
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
-
-        self.assertNotEqual(context.exception.code, 0)
-
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsNotNone(exit_code)
 
         self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
         self.assertTrue(any("addProjectV2ItemById" in query_of(call) for call in calls))
@@ -975,18 +841,16 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
         status_write = next(
             call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
         )
-        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_REVIEW_OPT")
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT_REVIEW")
 
         self.assertIn("### PR triage", summary_text)
         self.assertIn("mswertz", summary_text)
         self.assertIn("| Converted to draft | skipped, assignment failed |", summary_text)
-        self.assertIn("Board item id", summary_text)
+        self.assertIn("Board item", summary_text)
 
 
 class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
     def test_forbidden_draft_conversion_does_not_prevent_assignment_or_board_writes(self):
-        import tempfile
-
         event = {
             "action": "opened",
             "pull_request": {
@@ -1001,76 +865,20 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
 
         calls = []
 
-        def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
-            if url.endswith("/assignees"):
-                return {"assignees": [{"login": "mswertz"}]}
+        def refuse_draft_flip(url, token, method, body, query, variables):
             if "convertPullRequestToDraft" in query:
                 raise pr_triage.GraphqlError(
                     "GraphQL request returned errors: [{'type': 'FORBIDDEN', "
                     "'message': 'Resource not accessible by integration'}]"
                 )
-            if "addProjectV2ItemById" in query:
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
-            if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {
-                        "data": {
-                            "node": {
-                                "options": [
-                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
-                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
-                                ]
-                            }
-                        }
-                    }
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
-            if "configuration" in query:
-                return {
-                    "data": {
-                        "node": {
-                            "configuration": {
-                                "iterations": [
-                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
-                                ]
-                            }
-                        }
-                    }
-                }
-            raise AssertionError(f"unexpected call: {url} {query}")
+            return None
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
+        fake_http_request = make_fake_http_request(calls, extra=refuse_draft_flip)
 
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "github-token",
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
+        summary_text, exit_code = run_main(event, http_request=fake_http_request, current_date=datetime.date(2026, 8, 8))
 
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
-                with self.assertRaises(SystemExit) as context:
-                    pr_triage.main()
-
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
-
-        self.assertNotEqual(context.exception.code, 0)
-
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsNotNone(exit_code)
 
         assign_call = next(call for call in calls if call["url"].endswith("/assignees"))
         self.assertEqual(assign_call["token"], "github-token")
@@ -1084,15 +892,15 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
         status_write = next(
             call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
         )
-        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_REVIEW_OPT")
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT_REVIEW")
 
         self.assertIn("### PR triage", summary_text)
         self.assertIn("| Assignee set | True |", summary_text)
         self.assertIn("FORBIDDEN", summary_text)
-        self.assertIn("Board item id", summary_text)
-        self.assertIn("Status option id written", summary_text)
-        self.assertIn("Team option id written", summary_text)
-        self.assertIn("Sprint option id written", summary_text)
+        self.assertIn("Board item", summary_text)
+        self.assertIn("Status set", summary_text)
+        self.assertIn("Team set", summary_text)
+        self.assertIn("Sprint set", summary_text)
 
 
 class MappingFilePathTest(unittest.TestCase):
@@ -1119,7 +927,6 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         mapping=None,
         author_login="mswertz",
     ):
-        import tempfile
 
         event = {
             "action": action,
@@ -1242,7 +1049,9 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
         self.assertFalse(any("convertPullRequestToDraft" in self._query_of(call) for call in calls))
 
-    # --- transitions: Status is always overwritten ---
+    # --- Status flips when it differs from the target and is still managed
+    # (blank, Working, or Review); a non-managed value or an already-matching
+    # one is left alone (decide_status returns None for both) ---
 
     def test_ready_for_review_overwrites_status_even_when_already_set(self):
         calls, _ = self._run_board_update(
@@ -1314,7 +1123,8 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         ]
         self.assertEqual(status_writes, [])
 
-    # --- transitions: Team and Sprint fill only, never overwrite ---
+    # --- Team and Sprint fill only, never overwrite -- true for every action
+    # in BOARD_UPDATE_ACTIONS, not just the transitions exercised here ---
 
     def test_transition_fills_team_when_empty(self):
         calls, _ = self._run_board_update(
@@ -1382,7 +1192,8 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         ]
         self.assertEqual(sprint_writes, [])
 
-    # --- synchronize: fill-only for every field, never overwrite ---
+    # --- synchronize obeys the identical rule as the transitions: Status can
+    # still flip (it is managed, not fill-only), Team and Sprint are fill-only ---
 
     def test_synchronize_item_already_exists_with_everything_set_writes_nothing(self):
         calls, summary_text = self._run_board_update(
@@ -1536,7 +1347,6 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
 
 class BoardUpdateWritesStepSummaryOnFailureTest(unittest.TestCase):
     def test_step_summary_is_written_and_error_reraised_when_a_board_write_fails(self):
-        import tempfile
 
         event = {
             "action": "ready_for_review",
@@ -1579,7 +1389,6 @@ class BoardUpdateWritesStepSummaryOnFailureTest(unittest.TestCase):
 
 class BoardUpdateResolvesFieldsBeforeAddingBoardItemTest(unittest.TestCase):
     def test_fields_are_resolved_before_a_missing_item_is_added(self):
-        import tempfile
 
         event = {
             "action": "ready_for_review",
@@ -1651,7 +1460,6 @@ class BoardUpdateResolvesFieldsBeforeAddingBoardItemTest(unittest.TestCase):
         self.assertLess(call_kinds.index("fetch_options"), add_item_index)
 
     def test_a_status_resolution_failure_never_adds_a_board_item(self):
-        import tempfile
 
         event = {
             "action": "ready_for_review",
@@ -1701,8 +1509,6 @@ class BoardUpdateResolvesFieldsBeforeAddingBoardItemTest(unittest.TestCase):
 
 class MainWiringUnknownAuthorTest(unittest.TestCase):
     def _run_main_for(self, is_draft):
-        import tempfile
-
         event = {
             "action": "opened",
             "pull_request": {
@@ -1717,73 +1523,22 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
 
         calls = []
 
-        def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
+        def forbid_assign_or_draft(url, token, method, body, query, variables):
             if url.endswith("/assignees"):
                 raise AssertionError("unknown author must never be assigned")
             if "convertPullRequestToDraft" in query:
                 raise AssertionError("unknown author's draft state must never be touched")
-            if "addProjectV2ItemById" in query:
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
-            if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {
-                        "data": {
-                            "node": {
-                                "options": [
-                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
-                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
-                                ]
-                            }
-                        }
-                    }
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "TEAM_DEV_OPT", "name": "Dev"}]}}}
-            if "configuration" in query:
-                return {
-                    "data": {
-                        "node": {
-                            "configuration": {
-                                "iterations": [
-                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
-                                ]
-                            }
-                        }
-                    }
-                }
-            raise AssertionError(f"unexpected call: {url} {query}")
+            return None
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
+        fake_http_request = make_fake_http_request(
+            calls, team_options=[{"id": "TEAM_DEV_OPT", "name": "Dev"}], extra=forbid_assign_or_draft
+        )
 
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
-                pr_triage.main()
-
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
+        summary_text, _ = run_main(event, http_request=fake_http_request, current_date=datetime.date(2026, 8, 8))
 
         return calls, summary_text
 
     def _assert_unknown_author_boarded_correctly(self, calls, summary_text, expected_status_option_id):
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
-
         self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
         self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
 
@@ -1817,17 +1572,15 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
 
     def test_unknown_author_ready_for_review_is_boarded_review(self):
         calls, summary_text = self._run_main_for(is_draft=False)
-        self._assert_unknown_author_boarded_correctly(calls, summary_text, "STATUS_REVIEW_OPT")
+        self._assert_unknown_author_boarded_correctly(calls, summary_text, "STATUS_OPT_REVIEW")
 
     def test_unknown_author_already_draft_is_boarded_working(self):
         calls, summary_text = self._run_main_for(is_draft=True)
-        self._assert_unknown_author_boarded_correctly(calls, summary_text, "STATUS_WORKING_OPT")
+        self._assert_unknown_author_boarded_correctly(calls, summary_text, "STATUS_OPT_WORKING")
 
 
 class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
     def test_status_and_team_options_are_resolved_before_the_item_is_added(self):
-        import tempfile
-
         event = {
             "action": "opened",
             "pull_request": {
@@ -1840,72 +1593,27 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
             "repository": {"full_name": "molgenis/molgenis-emx2"},
         }
 
-        call_kinds = []
+        calls = []
+        run_main(event, http_request=make_fake_http_request(calls), current_date=datetime.date(2026, 8, 8))
 
-        def fake_http_request(url, token, method="GET", body=None):
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
-            if url.endswith("/assignees"):
-                call_kinds.append("assign")
-                return {"assignees": [{"login": "mswertz"}]}
-            if "convertPullRequestToDraft" in query:
-                call_kinds.append("draft")
-                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
-            if "addProjectV2ItemById" in query:
-                call_kinds.append("add_item")
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                call_kinds.append("set_field")
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+        def kind_of(call):
+            query = query_of(call)
             if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    call_kinds.append("fetch_status_options")
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
-                    call_kinds.append("fetch_team_options")
-                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+                variables = (call["body"] or {}).get("variables", {})
+                return "fetch_status_options" if variables["fieldId"] == pr_triage.STATUS_FIELD_ID else "fetch_team_options"
             if "configuration" in query:
-                call_kinds.append("fetch_iterations")
-                return {
-                    "data": {
-                        "node": {
-                            "configuration": {
-                                "iterations": [
-                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
-                                ]
-                            }
-                        }
-                    }
-                }
-            raise AssertionError(f"unexpected call: {url} {query}")
+                return "fetch_iterations"
+            if "addProjectV2ItemById" in query:
+                return "add_item"
+            return None
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
-
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "github-token",
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
-                pr_triage.main()
-
+        call_kinds = [kind_of(call) for call in calls]
         add_item_index = call_kinds.index("add_item")
         self.assertLess(call_kinds.index("fetch_status_options"), add_item_index)
         self.assertLess(call_kinds.index("fetch_team_options"), add_item_index)
         self.assertLess(call_kinds.index("fetch_iterations"), add_item_index)
 
     def test_a_resolution_failure_never_adds_a_board_item(self):
-        import tempfile
-
         event = {
             "action": "opened",
             "pull_request": {
@@ -1920,59 +1628,28 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
 
         calls = []
 
-        def fake_http_request(url, token, method="GET", body=None):
-            query = (body or {}).get("query", "")
-            calls.append(query)
-            if url.endswith("/assignees"):
-                return {"assignees": [{"login": "mswertz"}]}
-            if "convertPullRequestToDraft" in query:
-                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+        def refuse_add_item(url, token, method, body, query, variables):
             if "addProjectV2ItemById" in query:
                 raise AssertionError("must not add a board item when option resolution fails")
-            if "options { id name }" in query:
-                return {"data": {"node": {"options": [{"id": "SOME_OPT", "name": "NoMatchingOptionHere"}]}}}
-            raise AssertionError(f"unexpected call: {url} {query}")
+            return None
 
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
+        fake_http_request = make_fake_http_request(
+            calls,
+            status_options=[{"id": "SOME_OPT", "name": "NoMatchingOptionHere"}],
+            team_options=[{"id": "SOME_OPT", "name": "NoMatchingOptionHere"}],
+            extra=refuse_add_item,
+        )
 
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "github-token",
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
+        summary_text, exit_code = run_main(event, http_request=fake_http_request, current_date=datetime.date(2026, 8, 8))
 
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
-                with self.assertRaises(SystemExit) as context:
-                    pr_triage.main()
+        self.assertNotEqual(exit_code, 0)
+        self.assertIsNotNone(exit_code)
+        self.assertFalse(any("addProjectV2ItemById" in query_of(call) for call in calls))
 
-        self.assertNotEqual(context.exception.code, 0)
-        self.assertFalse(any("addProjectV2ItemById" in query for query in calls))
-
-
-LIVE_STATUS_OPTIONS = [
-    {"id": "285bb9d7", "name": "\U0001f4cb Epic"},
-    {"id": "ff9f2e2b", "name": "⛔️ Blocked"},
-    {"id": "f75ad846", "name": "\U0001f4da Backlog"},
-    {"id": "47fc9ee4", "name": "\U0001f6e0️ Working"},
-    {"id": "879449e7", "name": "\U0001f50d Review"},
-    {"id": "98236657", "name": "✅ Done"},
-    {"id": "58e93f55", "name": "\U0001f4e5 Inbox"},
-    {"id": "7164e058", "name": "Icebox"},
-]
-LIVE_STATUS_OPTION_ID_BY_NAME = {"Working": "47fc9ee4", "Review": "879449e7"}
 
 
 class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
     def test_an_unrecognized_action_makes_no_writes_and_reads_no_mapping_file(self):
-        import tempfile
 
         event = {
             "action": "labeled",
@@ -2011,97 +1688,6 @@ class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
         self.assertIn("labeled", summary_text)
         self.assertIn("no action", summary_text.lower())
 
-
-class MainReadsAssignDecisionTest(unittest.TestCase):
-    def test_main_does_not_assign_when_decision_says_not_to(self):
-        import tempfile
-
-        event = {
-            "action": "opened",
-            "pull_request": {
-                "user": {"login": "mswertz"},
-                "head": {"ref": "feature/x"},
-                "number": 1,
-                "node_id": "PR_node",
-                "draft": False,
-            },
-            "repository": {"full_name": "molgenis/molgenis-emx2"},
-        }
-
-        # known and assign always agree in the real decide(); this forces the
-        # only combination that ever skips assignment (both false), since
-        # "known but not assigned" is a state the all-or-nothing ruling forbids.
-        forced_decision = {
-            "known": False,
-            "assign": False,
-            "force_draft": False,
-            "team": "Dev",
-        }
-
-        calls = []
-
-        def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
-            if "addProjectV2ItemById" in query:
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
-            if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {
-                        "data": {
-                            "node": {
-                                "options": [
-                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
-                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
-                                ]
-                            }
-                        }
-                    }
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
-            if "configuration" in query:
-                return {
-                    "data": {
-                        "node": {
-                            "configuration": {
-                                "iterations": [
-                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
-                                ]
-                            }
-                        }
-                    }
-                }
-            raise AssertionError(f"unexpected call: {url} {query}")
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
-
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "github-token",
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ), mock.patch.object(pr_triage, "decide", return_value=forced_decision), mock.patch.object(
-                pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
-            ):
-                pr_triage.main()
-
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
-
-        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
-        self.assertIn("| Assignee set | skipped, unknown author is never assigned |", summary_text)
 
 
 class FindBoardItemForPrTest(unittest.TestCase):
@@ -2345,7 +1931,6 @@ class FindBannedTermsAcrossTriageSourceTest(unittest.TestCase):
         return scripts_dir, workflows_dir
 
     def test_flags_a_banned_term_planted_in_a_script_file(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             scripts_dir, _ = self._write_clean_triage_source(tmp_dir)
@@ -2357,7 +1942,6 @@ class FindBannedTermsAcrossTriageSourceTest(unittest.TestCase):
         self.assertEqual(findings, [("pr_triage.py", ["author_association"])])
 
     def test_flags_a_banned_term_planted_in_the_workflow_file_itself(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             _, workflows_dir = self._write_clean_triage_source(tmp_dir)
@@ -2369,7 +1953,6 @@ class FindBannedTermsAcrossTriageSourceTest(unittest.TestCase):
         self.assertEqual(findings, [("pr-triage.yml", ["author_association"])])
 
     def test_passes_clean_triage_source(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             self._write_clean_triage_source(tmp_dir)
@@ -2381,7 +1964,6 @@ class FindBannedTermsAcrossTriageSourceTest(unittest.TestCase):
 
 class ValidateMainExitsNonZeroOnDuplicateLoginTest(unittest.TestCase):
     def test_main_exits_non_zero_when_a_login_is_listed_twice(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = os.path.join(tmp_dir, "repo")
@@ -2418,7 +2000,7 @@ class ValidateMainExitsNonZeroOnDuplicateLoginTest(unittest.TestCase):
         self.assertNotEqual(context.exception.code, 0)
 
 
-class ValidateMainChecksTransitionStatusConstantsTest(unittest.TestCase):
+class ValidateMainChecksStatusConstantsResolveLiveTest(unittest.TestCase):
     def _write_clean_repo(self, tmp_dir):
         repo_root = os.path.join(tmp_dir, "repo")
         scripts_dir = os.path.join(repo_root, ".github", "scripts")
@@ -2438,7 +2020,6 @@ class ValidateMainChecksTransitionStatusConstantsTest(unittest.TestCase):
         return repo_root
 
     def test_validator_flags_a_status_review_that_diverged_from_the_unknown_author_status(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = self._write_clean_repo(tmp_dir)
@@ -2463,7 +2044,6 @@ class ValidateMainChecksTransitionStatusConstantsTest(unittest.TestCase):
 
 class ValidateMainExitsNonZeroOnBannedTermTest(unittest.TestCase):
     def test_main_exits_non_zero_when_a_banned_term_is_planted(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = os.path.join(tmp_dir, "repo")
@@ -2496,7 +2076,6 @@ class ValidateMainExitsNonZeroOnBannedTermTest(unittest.TestCase):
 
 class ValidateMainRunsOfflineWithoutBoardTokenTest(unittest.TestCase):
     def test_offline_checks_pass_green_with_a_clean_mapping_and_no_token_in_the_environment(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = os.path.join(tmp_dir, "repo")
@@ -2523,7 +2102,6 @@ class ValidateMainRunsOfflineWithoutBoardTokenTest(unittest.TestCase):
                 validate_pr_triage_teams.main(repo_root=repo_root)
 
     def test_a_genuine_mapping_defect_still_fails_with_no_token_present(self):
-        import tempfile
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             repo_root = os.path.join(tmp_dir, "repo")

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -1,3 +1,4 @@
+import datetime
 import json
 import os
 import sys
@@ -104,43 +105,281 @@ class DecidePrTriageTest(unittest.TestCase):
         self.assertFalse(decision["known"])
 
 
-class DecideTransitionTest(unittest.TestCase):
-    def test_ready_for_review_moves_status_to_review(self):
-        transition = pr_triage.decide_transition("ready_for_review")
+class DecideBoardUpdateTest(unittest.TestCase):
+    def test_ready_for_review_sets_status_review_outright(self):
+        fields = pr_triage.decide_board_update(
+            "ready_for_review", is_draft=False, current_status="Working", current_team="Dev", mapped_team="Dev"
+        )
 
-        self.assertEqual(transition["status"], pr_triage.STATUS_REVIEW)
-        self.assertEqual(transition["status"], "Review")
+        self.assertEqual(fields["status"], "Review")
 
-    def test_converted_to_draft_moves_status_to_working(self):
-        transition = pr_triage.decide_transition("converted_to_draft")
+    def test_converted_to_draft_sets_status_working_outright(self):
+        fields = pr_triage.decide_board_update(
+            "converted_to_draft", is_draft=True, current_status="Review", current_team="Dev", mapped_team="Dev"
+        )
 
-        self.assertEqual(transition["status"], pr_triage.STATUS_WORKING)
-        self.assertEqual(transition["status"], "Working")
+        self.assertEqual(fields["status"], "Working")
 
-    def test_opened_is_not_a_transition(self):
-        self.assertIsNone(pr_triage.decide_transition("opened"))
+    def test_reopened_draft_sets_status_working_outright(self):
+        fields = pr_triage.decide_board_update(
+            "reopened", is_draft=True, current_status="Review", current_team="Dev", mapped_team="Dev"
+        )
 
-    def test_reopened_draft_pr_moves_status_to_working(self):
-        transition = pr_triage.decide_transition("reopened", is_draft=True)
+        self.assertEqual(fields["status"], "Working")
 
-        self.assertEqual(transition["status"], "Working")
+    def test_reopened_ready_sets_status_review_outright(self):
+        fields = pr_triage.decide_board_update(
+            "reopened", is_draft=False, current_status="Working", current_team="Dev", mapped_team="Dev"
+        )
 
-    def test_reopened_ready_pr_moves_status_to_review(self):
-        transition = pr_triage.decide_transition("reopened", is_draft=False)
+        self.assertEqual(fields["status"], "Review")
 
-        self.assertEqual(transition["status"], "Review")
+    def test_transition_status_overwrites_even_when_status_already_set(self):
+        fields = pr_triage.decide_board_update(
+            "ready_for_review", is_draft=False, current_status="Review", current_team="Dev", mapped_team="Dev"
+        )
 
-    def test_transition_rule_is_decoupled_from_the_unknown_author_rule(self):
-        with mock.patch.object(pr_triage, "UNKNOWN_AUTHOR_STATUS", "SomethingElse"):
-            transition = pr_triage.decide_transition("ready_for_review")
+        self.assertEqual(fields["status"], "Review")
 
-        self.assertEqual(transition["status"], "Review")
+    def test_transition_fills_team_when_empty(self):
+        fields = pr_triage.decide_board_update(
+            "ready_for_review", is_draft=False, current_status="Working", current_team=None, mapped_team="Delivery"
+        )
 
-    def test_transition_rule_is_decoupled_from_the_known_author_rule(self):
-        with mock.patch.object(pr_triage, "KNOWN_AUTHOR_STATUS", "SomethingElse"):
-            transition = pr_triage.decide_transition("converted_to_draft")
+        self.assertEqual(fields["team"], "Delivery")
 
-        self.assertEqual(transition["status"], "Working")
+    def test_transition_never_overwrites_a_non_empty_team(self):
+        fields = pr_triage.decide_board_update(
+            "ready_for_review",
+            is_draft=False,
+            current_status="Working",
+            current_team="Analysis",
+            mapped_team="Delivery",
+        )
+
+        self.assertIsNone(fields["team"])
+
+    def test_synchronize_fills_status_only_when_empty_and_draft(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=True, current_status=None, current_team="Dev", mapped_team="Dev"
+        )
+
+        self.assertEqual(fields["status"], "Working")
+
+    def test_synchronize_fills_status_only_when_empty_and_ready(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=False, current_status=None, current_team="Dev", mapped_team="Dev"
+        )
+
+        self.assertEqual(fields["status"], "Review")
+
+    def test_synchronize_never_overwrites_a_non_empty_status(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=True, current_status="Review", current_team="Dev", mapped_team="Dev"
+        )
+
+        self.assertIsNone(fields["status"])
+
+    def test_synchronize_fills_team_when_empty(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=False, current_status="Review", current_team=None, mapped_team="Delivery"
+        )
+
+        self.assertEqual(fields["team"], "Delivery")
+
+    def test_synchronize_never_overwrites_a_non_empty_team(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=False, current_status="Review", current_team="Analysis", mapped_team="Delivery"
+        )
+
+        self.assertIsNone(fields["team"])
+
+    def test_synchronize_never_overwrites_status_or_team_together(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=True, current_status="Review", current_team="Analysis", mapped_team="Delivery"
+        )
+
+        self.assertIsNone(fields["status"])
+        self.assertIsNone(fields["team"])
+
+    def test_blank_string_team_counts_as_empty(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=False, current_status="Review", current_team="   ", mapped_team="Delivery"
+        )
+
+        self.assertEqual(fields["team"], "Delivery")
+
+    def test_opened_is_not_a_board_update_action(self):
+        self.assertIsNone(
+            pr_triage.decide_board_update(
+                "opened", is_draft=False, current_status=None, current_team=None, mapped_team="Dev"
+            )
+        )
+
+    def test_unrecognized_action_is_not_a_board_update_action(self):
+        self.assertIsNone(
+            pr_triage.decide_board_update(
+                "labeled", is_draft=False, current_status=None, current_team=None, mapped_team="Dev"
+            )
+        )
+
+    def test_transition_fills_sprint_when_empty(self):
+        fields = pr_triage.decide_board_update(
+            "ready_for_review",
+            is_draft=False,
+            current_status="Working",
+            current_team="Dev",
+            mapped_team="Dev",
+            current_sprint=None,
+            current_sprint_title="Sprint 260",
+        )
+
+        self.assertEqual(fields["sprint"], "Sprint 260")
+
+    def test_transition_never_overwrites_a_non_empty_sprint(self):
+        fields = pr_triage.decide_board_update(
+            "converted_to_draft",
+            is_draft=True,
+            current_status="Review",
+            current_team="Dev",
+            mapped_team="Dev",
+            current_sprint="Sprint 259",
+            current_sprint_title="Sprint 260",
+        )
+
+        self.assertIsNone(fields["sprint"])
+
+    def test_reopened_fills_sprint_when_empty(self):
+        fields = pr_triage.decide_board_update(
+            "reopened",
+            is_draft=False,
+            current_status="Working",
+            current_team="Dev",
+            mapped_team="Dev",
+            current_sprint=None,
+            current_sprint_title="Sprint 260",
+        )
+
+        self.assertEqual(fields["sprint"], "Sprint 260")
+
+    def test_synchronize_fills_sprint_when_empty(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize",
+            is_draft=False,
+            current_status="Review",
+            current_team="Dev",
+            mapped_team="Dev",
+            current_sprint=None,
+            current_sprint_title="Sprint 260",
+        )
+
+        self.assertEqual(fields["sprint"], "Sprint 260")
+
+    def test_synchronize_never_overwrites_a_non_empty_sprint(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize",
+            is_draft=False,
+            current_status="Review",
+            current_team="Dev",
+            mapped_team="Dev",
+            current_sprint="Sprint 259",
+            current_sprint_title="Sprint 260",
+        )
+
+        self.assertIsNone(fields["sprint"])
+
+    def test_blank_string_sprint_counts_as_empty(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize",
+            is_draft=False,
+            current_status="Review",
+            current_team="Dev",
+            mapped_team="Dev",
+            current_sprint="   ",
+            current_sprint_title="Sprint 260",
+        )
+
+        self.assertEqual(fields["sprint"], "Sprint 260")
+
+    def test_empty_sprint_stays_unwritten_when_no_current_iteration_resolves(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize",
+            is_draft=False,
+            current_status="Review",
+            current_team="Dev",
+            mapped_team="Dev",
+            current_sprint=None,
+            current_sprint_title=None,
+        )
+
+        self.assertIsNone(fields["sprint"])
+
+    def test_no_field_is_written_by_default_when_sprint_args_are_omitted(self):
+        fields = pr_triage.decide_board_update(
+            "synchronize", is_draft=False, current_status="Review", current_team="Dev", mapped_team="Dev"
+        )
+
+        self.assertIsNone(fields["sprint"])
+
+
+class FindCurrentIterationTest(unittest.TestCase):
+    def test_returns_the_iteration_containing_today(self):
+        import datetime
+
+        iterations = [
+            {"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21},
+            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21},
+        ]
+
+        iteration = pr_triage.find_current_iteration(iterations, datetime.date(2026, 8, 8))
+
+        self.assertEqual(iteration["id"], "bd551114")
+        self.assertEqual(iteration["title"], "Sprint 260")
+
+    def test_start_date_itself_is_inside_the_iteration(self):
+        import datetime
+
+        iterations = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
+
+        iteration = pr_triage.find_current_iteration(iterations, datetime.date(2026, 8, 3))
+
+        self.assertEqual(iteration["id"], "bd551114")
+
+    def test_the_day_after_the_iteration_ends_is_not_inside_it(self):
+        import datetime
+
+        iterations = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
+
+        end_date = datetime.date(2026, 8, 3) + datetime.timedelta(days=21)
+        iteration = pr_triage.find_current_iteration(iterations, end_date)
+
+        self.assertIsNone(iteration)
+
+    def test_returns_none_when_no_iteration_contains_the_date(self):
+        import datetime
+
+        iterations = [{"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21}]
+
+        iteration = pr_triage.find_current_iteration(iterations, datetime.date(2026, 9, 1))
+
+        self.assertIsNone(iteration)
+
+    def test_returns_none_for_an_empty_iteration_list(self):
+        import datetime
+
+        self.assertIsNone(pr_triage.find_current_iteration([], datetime.date(2026, 8, 8)))
+
+    def test_does_not_assume_the_first_entry_is_current(self):
+        import datetime
+
+        iterations = [
+            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21},
+            {"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21},
+        ]
+
+        iteration = pr_triage.find_current_iteration(iterations, datetime.date(2026, 7, 20))
+
+        self.assertEqual(iteration["id"], "bd551113")
 
 
 class CheckAssignmentSucceededTest(unittest.TestCase):
@@ -671,14 +910,24 @@ class MappingFilePathTest(unittest.TestCase):
         self.assertEqual(result, "/opt/checkout/.github/pr-triage-teams.yml")
 
 
-class MainWiringReopenedTest(unittest.TestCase):
-    def _run_reopened(self, is_draft, item_exists):
+class MainWiringBoardUpdateTest(unittest.TestCase):
+    def _run_board_update(
+        self,
+        action,
+        is_draft,
+        item_exists,
+        current_status=None,
+        current_team=None,
+        current_sprint=None,
+        mapping=None,
+        author_login="mswertz",
+    ):
         import tempfile
 
         event = {
-            "action": "reopened",
+            "action": action,
             "pull_request": {
-                "user": {"login": "mswertz"},
+                "user": {"login": author_login},
                 "head": {"ref": "feature/x"},
                 "number": 1,
                 "node_id": "PR_node",
@@ -695,11 +944,11 @@ class MainWiringReopenedTest(unittest.TestCase):
             variables = (body or {}).get("variables", {})
 
             if url.endswith("/assignees"):
-                raise AssertionError("reopened must never touch the assignee")
+                raise AssertionError("a board update must never touch the assignee")
             if "convertPullRequestToDraft" in query:
-                raise AssertionError("reopened must never call convertPullRequestToDraft")
+                raise AssertionError("a board update must never touch the draft state")
             if "ReadyForReview" in query:
-                raise AssertionError("reopened must never call a ready-conversion mutation")
+                raise AssertionError("a board update must never touch the draft state")
 
             if "projectItems" in query:
                 if item_exists:
@@ -707,7 +956,9 @@ class MainWiringReopenedTest(unittest.TestCase):
                         {
                             "id": "EXISTING_ITEM",
                             "project": {"id": pr_triage.BOARD_PROJECT_ID},
-                            "fieldValueByName": {"name": "Working"},
+                            "status": {"name": current_status} if current_status else None,
+                            "team": {"name": current_team} if current_team else None,
+                            "sprint": {"title": current_sprint} if current_sprint else None,
                         }
                     ]
                 else:
@@ -720,14 +971,40 @@ class MainWiringReopenedTest(unittest.TestCase):
                 return {"data": {"addProjectV2ItemById": {"item": {"id": "NEW_ITEM"}}}}
 
             if "updateProjectV2ItemFieldValue" in query:
-                if variables.get("fieldId") == pr_triage.TEAM_FIELD_ID:
-                    raise AssertionError("reopened must never write the Team field")
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM"}}}}
 
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
                     return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
-                raise AssertionError("reopened must never fetch Team options")
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    return {
+                        "data": {
+                            "node": {
+                                "options": [
+                                    {"id": "TEAM_DELIVERY_OPT", "name": "Delivery"},
+                                    {"id": "TEAM_DEV_OPT", "name": "Dev"},
+                                ]
+                            }
+                        }
+                    }
+
+            if "configuration" in query:
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {
+                                        "id": "bd551114",
+                                        "title": "Sprint 260",
+                                        "startDate": "2026-08-03",
+                                        "duration": 21,
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
 
             raise AssertionError(f"unexpected call: {url} {query}")
 
@@ -746,47 +1023,296 @@ class MainWiringReopenedTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
+            ), mock.patch.object(
+                pr_triage, "load_teams_mapping", return_value=mapping if mapping is not None else {"mswertz": "Dev"}
+            ), mock.patch.object(
+                pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
             ):
                 pr_triage.main()
 
-        return calls
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
 
-    def test_reopened_draft_pr_moves_status_to_working(self):
-        calls = self._run_reopened(is_draft=True, item_exists=True)
+        return calls, summary_text
 
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+    def _query_of(self, call):
+        return (call["body"] or {}).get("query", "")
 
-        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 1)
-        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
+    def _field_writes(self, calls):
+        return [call for call in calls if "updateProjectV2ItemFieldValue" in self._query_of(call)]
 
-    def test_reopened_ready_pr_moves_status_to_review(self):
-        calls = self._run_reopened(is_draft=False, item_exists=True)
+    def _assert_never_touches_assignee_or_draft(self, calls):
+        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
+        self.assertFalse(any("convertPullRequestToDraft" in self._query_of(call) for call in calls))
 
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+    # --- transitions: Status is always overwritten ---
 
-        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 1)
-        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")
+    def test_ready_for_review_overwrites_status_even_when_already_set(self):
+        calls, _ = self._run_board_update(
+            "ready_for_review", is_draft=False, item_exists=True, current_status="Working", current_team="Dev"
+        )
 
-    def test_reopened_with_no_existing_item_is_added_not_skipped(self):
-        calls = self._run_reopened(is_draft=False, item_exists=False)
+        status_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        ]
+        self.assertEqual(len(status_writes), 1)
+        self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "879449e7")
+        self.assertEqual(status_writes[0]["body"]["variables"]["itemId"], "EXISTING_ITEM")
+        self.assertEqual(status_writes[0]["token"], "board-token")
 
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+    def test_converted_to_draft_overwrites_status_even_when_already_set(self):
+        calls, _ = self._run_board_update(
+            "converted_to_draft", is_draft=True, item_exists=True, current_status="Review", current_team="Dev"
+        )
 
-        add_item_calls = [call for call in calls if "addProjectV2ItemById" in query_of(call)]
+        status_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        ]
+        self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
+
+    def test_reopened_draft_overwrites_status_to_working(self):
+        calls, _ = self._run_board_update(
+            "reopened", is_draft=True, item_exists=True, current_status="Review", current_team="Dev"
+        )
+
+        status_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        ]
+        self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
+
+    def test_reopened_ready_overwrites_status_to_review(self):
+        calls, _ = self._run_board_update(
+            "reopened", is_draft=False, item_exists=True, current_status="Working", current_team="Dev"
+        )
+
+        status_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        ]
+        self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "879449e7")
+
+    def test_transition_with_no_existing_item_adds_it(self):
+        calls, _ = self._run_board_update("ready_for_review", is_draft=False, item_exists=False)
+
+        add_item_calls = [call for call in calls if "addProjectV2ItemById" in self._query_of(call)]
         self.assertEqual(len(add_item_calls), 1)
+        self.assertEqual(add_item_calls[0]["token"], "board-token")
+
+    # --- transitions: Team and Sprint fill only, never overwrite ---
+
+    def test_transition_fills_team_when_empty(self):
+        calls, _ = self._run_board_update(
+            "ready_for_review",
+            is_draft=False,
+            item_exists=True,
+            current_status="Working",
+            current_team=None,
+            mapping={"mswertz": "Delivery"},
+        )
+
+        team_writes = [
+            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID
+        ]
+        self.assertEqual(len(team_writes), 1)
+        self.assertEqual(team_writes[0]["body"]["variables"]["optionId"], "TEAM_DELIVERY_OPT")
+
+    def test_transition_never_overwrites_a_non_empty_team(self):
+        calls, _ = self._run_board_update(
+            "ready_for_review",
+            is_draft=False,
+            item_exists=True,
+            current_status="Working",
+            current_team="Dev",
+            mapping={"mswertz": "Delivery"},
+        )
+
+        team_writes = [
+            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID
+        ]
+        self.assertEqual(team_writes, [])
+
+    def test_transition_fills_sprint_when_empty(self):
+        calls, _ = self._run_board_update(
+            "converted_to_draft",
+            is_draft=True,
+            item_exists=True,
+            current_status="Review",
+            current_team="Dev",
+            current_sprint=None,
+        )
+
+        sprint_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.SPRINT_FIELD_ID
+        ]
+        self.assertEqual(len(sprint_writes), 1)
+        self.assertEqual(sprint_writes[0]["body"]["variables"]["iterationId"], "bd551114")
+
+    def test_transition_never_overwrites_a_non_empty_sprint(self):
+        calls, _ = self._run_board_update(
+            "converted_to_draft",
+            is_draft=True,
+            item_exists=True,
+            current_status="Review",
+            current_team="Dev",
+            current_sprint="Sprint 259",
+        )
+
+        sprint_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.SPRINT_FIELD_ID
+        ]
+        self.assertEqual(sprint_writes, [])
+
+    # --- synchronize: fill-only for every field, never overwrite ---
+
+    def test_synchronize_item_already_exists_with_everything_set_writes_nothing(self):
+        calls, summary_text = self._run_board_update(
+            "synchronize",
+            is_draft=False,
+            item_exists=True,
+            current_status="Review",
+            current_team="Dev",
+            current_sprint="Sprint 260",
+        )
+
+        self._assert_never_touches_assignee_or_draft(calls)
+        self.assertEqual(self._field_writes(calls), [])
+        self.assertFalse(any("addProjectV2ItemById" in self._query_of(call) for call in calls))
+        self.assertIn("### PR triage", summary_text)
+
+    def test_synchronize_fills_status_only_when_empty(self):
+        calls, _ = self._run_board_update(
+            "synchronize", is_draft=True, item_exists=True, current_status=None, current_team="Dev", current_sprint="Sprint 260"
+        )
+
+        status_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        ]
+        self.assertEqual(len(status_writes), 1)
+        self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
+
+    def test_synchronize_never_overwrites_a_non_empty_status(self):
+        calls, _ = self._run_board_update(
+            "synchronize",
+            is_draft=True,
+            item_exists=True,
+            current_status="Review",
+            current_team="Dev",
+            current_sprint="Sprint 260",
+        )
+
+        status_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        ]
+        self.assertEqual(status_writes, [])
+
+    def test_synchronize_fills_team_when_empty(self):
+        calls, _ = self._run_board_update(
+            "synchronize",
+            is_draft=False,
+            item_exists=True,
+            current_status="Review",
+            current_team=None,
+            current_sprint="Sprint 260",
+            mapping={"mswertz": "Delivery"},
+        )
+
+        team_writes = [
+            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID
+        ]
+        self.assertEqual(len(team_writes), 1)
+        self.assertEqual(team_writes[0]["body"]["variables"]["optionId"], "TEAM_DELIVERY_OPT")
+
+    def test_synchronize_never_overwrites_a_non_empty_team(self):
+        calls, _ = self._run_board_update(
+            "synchronize",
+            is_draft=False,
+            item_exists=True,
+            current_status="Review",
+            current_team="Dev",
+            current_sprint="Sprint 260",
+            mapping={"mswertz": "Delivery"},
+        )
+
+        team_writes = [
+            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID
+        ]
+        self.assertEqual(team_writes, [])
+
+    def test_synchronize_fills_sprint_when_empty(self):
+        calls, _ = self._run_board_update(
+            "synchronize",
+            is_draft=False,
+            item_exists=True,
+            current_status="Review",
+            current_team="Dev",
+            current_sprint=None,
+        )
+
+        sprint_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.SPRINT_FIELD_ID
+        ]
+        self.assertEqual(len(sprint_writes), 1)
+        self.assertEqual(sprint_writes[0]["body"]["variables"]["iterationId"], "bd551114")
+
+    def test_synchronize_never_overwrites_a_non_empty_sprint(self):
+        calls, _ = self._run_board_update(
+            "synchronize",
+            is_draft=False,
+            item_exists=True,
+            current_status="Review",
+            current_team="Dev",
+            current_sprint="Sprint 259",
+        )
+
+        sprint_writes = [
+            call
+            for call in self._field_writes(calls)
+            if call["body"]["variables"]["fieldId"] == pr_triage.SPRINT_FIELD_ID
+        ]
+        self.assertEqual(sprint_writes, [])
+
+    def test_synchronize_with_no_existing_item_adds_it_and_fills_all_three(self):
+        calls, _ = self._run_board_update(
+            "synchronize", is_draft=True, item_exists=False, mapping={"mswertz": "Delivery"}
+        )
+
+        add_item_calls = [call for call in calls if "addProjectV2ItemById" in self._query_of(call)]
+        self.assertEqual(len(add_item_calls), 1)
+        self.assertEqual(add_item_calls[0]["token"], "board-token")
+
+        field_writes = self._field_writes(calls)
+        written_field_ids = {call["body"]["variables"]["fieldId"] for call in field_writes}
+        self.assertEqual(
+            written_field_ids, {pr_triage.STATUS_FIELD_ID, pr_triage.TEAM_FIELD_ID, pr_triage.SPRINT_FIELD_ID}
+        )
+        for call in field_writes:
+            self.assertEqual(call["body"]["variables"]["itemId"], "NEW_ITEM")
+            self.assertEqual(call["token"], "board-token")
 
 
-class MainWiringOpenedStillRunsFullOpenPathTest(unittest.TestCase):
-    def test_opened_action_still_assigns_drafts_and_writes_team(self):
+class BoardUpdateWritesStepSummaryOnFailureTest(unittest.TestCase):
+    def test_step_summary_is_written_and_error_reraised_when_a_board_write_fails(self):
         import tempfile
 
         event = {
-            "action": "opened",
+            "action": "ready_for_review",
             "pull_request": {
                 "user": {"login": "mswertz"},
                 "head": {"ref": "feature/x"},
@@ -797,27 +1323,6 @@ class MainWiringOpenedStillRunsFullOpenPathTest(unittest.TestCase):
             "repository": {"full_name": "molgenis/molgenis-emx2"},
         }
 
-        calls = []
-
-        def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
-            if url.endswith("/assignees"):
-                return {"assignees": [{"login": "mswertz"}]}
-            if "convertPullRequestToDraft" in query:
-                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
-            if "addProjectV2ItemById" in query:
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
-            if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
-            raise AssertionError(f"unexpected call: {url} {query}")
-
         with tempfile.TemporaryDirectory() as tmp_dir:
             event_path = os.path.join(tmp_dir, "event.json")
             with open(event_path, "w", encoding="utf-8") as handle:
@@ -827,88 +1332,72 @@ class MainWiringOpenedStillRunsFullOpenPathTest(unittest.TestCase):
 
             env = {
                 "GITHUB_EVENT_PATH": event_path,
-                "GITHUB_TOKEN": "github-token",
                 "PROJECT_BOARD_TOKEN": "board-token",
                 "GITHUB_STEP_SUMMARY": summary_path,
             }
 
-            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "find_board_item_for_pr", side_effect=pr_triage.GraphqlError("board boom")
             ):
-                pr_triage.main()
+                with self.assertRaises(pr_triage.GraphqlError):
+                    pr_triage.main()
 
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
 
-        assign_call = next(call for call in calls if call["url"].endswith("/assignees"))
-        self.assertEqual(assign_call["token"], "github-token")
-
-        draft_call = next(call for call in calls if "convertPullRequestToDraft" in query_of(call))
-        self.assertEqual(draft_call["token"], "board-token")
-
-        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 2)
-        self.assertEqual(field_writes[1]["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("Failure", summary_text)
+        self.assertIn("board boom", summary_text)
 
 
-class MainWiringSynchronizeTest(unittest.TestCase):
-    def _run_synchronize(self, is_draft, item_exists):
+class BoardUpdateResolvesFieldsBeforeAddingBoardItemTest(unittest.TestCase):
+    def test_fields_are_resolved_before_a_missing_item_is_added(self):
         import tempfile
 
         event = {
-            "action": "synchronize",
+            "action": "ready_for_review",
             "pull_request": {
                 "user": {"login": "mswertz"},
                 "head": {"ref": "feature/x"},
                 "number": 1,
                 "node_id": "PR_node",
-                "draft": is_draft,
+                "draft": False,
             },
             "repository": {"full_name": "molgenis/molgenis-emx2"},
         }
 
-        calls = []
+        call_kinds = []
 
         def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
             query = (body or {}).get("query", "")
             variables = (body or {}).get("variables", {})
-
-            if url.endswith("/assignees"):
-                raise AssertionError("synchronize must never touch the assignee")
-            if "convertPullRequestToDraft" in query:
-                raise AssertionError("synchronize must never touch the draft state")
-            if "ReadyForReview" in query:
-                raise AssertionError("synchronize must never touch the draft state")
-
             if "projectItems" in query:
-                if item_exists:
-                    nodes = [
-                        {
-                            "id": "EXISTING_ITEM",
-                            "project": {"id": pr_triage.BOARD_PROJECT_ID},
-                            "fieldValueByName": {"name": "Working"},
-                        }
-                    ]
-                else:
-                    nodes = []
-                return {"data": {"node": {"projectItems": {"nodes": nodes}}}}
-
+                call_kinds.append("find_item")
+                return {"data": {"node": {"projectItems": {"nodes": []}}}}
             if "addProjectV2ItemById" in query:
-                if item_exists:
-                    raise AssertionError("must not add an item that already exists")
+                call_kinds.append("add_item")
                 return {"data": {"addProjectV2ItemById": {"item": {"id": "NEW_ITEM"}}}}
-
             if "updateProjectV2ItemFieldValue" in query:
-                if variables.get("fieldId") == pr_triage.TEAM_FIELD_ID:
-                    raise AssertionError("synchronize must never write the Team field")
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM"}}}}
-
+                call_kinds.append("set_field")
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "NEW_ITEM"}}}}
             if "options { id name }" in query:
+                call_kinds.append("fetch_options")
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
                     return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
-                raise AssertionError("synchronize must never fetch Team options")
-
+                return {"data": {"node": {"options": [{"id": "TEAM_DEV_OPT", "name": "Dev"}]}}}
+            if "configuration" in query:
+                call_kinds.append("fetch_iterations")
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                                ]
+                            }
+                        }
+                    }
+                }
             raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -926,71 +1415,61 @@ class MainWiringSynchronizeTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
+            ), mock.patch.object(pr_triage, "load_teams_mapping", return_value={"mswertz": "Dev"}), mock.patch.object(
+                pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
             ):
                 pr_triage.main()
 
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
+        add_item_index = call_kinds.index("add_item")
+        self.assertLess(call_kinds.index("fetch_options"), add_item_index)
 
-        return calls, summary_text
+    def test_a_status_resolution_failure_never_adds_a_board_item(self):
+        import tempfile
 
-    def _assert_no_forbidden_calls(self, calls):
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+        event = {
+            "action": "ready_for_review",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
 
-        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
-        self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
-        self.assertFalse(any(
-            "updateProjectV2ItemFieldValue" in query_of(call)
-            and call["body"]["variables"].get("fieldId") == pr_triage.TEAM_FIELD_ID
-            for call in calls
-        ))
+        def fake_http_request(url, token, method="GET", body=None):
+            query = (body or {}).get("query", "")
+            if "projectItems" in query:
+                return {"data": {"node": {"projectItems": {"nodes": []}}}}
+            if "addProjectV2ItemById" in query:
+                raise AssertionError("must not add a board item when Status resolution fails")
+            if "options { id name }" in query:
+                return {"data": {"node": {"options": [{"id": "SOME_OPT", "name": "NoMatchingOptionHere"}]}}}
+            if "configuration" in query:
+                return {"data": {"node": {"configuration": {"iterations": []}}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
 
-    def test_item_already_exists_does_nothing_at_all(self):
-        calls, summary_text = self._run_synchronize(is_draft=False, item_exists=True)
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
 
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
 
-        self._assert_no_forbidden_calls(calls)
-        self.assertFalse(any("addProjectV2ItemById" in query_of(call) for call in calls))
-        self.assertFalse(any("updateProjectV2ItemFieldValue" in query_of(call) for call in calls))
-
-        self.assertIn("### PR triage", summary_text)
-        self.assertIn("no action", summary_text.lower())
-
-    def test_item_missing_and_draft_adds_and_boards_working(self):
-        calls, summary_text = self._run_synchronize(is_draft=True, item_exists=False)
-
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
-
-        self._assert_no_forbidden_calls(calls)
-
-        add_item_calls = [call for call in calls if "addProjectV2ItemById" in query_of(call)]
-        self.assertEqual(len(add_item_calls), 1)
-        self.assertEqual(add_item_calls[0]["token"], "board-token")
-
-        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 1)
-        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
-        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
-        self.assertEqual(field_writes[0]["body"]["variables"]["itemId"], "NEW_ITEM")
-        self.assertEqual(field_writes[0]["token"], "board-token")
-
-        self.assertIn("### PR triage", summary_text)
-
-    def test_item_missing_and_ready_adds_and_boards_review(self):
-        calls, summary_text = self._run_synchronize(is_draft=False, item_exists=False)
-
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
-
-        self._assert_no_forbidden_calls(calls)
-
-        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 1)
-        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ), mock.patch.object(pr_triage, "load_teams_mapping", return_value={"mswertz": "Dev"}), mock.patch.object(
+                pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
+            ):
+                with self.assertRaises(ValueError):
+                    pr_triage.main()
 
 
 class MainWiringUnknownAuthorTest(unittest.TestCase):
@@ -1224,286 +1703,6 @@ LIVE_STATUS_OPTIONS = [
 LIVE_STATUS_OPTION_ID_BY_NAME = {"Working": "47fc9ee4", "Review": "879449e7"}
 
 
-class MainWiringTransitionTest(unittest.TestCase):
-    def _run_transition(self, action, author_login, item_exists):
-        import tempfile
-
-        event = {
-            "action": action,
-            "pull_request": {
-                "user": {"login": author_login},
-                "head": {"ref": "feature/x"},
-                "number": 1,
-                "node_id": "PR_node",
-                "draft": action == "converted_to_draft",
-            },
-            "repository": {"full_name": "molgenis/molgenis-emx2"},
-        }
-
-        calls = []
-
-        def fake_http_request(url, token, method="GET", body=None):
-            calls.append({"url": url, "token": token, "body": body})
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
-
-            if url.endswith("/assignees"):
-                raise AssertionError("a transition must never touch the assignee")
-            if "convertPullRequestToDraft" in query:
-                raise AssertionError("a transition must never call convertPullRequestToDraft")
-            if "ReadyForReview" in query:
-                raise AssertionError("a transition must never call a ready-conversion mutation")
-
-            if "projectItems" in query:
-                if item_exists:
-                    nodes = [
-                        {
-                            "id": "EXISTING_ITEM",
-                            "project": {"id": pr_triage.BOARD_PROJECT_ID},
-                            "fieldValueByName": {"name": "Working"},
-                        }
-                    ]
-                else:
-                    nodes = []
-                return {"data": {"node": {"projectItems": {"nodes": nodes}}}}
-
-            if "addProjectV2ItemById" in query:
-                if item_exists:
-                    raise AssertionError("must not add an item that already exists")
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "NEW_ITEM"}}}}
-
-            if "updateProjectV2ItemFieldValue" in query:
-                if variables.get("fieldId") == pr_triage.TEAM_FIELD_ID:
-                    raise AssertionError("a transition must never write the Team field")
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM"}}}}
-
-            if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
-                raise AssertionError("a transition must never fetch Team options")
-
-            raise AssertionError(f"unexpected call: {url} {query}")
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
-
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ):
-                pr_triage.main()
-
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
-
-        return calls, summary_text
-
-    def _assert_transition_wiring(self, calls, summary_text, action, item_exists):
-        def query_of(call):
-            return (call["body"] or {}).get("query", "")
-
-        expected_status_name = "Review" if action == "ready_for_review" else "Working"
-        expected_option_id = LIVE_STATUS_OPTION_ID_BY_NAME[expected_status_name]
-        expected_item_id = "EXISTING_ITEM" if item_exists else "NEW_ITEM"
-
-        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
-        self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
-
-        add_item_calls = [call for call in calls if "addProjectV2ItemById" in query_of(call)]
-        if item_exists:
-            self.assertEqual(len(add_item_calls), 0)
-        else:
-            self.assertEqual(len(add_item_calls), 1)
-            self.assertEqual(add_item_calls[0]["token"], "board-token")
-
-        project_items_calls = [call for call in calls if "projectItems" in query_of(call)]
-        self.assertEqual(len(project_items_calls), 1)
-        self.assertIn("first: 100", query_of(project_items_calls[0]))
-
-        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 1)
-        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
-        self.assertEqual(field_writes[0]["body"]["variables"]["itemId"], expected_item_id)
-        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], expected_option_id)
-        self.assertEqual(field_writes[0]["token"], "board-token")
-
-        self.assertIn("### PR triage", summary_text)
-        self.assertIn("| Team | not touched, deliberate |", summary_text)
-        self.assertIn(
-            "| Assignee | not touched, deliberate, including when empty |", summary_text
-        )
-
-    def test_ready_for_review_known_author_existing_item(self):
-        calls, summary_text = self._run_transition("ready_for_review", "mswertz", item_exists=True)
-        self._assert_transition_wiring(calls, summary_text, "ready_for_review", item_exists=True)
-
-    def test_ready_for_review_unknown_author_no_existing_item(self):
-        calls, summary_text = self._run_transition("ready_for_review", "some-outside-contributor", item_exists=False)
-        self._assert_transition_wiring(calls, summary_text, "ready_for_review", item_exists=False)
-
-    def test_converted_to_draft_known_author_existing_item(self):
-        calls, summary_text = self._run_transition("converted_to_draft", "mswertz", item_exists=True)
-        self._assert_transition_wiring(calls, summary_text, "converted_to_draft", item_exists=True)
-
-    def test_converted_to_draft_unknown_author_no_existing_item(self):
-        calls, summary_text = self._run_transition(
-            "converted_to_draft", "some-outside-contributor", item_exists=False
-        )
-        self._assert_transition_wiring(calls, summary_text, "converted_to_draft", item_exists=False)
-
-
-class TransitionWritesStepSummaryOnFailureTest(unittest.TestCase):
-    def test_step_summary_is_written_and_error_reraised_when_a_transition_write_fails(self):
-        import tempfile
-
-        event = {
-            "action": "ready_for_review",
-            "pull_request": {
-                "user": {"login": "mswertz"},
-                "head": {"ref": "feature/x"},
-                "number": 1,
-                "node_id": "PR_node",
-                "draft": False,
-            },
-            "repository": {"full_name": "molgenis/molgenis-emx2"},
-        }
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
-
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "fetch_project_field_options", side_effect=pr_triage.GraphqlError("board boom")
-            ):
-                with self.assertRaises(pr_triage.GraphqlError):
-                    pr_triage.main()
-
-            with open(summary_path, encoding="utf-8") as handle:
-                summary_text = handle.read()
-
-        self.assertIn("### PR triage", summary_text)
-        self.assertIn("Failure", summary_text)
-        self.assertIn("board boom", summary_text)
-
-
-class TransitionResolvesStatusBeforeAddingBoardItemTest(unittest.TestCase):
-    def test_status_option_is_resolved_before_a_missing_item_is_added(self):
-        import tempfile
-
-        event = {
-            "action": "ready_for_review",
-            "pull_request": {
-                "user": {"login": "mswertz"},
-                "head": {"ref": "feature/x"},
-                "number": 1,
-                "node_id": "PR_node",
-                "draft": False,
-            },
-            "repository": {"full_name": "molgenis/molgenis-emx2"},
-        }
-
-        call_kinds = []
-
-        def fake_http_request(url, token, method="GET", body=None):
-            query = (body or {}).get("query", "")
-            variables = (body or {}).get("variables", {})
-            if "projectItems" in query:
-                call_kinds.append("find_item")
-                return {"data": {"node": {"projectItems": {"nodes": []}}}}
-            if "addProjectV2ItemById" in query:
-                call_kinds.append("add_item")
-                return {"data": {"addProjectV2ItemById": {"item": {"id": "NEW_ITEM"}}}}
-            if "updateProjectV2ItemFieldValue" in query:
-                call_kinds.append("set_field")
-                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "NEW_ITEM"}}}}
-            if "options { id name }" in query:
-                call_kinds.append("fetch_status_options")
-                return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
-            raise AssertionError(f"unexpected call: {url} {query}")
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
-
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ):
-                pr_triage.main()
-
-        self.assertLess(call_kinds.index("fetch_status_options"), call_kinds.index("add_item"))
-
-    def test_a_status_resolution_failure_never_adds_a_board_item(self):
-        import tempfile
-
-        event = {
-            "action": "ready_for_review",
-            "pull_request": {
-                "user": {"login": "mswertz"},
-                "head": {"ref": "feature/x"},
-                "number": 1,
-                "node_id": "PR_node",
-                "draft": False,
-            },
-            "repository": {"full_name": "molgenis/molgenis-emx2"},
-        }
-
-        def fake_http_request(url, token, method="GET", body=None):
-            query = (body or {}).get("query", "")
-            if "projectItems" in query:
-                return {"data": {"node": {"projectItems": {"nodes": []}}}}
-            if "addProjectV2ItemById" in query:
-                raise AssertionError("must not add a board item when Status resolution fails")
-            if "options { id name }" in query:
-                return {"data": {"node": {"options": [{"id": "SOME_OPT", "name": "NoMatchingOptionHere"}]}}}
-            raise AssertionError(f"unexpected call: {url} {query}")
-
-        with tempfile.TemporaryDirectory() as tmp_dir:
-            event_path = os.path.join(tmp_dir, "event.json")
-            with open(event_path, "w", encoding="utf-8") as handle:
-                json.dump(event, handle)
-            summary_path = os.path.join(tmp_dir, "summary.md")
-            open(summary_path, "w", encoding="utf-8").close()
-
-            env = {
-                "GITHUB_EVENT_PATH": event_path,
-                "PROJECT_BOARD_TOKEN": "board-token",
-                "GITHUB_STEP_SUMMARY": summary_path,
-            }
-
-            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
-            ):
-                with self.assertRaises(ValueError):
-                    pr_triage.main()
-
-
 class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
     def test_an_unrecognized_action_makes_no_writes_and_reads_no_mapping_file(self):
         import tempfile
@@ -1614,7 +1813,7 @@ class MainReadsAssignDecisionTest(unittest.TestCase):
 
 
 class FindBoardItemForPrTest(unittest.TestCase):
-    def test_returns_the_matching_project_item_and_its_current_status(self):
+    def test_returns_the_matching_project_item_with_its_current_status_team_and_sprint(self):
         response = {
             "data": {
                 "node": {
@@ -1623,12 +1822,16 @@ class FindBoardItemForPrTest(unittest.TestCase):
                             {
                                 "id": "OTHER_ITEM",
                                 "project": {"id": "PVT_someOtherBoard"},
-                                "fieldValueByName": {"name": "Done"},
+                                "status": {"name": "Done"},
+                                "team": {"name": "Analysis"},
+                                "sprint": {"title": "Sprint 100"},
                             },
                             {
                                 "id": "EXISTING_ITEM",
                                 "project": {"id": pr_triage.BOARD_PROJECT_ID},
-                                "fieldValueByName": {"name": "Working"},
+                                "status": {"name": "Working"},
+                                "team": {"name": "Dev"},
+                                "sprint": {"title": "Sprint 260"},
                             },
                         ]
                     }
@@ -1639,7 +1842,9 @@ class FindBoardItemForPrTest(unittest.TestCase):
             item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertEqual(item["id"], "EXISTING_ITEM")
-        self.assertEqual(item["old_status"], "Working")
+        self.assertEqual(item["status"], "Working")
+        self.assertEqual(item["team"], "Dev")
+        self.assertEqual(item["sprint"], "Sprint 260")
 
     def test_returns_none_when_pr_has_no_item_on_this_board(self):
         response = {
@@ -1650,7 +1855,9 @@ class FindBoardItemForPrTest(unittest.TestCase):
                             {
                                 "id": "OTHER_ITEM",
                                 "project": {"id": "PVT_someOtherBoard"},
-                                "fieldValueByName": {"name": "Done"},
+                                "status": {"name": "Done"},
+                                "team": {"name": "Analysis"},
+                                "sprint": {"title": "Sprint 100"},
                             }
                         ]
                     }
@@ -1669,7 +1876,7 @@ class FindBoardItemForPrTest(unittest.TestCase):
 
         self.assertIsNone(item)
 
-    def test_old_status_is_none_when_status_field_is_unset(self):
+    def test_status_team_and_sprint_are_none_when_the_fields_are_unset(self):
         response = {
             "data": {
                 "node": {
@@ -1678,7 +1885,9 @@ class FindBoardItemForPrTest(unittest.TestCase):
                             {
                                 "id": "EXISTING_ITEM",
                                 "project": {"id": pr_triage.BOARD_PROJECT_ID},
-                                "fieldValueByName": None,
+                                "status": None,
+                                "team": None,
+                                "sprint": None,
                             }
                         ]
                     }
@@ -1689,7 +1898,42 @@ class FindBoardItemForPrTest(unittest.TestCase):
             item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertEqual(item["id"], "EXISTING_ITEM")
-        self.assertIsNone(item["old_status"])
+        self.assertIsNone(item["status"])
+        self.assertIsNone(item["team"])
+        self.assertIsNone(item["sprint"])
+
+
+class FetchProjectIterationsTest(unittest.TestCase):
+    def test_returns_the_not_yet_completed_iterations(self):
+        response = {
+            "data": {
+                "node": {
+                    "configuration": {
+                        "iterations": [
+                            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                        ]
+                    }
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response) as mock_request:
+            iterations = pr_triage.fetch_project_iterations(pr_triage.SPRINT_FIELD_ID, "board-token")
+
+        self.assertEqual(iterations, [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}])
+        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
+        self.assertIn("iterations", called_body["query"])
+        self.assertNotIn("completedIterations", called_body["query"])
+
+
+class SetProjectFieldIterationTest(unittest.TestCase):
+    def test_writes_the_iteration_id_not_a_single_select_option(self):
+        with mock.patch.object(pr_triage, "http_request", return_value={"data": {}}) as mock_request:
+            pr_triage.set_project_field_iteration("ITEM_1", pr_triage.SPRINT_FIELD_ID, "bd551114", "board-token")
+
+        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
+        self.assertEqual(called_body["variables"]["iterationId"], "bd551114")
+        self.assertIn("iterationId", called_body["query"])
+        self.assertNotIn("singleSelectOptionId", called_body["query"])
 
 
 class GraphqlRequestErrorHandlingTest(unittest.TestCase):

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -1725,6 +1725,62 @@ class MainWiringClosingIssueTest(unittest.TestCase):
             self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
             self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")  # Review
 
+    # --- owner ruling: the PR's own card is removed LAST, only after every
+    # linked issue's card has been written -- if an issue write fails
+    # partway, the PR's card must survive (a transient duplicate is the
+    # spec's explicitly preferred outcome over zero cards) ---
+
+    def test_removal_happens_after_all_issue_writes_complete(self):
+        """Pins the ORDER, not just the outcome: a mutant that removes the
+        PR's card first and then writes the issue would still leave the
+        final state correct (both eventually happen), so an order-blind test
+        would not catch a regression back to remove-first."""
+        calls = []
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item={"id": "PR_ITEM_ORDER", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"},
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": None},
+            add_item_ids={"ISSUE_A": "NEW_ISSUE_ITEM"},
+        )
+
+        run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        remove_index = next(i for i, c in enumerate(calls) if "deleteProjectV2Item" in query_of(c))
+        issue_write_indices = [
+            i
+            for i, c in enumerate(calls)
+            if ("addProjectV2ItemById" in query_of(c) and c["body"]["variables"]["contentId"] == "ISSUE_A")
+            or (
+                "updateProjectV2ItemFieldValue" in query_of(c)
+                and c["body"]["variables"]["itemId"] == "NEW_ISSUE_ITEM"
+            )
+        ]
+        self.assertTrue(issue_write_indices, "expected at least the add call and one field write for the new issue item")
+        self.assertTrue(
+            all(i < remove_index for i in issue_write_indices),
+            "every issue write must complete before the PR's card is removed",
+        )
+
+    def test_removal_never_happens_when_an_issue_write_fails(self):
+        """The finding this reorder exists for: an issue write raising
+        partway through must leave the PR's card in place -- a transient
+        duplicate, not the zero-cards outcome the spec forbids."""
+        calls = []
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item={"id": "PR_ITEM_SURVIVES", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"},
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": None},
+            add_item_ids={"ISSUE_A": "NEW_ISSUE_ITEM"},
+            status_options=[{"id": "SOME_OPT", "name": "NoMatchingOptionHere"}],
+        )
+
+        with self.assertRaises(ValueError):
+            run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        self.assertEqual(self._remove_calls(calls), [], "the PR's card must survive an issue write that failed")
+
     # --- synchronize on a closing PR: writes NOTHING anywhere -- not the PR's
     # card (not even removal), not any issue's [owner ruling, fixes review
     # finding F1: a push must never leave zero cards for the same work] ---
@@ -1975,6 +2031,50 @@ class BoardUpdateWritesStepSummaryOnFailureTest(unittest.TestCase):
         self.assertIn("### PR triage", summary_text)
         self.assertIn("Failure", summary_text)
         self.assertIn("board boom", summary_text)
+
+    def test_step_summary_is_still_written_when_the_teams_mapping_fails_to_load(self):
+        """Review finding: handle_board_update used to load the teams mapping
+        OUTSIDE its try/finally, so a mapping-read failure on a
+        transition/synchronize/edited event wrote no step summary at all --
+        unlike the opened path (MainWritesStepSummaryOnFailureTest), which
+        already handled this gracefully and had a test for it."""
+        event = {
+            "action": "ready_for_review",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "load_teams_mapping", side_effect=FileNotFoundError("no such file: pr-triage-teams.yml")
+            ):
+                with self.assertRaises(FileNotFoundError):
+                    pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("Failure", summary_text)
+        self.assertIn("no such file", summary_text)
 
 
 class BoardUpdateResolvesFieldsBeforeAddingBoardItemTest(unittest.TestCase):

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -2602,20 +2602,6 @@ class WorkflowOnlyTriagesPrsBasedOnTheDefaultBranchTest(unittest.TestCase):
         self.assertNotIn('== "master"', triage_text)
 
 
-class WorkflowTriageCheckoutPinsToBaseShaTest(unittest.TestCase):
-    def test_triage_job_checks_out_the_base_sha_not_the_prs_own_code(self):
-        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-        workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
-        with open(workflow_path, encoding="utf-8") as handle:
-            workflow_text = handle.read()
-
-        jobs = workflow_text.split("\n  triage:", 1)
-        self.assertEqual(len(jobs), 2, "expected exactly one 'triage:' job in the workflow")
-        _, triage_text = jobs
-
-        self.assertIn("ref: ${{ github.event.pull_request.base.sha }}", triage_text)
-
-
 class WorkflowValidateJobHoldsNoBoardTokenTest(unittest.TestCase):
     def test_validate_job_env_has_no_project_board_token(self):
         repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -1,7 +1,19 @@
+"""Tests for pr_triage — the wiring, the handlers, and the workflow YAML itself.
+
+A test belongs here when it exercises main(), an event handler, or a function that
+mixes a decision with I/O. Pure verdicts go to test_pr_triage_decide.py and HTTP
+calls to test_pr_triage_github.py. The banned-term fixtures live here on purpose:
+this is the one file FILES_HOLDING_BANNED_TERMS_AS_LITERAL_FIXTURES excludes.
+
+New test file here? The workflow discovers test*.py, so name it accordingly.
+"""
+
 import contextlib
 import datetime
+import fnmatch
 import json
 import os
+import shlex
 import sys
 import tempfile
 import unittest
@@ -10,6 +22,8 @@ from unittest import mock
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
 import pr_triage
+import pr_triage_decide
+import pr_triage_github
 import validate_pr_triage_teams
 
 DEFAULT_ITERATIONS = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
@@ -49,7 +63,7 @@ def make_fake_http_request(
     extra=None,
 ):
     """One fake GitHub for every pr_triage test: records every call, and answers
-    each request shape pr_triage.http_request can make. `board_item` is what
+    each request shape pr_triage_github.http_request can make. `board_item` is what
     find_board_item_for_pr's query resolves to (None -> no existing item).
     `extra(url, token, method, body, query, variables)` is consulted first and,
     if it returns something other than None, that is the response -- the escape
@@ -97,7 +111,7 @@ def make_fake_http_request(
                 nodes = [
                     {
                         "id": board_item["id"],
-                        "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                        "project": {"id": pr_triage_github.BOARD_PROJECT_ID},
                         "status": {"name": board_item["status"]} if board_item.get("status") else None,
                         "team": {"name": board_item["team"]} if board_item.get("team") else None,
                         "sprint": {"title": board_item["sprint"]} if board_item.get("sprint") else None,
@@ -112,9 +126,9 @@ def make_fake_http_request(
             return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": variables.get("itemId")}}}}
 
         if "options { id name }" in query:
-            if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+            if variables["fieldId"] == pr_triage_github.STATUS_FIELD_ID:
                 return {"data": {"node": {"options": status_options}}}
-            if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+            if variables["fieldId"] == pr_triage_github.TEAM_FIELD_ID:
                 return {"data": {"node": {"options": team_options}}}
 
         if "configuration" in query:
@@ -128,7 +142,7 @@ def make_fake_http_request(
 def _item_node(item):
     return {
         "id": item["id"],
-        "project": {"id": pr_triage.BOARD_PROJECT_ID},
+        "project": {"id": pr_triage_github.BOARD_PROJECT_ID},
         "status": {"name": item["status"]} if item.get("status") else None,
         "team": {"name": item["team"]} if item.get("team") else None,
         "sprint": {"title": item["sprint"]} if item.get("sprint") else None,
@@ -210,7 +224,7 @@ def make_fake_http_request_for_redirect(
             return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": variables.get("itemId")}}}}
 
         if "options { id name }" in query:
-            if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+            if variables["fieldId"] == pr_triage_github.STATUS_FIELD_ID:
                 return {"data": {"node": {"options": status_options}}}
             return {"data": {"node": {"options": team_options}}}
 
@@ -248,7 +262,7 @@ def run_main(event, *, http_request=None, current_date=None, env_extra=None):
             with contextlib.ExitStack() as stack:
                 stack.enter_context(mock.patch.dict(os.environ, env, clear=False))
                 if http_request is not None:
-                    stack.enter_context(mock.patch.object(pr_triage, "http_request", side_effect=http_request))
+                    stack.enter_context(mock.patch.object(pr_triage_github, "http_request", side_effect=http_request))
                 if current_date is not None:
                     stack.enter_context(mock.patch.object(pr_triage, "current_date", return_value=current_date))
                 pr_triage.main()
@@ -257,419 +271,6 @@ def run_main(event, *, http_request=None, current_date=None, env_extra=None):
 
         with open(summary_path, encoding="utf-8") as handle:
             return handle.read(), exit_code
-
-
-class DecidePrTriageTest(unittest.TestCase):
-    def test_known_author_is_assigned_drafted_and_boarded_working(self):
-        mapping = {"mswertz": "Dev"}
-
-        decision = pr_triage.decide(author_login="mswertz", is_draft=False, mapping=mapping)
-
-        self.assertTrue(decision["known"])
-        self.assertTrue(decision["force_draft"])
-        self.assertEqual(decision["team"], "Dev")
-
-    def test_known_author_mapped_to_delivery_boards_under_delivery(self):
-        mapping = {"hslh": "Delivery"}
-
-        decision = pr_triage.decide(author_login="hslh", is_draft=True, mapping=mapping)
-
-        self.assertTrue(decision["known"])
-        self.assertEqual(decision["team"], "Delivery")
-
-    def test_unknown_author_is_boarded_review_dev_without_assign_or_draft(self):
-        mapping = {"mswertz": "Dev"}
-
-        decision = pr_triage.decide(author_login="some-outside-contributor", is_draft=False, mapping=mapping)
-
-        self.assertFalse(decision["known"])
-        self.assertFalse(decision["force_draft"])
-        self.assertEqual(decision["team"], "Dev")
-
-    def test_unknown_author_already_draft_is_still_not_touched(self):
-        mapping = {"mswertz": "Dev"}
-
-        decision = pr_triage.decide(author_login="some-outside-contributor", is_draft=True, mapping=mapping)
-
-        self.assertFalse(decision["known"])
-        self.assertFalse(decision["force_draft"])
-        self.assertEqual(decision["team"], "Dev")
-
-    def test_bot_author_is_unknown_regardless_of_login_shape(self):
-        mapping = {"mswertz": "Dev"}
-
-        decision = pr_triage.decide(author_login="dependabot[bot]", is_draft=False, mapping=mapping)
-
-        self.assertFalse(decision["known"])
-        self.assertEqual(decision["team"], "Dev")
-
-    def test_known_author_already_draft_is_not_re_converted(self):
-        mapping = {"mswertz": "Dev"}
-
-        decision = pr_triage.decide(author_login="mswertz", is_draft=True, mapping=mapping)
-
-        self.assertTrue(decision["known"])
-        self.assertFalse(decision["force_draft"])
-
-    def test_known_author_ready_for_review_is_converted_to_draft(self):
-        mapping = {"mswertz": "Dev"}
-
-        decision = pr_triage.decide(author_login="mswertz", is_draft=False, mapping=mapping)
-
-        self.assertTrue(decision["known"])
-        self.assertTrue(decision["force_draft"])
-
-    def test_empty_team_value_is_treated_as_unknown(self):
-        mapping = {"someuser": ""}
-
-        decision = pr_triage.decide(author_login="someuser", is_draft=False, mapping=mapping)
-
-        self.assertFalse(decision["known"])
-        self.assertFalse(decision["force_draft"])
-        self.assertEqual(decision["team"], "Dev")
-
-    def test_whitespace_only_team_value_is_treated_as_unknown(self):
-        mapping = {"someuser": "   "}
-
-        decision = pr_triage.decide(author_login="someuser", is_draft=False, mapping=mapping)
-
-        self.assertFalse(decision["known"])
-
-    def test_login_matching_is_exact_case_and_can_only_ever_miss(self):
-        mapping = {"mswertz": "Dev"}
-
-        decision = pr_triage.decide(author_login="Mswertz", is_draft=False, mapping=mapping)
-
-        self.assertFalse(decision["known"])
-
-
-class DecideStatusTest(unittest.TestCase):
-    def test_blank_status_fills_from_draft_state(self):
-        self.assertEqual(pr_triage.decide_status(True, None), "Working")
-        self.assertEqual(pr_triage.decide_status(False, None), "Review")
-
-    def test_blank_string_status_counts_as_blank(self):
-        self.assertEqual(pr_triage.decide_status(True, "   "), "Working")
-
-    def test_working_flips_to_review_when_pr_is_ready(self):
-        self.assertEqual(pr_triage.decide_status(False, "Working"), "Review")
-
-    def test_review_flips_to_working_when_pr_is_draft(self):
-        self.assertEqual(pr_triage.decide_status(True, "Review"), "Working")
-
-    def test_working_already_matching_draft_state_is_not_rewritten(self):
-        self.assertIsNone(pr_triage.decide_status(True, "Working"))
-
-    def test_review_already_matching_ready_state_is_not_rewritten(self):
-        self.assertIsNone(pr_triage.decide_status(False, "Review"))
-
-    def test_non_managed_statuses_are_never_touched_regardless_of_draft_state(self):
-        for status in ("Epic", "Blocked", "Backlog", "Done", "Inbox", "Icebox"):
-            with self.subTest(status=status):
-                self.assertIsNone(pr_triage.decide_status(True, status))
-                self.assertIsNone(pr_triage.decide_status(False, status))
-
-    def test_all_eight_real_board_option_names_behave_correctly_for_both_draft_states(self):
-        expected = {
-            "\U0001f4cb Epic": (None, None),
-            "⛔️ Blocked": (None, None),
-            "\U0001f4da Backlog": (None, None),
-            "\U0001f6e0️ Working": (None, "Review"),
-            "\U0001f50d Review": ("Working", None),
-            "✅ Done": (None, None),
-            "\U0001f4e5 Inbox": (None, None),
-            "Icebox": (None, None),
-        }
-
-        for real_name, (expected_draft, expected_ready) in expected.items():
-            with self.subTest(real_name=real_name):
-                self.assertEqual(pr_triage.decide_status(True, real_name), expected_draft)
-                self.assertEqual(pr_triage.decide_status(False, real_name), expected_ready)
-
-
-class DecideBoardUpdateTest(unittest.TestCase):
-    """decide_board_update takes no `action` argument, so a subTest loop over
-    BOARD_UPDATE_ACTIONS proved nothing beyond running the same assertion 5
-    times. Every other case this class used to cover that way is provably
-    redundant against MainWiringBoardUpdateTest and DecideStatusTest, per an
-    owner-approved mutation-tested trim. This one survives: without it, a
-    mutant that always overwrites a non-empty Sprint escapes every other test."""
-
-    def test_sprint_never_overwrites_a_non_empty_sprint(self):
-        for action in pr_triage.BOARD_UPDATE_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_board_update(
-                    is_draft=True,
-                    current_status="🔍 Review",
-                    current_team="Dev",
-                    mapped_team="Dev",
-                    current_sprint="Sprint 259",
-                    current_sprint_title="Sprint 260",
-                )
-                self.assertIsNone(fields["sprint"])
-
-
-class KeywordClosingIssuesTest(unittest.TestCase):
-    """Owner ruling, mid-ticket: only a KEYWORD-derived closing reference
-    redirects aim 6 -- a sidebar-only link (GitHub's Development panel, no
-    keyword in the body, e.g. this repo's `Addresses: <url>` habit) does not.
-    keyword_closing_issues = closingIssuesReferences minus its
-    userLinkedOnly=true counterpart, matched by node id. Verified against two
-    real PRs of each shape, see notes/github-facts.md §8."""
-
-    ISSUE_A = {"id": "ISSUE_A", "number": 1}
-    ISSUE_B = {"id": "ISSUE_B", "number": 2}
-
-    def test_a_keyword_only_link_counts(self):
-        result = pr_triage.keyword_closing_issues([self.ISSUE_A], [])
-
-        self.assertEqual(result, [self.ISSUE_A])
-
-    def test_a_sidebar_only_link_does_not_count(self):
-        result = pr_triage.keyword_closing_issues([self.ISSUE_A], [self.ISSUE_A])
-
-        self.assertEqual(result, [])
-
-    def test_both_sets_empty_means_no_redirection(self):
-        result = pr_triage.keyword_closing_issues([], [])
-
-        self.assertEqual(result, [])
-
-    def test_a_keyword_link_and_a_separate_sidebar_link_keeps_only_the_keyword_one(self):
-        result = pr_triage.keyword_closing_issues([self.ISSUE_A, self.ISSUE_B], [self.ISSUE_B])
-
-        self.assertEqual(result, [self.ISSUE_A])
-
-    def test_two_keyword_links_both_count(self):
-        result = pr_triage.keyword_closing_issues([self.ISSUE_A, self.ISSUE_B], [])
-
-        self.assertEqual(result, [self.ISSUE_A, self.ISSUE_B])
-
-
-class DecideRedirectToIssuesTest(unittest.TestCase):
-    def test_true_when_the_pr_closes_one_issue(self):
-        self.assertTrue(pr_triage.decide_redirect_to_issues([{"id": "ISSUE_A", "number": 1}]))
-
-    def test_true_when_the_pr_closes_two_issues(self):
-        self.assertTrue(
-            pr_triage.decide_redirect_to_issues([{"id": "ISSUE_A", "number": 1}, {"id": "ISSUE_B", "number": 2}])
-        )
-
-    def test_false_when_the_pr_closes_no_issue(self):
-        self.assertFalse(pr_triage.decide_redirect_to_issues([]))
-
-
-class DecideRemovePrCardTest(unittest.TestCase):
-    """Renamed from decide_delete_pr_item -- owner ruling: "delete" reads as
-    "delete the pull request", and it does not; this only removes a card
-    from board 15."""
-
-    def test_true_when_the_pr_closes_an_issue_and_already_has_a_card(self):
-        self.assertTrue(
-            pr_triage.decide_remove_pr_card([{"id": "ISSUE_A", "number": 1}], {"id": "PR_ITEM", "status": None, "team": None, "sprint": None})
-        )
-
-    def test_false_when_the_pr_closes_an_issue_but_has_no_card_yet(self):
-        self.assertFalse(pr_triage.decide_remove_pr_card([{"id": "ISSUE_A", "number": 1}], None))
-
-    def test_false_when_the_pr_closes_no_issue_even_if_it_has_a_card(self):
-        self.assertFalse(
-            pr_triage.decide_remove_pr_card([], {"id": "PR_ITEM", "status": None, "team": None, "sprint": None})
-        )
-
-
-class DecideIssueCardUpdateTest(unittest.TestCase):
-    """Pure decision for one linked issue's card. mapped_team/current_sprint_title
-    are only ever consulted when a card is being added (existing_issue_item is
-    None); an existing card's Team and Sprint are never touched by any action."""
-
-    EXISTING_WORKING = {"id": "ISSUE_ITEM", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 259"}
-    EXISTING_BLANK = {"id": "ISSUE_ITEM", "status": None, "team": None, "sprint": None}
-    EXISTING_PARKED = {"id": "ISSUE_ITEM", "status": "⛔️ Blocked", "team": "Dev", "sprint": "Sprint 259"}
-
-    # --- opened and the three transitions: Status only on an existing card ---
-
-    def test_opened_and_transitions_set_status_only_on_an_existing_card(self):
-        for action in pr_triage.ISSUE_STATUS_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_issue_card_update(action, False, self.EXISTING_WORKING, "Delivery", "Sprint 260")
-                self.assertEqual(fields, {"status": "Review", "team": None, "sprint": None})
-
-    def test_opened_and_transitions_fill_status_when_the_existing_card_is_blank(self):
-        for action in pr_triage.ISSUE_STATUS_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_issue_card_update(action, False, self.EXISTING_BLANK, "Delivery", "Sprint 260")
-                self.assertEqual(fields, {"status": "Review", "team": None, "sprint": None})
-
-    def test_opened_and_transitions_never_move_a_parked_status(self):
-        for action in pr_triage.ISSUE_STATUS_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_issue_card_update(action, False, self.EXISTING_PARKED, "Delivery", "Sprint 260")
-                self.assertEqual(fields, {"status": None, "team": None, "sprint": None})
-
-    def test_opened_and_transitions_add_and_fill_all_three_on_a_missing_card(self):
-        for action in pr_triage.ISSUE_STATUS_ACTIONS:
-            with self.subTest(action=action):
-                fields = pr_triage.decide_issue_card_update(action, True, None, "Delivery", "Sprint 260")
-                self.assertEqual(fields, {"status": "Working", "team": "Delivery", "sprint": "Sprint 260"})
-
-                fields = pr_triage.decide_issue_card_update(action, False, None, "Delivery", "Sprint 260")
-                self.assertEqual(fields, {"status": "Review", "team": "Delivery", "sprint": "Sprint 260"})
-
-    # --- synchronize: never touches a linked issue's card, existing or missing ---
-
-    def test_synchronize_never_touches_an_existing_card(self):
-        fields = pr_triage.decide_issue_card_update("synchronize", True, self.EXISTING_WORKING, "Delivery", "Sprint 260")
-        self.assertIsNone(fields)
-
-    def test_synchronize_never_touches_a_missing_card_either(self):
-        fields = pr_triage.decide_issue_card_update("synchronize", True, None, "Delivery", "Sprint 260")
-        self.assertIsNone(fields)
-
-    # --- edited: adds and fills Team+Sprint on a missing card, but never
-    # touches an existing one, and never writes Status even on the card it adds ---
-
-    def test_edited_never_touches_an_existing_card(self):
-        fields = pr_triage.decide_issue_card_update("edited", True, self.EXISTING_WORKING, "Delivery", "Sprint 260")
-        self.assertIsNone(fields)
-
-    def test_edited_adds_and_fills_team_and_sprint_on_a_missing_card_but_leaves_status_unwritten(self):
-        fields = pr_triage.decide_issue_card_update("edited", True, None, "Delivery", "Sprint 260")
-        self.assertEqual(fields, {"status": None, "team": "Delivery", "sprint": "Sprint 260"})
-
-        fields = pr_triage.decide_issue_card_update("edited", False, None, "Delivery", "Sprint 260")
-        self.assertEqual(fields, {"status": None, "team": "Delivery", "sprint": "Sprint 260"})
-
-
-class FindCurrentIterationTest(unittest.TestCase):
-    def test_returns_the_iteration_containing_today(self):
-
-        iterations = [
-            {"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21},
-            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21},
-        ]
-
-        iteration = pr_triage.find_current_iteration(iterations, datetime.date(2026, 8, 8))
-
-        self.assertEqual(iteration["id"], "bd551114")
-        self.assertEqual(iteration["title"], "Sprint 260")
-
-    def test_start_date_itself_is_inside_the_iteration(self):
-
-        iterations = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
-
-        iteration = pr_triage.find_current_iteration(iterations, datetime.date(2026, 8, 3))
-
-        self.assertEqual(iteration["id"], "bd551114")
-
-    def test_the_day_after_the_iteration_ends_is_not_inside_it(self):
-
-        iterations = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
-
-        end_date = datetime.date(2026, 8, 3) + datetime.timedelta(days=21)
-        iteration = pr_triage.find_current_iteration(iterations, end_date)
-
-        self.assertIsNone(iteration)
-
-    def test_returns_none_when_no_iteration_contains_the_date(self):
-
-        iterations = [{"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21}]
-
-        iteration = pr_triage.find_current_iteration(iterations, datetime.date(2026, 9, 1))
-
-        self.assertIsNone(iteration)
-
-    def test_returns_none_for_an_empty_iteration_list(self):
-
-        self.assertIsNone(pr_triage.find_current_iteration([], datetime.date(2026, 8, 8)))
-
-    def test_does_not_assume_the_first_entry_is_current(self):
-
-        iterations = [
-            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21},
-            {"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21},
-        ]
-
-        iteration = pr_triage.find_current_iteration(iterations, datetime.date(2026, 7, 20))
-
-        self.assertEqual(iteration["id"], "bd551113")
-
-
-class CheckAssignmentSucceededTest(unittest.TestCase):
-    def test_raises_when_author_login_is_absent_from_the_assignees_response(self):
-        assign_result = {"assignees": []}
-
-        with self.assertRaises(pr_triage.AssignmentDroppedError) as context:
-            pr_triage.check_assignment_succeeded("someuser", assign_result)
-
-        self.assertIn("someuser", str(context.exception))
-        self.assertIn("pr-triage-teams.yml", str(context.exception))
-
-    def test_does_not_raise_when_author_login_is_present(self):
-        assign_result = {"assignees": [{"login": "someuser"}]}
-
-        pr_triage.check_assignment_succeeded("someuser", assign_result)
-
-
-class StripEmojiPrefixTest(unittest.TestCase):
-    def test_strips_leading_emoji_and_whitespace(self):
-        self.assertEqual(pr_triage.strip_emoji_prefix("\U0001f6e0️ Working"), "Working")
-
-    def test_leaves_plain_name_unchanged(self):
-        self.assertEqual(pr_triage.strip_emoji_prefix("Icebox"), "Icebox")
-
-
-class FindOptionIdByNameTest(unittest.TestCase):
-    def test_matches_status_option_ignoring_emoji_prefix(self):
-        options = [
-            {"name": "\U0001f6e0️ Working", "id": "47fc9ee4"},
-            {"name": "\U0001f50d Review", "id": "879449e7"},
-        ]
-
-        option_id = pr_triage.find_option_id_by_name(options, "Working", strip_emoji=True)
-
-        self.assertEqual(option_id, "47fc9ee4")
-
-    def test_matches_team_option_by_exact_name(self):
-        options = [{"name": "Dev", "id": "f2a5529c"}, {"name": "Delivery", "id": "34b176a9"}]
-
-        option_id = pr_triage.find_option_id_by_name(options, "Delivery", strip_emoji=False)
-
-        self.assertEqual(option_id, "34b176a9")
-
-    def test_raises_with_full_option_list_when_name_does_not_resolve(self):
-        options = [{"name": "Dev", "id": "f2a5529c"}]
-
-        with self.assertRaises(ValueError) as context:
-            pr_triage.find_option_id_by_name(options, "Nonexistent", strip_emoji=False)
-
-        self.assertIn("Dev", str(context.exception))
-        self.assertIn("Nonexistent", str(context.exception))
-
-
-class ParseTeamsMappingTest(unittest.TestCase):
-    def test_parses_flat_login_to_team_mapping(self):
-        text = (
-            "# header comment\n"
-            "teams:\n"
-            "  mswertz: Dev\n"
-            "  hslh: Delivery\n"
-        )
-
-        mapping = pr_triage.parse_teams_mapping(text)
-
-        self.assertEqual(mapping, {"mswertz": "Dev", "hslh": "Delivery"})
-
-    def test_ignores_blank_lines_and_trailing_comments(self):
-        text = (
-            "teams:\n"
-            "\n"
-            "  mswertz: Dev\n"
-        )
-
-        mapping = pr_triage.parse_teams_mapping(text)
-
-        self.assertEqual(mapping, {"mswertz": "Dev"})
 
 
 class ValidateNoBotOrMachineLoginsTest(unittest.TestCase):
@@ -751,7 +352,7 @@ class ValidateBlankTeamValuesTest(unittest.TestCase):
 
 
 class ValidateStatusOptionTest(unittest.TestCase):
-    """find_missing_option is built on pr_triage.find_option_id_by_name, the same
+    """find_missing_option is built on pr_triage_decide.find_option_id_by_name, the same
     lookup write time uses -- so a value missing here and a value missing at
     write time report the identical message."""
 
@@ -846,7 +447,7 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
 
         fake_http_request = make_fake_http_request(calls, extra=refuse_draft_flip)
 
-        with mock.patch.object(pr_triage, "assign_author", side_effect=pr_triage.GraphqlError("boom")):
+        with mock.patch.object(pr_triage_github, "assign_author", side_effect=pr_triage_github.GraphqlError("boom")):
             summary_text, exit_code = run_main(event, http_request=fake_http_request, current_date=datetime.date(2026, 8, 8))
 
         self.assertNotEqual(exit_code, 0)
@@ -858,7 +459,7 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
         self.assertEqual(len(field_writes), 3)
         status_write = next(
-            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         )
         self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT_REVIEW")
 
@@ -900,17 +501,17 @@ class MainWiringTest(unittest.TestCase):
         self.assertEqual(len(field_writes), 3)
 
         status_write = field_writes[0]
-        self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage_github.STATUS_FIELD_ID)
         self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT_WORKING")
         self.assertEqual(status_write["token"], "board-token")
 
         team_write = field_writes[1]
-        self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
+        self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage_github.TEAM_FIELD_ID)
         self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_OPT_DEV")
         self.assertEqual(team_write["token"], "board-token")
 
         sprint_write = field_writes[2]
-        self.assertEqual(sprint_write["body"]["variables"]["fieldId"], pr_triage.SPRINT_FIELD_ID)
+        self.assertEqual(sprint_write["body"]["variables"]["fieldId"], pr_triage_github.SPRINT_FIELD_ID)
         self.assertEqual(sprint_write["body"]["variables"]["iterationId"], "bd551114")
         self.assertEqual(sprint_write["token"], "board-token")
 
@@ -949,7 +550,7 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
         self.assertEqual(len(field_writes), 3)
         status_write = next(
-            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         )
         self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT_REVIEW")
 
@@ -977,7 +578,7 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
 
         def refuse_draft_flip(url, token, method, body, query, variables):
             if "convertPullRequestToDraft" in query:
-                raise pr_triage.GraphqlError(
+                raise pr_triage_github.GraphqlError(
                     "GraphQL request returned errors: [{'type': 'FORBIDDEN', "
                     "'message': 'Resource not accessible by integration'}]"
                 )
@@ -1000,7 +601,7 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
         self.assertEqual(len(field_writes), 3)
 
         status_write = next(
-            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         )
         self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT_REVIEW")
 
@@ -1069,7 +670,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
                     nodes = [
                         {
                             "id": "EXISTING_ITEM",
-                            "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                            "project": {"id": pr_triage_github.BOARD_PROJECT_ID},
                             "status": {"name": current_status} if current_status else None,
                             "team": {"name": current_team} if current_team else None,
                             "sprint": {"title": current_sprint} if current_sprint else None,
@@ -1088,9 +689,9 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM"}}}}
 
             if "options { id name }" in query:
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                if variables["fieldId"] == pr_triage_github.STATUS_FIELD_ID:
                     return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
-                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                if variables["fieldId"] == pr_triage_github.TEAM_FIELD_ID:
                     return {
                         "data": {
                             "node": {
@@ -1136,7 +737,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             }
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
+                pr_triage_github, "http_request", side_effect=fake_http_request
             ), mock.patch.object(
                 pr_triage, "load_teams_mapping", return_value=mapping if mapping is not None else {"mswertz": "Dev"}
             ), mock.patch.object(
@@ -1171,7 +772,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         status_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         ]
         self.assertEqual(len(status_writes), 1)
         self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "879449e7")
@@ -1186,7 +787,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         status_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         ]
         self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
 
@@ -1198,7 +799,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         status_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         ]
         self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
 
@@ -1210,7 +811,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         status_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         ]
         self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "879449e7")
 
@@ -1229,7 +830,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         status_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         ]
         self.assertEqual(status_writes, [])
 
@@ -1247,7 +848,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         )
 
         team_writes = [
-            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID
+            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage_github.TEAM_FIELD_ID
         ]
         self.assertEqual(len(team_writes), 1)
         self.assertEqual(team_writes[0]["body"]["variables"]["optionId"], "TEAM_DELIVERY_OPT")
@@ -1263,7 +864,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         )
 
         team_writes = [
-            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID
+            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage_github.TEAM_FIELD_ID
         ]
         self.assertEqual(team_writes, [])
 
@@ -1280,7 +881,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         sprint_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.SPRINT_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.SPRINT_FIELD_ID
         ]
         self.assertEqual(len(sprint_writes), 1)
         self.assertEqual(sprint_writes[0]["body"]["variables"]["iterationId"], "bd551114")
@@ -1298,7 +899,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         sprint_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.SPRINT_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.SPRINT_FIELD_ID
         ]
         self.assertEqual(sprint_writes, [])
 
@@ -1328,7 +929,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         status_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         ]
         self.assertEqual(len(status_writes), 1)
         self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
@@ -1346,7 +947,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         status_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         ]
         self.assertEqual(len(status_writes), 1)
         self.assertEqual(status_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
@@ -1364,7 +965,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         status_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID
         ]
         self.assertEqual(status_writes, [])
 
@@ -1380,7 +981,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         )
 
         team_writes = [
-            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID
+            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage_github.TEAM_FIELD_ID
         ]
         self.assertEqual(len(team_writes), 1)
         self.assertEqual(team_writes[0]["body"]["variables"]["optionId"], "TEAM_DELIVERY_OPT")
@@ -1397,7 +998,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         )
 
         team_writes = [
-            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID
+            call for call in self._field_writes(calls) if call["body"]["variables"]["fieldId"] == pr_triage_github.TEAM_FIELD_ID
         ]
         self.assertEqual(team_writes, [])
 
@@ -1414,7 +1015,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         sprint_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.SPRINT_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.SPRINT_FIELD_ID
         ]
         self.assertEqual(len(sprint_writes), 1)
         self.assertEqual(sprint_writes[0]["body"]["variables"]["iterationId"], "bd551114")
@@ -1432,7 +1033,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         sprint_writes = [
             call
             for call in self._field_writes(calls)
-            if call["body"]["variables"]["fieldId"] == pr_triage.SPRINT_FIELD_ID
+            if call["body"]["variables"]["fieldId"] == pr_triage_github.SPRINT_FIELD_ID
         ]
         self.assertEqual(sprint_writes, [])
 
@@ -1448,7 +1049,7 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
         field_writes = self._field_writes(calls)
         written_field_ids = {call["body"]["variables"]["fieldId"] for call in field_writes}
         self.assertEqual(
-            written_field_ids, {pr_triage.STATUS_FIELD_ID, pr_triage.TEAM_FIELD_ID, pr_triage.SPRINT_FIELD_ID}
+            written_field_ids, {pr_triage_github.STATUS_FIELD_ID, pr_triage_github.TEAM_FIELD_ID, pr_triage_github.SPRINT_FIELD_ID}
         )
         for call in field_writes:
             self.assertEqual(call["body"]["variables"]["itemId"], "NEW_ITEM")
@@ -1513,7 +1114,7 @@ class MainWiringClosingIssueTest(unittest.TestCase):
 
         field_writes = self._field_writes(calls, "ISSUE_ITEM_A")
         self.assertEqual(len(field_writes), 1)
-        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage_github.STATUS_FIELD_ID)
         self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")  # Working
 
     def test_opened_closing_an_unboarded_issue_boards_the_issue_with_all_three_fields(self):
@@ -1535,9 +1136,9 @@ class MainWiringClosingIssueTest(unittest.TestCase):
         field_writes = self._field_writes(calls, "NEW_ISSUE_ITEM")
         written_field_ids = {call["body"]["variables"]["fieldId"] for call in field_writes}
         self.assertEqual(
-            written_field_ids, {pr_triage.STATUS_FIELD_ID, pr_triage.TEAM_FIELD_ID, pr_triage.SPRINT_FIELD_ID}
+            written_field_ids, {pr_triage_github.STATUS_FIELD_ID, pr_triage_github.TEAM_FIELD_ID, pr_triage_github.SPRINT_FIELD_ID}
         )
-        team_write = next(c for c in field_writes if c["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID)
+        team_write = next(c for c in field_writes if c["body"]["variables"]["fieldId"] == pr_triage_github.TEAM_FIELD_ID)
         self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_DEV_OPT")
 
     def test_opened_removes_the_prs_existing_card(self):
@@ -1596,7 +1197,7 @@ class MainWiringClosingIssueTest(unittest.TestCase):
 
         field_writes = self._field_writes(calls, "ISSUE_ITEM")
         self.assertEqual(len(field_writes), 1)
-        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage_github.STATUS_FIELD_ID)
         self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")  # Review
 
     def test_converted_to_draft_moves_the_linked_issues_card_to_working(self):
@@ -1613,7 +1214,7 @@ class MainWiringClosingIssueTest(unittest.TestCase):
 
         field_writes = self._field_writes(calls, "ISSUE_ITEM")
         self.assertEqual(len(field_writes), 1)
-        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage_github.STATUS_FIELD_ID)
         self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")  # Working
 
     # --- F10: removal on `opened` and each transition, asserted individually.
@@ -1722,7 +1323,7 @@ class MainWiringClosingIssueTest(unittest.TestCase):
         for item_id in ("ISSUE_ITEM_A", "ISSUE_ITEM_B"):
             field_writes = self._field_writes(calls, item_id)
             self.assertEqual(len(field_writes), 1)
-            self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+            self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage_github.STATUS_FIELD_ID)
             self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")  # Review
 
     # --- owner ruling: the PR's own card is removed LAST, only after every
@@ -1867,7 +1468,7 @@ class MainWiringClosingIssueTest(unittest.TestCase):
         self.assertEqual(self._add_calls(calls)[0]["body"]["variables"]["contentId"], "ISSUE_B")
         field_writes = self._field_writes(calls, "NEW_ISSUE")
         written_field_ids = {call["body"]["variables"]["fieldId"] for call in field_writes}
-        self.assertEqual(written_field_ids, {pr_triage.TEAM_FIELD_ID, pr_triage.SPRINT_FIELD_ID})
+        self.assertEqual(written_field_ids, {pr_triage_github.TEAM_FIELD_ID, pr_triage_github.SPRINT_FIELD_ID})
 
     # --- edited: link disappears (the PR is boarded exactly like any other) ---
 
@@ -1887,9 +1488,9 @@ class MainWiringClosingIssueTest(unittest.TestCase):
         field_writes = self._field_writes(calls, "NEW_PR_ITEM")
         written_field_ids = {call["body"]["variables"]["fieldId"] for call in field_writes}
         self.assertEqual(
-            written_field_ids, {pr_triage.STATUS_FIELD_ID, pr_triage.TEAM_FIELD_ID, pr_triage.SPRINT_FIELD_ID}
+            written_field_ids, {pr_triage_github.STATUS_FIELD_ID, pr_triage_github.TEAM_FIELD_ID, pr_triage_github.SPRINT_FIELD_ID}
         )
-        status_write = next(c for c in field_writes if c["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID)
+        status_write = next(c for c in field_writes if c["body"]["variables"]["fieldId"] == pr_triage_github.STATUS_FIELD_ID)
         self.assertEqual(status_write["body"]["variables"]["optionId"], "47fc9ee4")  # Working, is_draft=True
 
     def test_add_remove_add_cycle_is_stable_not_one_shot(self):
@@ -2020,9 +1621,9 @@ class BoardUpdateWritesStepSummaryOnFailureTest(unittest.TestCase):
             }
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "find_board_item_for_pr", side_effect=pr_triage.GraphqlError("board boom")
+                pr_triage, "find_board_item_for_pr", side_effect=pr_triage_github.GraphqlError("board boom")
             ):
-                with self.assertRaises(pr_triage.GraphqlError):
+                with self.assertRaises(pr_triage_github.GraphqlError):
                     pr_triage.main()
 
             with open(summary_path, encoding="utf-8") as handle:
@@ -2108,7 +1709,7 @@ class BoardUpdateResolvesFieldsBeforeAddingBoardItemTest(unittest.TestCase):
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "NEW_ITEM"}}}}
             if "options { id name }" in query:
                 call_kinds.append("fetch_options")
-                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                if variables["fieldId"] == pr_triage_github.STATUS_FIELD_ID:
                     return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
                 return {"data": {"node": {"options": [{"id": "TEAM_DEV_OPT", "name": "Dev"}]}}}
             if "configuration" in query:
@@ -2140,7 +1741,7 @@ class BoardUpdateResolvesFieldsBeforeAddingBoardItemTest(unittest.TestCase):
             }
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
+                pr_triage_github, "http_request", side_effect=fake_http_request
             ), mock.patch.object(pr_triage, "load_teams_mapping", return_value={"mswertz": "Dev"}), mock.patch.object(
                 pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
             ):
@@ -2189,7 +1790,7 @@ class BoardUpdateResolvesFieldsBeforeAddingBoardItemTest(unittest.TestCase):
             }
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
+                pr_triage_github, "http_request", side_effect=fake_http_request
             ), mock.patch.object(pr_triage, "load_teams_mapping", return_value={"mswertz": "Dev"}), mock.patch.object(
                 pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
             ):
@@ -2239,17 +1840,17 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
         self.assertEqual(len(field_writes), 3)
 
         status_write = field_writes[0]
-        self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage_github.STATUS_FIELD_ID)
         self.assertEqual(status_write["body"]["variables"]["optionId"], expected_status_option_id)
         self.assertEqual(status_write["token"], "board-token")
 
         team_write = field_writes[1]
-        self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
+        self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage_github.TEAM_FIELD_ID)
         self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_DEV_OPT")
         self.assertEqual(team_write["token"], "board-token")
 
         sprint_write = field_writes[2]
-        self.assertEqual(sprint_write["body"]["variables"]["fieldId"], pr_triage.SPRINT_FIELD_ID)
+        self.assertEqual(sprint_write["body"]["variables"]["fieldId"], pr_triage_github.SPRINT_FIELD_ID)
         self.assertEqual(sprint_write["body"]["variables"]["iterationId"], "bd551114")
         self.assertEqual(sprint_write["token"], "board-token")
 
@@ -2290,7 +1891,7 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
             query = query_of(call)
             if "options { id name }" in query:
                 variables = (call["body"] or {}).get("variables", {})
-                return "fetch_status_options" if variables["fieldId"] == pr_triage.STATUS_FIELD_ID else "fetch_team_options"
+                return "fetch_status_options" if variables["fieldId"] == pr_triage_github.STATUS_FIELD_ID else "fetch_team_options"
             if "configuration" in query:
                 return "fetch_iterations"
             if "addProjectV2ItemById" in query:
@@ -2337,7 +1938,6 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
         self.assertFalse(any("addProjectV2ItemById" in query_of(call) for call in calls))
 
 
-
 class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
     def test_an_unrecognized_action_makes_no_writes_and_reads_no_mapping_file(self):
 
@@ -2366,7 +1966,7 @@ class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
             env = {"GITHUB_EVENT_PATH": event_path, "GITHUB_STEP_SUMMARY": summary_path}
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "http_request", side_effect=fake_http_request
+                pr_triage_github, "http_request", side_effect=fake_http_request
             ), mock.patch.object(
                 pr_triage, "load_teams_mapping", side_effect=AssertionError("must not read the mapping file")
             ):
@@ -2377,7 +1977,6 @@ class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
 
         self.assertIn("labeled", summary_text)
         self.assertIn("no action", summary_text.lower())
-
 
 
 class FindBoardItemForPrTest(unittest.TestCase):
@@ -2402,7 +2001,7 @@ class FindBoardItemForPrTest(unittest.TestCase):
                             },
                             {
                                 "id": "EXISTING_ITEM",
-                                "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                                "project": {"id": pr_triage_github.BOARD_PROJECT_ID},
                                 "status": {"name": "🛠️ Working"},
                                 "team": {"name": "Dev"},
                                 "sprint": {"title": "Sprint 260"},
@@ -2412,7 +2011,7 @@ class FindBoardItemForPrTest(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         item = result["item"]
@@ -2440,14 +2039,14 @@ class FindBoardItemForPrTest(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertIsNone(result["item"])
 
     def test_returns_none_when_pr_has_no_items_at_all(self):
         response = {"data": {"node": {"projectItems": {"nodes": []}}}}
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertIsNone(result["item"])
@@ -2460,7 +2059,7 @@ class FindBoardItemForPrTest(unittest.TestCase):
                         "nodes": [
                             {
                                 "id": "EXISTING_ITEM",
-                                "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                                "project": {"id": pr_triage_github.BOARD_PROJECT_ID},
                                 "status": None,
                                 "team": None,
                                 "sprint": None,
@@ -2470,7 +2069,7 @@ class FindBoardItemForPrTest(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         item = result["item"]
@@ -2478,6 +2077,13 @@ class FindBoardItemForPrTest(unittest.TestCase):
         self.assertIsNone(item["status"])
         self.assertIsNone(item["team"])
         self.assertIsNone(item["sprint"])
+
+    def test_find_board_item_for_pr_raises_naming_the_pr_node_id_when_node_is_null(self):
+        with mock.patch.object(pr_triage_github, "http_request", return_value={"data": {"node": None}}):
+            with self.assertRaises(pr_triage_github.GraphqlError) as context:
+                pr_triage.find_board_item_for_pr("STALE_PR_NODE_ID", "board-token")
+
+        self.assertIn("STALE_PR_NODE_ID", str(context.exception))
 
 
 class ClosingIssuesReferencesTest(unittest.TestCase):
@@ -2497,7 +2103,7 @@ class ClosingIssuesReferencesTest(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertEqual(result["closing_issues"], [{"id": "ISSUE_A", "number": 42}])
@@ -2514,7 +2120,7 @@ class ClosingIssuesReferencesTest(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertEqual(result["closing_issues"], [{"id": "ISSUE_A", "number": 42}, {"id": "ISSUE_B", "number": 43}])
@@ -2531,7 +2137,7 @@ class ClosingIssuesReferencesTest(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertEqual(result["closing_issues"], [])
@@ -2546,14 +2152,14 @@ class ClosingIssuesReferencesTest(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertEqual(result["closing_issues"], [])
 
     def test_empty_list_when_the_field_is_absent_entirely_as_an_issue_node_would_be(self):
         response = {"data": {"node": {"projectItems": {"nodes": []}}}}
-        with mock.patch.object(pr_triage, "http_request", return_value=response):
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response):
             result = pr_triage.find_board_item_for_pr("ISSUE_node", "board-token")
 
         self.assertEqual(result["closing_issues"], [])
@@ -2568,7 +2174,7 @@ class ClosingIssuesReferencesTest(unittest.TestCase):
                 }
             }
         }
-        with mock.patch.object(pr_triage, "http_request", return_value=response) as mock_request:
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response) as mock_request:
             pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
         self.assertEqual(mock_request.call_count, 1)
@@ -2576,97 +2182,6 @@ class ClosingIssuesReferencesTest(unittest.TestCase):
         self.assertIn("projectItems", called_body["query"])
         self.assertIn("closingIssuesReferences", called_body["query"])
         self.assertIn("userLinkedOnly: true", called_body["query"])
-
-
-class FetchProjectIterationsTest(unittest.TestCase):
-    def test_returns_the_not_yet_completed_iterations(self):
-        response = {
-            "data": {
-                "node": {
-                    "configuration": {
-                        "iterations": [
-                            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
-                        ]
-                    }
-                }
-            }
-        }
-        with mock.patch.object(pr_triage, "http_request", return_value=response) as mock_request:
-            iterations = pr_triage.fetch_project_iterations(pr_triage.SPRINT_FIELD_ID, "board-token")
-
-        self.assertEqual(iterations, [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}])
-        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
-        self.assertIn("iterations", called_body["query"])
-        self.assertNotIn("completedIterations", called_body["query"])
-
-
-class SetProjectFieldIterationTest(unittest.TestCase):
-    def test_writes_the_iteration_id_not_a_single_select_option(self):
-        with mock.patch.object(pr_triage, "http_request", return_value={"data": {}}) as mock_request:
-            pr_triage.set_project_field_iteration("ITEM_1", pr_triage.SPRINT_FIELD_ID, "bd551114", "board-token")
-
-        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
-        self.assertEqual(called_body["variables"]["iterationId"], "bd551114")
-        self.assertIn("iterationId", called_body["query"])
-        self.assertNotIn("singleSelectOptionId", called_body["query"])
-
-
-class RemoveItemFromBoardTest(unittest.TestCase):
-    """The story's one removal (aim 6): remove_item_from_board, called only
-    with the PR's own item id -- never an issue's. The GraphQL mutation
-    keeps GitHub's real name, deleteProjectV2Item; only our identifier
-    changed (owner ruling: "delete" reads as "delete the pull request")."""
-
-    def test_removes_the_given_item_from_board_15(self):
-        with mock.patch.object(
-            pr_triage, "http_request", return_value={"data": {"deleteProjectV2Item": {"deletedItemId": "PR_ITEM"}}}
-        ) as mock_request:
-            pr_triage.remove_item_from_board("PR_ITEM", "board-token")
-
-        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
-        self.assertIn("deleteProjectV2Item", called_body["query"])
-        self.assertEqual(called_body["variables"]["projectId"], pr_triage.BOARD_PROJECT_ID)
-        self.assertEqual(called_body["variables"]["itemId"], "PR_ITEM")
-        self.assertEqual(mock_request.call_args.kwargs.get("token") or mock_request.call_args.args[1], "board-token")
-
-
-class NullNodeIsRaisedActionablyTest(unittest.TestCase):
-    def test_fetch_project_field_options_raises_naming_the_field_id_when_node_is_null(self):
-        with mock.patch.object(pr_triage, "http_request", return_value={"data": {"node": None}}):
-            with self.assertRaises(pr_triage.GraphqlError) as context:
-                pr_triage.fetch_project_field_options("STALE_FIELD_ID", "board-token")
-
-        self.assertIn("STALE_FIELD_ID", str(context.exception))
-
-    def test_find_board_item_for_pr_raises_naming_the_pr_node_id_when_node_is_null(self):
-        with mock.patch.object(pr_triage, "http_request", return_value={"data": {"node": None}}):
-            with self.assertRaises(pr_triage.GraphqlError) as context:
-                pr_triage.find_board_item_for_pr("STALE_PR_NODE_ID", "board-token")
-
-        self.assertIn("STALE_PR_NODE_ID", str(context.exception))
-
-    def test_fetch_project_iterations_raises_naming_the_field_id_when_node_is_null(self):
-        with mock.patch.object(pr_triage, "http_request", return_value={"data": {"node": None}}):
-            with self.assertRaises(pr_triage.GraphqlError) as context:
-                pr_triage.fetch_project_iterations("STALE_SPRINT_FIELD_ID", "board-token")
-
-        self.assertIn("STALE_SPRINT_FIELD_ID", str(context.exception))
-
-
-class GraphqlRequestErrorHandlingTest(unittest.TestCase):
-    def test_raises_when_response_body_carries_errors_despite_http_200(self):
-        errors_payload = [{"message": "Resource not accessible - requires one of the following scopes: ['project']"}]
-        with mock.patch.object(pr_triage, "http_request", return_value={"data": None, "errors": errors_payload}):
-            with self.assertRaises(pr_triage.GraphqlError) as context:
-                pr_triage.graphql_request("query {}", {}, "token")
-
-        self.assertIn("requires one of the following scopes", str(context.exception))
-
-    def test_passes_through_a_clean_response(self):
-        with mock.patch.object(pr_triage, "http_request", return_value={"data": {"ok": True}}):
-            result = pr_triage.graphql_request("query {}", {}, "token")
-
-        self.assertEqual(result, {"data": {"ok": True}})
 
 
 class IsCredentialErrorTest(unittest.TestCase):
@@ -2803,12 +2318,12 @@ class ValidateMainExitsNonZeroOnDuplicateLoginTest(unittest.TestCase):
             fake_team_options = [{"id": "t1", "name": "Dev"}, {"id": "t2", "name": "Delivery"}]
 
             def fake_fetch(field_id, token):
-                if field_id == pr_triage.TEAM_FIELD_ID:
+                if field_id == pr_triage_github.TEAM_FIELD_ID:
                     return fake_team_options
                 return fake_status_options
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "fetch_project_field_options", side_effect=fake_fetch
+                pr_triage_github, "fetch_project_field_options", side_effect=fake_fetch
             ):
                 with self.assertRaises(SystemExit) as context:
                     validate_pr_triage_teams.main(repo_root=repo_root)
@@ -2845,13 +2360,13 @@ class ValidateMainChecksStatusConstantsResolveLiveTest(unittest.TestCase):
             fake_team_options = [{"id": "t1", "name": "Dev"}]
 
             def fake_fetch(field_id, token):
-                if field_id == pr_triage.TEAM_FIELD_ID:
+                if field_id == pr_triage_github.TEAM_FIELD_ID:
                     return fake_team_options
                 return fake_status_options
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "fetch_project_field_options", side_effect=fake_fetch
-            ), mock.patch.object(pr_triage, "STATUS_REVIEW", "DivergedFromUnknownAuthorStatus"):
+                pr_triage_github, "fetch_project_field_options", side_effect=fake_fetch
+            ), mock.patch.object(pr_triage_decide, "STATUS_REVIEW", "DivergedFromUnknownAuthorStatus"):
                 with self.assertRaises(SystemExit) as context:
                     validate_pr_triage_teams.main(repo_root=repo_root)
 
@@ -2882,7 +2397,7 @@ class ValidateMainExitsNonZeroOnBannedTermTest(unittest.TestCase):
             fake_options = [{"id": "opt", "name": "Dev"}]
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
-                pr_triage, "fetch_project_field_options", return_value=fake_options
+                pr_triage_github, "fetch_project_field_options", return_value=fake_options
             ):
                 with self.assertRaises(SystemExit) as context:
                     validate_pr_triage_teams.main(repo_root=repo_root)
@@ -2911,7 +2426,7 @@ class ValidateMainRunsOfflineWithoutBoardTokenTest(unittest.TestCase):
                 handle.write("workflow_text = 'author_association'\n")
 
             with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
-                pr_triage,
+                pr_triage_github,
                 "fetch_project_field_options",
                 side_effect=AssertionError("offline validation must never call the live board"),
             ):
@@ -2956,7 +2471,7 @@ class WorkflowIncludesEditedInPullRequestTypesTest(unittest.TestCase):
         types_line = next(line for line in workflow_text.splitlines() if "types:" in line)
         self.assertIn("edited", types_line)
 
-        self.assertIn("edited", pr_triage.BOARD_UPDATE_ACTIONS)
+        self.assertIn("edited", pr_triage_decide.BOARD_UPDATE_ACTIONS)
 
 
 class WorkflowHasAPerPrConcurrencyGroupTest(unittest.TestCase):
@@ -3024,6 +2539,68 @@ class WorkflowValidateJobHoldsNoBoardTokenTest(unittest.TestCase):
         validate_text, _ = jobs
 
         self.assertNotIn("PROJECT_BOARD_TOKEN", validate_text)
+
+
+class WorkflowRunUnitTestsStepDiscoversEveryTestFileTest(unittest.TestCase):
+    """The split (ticket 06) turned one test file into three, and a run
+    command that once worked -- `python3 .github/scripts/test_pr_triage.py`
+    -- now silently drops 60 of 167 tests, because unittest.main() only
+    loads TestCase classes defined in __main__ itself. The fix is a
+    `unittest discover` invocation, but discover has its own silent-drop
+    failure mode: a `-p` pattern that does not match every test*.py file
+    actually present in the directory skips whatever it misses, and still
+    prints OK. This pins the REQUIREMENT, not one exact command string --
+    a differently-spelled discover invocation that still satisfies it must
+    stay green."""
+
+    def test_run_unit_tests_step_is_a_discover_invocation_whose_pattern_matches_every_test_file(self):
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
+        with open(workflow_path, encoding="utf-8") as handle:
+            workflow_text = handle.read()
+
+        step_marker = "- name: Run unit tests"
+        self.assertIn(step_marker, workflow_text, "expected a 'Run unit tests' step in the workflow")
+        after_step = workflow_text.split(step_marker, 1)[1]
+        run_line = next(line for line in after_step.splitlines() if "run:" in line)
+        run_command = run_line.split("run:", 1)[1].strip()
+
+        # Tokenise rather than match one exact spelling -- a `-v` for debugging,
+        # a `-t` start-directory, or `-s`/`-p` in the other order are all still
+        # valid discover invocations and must not go red for being spelled
+        # differently.
+        tokens = shlex.split(run_command)
+        try:
+            m_index = tokens.index("-m")
+            unittest_index = tokens.index("unittest")
+            discover_index = tokens.index("discover")
+            is_discover_invocation = m_index < unittest_index < discover_index
+        except ValueError:
+            is_discover_invocation = False
+        self.assertTrue(
+            is_discover_invocation,
+            f"'Run unit tests' step must be a `unittest discover` invocation, got: {run_command!r}",
+        )
+
+        def value_after(flags):
+            for index, token in enumerate(tokens):
+                if token in flags and index + 1 < len(tokens):
+                    return tokens[index + 1]
+            return None
+
+        discover_dir = value_after({"-s", "--start-directory"})
+        pattern = value_after({"-p", "--pattern"}) or "test*.py"
+
+        self.assertIsNotNone(discover_dir, f"no -s/--start-directory found in: {run_command!r}")
+        scripts_dir = os.path.join(repo_root, ".github", "scripts")
+        self.assertEqual(os.path.join(repo_root, discover_dir), scripts_dir)
+
+        test_files = [name for name in os.listdir(scripts_dir) if name.startswith("test") and name.endswith(".py")]
+        self.assertTrue(test_files, "expected at least one test*.py file in .github/scripts")
+        unmatched = [name for name in test_files if not fnmatch.fnmatch(name, pattern)]
+        self.assertEqual(
+            unmatched, [], f"pattern {pattern!r} does not match every test*.py file present: {unmatched}"
+        )
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -108,13 +108,13 @@ class DecideTransitionTest(unittest.TestCase):
     def test_ready_for_review_moves_status_to_review(self):
         transition = pr_triage.decide_transition("ready_for_review")
 
-        self.assertEqual(transition["status"], pr_triage.UNKNOWN_AUTHOR_STATUS)
+        self.assertEqual(transition["status"], pr_triage.STATUS_REVIEW)
         self.assertEqual(transition["status"], "Review")
 
     def test_converted_to_draft_moves_status_to_working(self):
         transition = pr_triage.decide_transition("converted_to_draft")
 
-        self.assertEqual(transition["status"], pr_triage.KNOWN_AUTHOR_STATUS)
+        self.assertEqual(transition["status"], pr_triage.STATUS_WORKING)
         self.assertEqual(transition["status"], "Working")
 
     def test_opened_is_not_a_transition(self):
@@ -122,6 +122,18 @@ class DecideTransitionTest(unittest.TestCase):
 
     def test_reopened_is_not_a_transition(self):
         self.assertIsNone(pr_triage.decide_transition("reopened"))
+
+    def test_transition_rule_is_decoupled_from_the_unknown_author_rule(self):
+        with mock.patch.object(pr_triage, "UNKNOWN_AUTHOR_STATUS", "SomethingElse"):
+            transition = pr_triage.decide_transition("ready_for_review")
+
+        self.assertEqual(transition["status"], "Review")
+
+    def test_transition_rule_is_decoupled_from_the_known_author_rule(self):
+        with mock.patch.object(pr_triage, "KNOWN_AUTHOR_STATUS", "SomethingElse"):
+            transition = pr_triage.decide_transition("converted_to_draft")
+
+        self.assertEqual(transition["status"], "Working")
 
 
 class StripEmojiPrefixTest(unittest.TestCase):
@@ -634,6 +646,19 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
                     pr_triage.main()
 
 
+LIVE_STATUS_OPTIONS = [
+    {"id": "285bb9d7", "name": "\U0001f4cb Epic"},
+    {"id": "ff9f2e2b", "name": "⛔️ Blocked"},
+    {"id": "f75ad846", "name": "\U0001f4da Backlog"},
+    {"id": "47fc9ee4", "name": "\U0001f6e0️ Working"},
+    {"id": "879449e7", "name": "\U0001f50d Review"},
+    {"id": "98236657", "name": "✅ Done"},
+    {"id": "58e93f55", "name": "\U0001f4e5 Inbox"},
+    {"id": "7164e058", "name": "Icebox"},
+]
+LIVE_STATUS_OPTION_ID_BY_NAME = {"Working": "47fc9ee4", "Review": "879449e7"}
+
+
 class MainWiringTransitionTest(unittest.TestCase):
     def _run_transition(self, action, author_login, item_exists):
         import tempfile
@@ -651,7 +676,6 @@ class MainWiringTransitionTest(unittest.TestCase):
         }
 
         calls = []
-        expected_status_name = "Review" if action == "ready_for_review" else "Working"
 
         def fake_http_request(url, token, method="GET", body=None):
             calls.append({"url": url, "token": token, "body": body})
@@ -690,13 +714,7 @@ class MainWiringTransitionTest(unittest.TestCase):
 
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {
-                        "data": {
-                            "node": {
-                                "options": [{"id": "STATUS_OPT_ID", "name": expected_status_name}]
-                            }
-                        }
-                    }
+                    return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
                 raise AssertionError("a transition must never fetch Team options")
 
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -724,9 +742,13 @@ class MainWiringTransitionTest(unittest.TestCase):
 
         return calls, summary_text
 
-    def _assert_transition_wiring(self, calls, summary_text, item_exists):
+    def _assert_transition_wiring(self, calls, summary_text, action, item_exists):
         def query_of(call):
             return (call["body"] or {}).get("query", "")
+
+        expected_status_name = "Review" if action == "ready_for_review" else "Working"
+        expected_option_id = LIVE_STATUS_OPTION_ID_BY_NAME[expected_status_name]
+        expected_item_id = "EXISTING_ITEM" if item_exists else "NEW_ITEM"
 
         self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
         self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
@@ -738,32 +760,225 @@ class MainWiringTransitionTest(unittest.TestCase):
             self.assertEqual(len(add_item_calls), 1)
             self.assertEqual(add_item_calls[0]["token"], "board-token")
 
+        project_items_calls = [call for call in calls if "projectItems" in query_of(call)]
+        self.assertEqual(len(project_items_calls), 1)
+        self.assertIn("first: 100", query_of(project_items_calls[0]))
+
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
         self.assertEqual(len(field_writes), 1)
         self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["body"]["variables"]["itemId"], expected_item_id)
+        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], expected_option_id)
         self.assertEqual(field_writes[0]["token"], "board-token")
 
         self.assertIn("### PR triage", summary_text)
-        self.assertIn("Team", summary_text)
-        self.assertIn("Assignee", summary_text)
+        self.assertIn("| Team | not touched, deliberate |", summary_text)
+        self.assertIn(
+            "| Assignee | not touched, deliberate, including when empty |", summary_text
+        )
 
     def test_ready_for_review_known_author_existing_item(self):
         calls, summary_text = self._run_transition("ready_for_review", "mswertz", item_exists=True)
-        self._assert_transition_wiring(calls, summary_text, item_exists=True)
+        self._assert_transition_wiring(calls, summary_text, "ready_for_review", item_exists=True)
 
     def test_ready_for_review_unknown_author_no_existing_item(self):
         calls, summary_text = self._run_transition("ready_for_review", "some-outside-contributor", item_exists=False)
-        self._assert_transition_wiring(calls, summary_text, item_exists=False)
+        self._assert_transition_wiring(calls, summary_text, "ready_for_review", item_exists=False)
 
     def test_converted_to_draft_known_author_existing_item(self):
         calls, summary_text = self._run_transition("converted_to_draft", "mswertz", item_exists=True)
-        self._assert_transition_wiring(calls, summary_text, item_exists=True)
+        self._assert_transition_wiring(calls, summary_text, "converted_to_draft", item_exists=True)
 
     def test_converted_to_draft_unknown_author_no_existing_item(self):
         calls, summary_text = self._run_transition(
             "converted_to_draft", "some-outside-contributor", item_exists=False
         )
-        self._assert_transition_wiring(calls, summary_text, item_exists=False)
+        self._assert_transition_wiring(calls, summary_text, "converted_to_draft", item_exists=False)
+
+
+class TransitionWritesStepSummaryOnFailureTest(unittest.TestCase):
+    def test_step_summary_is_written_and_error_reraised_when_a_transition_write_fails(self):
+        import tempfile
+
+        event = {
+            "action": "ready_for_review",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "fetch_project_field_options", side_effect=pr_triage.GraphqlError("board boom")
+            ):
+                with self.assertRaises(pr_triage.GraphqlError):
+                    pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("Failure", summary_text)
+        self.assertIn("board boom", summary_text)
+
+
+class TransitionResolvesStatusBeforeAddingBoardItemTest(unittest.TestCase):
+    def test_status_option_is_resolved_before_a_missing_item_is_added(self):
+        import tempfile
+
+        event = {
+            "action": "ready_for_review",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        call_kinds = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+            if "projectItems" in query:
+                call_kinds.append("find_item")
+                return {"data": {"node": {"projectItems": {"nodes": []}}}}
+            if "addProjectV2ItemById" in query:
+                call_kinds.append("add_item")
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "NEW_ITEM"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                call_kinds.append("set_field")
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "NEW_ITEM"}}}}
+            if "options { id name }" in query:
+                call_kinds.append("fetch_status_options")
+                return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                pr_triage.main()
+
+        self.assertLess(call_kinds.index("fetch_status_options"), call_kinds.index("add_item"))
+
+    def test_a_status_resolution_failure_never_adds_a_board_item(self):
+        import tempfile
+
+        event = {
+            "action": "ready_for_review",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        def fake_http_request(url, token, method="GET", body=None):
+            query = (body or {}).get("query", "")
+            if "projectItems" in query:
+                return {"data": {"node": {"projectItems": {"nodes": []}}}}
+            if "addProjectV2ItemById" in query:
+                raise AssertionError("must not add a board item when Status resolution fails")
+            if "options { id name }" in query:
+                return {"data": {"node": {"options": [{"id": "SOME_OPT", "name": "NoMatchingOptionHere"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                with self.assertRaises(ValueError):
+                    pr_triage.main()
+
+
+class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
+    def test_an_unrecognized_action_makes_no_writes_and_reads_no_mapping_file(self):
+        import tempfile
+
+        event = {
+            "action": "synchronize",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        def fake_http_request(url, token, method="GET", body=None):
+            raise AssertionError(f"an unrecognized action must make no API call, got: {url}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {"GITHUB_EVENT_PATH": event_path, "GITHUB_STEP_SUMMARY": summary_path}
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ), mock.patch.object(
+                pr_triage, "load_teams_mapping", side_effect=AssertionError("must not read the mapping file")
+            ):
+                pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        self.assertIn("synchronize", summary_text)
+        self.assertIn("no action", summary_text.lower())
 
 
 class MainReadsAssignDecisionTest(unittest.TestCase):

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -637,6 +637,48 @@ class ValidateTeamOptionTest(unittest.TestCase):
 
 
 class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
+    def test_a_missing_mapping_file_still_writes_a_summary_and_exits_non_zero(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "fake-github-token",
+                "PROJECT_BOARD_TOKEN": "fake-board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "load_teams_mapping", side_effect=FileNotFoundError("no such file: pr-triage-teams.yml")
+            ):
+                with self.assertRaises(SystemExit) as context:
+                    pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        self.assertNotEqual(context.exception.code, 0)
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("no such file", summary_text)
+
     def test_assign_failure_skips_the_draft_flip_but_still_boards_review_and_exits_non_zero(self):
         import tempfile
 
@@ -678,6 +720,18 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
                     }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            if "configuration" in query:
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                                ]
+                            }
+                        }
+                    }
+                }
             raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -696,7 +750,9 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "assign_author", side_effect=pr_triage.GraphqlError("boom")
-            ), mock.patch.object(pr_triage, "http_request", side_effect=fake_http_request):
+            ), mock.patch.object(pr_triage, "http_request", side_effect=fake_http_request), mock.patch.object(
+                pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
+            ):
                 with self.assertRaises(SystemExit) as context:
                     pr_triage.main()
 
@@ -712,6 +768,7 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
         self.assertTrue(any("addProjectV2ItemById" in query_of(call) for call in calls))
 
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 3)
         status_write = next(
             call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
         )
@@ -760,6 +817,18 @@ class MainWiringTest(unittest.TestCase):
                     return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            if "configuration" in query:
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                                ]
+                            }
+                        }
+                    }
+                }
             raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -778,7 +847,7 @@ class MainWiringTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
-            ):
+            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
                 pr_triage.main()
 
         def query_of(call):
@@ -794,7 +863,7 @@ class MainWiringTest(unittest.TestCase):
         self.assertEqual(add_item_call["token"], "board-token")
 
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 2)
+        self.assertEqual(len(field_writes), 3)
 
         status_write = field_writes[0]
         self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
@@ -805,6 +874,11 @@ class MainWiringTest(unittest.TestCase):
         self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
         self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_OPT")
         self.assertEqual(team_write["token"], "board-token")
+
+        sprint_write = field_writes[2]
+        self.assertEqual(sprint_write["body"]["variables"]["fieldId"], pr_triage.SPRINT_FIELD_ID)
+        self.assertEqual(sprint_write["body"]["variables"]["iterationId"], "bd551114")
+        self.assertEqual(sprint_write["token"], "board-token")
 
 
 class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
@@ -851,6 +925,18 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
                     }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            if "configuration" in query:
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                                ]
+                            }
+                        }
+                    }
+                }
             raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -869,7 +955,7 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
-            ):
+            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
                 with self.assertRaises(SystemExit) as context:
                     pr_triage.main()
 
@@ -885,6 +971,7 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
         self.assertTrue(any("addProjectV2ItemById" in query_of(call) for call in calls))
 
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 3)
         status_write = next(
             call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
         )
@@ -943,6 +1030,18 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
                     }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            if "configuration" in query:
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                                ]
+                            }
+                        }
+                    }
+                }
             raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -961,7 +1060,7 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
-            ):
+            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
                 with self.assertRaises(SystemExit) as context:
                     pr_triage.main()
 
@@ -980,7 +1079,7 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
         self.assertEqual(add_item_call["token"], "board-token")
 
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 2)
+        self.assertEqual(len(field_writes), 3)
 
         status_write = next(
             call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
@@ -993,6 +1092,7 @@ class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
         self.assertIn("Board item id", summary_text)
         self.assertIn("Status option id written", summary_text)
         self.assertIn("Team option id written", summary_text)
+        self.assertIn("Sprint option id written", summary_text)
 
 
 class MappingFilePathTest(unittest.TestCase):
@@ -1643,6 +1743,18 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
                     }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_DEV_OPT", "name": "Dev"}]}}}
+            if "configuration" in query:
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                                ]
+                            }
+                        }
+                    }
+                }
             raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1660,7 +1772,7 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
-            ):
+            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
                 pr_triage.main()
 
             with open(summary_path, encoding="utf-8") as handle:
@@ -1679,7 +1791,7 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
         self.assertEqual(add_item_call["token"], "board-token")
 
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
-        self.assertEqual(len(field_writes), 2)
+        self.assertEqual(len(field_writes), 3)
 
         status_write = field_writes[0]
         self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
@@ -1690,6 +1802,11 @@ class MainWiringUnknownAuthorTest(unittest.TestCase):
         self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
         self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_DEV_OPT")
         self.assertEqual(team_write["token"], "board-token")
+
+        sprint_write = field_writes[2]
+        self.assertEqual(sprint_write["body"]["variables"]["fieldId"], pr_triage.SPRINT_FIELD_ID)
+        self.assertEqual(sprint_write["body"]["variables"]["iterationId"], "bd551114")
+        self.assertEqual(sprint_write["token"], "board-token")
 
         self.assertIn("### PR triage", summary_text)
         self.assertIn("| Assignee set | skipped, unknown author is never assigned |", summary_text)
@@ -1747,6 +1864,19 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     call_kinds.append("fetch_team_options")
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            if "configuration" in query:
+                call_kinds.append("fetch_iterations")
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                                ]
+                            }
+                        }
+                    }
+                }
             raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1765,12 +1895,13 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
-            ):
+            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
                 pr_triage.main()
 
         add_item_index = call_kinds.index("add_item")
         self.assertLess(call_kinds.index("fetch_status_options"), add_item_index)
         self.assertLess(call_kinds.index("fetch_team_options"), add_item_index)
+        self.assertLess(call_kinds.index("fetch_iterations"), add_item_index)
 
     def test_a_resolution_failure_never_adds_a_board_item(self):
         import tempfile
@@ -1818,7 +1949,7 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
-            ):
+            ), mock.patch.object(pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)):
                 with self.assertRaises(SystemExit) as context:
                     pr_triage.main()
 
@@ -1897,11 +2028,13 @@ class MainReadsAssignDecisionTest(unittest.TestCase):
             "repository": {"full_name": "molgenis/molgenis-emx2"},
         }
 
+        # known and assign always agree in the real decide(); this forces the
+        # only combination that ever skips assignment (both false), since
+        # "known but not assigned" is a state the all-or-nothing ruling forbids.
         forced_decision = {
-            "known": True,
+            "known": False,
             "assign": False,
             "force_draft": False,
-            "status": "Working",
             "team": "Dev",
         }
 
@@ -1929,6 +2062,18 @@ class MainReadsAssignDecisionTest(unittest.TestCase):
                     }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            if "configuration" in query:
+                return {
+                    "data": {
+                        "node": {
+                            "configuration": {
+                                "iterations": [
+                                    {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                                ]
+                            }
+                        }
+                    }
+                }
             raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
@@ -1947,14 +2092,16 @@ class MainReadsAssignDecisionTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
-            ), mock.patch.object(pr_triage, "decide", return_value=forced_decision):
+            ), mock.patch.object(pr_triage, "decide", return_value=forced_decision), mock.patch.object(
+                pr_triage, "current_date", return_value=datetime.date(2026, 8, 8)
+            ):
                 pr_triage.main()
 
             with open(summary_path, encoding="utf-8") as handle:
                 summary_text = handle.read()
 
         self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
-        self.assertIn("| Assignee set | skipped, not required by decision |", summary_text)
+        self.assertIn("| Assignee set | skipped, unknown author is never assigned |", summary_text)
 
 
 class FindBoardItemForPrTest(unittest.TestCase):
@@ -2079,6 +2226,29 @@ class SetProjectFieldIterationTest(unittest.TestCase):
         self.assertEqual(called_body["variables"]["iterationId"], "bd551114")
         self.assertIn("iterationId", called_body["query"])
         self.assertNotIn("singleSelectOptionId", called_body["query"])
+
+
+class NullNodeIsRaisedActionablyTest(unittest.TestCase):
+    def test_fetch_project_field_options_raises_naming_the_field_id_when_node_is_null(self):
+        with mock.patch.object(pr_triage, "http_request", return_value={"data": {"node": None}}):
+            with self.assertRaises(pr_triage.GraphqlError) as context:
+                pr_triage.fetch_project_field_options("STALE_FIELD_ID", "board-token")
+
+        self.assertIn("STALE_FIELD_ID", str(context.exception))
+
+    def test_find_board_item_for_pr_raises_naming_the_pr_node_id_when_node_is_null(self):
+        with mock.patch.object(pr_triage, "http_request", return_value={"data": {"node": None}}):
+            with self.assertRaises(pr_triage.GraphqlError) as context:
+                pr_triage.find_board_item_for_pr("STALE_PR_NODE_ID", "board-token")
+
+        self.assertIn("STALE_PR_NODE_ID", str(context.exception))
+
+    def test_fetch_project_iterations_raises_naming_the_field_id_when_node_is_null(self):
+        with mock.patch.object(pr_triage, "http_request", return_value={"data": {"node": None}}):
+            with self.assertRaises(pr_triage.GraphqlError) as context:
+                pr_triage.fetch_project_iterations("STALE_SPRINT_FIELD_ID", "board-token")
+
+        self.assertIn("STALE_SPRINT_FIELD_ID", str(context.exception))
 
 
 class GraphqlRequestErrorHandlingTest(unittest.TestCase):
@@ -2324,6 +2494,61 @@ class ValidateMainExitsNonZeroOnBannedTermTest(unittest.TestCase):
         self.assertNotEqual(context.exception.code, 0)
 
 
+class ValidateMainRunsOfflineWithoutBoardTokenTest(unittest.TestCase):
+    def test_offline_checks_pass_green_with_a_clean_mapping_and_no_token_in_the_environment(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = os.path.join(tmp_dir, "repo")
+            scripts_dir = os.path.join(repo_root, ".github", "scripts")
+            workflows_dir = os.path.join(repo_root, ".github", "workflows")
+            os.makedirs(scripts_dir)
+            os.makedirs(workflows_dir)
+            with open(os.path.join(repo_root, ".github", "pr-triage-teams.yml"), "w", encoding="utf-8") as handle:
+                handle.write("teams:\n  mswertz: Dev\n")
+            with open(os.path.join(workflows_dir, "pr-triage.yml"), "w", encoding="utf-8") as handle:
+                handle.write("on:\n  pull_request:\n    types: [opened]\n")
+            with open(os.path.join(scripts_dir, "pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("def decide():\n    pass\n")
+            with open(os.path.join(scripts_dir, "validate_pr_triage_teams.py"), "w", encoding="utf-8") as handle:
+                handle.write("BANNED = ('author_association',)\n")
+            with open(os.path.join(scripts_dir, "test_pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("workflow_text = 'author_association'\n")
+
+            with mock.patch.dict(os.environ, {}, clear=True), mock.patch.object(
+                pr_triage,
+                "fetch_project_field_options",
+                side_effect=AssertionError("offline validation must never call the live board"),
+            ):
+                validate_pr_triage_teams.main(repo_root=repo_root)
+
+    def test_a_genuine_mapping_defect_still_fails_with_no_token_present(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = os.path.join(tmp_dir, "repo")
+            scripts_dir = os.path.join(repo_root, ".github", "scripts")
+            workflows_dir = os.path.join(repo_root, ".github", "workflows")
+            os.makedirs(scripts_dir)
+            os.makedirs(workflows_dir)
+            with open(os.path.join(repo_root, ".github", "pr-triage-teams.yml"), "w", encoding="utf-8") as handle:
+                handle.write("teams:\n  dependabot[bot]: Dev\n")
+            with open(os.path.join(workflows_dir, "pr-triage.yml"), "w", encoding="utf-8") as handle:
+                handle.write("on:\n  pull_request:\n    types: [opened]\n")
+            with open(os.path.join(scripts_dir, "pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("def decide():\n    pass\n")
+            with open(os.path.join(scripts_dir, "validate_pr_triage_teams.py"), "w", encoding="utf-8") as handle:
+                handle.write("BANNED = ('author_association',)\n")
+            with open(os.path.join(scripts_dir, "test_pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("workflow_text = 'author_association'\n")
+
+            with mock.patch.dict(os.environ, {}, clear=True):
+                with self.assertRaises(SystemExit) as context:
+                    validate_pr_triage_teams.main(repo_root=repo_root)
+
+        self.assertNotEqual(context.exception.code, 0)
+
+
 class WorkflowHasAPerPrConcurrencyGroupTest(unittest.TestCase):
     def test_concurrency_group_is_scoped_per_pr_and_does_not_cancel_in_progress_runs(self):
         repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -2355,6 +2580,54 @@ class WorkflowGithubTokenPermissionsTest(unittest.TestCase):
 
         self.assertIn("issues: write", workflow_text)
         self.assertIn("pull-requests: write", workflow_text)
+
+
+class WorkflowOnlyTriagesPrsBasedOnTheDefaultBranchTest(unittest.TestCase):
+    def test_triage_job_guards_on_base_ref_matching_the_default_branch(self):
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
+        with open(workflow_path, encoding="utf-8") as handle:
+            workflow_text = handle.read()
+
+        jobs = workflow_text.split("\n  triage:", 1)
+        self.assertEqual(len(jobs), 2, "expected exactly one 'triage:' job in the workflow")
+        validate_text, triage_text = jobs
+
+        self.assertNotIn("base.ref", validate_text)
+        self.assertNotIn("default_branch", validate_text)
+
+        self.assertIn("github.event.pull_request.base.ref", triage_text)
+        self.assertIn("github.event.repository.default_branch", triage_text)
+        self.assertNotIn("== 'master'", triage_text)
+        self.assertNotIn('== "master"', triage_text)
+
+
+class WorkflowTriageCheckoutPinsToBaseShaTest(unittest.TestCase):
+    def test_triage_job_checks_out_the_base_sha_not_the_prs_own_code(self):
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
+        with open(workflow_path, encoding="utf-8") as handle:
+            workflow_text = handle.read()
+
+        jobs = workflow_text.split("\n  triage:", 1)
+        self.assertEqual(len(jobs), 2, "expected exactly one 'triage:' job in the workflow")
+        _, triage_text = jobs
+
+        self.assertIn("ref: ${{ github.event.pull_request.base.sha }}", triage_text)
+
+
+class WorkflowValidateJobHoldsNoBoardTokenTest(unittest.TestCase):
+    def test_validate_job_env_has_no_project_board_token(self):
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
+        with open(workflow_path, encoding="utf-8") as handle:
+            workflow_text = handle.read()
+
+        jobs = workflow_text.split("\n  triage:", 1)
+        self.assertEqual(len(jobs), 2, "expected exactly one 'triage:' job in the workflow")
+        validate_text, _ = jobs
+
+        self.assertNotIn("PROJECT_BOARD_TOKEN", validate_text)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -125,6 +125,103 @@ def make_fake_http_request(
     return fake_http_request
 
 
+def _item_node(item):
+    return {
+        "id": item["id"],
+        "project": {"id": pr_triage.BOARD_PROJECT_ID},
+        "status": {"name": item["status"]} if item.get("status") else None,
+        "team": {"name": item["team"]} if item.get("team") else None,
+        "sprint": {"title": item["sprint"]} if item.get("sprint") else None,
+    }
+
+
+def make_fake_http_request_for_redirect(
+    calls,
+    *,
+    pr_item=None,
+    closing_issues=(),
+    user_linked_issues=(),
+    issue_items=None,
+    add_item_ids=None,
+    status_options=None,
+    team_options=None,
+    iterations=None,
+    assign_result=None,
+):
+    """One fake GitHub for aim-6 (closing-PR redirection) tests: distinguishes
+    a PullRequest node from an Issue node by the `contentId` variable, so a
+    single fake covers both the PR's own lookup (which also carries
+    closingIssuesReferences / userLinkedClosingIssues) and each linked
+    issue's lookup (which never does, exactly like a real Issue fragment)."""
+    issue_items = {} if issue_items is None else issue_items
+    add_item_ids = {} if add_item_ids is None else add_item_ids
+    if status_options is None:
+        status_options = LIVE_STATUS_OPTIONS
+    if team_options is None:
+        team_options = [{"id": "TEAM_DEV_OPT", "name": "Dev"}, {"id": "TEAM_DELIVERY_OPT", "name": "Delivery"}]
+    if iterations is None:
+        iterations = DEFAULT_ITERATIONS
+
+    def fake(url, token, method="GET", body=None):
+        calls.append({"url": url, "token": token, "body": body})
+        query = (body or {}).get("query", "")
+        variables = (body or {}).get("variables", {})
+
+        if url.endswith("/assignees"):
+            if assign_result is not None:
+                return assign_result
+            return {"assignees": [{"login": login} for login in (body or {}).get("assignees", [])]}
+
+        if "convertPullRequestToDraft" in query:
+            return {
+                "data": {
+                    "convertPullRequestToDraft": {
+                        "pullRequest": {"id": variables.get("pullRequestId"), "isDraft": True}
+                    }
+                }
+            }
+
+        if "closingIssuesReferences" in query:
+            content_id = variables["contentId"]
+            if content_id in issue_items:
+                item = issue_items[content_id]
+                nodes = [] if item is None else [_item_node(item)]
+                return {"data": {"node": {"projectItems": {"nodes": nodes}}}}
+            nodes = [] if pr_item is None else [_item_node(pr_item)]
+            return {
+                "data": {
+                    "node": {
+                        "projectItems": {"nodes": nodes},
+                        "closingIssuesReferences": {"nodes": list(closing_issues)},
+                        "userLinkedClosingIssues": {"nodes": list(user_linked_issues)},
+                    }
+                }
+            }
+
+        if "deleteProjectV2Item" in query:
+            return {"data": {"deleteProjectV2Item": {"deletedItemId": variables["itemId"]}}}
+
+        if "addProjectV2ItemById" in query:
+            content_id = variables["contentId"]
+            new_id = add_item_ids.get(content_id, f"NEW_{content_id}")
+            return {"data": {"addProjectV2ItemById": {"item": {"id": new_id}}}}
+
+        if "updateProjectV2ItemFieldValue" in query:
+            return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": variables.get("itemId")}}}}
+
+        if "options { id name }" in query:
+            if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                return {"data": {"node": {"options": status_options}}}
+            return {"data": {"node": {"options": team_options}}}
+
+        if "configuration" in query:
+            return {"data": {"node": {"configuration": {"iterations": iterations}}}}
+
+        raise AssertionError(f"unexpected call: {url} {query}")
+
+    return fake
+
+
 def run_main(event, *, http_request=None, current_date=None, env_extra=None):
     """The tempdir + event.json + summary file + env + mock.patch scaffold every
     main() test needs, collapsed to one call. Returns (summary_text, exit_code):
@@ -429,6 +526,138 @@ class DecideBoardUpdateTest(unittest.TestCase):
         )
 
         self.assertIsNone(fields["sprint"])
+
+
+class KeywordClosingIssuesTest(unittest.TestCase):
+    """Owner ruling, mid-ticket: only a KEYWORD-derived closing reference
+    redirects aim 6 -- a sidebar-only link (GitHub's Development panel, no
+    keyword in the body, e.g. this repo's `Addresses: <url>` habit) does not.
+    keyword_closing_issues = closingIssuesReferences minus its
+    userLinkedOnly=true counterpart, matched by node id. Verified against two
+    real PRs of each shape, see notes/github-facts.md §8."""
+
+    ISSUE_A = {"id": "ISSUE_A", "number": 1}
+    ISSUE_B = {"id": "ISSUE_B", "number": 2}
+
+    def test_a_keyword_only_link_counts(self):
+        result = pr_triage.keyword_closing_issues([self.ISSUE_A], [])
+
+        self.assertEqual(result, [self.ISSUE_A])
+
+    def test_a_sidebar_only_link_does_not_count(self):
+        result = pr_triage.keyword_closing_issues([self.ISSUE_A], [self.ISSUE_A])
+
+        self.assertEqual(result, [])
+
+    def test_both_sets_empty_means_no_redirection(self):
+        result = pr_triage.keyword_closing_issues([], [])
+
+        self.assertEqual(result, [])
+
+    def test_a_keyword_link_and_a_separate_sidebar_link_keeps_only_the_keyword_one(self):
+        result = pr_triage.keyword_closing_issues([self.ISSUE_A, self.ISSUE_B], [self.ISSUE_B])
+
+        self.assertEqual(result, [self.ISSUE_A])
+
+    def test_two_keyword_links_both_count(self):
+        result = pr_triage.keyword_closing_issues([self.ISSUE_A, self.ISSUE_B], [])
+
+        self.assertEqual(result, [self.ISSUE_A, self.ISSUE_B])
+
+
+class DecideRedirectToIssuesTest(unittest.TestCase):
+    def test_true_when_the_pr_closes_one_issue(self):
+        self.assertTrue(pr_triage.decide_redirect_to_issues([{"id": "ISSUE_A", "number": 1}]))
+
+    def test_true_when_the_pr_closes_two_issues(self):
+        self.assertTrue(
+            pr_triage.decide_redirect_to_issues([{"id": "ISSUE_A", "number": 1}, {"id": "ISSUE_B", "number": 2}])
+        )
+
+    def test_false_when_the_pr_closes_no_issue(self):
+        self.assertFalse(pr_triage.decide_redirect_to_issues([]))
+
+
+class DecideRemovePrCardTest(unittest.TestCase):
+    """Renamed from decide_delete_pr_item -- owner ruling: "delete" reads as
+    "delete the pull request", and it does not; this only removes a card
+    from board 15."""
+
+    def test_true_when_the_pr_closes_an_issue_and_already_has_a_card(self):
+        self.assertTrue(
+            pr_triage.decide_remove_pr_card([{"id": "ISSUE_A", "number": 1}], {"id": "PR_ITEM", "status": None, "team": None, "sprint": None})
+        )
+
+    def test_false_when_the_pr_closes_an_issue_but_has_no_card_yet(self):
+        self.assertFalse(pr_triage.decide_remove_pr_card([{"id": "ISSUE_A", "number": 1}], None))
+
+    def test_false_when_the_pr_closes_no_issue_even_if_it_has_a_card(self):
+        self.assertFalse(
+            pr_triage.decide_remove_pr_card([], {"id": "PR_ITEM", "status": None, "team": None, "sprint": None})
+        )
+
+
+class DecideIssueCardUpdateTest(unittest.TestCase):
+    """Pure decision for one linked issue's card. mapped_team/current_sprint_title
+    are only ever consulted when a card is being added (existing_issue_item is
+    None); an existing card's Team and Sprint are never touched by any action."""
+
+    EXISTING_WORKING = {"id": "ISSUE_ITEM", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 259"}
+    EXISTING_BLANK = {"id": "ISSUE_ITEM", "status": None, "team": None, "sprint": None}
+    EXISTING_PARKED = {"id": "ISSUE_ITEM", "status": "⛔️ Blocked", "team": "Dev", "sprint": "Sprint 259"}
+
+    # --- opened and the three transitions: Status only on an existing card ---
+
+    def test_opened_and_transitions_set_status_only_on_an_existing_card(self):
+        for action in pr_triage.ISSUE_STATUS_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_issue_card_update(action, False, self.EXISTING_WORKING, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": "Review", "team": None, "sprint": None})
+
+    def test_opened_and_transitions_fill_status_when_the_existing_card_is_blank(self):
+        for action in pr_triage.ISSUE_STATUS_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_issue_card_update(action, False, self.EXISTING_BLANK, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": "Review", "team": None, "sprint": None})
+
+    def test_opened_and_transitions_never_move_a_parked_status(self):
+        for action in pr_triage.ISSUE_STATUS_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_issue_card_update(action, False, self.EXISTING_PARKED, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": None, "team": None, "sprint": None})
+
+    def test_opened_and_transitions_add_and_fill_all_three_on_a_missing_card(self):
+        for action in pr_triage.ISSUE_STATUS_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage.decide_issue_card_update(action, True, None, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": "Working", "team": "Delivery", "sprint": "Sprint 260"})
+
+                fields = pr_triage.decide_issue_card_update(action, False, None, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": "Review", "team": "Delivery", "sprint": "Sprint 260"})
+
+    # --- synchronize: never touches a linked issue's card, existing or missing ---
+
+    def test_synchronize_never_touches_an_existing_card(self):
+        fields = pr_triage.decide_issue_card_update("synchronize", True, self.EXISTING_WORKING, "Delivery", "Sprint 260")
+        self.assertIsNone(fields)
+
+    def test_synchronize_never_touches_a_missing_card_either(self):
+        fields = pr_triage.decide_issue_card_update("synchronize", True, None, "Delivery", "Sprint 260")
+        self.assertIsNone(fields)
+
+    # --- edited: adds and fills Team+Sprint on a missing card, but never
+    # touches an existing one, and never writes Status even on the card it adds ---
+
+    def test_edited_never_touches_an_existing_card(self):
+        fields = pr_triage.decide_issue_card_update("edited", True, self.EXISTING_WORKING, "Delivery", "Sprint 260")
+        self.assertIsNone(fields)
+
+    def test_edited_adds_and_fills_team_and_sprint_on_a_missing_card_but_leaves_status_unwritten(self):
+        fields = pr_triage.decide_issue_card_update("edited", True, None, "Delivery", "Sprint 260")
+        self.assertEqual(fields, {"status": None, "team": "Delivery", "sprint": "Sprint 260"})
+
+        fields = pr_triage.decide_issue_card_update("edited", False, None, "Delivery", "Sprint 260")
+        self.assertEqual(fields, {"status": None, "team": "Delivery", "sprint": "Sprint 260"})
 
 
 class FindCurrentIterationTest(unittest.TestCase):
@@ -1345,6 +1574,486 @@ class MainWiringBoardUpdateTest(unittest.TestCase):
             self.assertEqual(call["token"], "board-token")
 
 
+def _pr_event(action, is_draft, author="mswertz", number=1, node_id="PR_node"):
+    return {
+        "action": action,
+        "pull_request": {
+            "user": {"login": author},
+            "head": {"ref": "feature/x"},
+            "number": number,
+            "node_id": node_id,
+            "draft": is_draft,
+        },
+        "repository": {"full_name": "molgenis/molgenis-emx2"},
+    }
+
+
+class MainWiringClosingIssueTest(unittest.TestCase):
+    """End-to-end (aim 6): a PR closing an issue redirects the board write
+    from the PR's own card to each linked issue's, per ticket 05's
+    acceptance criteria. `mswertz` maps to `Dev` in the real
+    .github/pr-triage-teams.yml, same as every other opened-action test in
+    this file."""
+
+    def _field_writes(self, calls, item_id):
+        return [
+            call
+            for call in calls
+            if "updateProjectV2ItemFieldValue" in query_of(call) and call["body"]["variables"]["itemId"] == item_id
+        ]
+
+    def _add_calls(self, calls):
+        return [call for call in calls if "addProjectV2ItemById" in query_of(call)]
+
+    def _remove_calls(self, calls):
+        """Calls to the removal mutation -- deleteProjectV2Item is GitHub's
+        own name for it, kept in the GraphQL text; our identifiers say
+        "remove"."""
+        return [call for call in calls if "deleteProjectV2Item" in query_of(call)]
+
+    # --- opened: assignee/draft run in full, board write redirects ---
+
+    def test_opened_closing_a_boarded_issue_adds_no_pr_card_and_sets_only_status(self):
+        calls = []
+        existing_issue_item = {"id": "ISSUE_ITEM_A", "status": "🔍 Review", "team": "Analysis", "sprint": "Sprint 259"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        run_main(_pr_event("opened", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        self.assertTrue(any(call["url"].endswith("/assignees") for call in calls))
+        self.assertTrue(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+
+        self.assertEqual(self._add_calls(calls), [], "no card, for the PR or the issue, should be added")
+
+        field_writes = self._field_writes(calls, "ISSUE_ITEM_A")
+        self.assertEqual(len(field_writes), 1)
+        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")  # Working
+
+    def test_opened_closing_an_unboarded_issue_boards_the_issue_with_all_three_fields(self):
+        calls = []
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_B", "number": 11}],
+            issue_items={"ISSUE_B": None},
+            add_item_ids={"ISSUE_B": "NEW_ISSUE_ITEM"},
+        )
+
+        run_main(_pr_event("opened", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        add_calls = self._add_calls(calls)
+        self.assertEqual(len(add_calls), 1)
+        self.assertEqual(add_calls[0]["body"]["variables"]["contentId"], "ISSUE_B")
+
+        field_writes = self._field_writes(calls, "NEW_ISSUE_ITEM")
+        written_field_ids = {call["body"]["variables"]["fieldId"] for call in field_writes}
+        self.assertEqual(
+            written_field_ids, {pr_triage.STATUS_FIELD_ID, pr_triage.TEAM_FIELD_ID, pr_triage.SPRINT_FIELD_ID}
+        )
+        team_write = next(c for c in field_writes if c["body"]["variables"]["fieldId"] == pr_triage.TEAM_FIELD_ID)
+        self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_DEV_OPT")
+
+    def test_opened_removes_the_prs_existing_card(self):
+        """F10: Auto-add (board 15's own built-in workflow) can put a card on
+        the PR before this workflow's `opened` handler ever runs. That card
+        must still be removed -- this was asserted by nothing before this
+        test; every prior opened/transition removal test used pr_item=None."""
+        calls = []
+        existing_issue_item = {"id": "ISSUE_ITEM_A", "status": "🔍 Review", "team": "Analysis", "sprint": "Sprint 259"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item={"id": "AUTO_ADDED_PR_ITEM", "status": None, "team": None, "sprint": None},
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        run_main(_pr_event("opened", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        remove_calls = self._remove_calls(calls)
+        self.assertEqual(len(remove_calls), 1)
+        self.assertEqual(remove_calls[0]["body"]["variables"]["itemId"], "AUTO_ADDED_PR_ITEM")
+
+    def test_unknown_author_closing_an_issue_skips_assignment_and_draft_but_still_redirects(self):
+        calls = []
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_B", "number": 11}],
+            issue_items={"ISSUE_B": None},
+            add_item_ids={"ISSUE_B": "NEW_ISSUE_ITEM"},
+        )
+
+        run_main(
+            _pr_event("opened", is_draft=False, author="some-outside-contributor"),
+            http_request=fake,
+            current_date=datetime.date(2026, 8, 8),
+        )
+
+        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
+        self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+        self.assertEqual(self._add_calls(calls)[0]["body"]["variables"]["contentId"], "ISSUE_B")
+
+    # --- the three transitions: Status only on an existing linked issue card ---
+
+    def test_ready_for_review_moves_the_linked_issues_card_to_review(self):
+        calls = []
+        existing_issue_item = {"id": "ISSUE_ITEM", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        field_writes = self._field_writes(calls, "ISSUE_ITEM")
+        self.assertEqual(len(field_writes), 1)
+        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")  # Review
+
+    def test_converted_to_draft_moves_the_linked_issues_card_to_working(self):
+        calls = []
+        existing_issue_item = {"id": "ISSUE_ITEM", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        run_main(_pr_event("converted_to_draft", is_draft=True), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        field_writes = self._field_writes(calls, "ISSUE_ITEM")
+        self.assertEqual(len(field_writes), 1)
+        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")  # Working
+
+    # --- F10: removal on `opened` and each transition, asserted individually.
+    # A subTest loop over the three actions never varies `action` inside the
+    # fake/assertions, so it cannot catch a mutant that only removes on one
+    # specific action -- that is exactly the shape of the hole this closes. ---
+
+    def test_ready_for_review_removes_the_prs_existing_card(self):
+        calls = []
+        existing_issue_item = {"id": "ISSUE_ITEM", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item={"id": "PR_ITEM_RFR", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"},
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        remove_calls = self._remove_calls(calls)
+        self.assertEqual(len(remove_calls), 1)
+        self.assertEqual(remove_calls[0]["body"]["variables"]["itemId"], "PR_ITEM_RFR")
+
+    def test_converted_to_draft_removes_the_prs_existing_card(self):
+        calls = []
+        existing_issue_item = {"id": "ISSUE_ITEM", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item={"id": "PR_ITEM_CTD", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"},
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        run_main(_pr_event("converted_to_draft", is_draft=True), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        remove_calls = self._remove_calls(calls)
+        self.assertEqual(len(remove_calls), 1)
+        self.assertEqual(remove_calls[0]["body"]["variables"]["itemId"], "PR_ITEM_CTD")
+
+    def test_reopened_removes_the_prs_existing_card(self):
+        calls = []
+        existing_issue_item = {"id": "ISSUE_ITEM", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item={"id": "PR_ITEM_REOPENED", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"},
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        run_main(_pr_event("reopened", is_draft=True), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        remove_calls = self._remove_calls(calls)
+        self.assertEqual(len(remove_calls), 1)
+        self.assertEqual(remove_calls[0]["body"]["variables"]["itemId"], "PR_ITEM_REOPENED")
+
+    def test_a_parked_linked_issue_is_not_moved(self):
+        calls = []
+        existing_issue_item = {"id": "ISSUE_ITEM", "status": "⛔️ Blocked", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        self.assertEqual(self._field_writes(calls, "ISSUE_ITEM"), [])
+        self.assertEqual(self._add_calls(calls), [])
+
+    def test_a_pr_closing_two_issues_moves_both_and_still_gets_no_card(self):
+        calls = []
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}, {"id": "ISSUE_B", "number": 11}],
+            issue_items={"ISSUE_A": None, "ISSUE_B": None},
+            add_item_ids={"ISSUE_A": "NEW_A", "ISSUE_B": "NEW_B"},
+        )
+
+        run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        add_calls = self._add_calls(calls)
+        self.assertEqual({c["body"]["variables"]["contentId"] for c in add_calls}, {"ISSUE_A", "ISSUE_B"})
+        self.assertEqual(len(self._field_writes(calls, "NEW_A")), 3)
+        self.assertEqual(len(self._field_writes(calls, "NEW_B")), 3)
+
+    def test_a_pr_closing_two_already_boarded_issues_sets_status_only_on_both(self):
+        """Review gap: the two-issue test above used two UNBOARDED issues,
+        never exercising the existing-card path for more than one issue at
+        once."""
+        calls = []
+        existing_a = {"id": "ISSUE_ITEM_A", "status": "🛠️ Working", "team": "Analysis", "sprint": "Sprint 259"}
+        existing_b = {"id": "ISSUE_ITEM_B", "status": "🛠️ Working", "team": "Delivery", "sprint": "Sprint 259"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}, {"id": "ISSUE_B", "number": 11}],
+            issue_items={"ISSUE_A": existing_a, "ISSUE_B": existing_b},
+        )
+
+        run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        self.assertEqual(self._add_calls(calls), [], "neither existing issue card should be re-added")
+
+        for item_id in ("ISSUE_ITEM_A", "ISSUE_ITEM_B"):
+            field_writes = self._field_writes(calls, item_id)
+            self.assertEqual(len(field_writes), 1)
+            self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+            self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")  # Review
+
+    # --- synchronize on a closing PR: writes NOTHING anywhere -- not the PR's
+    # card (not even removal), not any issue's [owner ruling, fixes review
+    # finding F1: a push must never leave zero cards for the same work] ---
+
+    def test_synchronize_on_a_closing_pr_makes_no_write_and_no_removal_anywhere(self):
+        calls = []
+        pr_item = {"id": "PR_ITEM", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=pr_item,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": {"id": "ISSUE_ITEM", "status": None, "team": None, "sprint": None}},
+        )
+
+        run_main(_pr_event("synchronize", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        self.assertFalse(
+            any(call["body"]["variables"].get("contentId") == "ISSUE_A" for call in calls if call["body"]),
+            "synchronize must never even look up a linked issue's item",
+        )
+        self.assertEqual(self._field_writes(calls, "ISSUE_ITEM"), [])
+        self.assertEqual(self._field_writes(calls, "PR_ITEM"), [])
+        self.assertEqual(self._add_calls(calls), [])
+        self.assertEqual(self._remove_calls(calls), [], "a push must never remove the PR's own card")
+
+    def test_synchronize_f1_a_closing_pr_with_a_card_against_an_unboarded_issue_keeps_its_card(self):
+        """Review finding F1: removing the PR's card on a push while never
+        adding the issue's would leave zero cards for the same work. This is
+        the exact scenario the fix (excluding synchronize from
+        PR_CARD_REMOVAL_ACTIONS) closes."""
+        calls = []
+        pr_item = {"id": "PR_ITEM", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=pr_item,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": None},
+            add_item_ids={"ISSUE_A": "NEW_ISSUE_ITEM"},
+        )
+
+        run_main(_pr_event("synchronize", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        self.assertEqual(self._remove_calls(calls), [], "the PR's own card must survive a synchronize")
+        self.assertEqual(self._add_calls(calls), [], "the unboarded issue must not be added by synchronize either")
+
+    # --- edited: link appears (remove the PR's card, never an issue's) ---
+
+    def test_edited_link_appears_removes_the_prs_card_and_only_it(self):
+        calls = []
+        pr_item = {"id": "PR_ITEM_OLD", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"}
+        existing_issue_item = {"id": "ISSUE_ITEM", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=pr_item,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": existing_issue_item},
+        )
+
+        summary_text, _ = run_main(_pr_event("edited", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        remove_calls = self._remove_calls(calls)
+        self.assertEqual(len(remove_calls), 1)
+        self.assertEqual(remove_calls[0]["body"]["variables"]["itemId"], "PR_ITEM_OLD")
+        self.assertEqual(self._field_writes(calls, "ISSUE_ITEM"), [], "edited never touches an existing issue card")
+
+        self.assertIn("PR card removed", summary_text)
+        self.assertIn("PR_ITEM_OLD", summary_text)
+        self.assertIn("Review", summary_text)
+        self.assertIn("Dev", summary_text)
+        self.assertIn("Sprint 260", summary_text)
+
+    def test_edited_adds_and_fills_a_missing_issue_card_but_leaves_status_unwritten(self):
+        calls = []
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_B", "number": 11}],
+            issue_items={"ISSUE_B": None},
+            add_item_ids={"ISSUE_B": "NEW_ISSUE"},
+        )
+
+        run_main(_pr_event("edited", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        self.assertEqual(self._add_calls(calls)[0]["body"]["variables"]["contentId"], "ISSUE_B")
+        field_writes = self._field_writes(calls, "NEW_ISSUE")
+        written_field_ids = {call["body"]["variables"]["fieldId"] for call in field_writes}
+        self.assertEqual(written_field_ids, {pr_triage.TEAM_FIELD_ID, pr_triage.SPRINT_FIELD_ID})
+
+    # --- edited: link disappears (the PR is boarded exactly like any other) ---
+
+    def test_edited_link_disappears_reboards_the_pr_normally(self):
+        calls = []
+        fake = make_fake_http_request_for_redirect(calls, pr_item=None, closing_issues=[], add_item_ids={"PR_node": "NEW_PR_ITEM"})
+
+        run_main(_pr_event("edited", is_draft=True), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        add_calls = self._add_calls(calls)
+        self.assertEqual(len(add_calls), 1)
+        self.assertEqual(add_calls[0]["body"]["variables"]["contentId"], "PR_node")
+        self.assertEqual(self._remove_calls(calls), [])
+
+        # Review gap: the re-add was asserted, but not that it is FILLED --
+        # a mutant that adds an empty card survived without this.
+        field_writes = self._field_writes(calls, "NEW_PR_ITEM")
+        written_field_ids = {call["body"]["variables"]["fieldId"] for call in field_writes}
+        self.assertEqual(
+            written_field_ids, {pr_triage.STATUS_FIELD_ID, pr_triage.TEAM_FIELD_ID, pr_triage.SPRINT_FIELD_ID}
+        )
+        status_write = next(c for c in field_writes if c["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "47fc9ee4")  # Working, is_draft=True
+
+    def test_add_remove_add_cycle_is_stable_not_one_shot(self):
+        """The ticket calls this out explicitly: adding closes #N removes the
+        PR's card, removing it re-boards and fills the PR, adding it again
+        removes the NEW card too. Three independent edited events, each
+        reflecting the board state the previous one would have left."""
+        # Step 1: closes present, PR already has a card -> removed.
+        calls_1 = []
+        fake_1 = make_fake_http_request_for_redirect(
+            calls_1,
+            pr_item={"id": "PR_ITEM_1", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"},
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": {"id": "ISSUE_ITEM_A", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 260"}},
+        )
+        run_main(_pr_event("edited", is_draft=False), http_request=fake_1, current_date=datetime.date(2026, 8, 8))
+        self.assertEqual(len(self._remove_calls(calls_1)), 1)
+        self.assertEqual(self._remove_calls(calls_1)[0]["body"]["variables"]["itemId"], "PR_ITEM_1")
+
+        # Step 2: closes removed, PR has no card -> re-added and filled.
+        calls_2 = []
+        fake_2 = make_fake_http_request_for_redirect(
+            calls_2, pr_item=None, closing_issues=[], add_item_ids={"PR_node": "PR_ITEM_2"}
+        )
+        run_main(_pr_event("edited", is_draft=False), http_request=fake_2, current_date=datetime.date(2026, 8, 8))
+        add_calls_2 = self._add_calls(calls_2)
+        self.assertEqual(len(add_calls_2), 1)
+        self.assertEqual(add_calls_2[0]["body"]["variables"]["contentId"], "PR_node")
+        self.assertEqual(self._remove_calls(calls_2), [])
+
+        # Step 3: closes added again, PR now has the card step 2 created -> removed again.
+        calls_3 = []
+        fake_3 = make_fake_http_request_for_redirect(
+            calls_3,
+            pr_item={"id": "PR_ITEM_2", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"},
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": {"id": "ISSUE_ITEM_A", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 260"}},
+        )
+        run_main(_pr_event("edited", is_draft=False), http_request=fake_3, current_date=datetime.date(2026, 8, 8))
+        remove_calls_3 = self._remove_calls(calls_3)
+        self.assertEqual(len(remove_calls_3), 1)
+        self.assertEqual(remove_calls_3[0]["body"]["variables"]["itemId"], "PR_ITEM_2")
+
+    # --- the mutant this ticket names explicitly: the removal call must
+    # carry the PR's item id, never an issue's ---
+
+    def test_removal_call_uses_the_prs_item_id_never_an_issues(self):
+        calls = []
+        pr_item = {"id": "PR_ITEM", "status": "🔍 Review", "team": "Dev", "sprint": "Sprint 260"}
+        issue_item = {"id": "ISSUE_ITEM", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 260"}
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=pr_item,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            issue_items={"ISSUE_A": issue_item},
+        )
+
+        run_main(_pr_event("edited", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        remove_calls = self._remove_calls(calls)
+        self.assertEqual(len(remove_calls), 1)
+        self.assertEqual(remove_calls[0]["body"]["variables"]["itemId"], "PR_ITEM")
+        self.assertNotEqual(remove_calls[0]["body"]["variables"]["itemId"], "ISSUE_ITEM")
+
+    # --- a sidebar-only link never redirects (owner ruling, keyword-only) ---
+
+    def test_a_sidebar_only_linked_issue_does_not_redirect_the_pr_gets_its_own_card(self):
+        calls = []
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_A", "number": 10}],
+            user_linked_issues=[{"id": "ISSUE_A", "number": 10}],
+            add_item_ids={"PR_node": "NEW_PR_ITEM"},
+        )
+
+        run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        add_calls = self._add_calls(calls)
+        self.assertEqual(len(add_calls), 1)
+        self.assertEqual(add_calls[0]["body"]["variables"]["contentId"], "PR_node")
+        self.assertEqual(self._remove_calls(calls), [])
+
+    def test_a_keyword_and_a_sidebar_link_together_redirect_on_the_keyword_one_only(self):
+        calls = []
+        fake = make_fake_http_request_for_redirect(
+            calls,
+            pr_item=None,
+            closing_issues=[{"id": "ISSUE_KEYWORD", "number": 10}, {"id": "ISSUE_SIDEBAR", "number": 11}],
+            user_linked_issues=[{"id": "ISSUE_SIDEBAR", "number": 11}],
+            issue_items={"ISSUE_KEYWORD": None},
+            add_item_ids={"ISSUE_KEYWORD": "NEW_ISSUE_ITEM"},
+        )
+
+        run_main(_pr_event("ready_for_review", is_draft=False), http_request=fake, current_date=datetime.date(2026, 8, 8))
+
+        add_calls = self._add_calls(calls)
+        self.assertEqual(len(add_calls), 1)
+        self.assertEqual(add_calls[0]["body"]["variables"]["contentId"], "ISSUE_KEYWORD")
+
+
 class BoardUpdateWritesStepSummaryOnFailureTest(unittest.TestCase):
     def test_step_summary_is_written_and_error_reraised_when_a_board_write_fails(self):
 
@@ -1691,6 +2400,12 @@ class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
 
 
 class FindBoardItemForPrTest(unittest.TestCase):
+    """find_board_item_for_pr now returns {"item", "closing_issues"} rather
+    than the item alone -- ticket 05 rides closingIssuesReferences on this
+    same query. See ClosingIssuesReferencesTest below for that half; these
+    fixtures omit the field entirely (as an Issue-fragment response would),
+    proving the parser tolerates its absence."""
+
     def test_returns_the_matching_project_item_with_its_current_status_team_and_sprint(self):
         response = {
             "data": {
@@ -1717,12 +2432,14 @@ class FindBoardItemForPrTest(unittest.TestCase):
             }
         }
         with mock.patch.object(pr_triage, "http_request", return_value=response):
-            item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+            result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
+        item = result["item"]
         self.assertEqual(item["id"], "EXISTING_ITEM")
         self.assertEqual(item["status"], "🛠️ Working")
         self.assertEqual(item["team"], "Dev")
         self.assertEqual(item["sprint"], "Sprint 260")
+        self.assertEqual(result["closing_issues"], [])
 
     def test_returns_none_when_pr_has_no_item_on_this_board(self):
         response = {
@@ -1743,16 +2460,16 @@ class FindBoardItemForPrTest(unittest.TestCase):
             }
         }
         with mock.patch.object(pr_triage, "http_request", return_value=response):
-            item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+            result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
-        self.assertIsNone(item)
+        self.assertIsNone(result["item"])
 
     def test_returns_none_when_pr_has_no_items_at_all(self):
         response = {"data": {"node": {"projectItems": {"nodes": []}}}}
         with mock.patch.object(pr_triage, "http_request", return_value=response):
-            item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+            result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
-        self.assertIsNone(item)
+        self.assertIsNone(result["item"])
 
     def test_status_team_and_sprint_are_none_when_the_fields_are_unset(self):
         response = {
@@ -1773,12 +2490,111 @@ class FindBoardItemForPrTest(unittest.TestCase):
             }
         }
         with mock.patch.object(pr_triage, "http_request", return_value=response):
-            item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+            result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
 
+        item = result["item"]
         self.assertEqual(item["id"], "EXISTING_ITEM")
         self.assertIsNone(item["status"])
         self.assertIsNone(item["team"])
         self.assertIsNone(item["sprint"])
+
+
+class ClosingIssuesReferencesTest(unittest.TestCase):
+    """closingIssuesReferences (both the unfiltered and userLinkedOnly=true
+    variants) rides the same node(id:) query as projectItems -- one round
+    trip, see notes/github-facts.md §7-8 for the live probes. The returned
+    closing_issues is already the KEYWORD-derived set (keyword_closing_issues
+    applied); KeywordClosingIssuesTest above covers the subtraction itself."""
+
+    def test_returns_the_closing_issues_when_present_and_none_are_user_linked(self):
+        response = {
+            "data": {
+                "node": {
+                    "projectItems": {"nodes": []},
+                    "closingIssuesReferences": {"nodes": [{"id": "ISSUE_A", "number": 42}]},
+                    "userLinkedClosingIssues": {"nodes": []},
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertEqual(result["closing_issues"], [{"id": "ISSUE_A", "number": 42}])
+
+    def test_returns_all_linked_issues_for_a_pr_closing_more_than_one(self):
+        response = {
+            "data": {
+                "node": {
+                    "projectItems": {"nodes": []},
+                    "closingIssuesReferences": {
+                        "nodes": [{"id": "ISSUE_A", "number": 42}, {"id": "ISSUE_B", "number": 43}]
+                    },
+                    "userLinkedClosingIssues": {"nodes": []},
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertEqual(result["closing_issues"], [{"id": "ISSUE_A", "number": 42}, {"id": "ISSUE_B", "number": 43}])
+
+    def test_a_sidebar_only_link_is_excluded(self):
+        """all == userLinked, exactly as the live probe recorded for a
+        sidebar-only PR (notes/github-facts.md §8, PR #6602)."""
+        response = {
+            "data": {
+                "node": {
+                    "projectItems": {"nodes": []},
+                    "closingIssuesReferences": {"nodes": [{"id": "ISSUE_A", "number": 42}]},
+                    "userLinkedClosingIssues": {"nodes": [{"id": "ISSUE_A", "number": 42}]},
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertEqual(result["closing_issues"], [])
+
+    def test_empty_list_when_the_field_is_present_but_empty(self):
+        response = {
+            "data": {
+                "node": {
+                    "projectItems": {"nodes": []},
+                    "closingIssuesReferences": {"nodes": []},
+                    "userLinkedClosingIssues": {"nodes": []},
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            result = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertEqual(result["closing_issues"], [])
+
+    def test_empty_list_when_the_field_is_absent_entirely_as_an_issue_node_would_be(self):
+        response = {"data": {"node": {"projectItems": {"nodes": []}}}}
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            result = pr_triage.find_board_item_for_pr("ISSUE_node", "board-token")
+
+        self.assertEqual(result["closing_issues"], [])
+
+    def test_the_query_asks_for_projectitems_and_both_closing_issue_variants_in_one_call(self):
+        response = {
+            "data": {
+                "node": {
+                    "projectItems": {"nodes": []},
+                    "closingIssuesReferences": {"nodes": []},
+                    "userLinkedClosingIssues": {"nodes": []},
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response) as mock_request:
+            pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertEqual(mock_request.call_count, 1)
+        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
+        self.assertIn("projectItems", called_body["query"])
+        self.assertIn("closingIssuesReferences", called_body["query"])
+        self.assertIn("userLinkedOnly: true", called_body["query"])
 
 
 class FetchProjectIterationsTest(unittest.TestCase):
@@ -1812,6 +2628,25 @@ class SetProjectFieldIterationTest(unittest.TestCase):
         self.assertEqual(called_body["variables"]["iterationId"], "bd551114")
         self.assertIn("iterationId", called_body["query"])
         self.assertNotIn("singleSelectOptionId", called_body["query"])
+
+
+class RemoveItemFromBoardTest(unittest.TestCase):
+    """The story's one removal (aim 6): remove_item_from_board, called only
+    with the PR's own item id -- never an issue's. The GraphQL mutation
+    keeps GitHub's real name, deleteProjectV2Item; only our identifier
+    changed (owner ruling: "delete" reads as "delete the pull request")."""
+
+    def test_removes_the_given_item_from_board_15(self):
+        with mock.patch.object(
+            pr_triage, "http_request", return_value={"data": {"deleteProjectV2Item": {"deletedItemId": "PR_ITEM"}}}
+        ) as mock_request:
+            pr_triage.remove_item_from_board("PR_ITEM", "board-token")
+
+        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
+        self.assertIn("deleteProjectV2Item", called_body["query"])
+        self.assertEqual(called_body["variables"]["projectId"], pr_triage.BOARD_PROJECT_ID)
+        self.assertEqual(called_body["variables"]["itemId"], "PR_ITEM")
+        self.assertEqual(mock_request.call_args.kwargs.get("token") or mock_request.call_args.args[1], "board-token")
 
 
 class NullNodeIsRaisedActionablyTest(unittest.TestCase):
@@ -2125,6 +2960,22 @@ class ValidateMainRunsOfflineWithoutBoardTokenTest(unittest.TestCase):
                     validate_pr_triage_teams.main(repo_root=repo_root)
 
         self.assertNotEqual(context.exception.code, 0)
+
+
+class WorkflowIncludesEditedInPullRequestTypesTest(unittest.TestCase):
+    """Ticket 05: the link can appear or disappear after open, so `edited`
+    must be seen the moment it happens, not at the next push."""
+
+    def test_edited_is_a_triggering_type_and_reaches_the_board_update_handler(self):
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
+        with open(workflow_path, encoding="utf-8") as handle:
+            workflow_text = handle.read()
+
+        types_line = next(line for line in workflow_text.splitlines() if "types:" in line)
+        self.assertIn("edited", types_line)
+
+        self.assertIn("edited", pr_triage.BOARD_UPDATE_ACTIONS)
 
 
 class WorkflowHasAPerPrConcurrencyGroupTest(unittest.TestCase):

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -1,0 +1,1077 @@
+import json
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pr_triage
+import validate_pr_triage_teams
+
+
+class DecidePrTriageTest(unittest.TestCase):
+    def test_known_author_is_assigned_drafted_and_boarded_working(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage.decide(author_login="mswertz", is_draft=False, mapping=mapping)
+
+        self.assertTrue(decision["known"])
+        self.assertTrue(decision["assign"])
+        self.assertTrue(decision["force_draft"])
+        self.assertEqual(decision["status"], "Working")
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_known_author_mapped_to_delivery_boards_under_delivery(self):
+        mapping = {"hslh": "Delivery"}
+
+        decision = pr_triage.decide(author_login="hslh", is_draft=True, mapping=mapping)
+
+        self.assertTrue(decision["known"])
+        self.assertEqual(decision["team"], "Delivery")
+
+    def test_unknown_author_is_boarded_review_dev_without_assign_or_draft(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage.decide(author_login="some-outside-contributor", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+        self.assertFalse(decision["assign"])
+        self.assertFalse(decision["force_draft"])
+        self.assertEqual(decision["status"], "Review")
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_unknown_author_already_draft_is_still_not_touched(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage.decide(author_login="some-outside-contributor", is_draft=True, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+        self.assertFalse(decision["assign"])
+        self.assertFalse(decision["force_draft"])
+        self.assertEqual(decision["status"], "Review")
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_bot_author_is_unknown_regardless_of_login_shape(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage.decide(author_login="dependabot[bot]", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+        self.assertFalse(decision["assign"])
+        self.assertEqual(decision["status"], "Review")
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_known_author_already_draft_is_not_re_converted(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage.decide(author_login="mswertz", is_draft=True, mapping=mapping)
+
+        self.assertTrue(decision["known"])
+        self.assertFalse(decision["force_draft"])
+
+    def test_known_author_ready_for_review_is_converted_to_draft(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage.decide(author_login="mswertz", is_draft=False, mapping=mapping)
+
+        self.assertTrue(decision["known"])
+        self.assertTrue(decision["force_draft"])
+
+    def test_empty_team_value_is_treated_as_unknown(self):
+        mapping = {"someuser": ""}
+
+        decision = pr_triage.decide(author_login="someuser", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+        self.assertFalse(decision["assign"])
+        self.assertFalse(decision["force_draft"])
+        self.assertEqual(decision["status"], "Review")
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_whitespace_only_team_value_is_treated_as_unknown(self):
+        mapping = {"someuser": "   "}
+
+        decision = pr_triage.decide(author_login="someuser", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+
+    def test_login_matching_is_exact_case_and_can_only_ever_miss(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage.decide(author_login="Mswertz", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+
+
+class DecideTransitionTest(unittest.TestCase):
+    def test_ready_for_review_moves_status_to_review(self):
+        transition = pr_triage.decide_transition("ready_for_review")
+
+        self.assertEqual(transition["status"], pr_triage.UNKNOWN_AUTHOR_STATUS)
+        self.assertEqual(transition["status"], "Review")
+
+    def test_converted_to_draft_moves_status_to_working(self):
+        transition = pr_triage.decide_transition("converted_to_draft")
+
+        self.assertEqual(transition["status"], pr_triage.KNOWN_AUTHOR_STATUS)
+        self.assertEqual(transition["status"], "Working")
+
+    def test_opened_is_not_a_transition(self):
+        self.assertIsNone(pr_triage.decide_transition("opened"))
+
+    def test_reopened_is_not_a_transition(self):
+        self.assertIsNone(pr_triage.decide_transition("reopened"))
+
+
+class StripEmojiPrefixTest(unittest.TestCase):
+    def test_strips_leading_emoji_and_whitespace(self):
+        self.assertEqual(pr_triage.strip_emoji_prefix("\U0001f6e0️ Working"), "Working")
+
+    def test_leaves_plain_name_unchanged(self):
+        self.assertEqual(pr_triage.strip_emoji_prefix("Icebox"), "Icebox")
+
+
+class FindOptionIdByNameTest(unittest.TestCase):
+    def test_matches_status_option_ignoring_emoji_prefix(self):
+        options = [
+            {"name": "\U0001f6e0️ Working", "id": "47fc9ee4"},
+            {"name": "\U0001f50d Review", "id": "879449e7"},
+        ]
+
+        option_id = pr_triage.find_option_id_by_name(options, "Working", strip_emoji=True)
+
+        self.assertEqual(option_id, "47fc9ee4")
+
+    def test_matches_team_option_by_exact_name(self):
+        options = [{"name": "Dev", "id": "f2a5529c"}, {"name": "Delivery", "id": "34b176a9"}]
+
+        option_id = pr_triage.find_option_id_by_name(options, "Delivery", strip_emoji=False)
+
+        self.assertEqual(option_id, "34b176a9")
+
+    def test_raises_with_full_option_list_when_name_does_not_resolve(self):
+        options = [{"name": "Dev", "id": "f2a5529c"}]
+
+        with self.assertRaises(ValueError) as context:
+            pr_triage.find_option_id_by_name(options, "Nonexistent", strip_emoji=False)
+
+        self.assertIn("Dev", str(context.exception))
+        self.assertIn("Nonexistent", str(context.exception))
+
+
+class ParseTeamsMappingTest(unittest.TestCase):
+    def test_parses_flat_login_to_team_mapping(self):
+        text = (
+            "# header comment\n"
+            "teams:\n"
+            "  mswertz: Dev\n"
+            "  hslh: Delivery\n"
+        )
+
+        mapping = pr_triage.parse_teams_mapping(text)
+
+        self.assertEqual(mapping, {"mswertz": "Dev", "hslh": "Delivery"})
+
+    def test_ignores_blank_lines_and_trailing_comments(self):
+        text = (
+            "teams:\n"
+            "\n"
+            "  mswertz: Dev\n"
+        )
+
+        mapping = pr_triage.parse_teams_mapping(text)
+
+        self.assertEqual(mapping, {"mswertz": "Dev"})
+
+
+class ValidateNoBotOrMachineLoginsTest(unittest.TestCase):
+    def test_flags_a_bot_login(self):
+        mapping = {"dependabot[bot]": "Dev"}
+
+        errors = validate_pr_triage_teams.find_bot_or_machine_logins(mapping)
+
+        self.assertEqual(errors, ["dependabot[bot]"])
+
+    def test_flags_the_known_machine_accounts(self):
+        mapping = {"JV-CI-CD": "Dev", "molgenis-jenkins": "Dev"}
+
+        errors = validate_pr_triage_teams.find_bot_or_machine_logins(mapping)
+
+        self.assertCountEqual(errors, ["JV-CI-CD", "molgenis-jenkins"])
+
+    def test_passes_a_clean_mapping(self):
+        mapping = {"mswertz": "Dev"}
+
+        errors = validate_pr_triage_teams.find_bot_or_machine_logins(mapping)
+
+        self.assertEqual(errors, [])
+
+
+class ValidateTeamValuesTest(unittest.TestCase):
+    def test_flags_a_team_value_that_is_not_a_live_board_option(self):
+        mapping = {"mswertz": "Nonexistent"}
+
+        errors = validate_pr_triage_teams.find_unknown_team_values(mapping, valid_team_names={"Dev", "Delivery"})
+
+        self.assertEqual(errors, [("mswertz", "Nonexistent")])
+
+    def test_passes_when_every_team_value_is_a_live_option(self):
+        mapping = {"mswertz": "Dev", "hslh": "Delivery"}
+
+        errors = validate_pr_triage_teams.find_unknown_team_values(mapping, valid_team_names={"Dev", "Delivery"})
+
+        self.assertEqual(errors, [])
+
+
+class ValidateBlankTeamValuesTest(unittest.TestCase):
+    def test_flags_an_empty_team_value(self):
+        mapping = {"someuser": ""}
+
+        errors = validate_pr_triage_teams.find_blank_team_values(mapping)
+
+        self.assertEqual(errors, ["someuser"])
+
+    def test_flags_a_whitespace_only_team_value(self):
+        mapping = {"someuser": "   "}
+
+        errors = validate_pr_triage_teams.find_blank_team_values(mapping)
+
+        self.assertEqual(errors, ["someuser"])
+
+    def test_passes_a_non_blank_team_value(self):
+        mapping = {"mswertz": "Dev"}
+
+        errors = validate_pr_triage_teams.find_blank_team_values(mapping)
+
+        self.assertEqual(errors, [])
+
+
+class ValidateStatusOptionTest(unittest.TestCase):
+    def test_passes_when_working_is_a_live_status_option(self):
+        status_options = [{"id": "47fc9ee4", "name": "\U0001f6e0️ Working"}]
+
+        error = validate_pr_triage_teams.find_missing_status_option(status_options, "Working")
+
+        self.assertIsNone(error)
+
+    def test_flags_when_working_is_not_a_live_status_option(self):
+        status_options = [{"id": "98236657", "name": "✅ Done"}]
+
+        error = validate_pr_triage_teams.find_missing_status_option(status_options, "Working")
+
+        self.assertIsNotNone(error)
+
+    def test_passes_when_review_is_a_live_status_option(self):
+        status_options = [{"id": "879449e7", "name": "\U0001f50d Review"}]
+
+        error = validate_pr_triage_teams.find_missing_status_option(status_options, "Review")
+
+        self.assertIsNone(error)
+
+    def test_flags_when_review_is_not_a_live_status_option(self):
+        status_options = [{"id": "98236657", "name": "✅ Done"}]
+
+        error = validate_pr_triage_teams.find_missing_status_option(status_options, "Review")
+
+        self.assertIsNotNone(error)
+
+
+class ValidateTeamOptionTest(unittest.TestCase):
+    def test_passes_when_dev_is_a_live_team_option(self):
+        team_options = [{"id": "f2a5529c", "name": "Dev"}]
+
+        error = validate_pr_triage_teams.find_missing_team_option(team_options, "Dev")
+
+        self.assertIsNone(error)
+
+    def test_flags_when_dev_is_not_a_live_team_option(self):
+        team_options = [{"id": "34b176a9", "name": "Delivery"}]
+
+        error = validate_pr_triage_teams.find_missing_team_option(team_options, "Dev")
+
+        self.assertIsNotNone(error)
+
+
+class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
+    def test_step_summary_is_written_even_when_a_write_raises(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "fake-github-token",
+                "PROJECT_BOARD_TOKEN": "fake-board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "assign_author", side_effect=pr_triage.GraphqlError("boom")
+            ):
+                with self.assertRaises(pr_triage.GraphqlError):
+                    pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("Failure", summary_text)
+        self.assertIn("boom", summary_text)
+
+
+class MainWiringTest(unittest.TestCase):
+    def test_known_author_writes_go_to_the_right_endpoint_field_and_token(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+            if url.endswith("/assignees"):
+                return {"assignees": [{"login": "mswertz"}]}
+            if "convertPullRequestToDraft" in query:
+                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+            if "addProjectV2ItemById" in query:
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "github-token",
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                pr_triage.main()
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        assign_call = next(call for call in calls if call["url"].endswith("/assignees"))
+        self.assertEqual(assign_call["token"], "github-token")
+
+        draft_call = next(call for call in calls if "convertPullRequestToDraft" in query_of(call))
+        self.assertEqual(draft_call["token"], "github-token")
+
+        add_item_call = next(call for call in calls if "addProjectV2ItemById" in query_of(call))
+        self.assertEqual(add_item_call["token"], "board-token")
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 2)
+
+        status_write = field_writes[0]
+        self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_OPT")
+        self.assertEqual(status_write["token"], "board-token")
+
+        team_write = field_writes[1]
+        self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
+        self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_OPT")
+        self.assertEqual(team_write["token"], "board-token")
+
+
+class MainWiringUnknownAuthorTest(unittest.TestCase):
+    def _run_main_for(self, is_draft):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "some-outside-contributor"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": is_draft,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+            if url.endswith("/assignees"):
+                raise AssertionError("unknown author must never be assigned")
+            if "convertPullRequestToDraft" in query:
+                raise AssertionError("unknown author's draft state must never be touched")
+            if "addProjectV2ItemById" in query:
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "STATUS_REVIEW_OPT", "name": "Review"}]}}}
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "TEAM_DEV_OPT", "name": "Dev"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        return calls, summary_text
+
+    def _assert_unknown_author_boarded_correctly(self, calls, summary_text):
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
+        self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+
+        add_item_call = next(call for call in calls if "addProjectV2ItemById" in query_of(call))
+        self.assertEqual(add_item_call["token"], "board-token")
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 2)
+
+        status_write = field_writes[0]
+        self.assertEqual(status_write["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_REVIEW_OPT")
+        self.assertEqual(status_write["token"], "board-token")
+
+        team_write = field_writes[1]
+        self.assertEqual(team_write["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
+        self.assertEqual(team_write["body"]["variables"]["optionId"], "TEAM_DEV_OPT")
+        self.assertEqual(team_write["token"], "board-token")
+
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("| Assignee set | skipped, unknown author is never assigned |", summary_text)
+        self.assertIn(
+            "| Converted to draft | skipped, draft state left untouched for unknown author |", summary_text
+        )
+        self.assertIn("absent from .github/pr-triage-teams.yml", summary_text)
+
+    def test_unknown_author_ready_for_review_is_boarded_without_assign_or_draft(self):
+        calls, summary_text = self._run_main_for(is_draft=False)
+        self._assert_unknown_author_boarded_correctly(calls, summary_text)
+
+    def test_unknown_author_already_draft_is_boarded_without_assign_or_draft(self):
+        calls, summary_text = self._run_main_for(is_draft=True)
+        self._assert_unknown_author_boarded_correctly(calls, summary_text)
+
+
+class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
+    def test_status_and_team_options_are_resolved_before_the_item_is_added(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        call_kinds = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+            if url.endswith("/assignees"):
+                call_kinds.append("assign")
+                return {"assignees": [{"login": "mswertz"}]}
+            if "convertPullRequestToDraft" in query:
+                call_kinds.append("draft")
+                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+            if "addProjectV2ItemById" in query:
+                call_kinds.append("add_item")
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                call_kinds.append("set_field")
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    call_kinds.append("fetch_status_options")
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    call_kinds.append("fetch_team_options")
+                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "github-token",
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                pr_triage.main()
+
+        add_item_index = call_kinds.index("add_item")
+        self.assertLess(call_kinds.index("fetch_status_options"), add_item_index)
+        self.assertLess(call_kinds.index("fetch_team_options"), add_item_index)
+
+    def test_a_resolution_failure_never_adds_a_board_item(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append(url)
+            query = (body or {}).get("query", "")
+            if url.endswith("/assignees"):
+                return {"assignees": [{"login": "mswertz"}]}
+            if "convertPullRequestToDraft" in query:
+                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+            if "addProjectV2ItemById" in query:
+                raise AssertionError("must not add a board item when option resolution fails")
+            if "options { id name }" in query:
+                return {"data": {"node": {"options": [{"id": "SOME_OPT", "name": "NoMatchingOptionHere"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "github-token",
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                with self.assertRaises(ValueError):
+                    pr_triage.main()
+
+
+class MainWiringTransitionTest(unittest.TestCase):
+    def _run_transition(self, action, author_login, item_exists):
+        import tempfile
+
+        event = {
+            "action": action,
+            "pull_request": {
+                "user": {"login": author_login},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": action == "converted_to_draft",
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        calls = []
+        expected_status_name = "Review" if action == "ready_for_review" else "Working"
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+
+            if url.endswith("/assignees"):
+                raise AssertionError("a transition must never touch the assignee")
+            if "convertPullRequestToDraft" in query:
+                raise AssertionError("a transition must never call convertPullRequestToDraft")
+            if "ReadyForReview" in query:
+                raise AssertionError("a transition must never call a ready-conversion mutation")
+
+            if "projectItems" in query:
+                if item_exists:
+                    nodes = [
+                        {
+                            "id": "EXISTING_ITEM",
+                            "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                            "fieldValueByName": {"name": "Working"},
+                        }
+                    ]
+                else:
+                    nodes = []
+                return {"data": {"node": {"projectItems": {"nodes": nodes}}}}
+
+            if "addProjectV2ItemById" in query:
+                if item_exists:
+                    raise AssertionError("must not add an item that already exists")
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "NEW_ITEM"}}}}
+
+            if "updateProjectV2ItemFieldValue" in query:
+                if variables.get("fieldId") == pr_triage.TEAM_FIELD_ID:
+                    raise AssertionError("a transition must never write the Team field")
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM"}}}}
+
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {
+                        "data": {
+                            "node": {
+                                "options": [{"id": "STATUS_OPT_ID", "name": expected_status_name}]
+                            }
+                        }
+                    }
+                raise AssertionError("a transition must never fetch Team options")
+
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        return calls, summary_text
+
+    def _assert_transition_wiring(self, calls, summary_text, item_exists):
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
+        self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+
+        add_item_calls = [call for call in calls if "addProjectV2ItemById" in query_of(call)]
+        if item_exists:
+            self.assertEqual(len(add_item_calls), 0)
+        else:
+            self.assertEqual(len(add_item_calls), 1)
+            self.assertEqual(add_item_calls[0]["token"], "board-token")
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 1)
+        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["token"], "board-token")
+
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("Team", summary_text)
+        self.assertIn("Assignee", summary_text)
+
+    def test_ready_for_review_known_author_existing_item(self):
+        calls, summary_text = self._run_transition("ready_for_review", "mswertz", item_exists=True)
+        self._assert_transition_wiring(calls, summary_text, item_exists=True)
+
+    def test_ready_for_review_unknown_author_no_existing_item(self):
+        calls, summary_text = self._run_transition("ready_for_review", "some-outside-contributor", item_exists=False)
+        self._assert_transition_wiring(calls, summary_text, item_exists=False)
+
+    def test_converted_to_draft_known_author_existing_item(self):
+        calls, summary_text = self._run_transition("converted_to_draft", "mswertz", item_exists=True)
+        self._assert_transition_wiring(calls, summary_text, item_exists=True)
+
+    def test_converted_to_draft_unknown_author_no_existing_item(self):
+        calls, summary_text = self._run_transition(
+            "converted_to_draft", "some-outside-contributor", item_exists=False
+        )
+        self._assert_transition_wiring(calls, summary_text, item_exists=False)
+
+
+class MainReadsAssignDecisionTest(unittest.TestCase):
+    def test_main_does_not_assign_when_decision_says_not_to(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        forced_decision = {
+            "known": True,
+            "assign": False,
+            "force_draft": False,
+            "status": "Working",
+            "team": "Dev",
+        }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+            if "addProjectV2ItemById" in query:
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "github-token",
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ), mock.patch.object(pr_triage, "decide", return_value=forced_decision):
+                pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
+        self.assertIn("| Assignee set | skipped, not required by decision |", summary_text)
+
+
+class FindBoardItemForPrTest(unittest.TestCase):
+    def test_returns_the_matching_project_item_and_its_current_status(self):
+        response = {
+            "data": {
+                "node": {
+                    "projectItems": {
+                        "nodes": [
+                            {
+                                "id": "OTHER_ITEM",
+                                "project": {"id": "PVT_someOtherBoard"},
+                                "fieldValueByName": {"name": "Done"},
+                            },
+                            {
+                                "id": "EXISTING_ITEM",
+                                "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                                "fieldValueByName": {"name": "Working"},
+                            },
+                        ]
+                    }
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertEqual(item["id"], "EXISTING_ITEM")
+        self.assertEqual(item["old_status"], "Working")
+
+    def test_returns_none_when_pr_has_no_item_on_this_board(self):
+        response = {
+            "data": {
+                "node": {
+                    "projectItems": {
+                        "nodes": [
+                            {
+                                "id": "OTHER_ITEM",
+                                "project": {"id": "PVT_someOtherBoard"},
+                                "fieldValueByName": {"name": "Done"},
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertIsNone(item)
+
+    def test_returns_none_when_pr_has_no_items_at_all(self):
+        response = {"data": {"node": {"projectItems": {"nodes": []}}}}
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertIsNone(item)
+
+    def test_old_status_is_none_when_status_field_is_unset(self):
+        response = {
+            "data": {
+                "node": {
+                    "projectItems": {
+                        "nodes": [
+                            {
+                                "id": "EXISTING_ITEM",
+                                "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                                "fieldValueByName": None,
+                            }
+                        ]
+                    }
+                }
+            }
+        }
+        with mock.patch.object(pr_triage, "http_request", return_value=response):
+            item = pr_triage.find_board_item_for_pr("PR_node", "board-token")
+
+        self.assertEqual(item["id"], "EXISTING_ITEM")
+        self.assertIsNone(item["old_status"])
+
+
+class GraphqlRequestErrorHandlingTest(unittest.TestCase):
+    def test_raises_when_response_body_carries_errors_despite_http_200(self):
+        errors_payload = [{"message": "Resource not accessible - requires one of the following scopes: ['project']"}]
+        with mock.patch.object(pr_triage, "http_request", return_value={"data": None, "errors": errors_payload}):
+            with self.assertRaises(pr_triage.GraphqlError) as context:
+                pr_triage.graphql_request("query {}", {}, "token")
+
+        self.assertIn("requires one of the following scopes", str(context.exception))
+
+    def test_passes_through_a_clean_response(self):
+        with mock.patch.object(pr_triage, "http_request", return_value={"data": {"ok": True}}):
+            result = pr_triage.graphql_request("query {}", {}, "token")
+
+        self.assertEqual(result, {"data": {"ok": True}})
+
+
+class IsCredentialErrorTest(unittest.TestCase):
+    def test_401_is_a_credential_error(self):
+        self.assertTrue(validate_pr_triage_teams.is_credential_error(_FakeHttpError(401)))
+
+    def test_403_is_a_credential_error(self):
+        self.assertTrue(validate_pr_triage_teams.is_credential_error(_FakeHttpError(403)))
+
+    def test_500_is_not_a_credential_error(self):
+        self.assertFalse(validate_pr_triage_teams.is_credential_error(_FakeHttpError(500)))
+
+
+class _FakeHttpError(Exception):
+    def __init__(self, code):
+        super().__init__(f"HTTP {code}")
+        self.code = code
+
+
+class FindBannedTermsInSourceTest(unittest.TestCase):
+    def test_flags_author_association(self):
+        source_text = "if: github.event.pull_request.author_association == 'OWNER'\n"
+
+        found = validate_pr_triage_teams.find_banned_terms_in_source(source_text)
+
+        self.assertEqual(found, ["author_association"])
+
+    def test_flags_user_type(self):
+        source_text = "if pull_request.user.type == 'Bot':\n    pass\n"
+
+        found = validate_pr_triage_teams.find_banned_terms_in_source(source_text)
+
+        self.assertEqual(found, ["user.type"])
+
+    def test_flags_collaborators_endpoint(self):
+        source_text = "url = f'{GITHUB_API_URL}/repos/{repo}/collaborators/{login}/permission'\n"
+
+        found = validate_pr_triage_teams.find_banned_terms_in_source(source_text)
+
+        self.assertEqual(found, ["/collaborators"])
+
+    def test_flags_double_quoted_python_user_type_subscript(self):
+        source_text = 'author_type = pull_request["user"]["type"]\n'
+
+        found = validate_pr_triage_teams.find_banned_terms_in_source(source_text)
+
+        self.assertEqual(found, ['["user"]["type"]'])
+
+    def test_flags_single_quoted_python_user_type_subscript(self):
+        source_text = "author_type = pull_request['user']['type']\n"
+
+        found = validate_pr_triage_teams.find_banned_terms_in_source(source_text)
+
+        self.assertEqual(found, ["['user']['type']"])
+
+    def test_passes_source_without_banned_terms(self):
+        source_text = "on:\n  pull_request:\n    types: [opened, reopened]\n"
+
+        found = validate_pr_triage_teams.find_banned_terms_in_source(source_text)
+
+        self.assertEqual(found, [])
+
+
+class FindBannedTermsAcrossTriageSourceTest(unittest.TestCase):
+    def _write_clean_triage_source(self, tmp_dir):
+        scripts_dir = os.path.join(tmp_dir, ".github", "scripts")
+        workflows_dir = os.path.join(tmp_dir, ".github", "workflows")
+        os.makedirs(scripts_dir)
+        os.makedirs(workflows_dir)
+        with open(os.path.join(workflows_dir, "pr-triage.yml"), "w", encoding="utf-8") as handle:
+            handle.write("on:\n  pull_request:\n    types: [opened, reopened]\n")
+        with open(os.path.join(scripts_dir, "pr_triage.py"), "w", encoding="utf-8") as handle:
+            handle.write("def decide():\n    pass\n")
+        with open(os.path.join(scripts_dir, "validate_pr_triage_teams.py"), "w", encoding="utf-8") as handle:
+            handle.write("BANNED = ('author_association',)\n")
+        with open(os.path.join(scripts_dir, "test_pr_triage.py"), "w", encoding="utf-8") as handle:
+            handle.write("workflow_text = 'author_association'\n")
+        return scripts_dir, workflows_dir
+
+    def test_flags_a_banned_term_planted_in_a_script_file(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            scripts_dir, _ = self._write_clean_triage_source(tmp_dir)
+            with open(os.path.join(scripts_dir, "pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("if pull_request.author_association == 'OWNER':\n    pass\n")
+
+            findings = validate_pr_triage_teams.find_banned_terms_across_triage_source(tmp_dir)
+
+        self.assertEqual(findings, [("pr_triage.py", ["author_association"])])
+
+    def test_flags_a_banned_term_planted_in_the_workflow_file_itself(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            _, workflows_dir = self._write_clean_triage_source(tmp_dir)
+            with open(os.path.join(workflows_dir, "pr-triage.yml"), "w", encoding="utf-8") as handle:
+                handle.write("if: github.event.pull_request.author_association == 'OWNER'\n")
+
+            findings = validate_pr_triage_teams.find_banned_terms_across_triage_source(tmp_dir)
+
+        self.assertEqual(findings, [("pr-triage.yml", ["author_association"])])
+
+    def test_passes_clean_triage_source(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            self._write_clean_triage_source(tmp_dir)
+
+            findings = validate_pr_triage_teams.find_banned_terms_across_triage_source(tmp_dir)
+
+        self.assertEqual(findings, [])
+
+
+class ValidateMainExitsNonZeroOnBannedTermTest(unittest.TestCase):
+    def test_main_exits_non_zero_when_a_banned_term_is_planted(self):
+        import tempfile
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            repo_root = os.path.join(tmp_dir, "repo")
+            scripts_dir = os.path.join(repo_root, ".github", "scripts")
+            workflows_dir = os.path.join(repo_root, ".github", "workflows")
+            os.makedirs(scripts_dir)
+            os.makedirs(workflows_dir)
+            with open(os.path.join(repo_root, ".github", "pr-triage-teams.yml"), "w", encoding="utf-8") as handle:
+                handle.write("teams:\n  mswertz: Dev\n")
+            with open(os.path.join(workflows_dir, "pr-triage.yml"), "w", encoding="utf-8") as handle:
+                handle.write("if: github.event.pull_request.author_association == 'OWNER'\n")
+            with open(os.path.join(scripts_dir, "pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("def decide():\n    pass\n")
+            with open(os.path.join(scripts_dir, "validate_pr_triage_teams.py"), "w", encoding="utf-8") as handle:
+                handle.write("BANNED = ('author_association',)\n")
+            with open(os.path.join(scripts_dir, "test_pr_triage.py"), "w", encoding="utf-8") as handle:
+                handle.write("workflow_text = 'author_association'\n")
+
+            env = {"PROJECT_BOARD_TOKEN": "board-token"}
+            fake_options = [{"id": "opt", "name": "Dev"}]
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "fetch_project_field_options", return_value=fake_options
+            ):
+                with self.assertRaises(SystemExit) as context:
+                    validate_pr_triage_teams.main(repo_root=repo_root)
+
+        self.assertNotEqual(context.exception.code, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -637,7 +637,7 @@ class ValidateTeamOptionTest(unittest.TestCase):
 
 
 class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
-    def test_assign_failure_does_not_prevent_draft_or_board_writes_and_exits_non_zero(self):
+    def test_assign_failure_skips_the_draft_flip_but_still_boards_review_and_exits_non_zero(self):
         import tempfile
 
         event = {
@@ -659,14 +659,23 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
             query = (body or {}).get("query", "")
             variables = (body or {}).get("variables", {})
             if "convertPullRequestToDraft" in query:
-                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+                raise AssertionError("assignment failure must skip the draft flip entirely")
             if "addProjectV2ItemById" in query:
                 return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
             if "updateProjectV2ItemFieldValue" in query:
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
+                    return {
+                        "data": {
+                            "node": {
+                                "options": [
+                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
+                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
+                                ]
+                            }
+                        }
+                    }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -699,14 +708,20 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
         def query_of(call):
             return (call["body"] or {}).get("query", "")
 
-        self.assertTrue(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+        self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
         self.assertTrue(any("addProjectV2ItemById" in query_of(call) for call in calls))
-        self.assertTrue(any("updateProjectV2ItemFieldValue" in query_of(call) for call in calls))
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        status_write = next(
+            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        )
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_REVIEW_OPT")
 
         self.assertIn("### PR triage", summary_text)
         self.assertIn("boom", summary_text)
         self.assertIn("Board item id", summary_text)
         self.assertIn("Status option id written", summary_text)
+        self.assertIn("| Converted to draft | skipped, assignment failed |", summary_text)
         self.assertIn("Team option id written", summary_text)
 
 
@@ -793,7 +808,7 @@ class MainWiringTest(unittest.TestCase):
 
 
 class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
-    def test_dropped_assignment_does_not_prevent_draft_or_board_writes_and_exits_non_zero(self):
+    def test_dropped_assignment_skips_the_draft_flip_but_still_boards_review_and_exits_non_zero(self):
         import tempfile
 
         event = {
@@ -817,14 +832,23 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
             if url.endswith("/assignees"):
                 return {"assignees": []}
             if "convertPullRequestToDraft" in query:
-                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+                raise AssertionError("a dropped assignment must skip the draft flip entirely")
             if "addProjectV2ItemById" in query:
                 return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
             if "updateProjectV2ItemFieldValue" in query:
                 return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
             if "options { id name }" in query:
                 if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
-                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "🛠️ Working"}]}}}
+                    return {
+                        "data": {
+                            "node": {
+                                "options": [
+                                    {"id": "STATUS_WORKING_OPT", "name": "🛠️ Working"},
+                                    {"id": "STATUS_REVIEW_OPT", "name": "🔍 Review"},
+                                ]
+                            }
+                        }
+                    }
                 if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
                     return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
             raise AssertionError(f"unexpected call: {url} {query}")
@@ -857,12 +881,18 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
         def query_of(call):
             return (call["body"] or {}).get("query", "")
 
-        self.assertTrue(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+        self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
         self.assertTrue(any("addProjectV2ItemById" in query_of(call) for call in calls))
-        self.assertTrue(any("updateProjectV2ItemFieldValue" in query_of(call) for call in calls))
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        status_write = next(
+            call for call in field_writes if call["body"]["variables"]["fieldId"] == pr_triage.STATUS_FIELD_ID
+        )
+        self.assertEqual(status_write["body"]["variables"]["optionId"], "STATUS_REVIEW_OPT")
 
         self.assertIn("### PR triage", summary_text)
         self.assertIn("mswertz", summary_text)
+        self.assertIn("| Converted to draft | skipped, assignment failed |", summary_text)
         self.assertIn("Board item id", summary_text)
 
 

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -2191,15 +2191,25 @@ class WorkflowHasAPerPrConcurrencyGroupTest(unittest.TestCase):
         self.assertNotIn("cancel-in-progress: true", workflow_text)
 
 
-class WorkflowGithubTokenPermissionsAreNarrowedTest(unittest.TestCase):
-    def test_triage_job_no_longer_grants_pull_requests_write(self):
+class WorkflowGithubTokenPermissionsTest(unittest.TestCase):
+    """Assigning a PULL REQUEST needs pull-requests:write as well as issues:write.
+
+    This assertion was once the exact opposite: it pinned the narrower block,
+    on the reasoning that assignment goes through an /issues/ endpoint so only
+    issues:write could be required. A real run disproved it — the assignees
+    call returned 403 "Resource not accessible by integration". The requirement
+    changed, so the check changed with it. issues:write alone is observed to
+    fail; this pair is observed to work; pull-requests:write alone is untried.
+    """
+
+    def test_triage_job_grants_both_permissions_assignment_needs(self):
         repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
         workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
         with open(workflow_path, encoding="utf-8") as handle:
             workflow_text = handle.read()
 
         self.assertIn("issues: write", workflow_text)
-        self.assertNotIn("pull-requests: write", workflow_text)
+        self.assertIn("pull-requests: write", workflow_text)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_triage.py
+++ b/.github/scripts/test_pr_triage.py
@@ -345,7 +345,7 @@ class ValidateTeamOptionTest(unittest.TestCase):
 
 
 class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
-    def test_step_summary_is_written_even_when_a_write_raises(self):
+    def test_assign_failure_does_not_prevent_draft_or_board_writes_and_exits_non_zero(self):
         import tempfile
 
         event = {
@@ -359,6 +359,25 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
             },
             "repository": {"full_name": "molgenis/molgenis-emx2"},
         }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+            if "convertPullRequestToDraft" in query:
+                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+            if "addProjectV2ItemById" in query:
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             event_path = os.path.join(tmp_dir, "event.json")
@@ -376,16 +395,27 @@ class MainWritesStepSummaryOnFailureTest(unittest.TestCase):
 
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "assign_author", side_effect=pr_triage.GraphqlError("boom")
-            ):
-                with self.assertRaises(pr_triage.GraphqlError):
+            ), mock.patch.object(pr_triage, "http_request", side_effect=fake_http_request):
+                with self.assertRaises(SystemExit) as context:
                     pr_triage.main()
 
             with open(summary_path, encoding="utf-8") as handle:
                 summary_text = handle.read()
 
+        self.assertNotEqual(context.exception.code, 0)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        self.assertTrue(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+        self.assertTrue(any("addProjectV2ItemById" in query_of(call) for call in calls))
+        self.assertTrue(any("updateProjectV2ItemFieldValue" in query_of(call) for call in calls))
+
         self.assertIn("### PR triage", summary_text)
-        self.assertIn("Failure", summary_text)
         self.assertIn("boom", summary_text)
+        self.assertIn("Board item id", summary_text)
+        self.assertIn("Status option id written", summary_text)
+        self.assertIn("Team option id written", summary_text)
 
 
 class MainWiringTest(unittest.TestCase):
@@ -451,7 +481,7 @@ class MainWiringTest(unittest.TestCase):
         self.assertEqual(assign_call["token"], "github-token")
 
         draft_call = next(call for call in calls if "convertPullRequestToDraft" in query_of(call))
-        self.assertEqual(draft_call["token"], "github-token")
+        self.assertEqual(draft_call["token"], "board-token")
 
         add_item_call = next(call for call in calls if "addProjectV2ItemById" in query_of(call))
         self.assertEqual(add_item_call["token"], "board-token")
@@ -471,7 +501,7 @@ class MainWiringTest(unittest.TestCase):
 
 
 class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
-    def test_main_raises_and_records_failure_when_github_drops_the_assignment(self):
+    def test_dropped_assignment_does_not_prevent_draft_or_board_writes_and_exits_non_zero(self):
         import tempfile
 
         event = {
@@ -486,10 +516,26 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
             "repository": {"full_name": "molgenis/molgenis-emx2"},
         }
 
+        calls = []
+
         def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
             if url.endswith("/assignees"):
                 return {"assignees": []}
-            raise AssertionError(f"unexpected call: {url}")
+            if "convertPullRequestToDraft" in query:
+                return {"data": {"convertPullRequestToDraft": {"pullRequest": {"id": "PR_node", "isDraft": True}}}}
+            if "addProjectV2ItemById" in query:
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
 
         with tempfile.TemporaryDirectory() as tmp_dir:
             event_path = os.path.join(tmp_dir, "event.json")
@@ -508,15 +554,109 @@ class MainRaisesOnDroppedAssignmentTest(unittest.TestCase):
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
             ):
-                with self.assertRaises(pr_triage.AssignmentDroppedError):
+                with self.assertRaises(SystemExit) as context:
                     pr_triage.main()
 
             with open(summary_path, encoding="utf-8") as handle:
                 summary_text = handle.read()
 
+        self.assertNotEqual(context.exception.code, 0)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        self.assertTrue(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+        self.assertTrue(any("addProjectV2ItemById" in query_of(call) for call in calls))
+        self.assertTrue(any("updateProjectV2ItemFieldValue" in query_of(call) for call in calls))
+
         self.assertIn("### PR triage", summary_text)
-        self.assertIn("Failure", summary_text)
         self.assertIn("mswertz", summary_text)
+        self.assertIn("Board item id", summary_text)
+
+
+class MainDraftFailureStillBoardsAndExitsNonZeroTest(unittest.TestCase):
+    def test_forbidden_draft_conversion_does_not_prevent_assignment_or_board_writes(self):
+        import tempfile
+
+        event = {
+            "action": "opened",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": False,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+            if url.endswith("/assignees"):
+                return {"assignees": [{"login": "mswertz"}]}
+            if "convertPullRequestToDraft" in query:
+                raise pr_triage.GraphqlError(
+                    "GraphQL request returned errors: [{'type': 'FORBIDDEN', "
+                    "'message': 'Resource not accessible by integration'}]"
+                )
+            if "addProjectV2ItemById" in query:
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "ITEM_1"}}}}
+            if "updateProjectV2ItemFieldValue" in query:
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM_1"}}}}
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "STATUS_OPT", "name": "Working"}]}}}
+                if variables["fieldId"] == pr_triage.TEAM_FIELD_ID:
+                    return {"data": {"node": {"options": [{"id": "TEAM_OPT", "name": "Dev"}]}}}
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "GITHUB_TOKEN": "github-token",
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                with self.assertRaises(SystemExit) as context:
+                    pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        self.assertNotEqual(context.exception.code, 0)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        assign_call = next(call for call in calls if call["url"].endswith("/assignees"))
+        self.assertEqual(assign_call["token"], "github-token")
+
+        add_item_call = next(call for call in calls if "addProjectV2ItemById" in query_of(call))
+        self.assertEqual(add_item_call["token"], "board-token")
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 2)
+
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("| Assignee set | True |", summary_text)
+        self.assertIn("FORBIDDEN", summary_text)
+        self.assertIn("Board item id", summary_text)
+        self.assertIn("Status option id written", summary_text)
+        self.assertIn("Team option id written", summary_text)
 
 
 class MappingFilePathTest(unittest.TestCase):
@@ -704,11 +844,153 @@ class MainWiringOpenedStillRunsFullOpenPathTest(unittest.TestCase):
         self.assertEqual(assign_call["token"], "github-token")
 
         draft_call = next(call for call in calls if "convertPullRequestToDraft" in query_of(call))
-        self.assertEqual(draft_call["token"], "github-token")
+        self.assertEqual(draft_call["token"], "board-token")
 
         field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
         self.assertEqual(len(field_writes), 2)
         self.assertEqual(field_writes[1]["body"]["variables"]["fieldId"], pr_triage.TEAM_FIELD_ID)
+
+
+class MainWiringSynchronizeTest(unittest.TestCase):
+    def _run_synchronize(self, is_draft, item_exists):
+        import tempfile
+
+        event = {
+            "action": "synchronize",
+            "pull_request": {
+                "user": {"login": "mswertz"},
+                "head": {"ref": "feature/x"},
+                "number": 1,
+                "node_id": "PR_node",
+                "draft": is_draft,
+            },
+            "repository": {"full_name": "molgenis/molgenis-emx2"},
+        }
+
+        calls = []
+
+        def fake_http_request(url, token, method="GET", body=None):
+            calls.append({"url": url, "token": token, "body": body})
+            query = (body or {}).get("query", "")
+            variables = (body or {}).get("variables", {})
+
+            if url.endswith("/assignees"):
+                raise AssertionError("synchronize must never touch the assignee")
+            if "convertPullRequestToDraft" in query:
+                raise AssertionError("synchronize must never touch the draft state")
+            if "ReadyForReview" in query:
+                raise AssertionError("synchronize must never touch the draft state")
+
+            if "projectItems" in query:
+                if item_exists:
+                    nodes = [
+                        {
+                            "id": "EXISTING_ITEM",
+                            "project": {"id": pr_triage.BOARD_PROJECT_ID},
+                            "fieldValueByName": {"name": "Working"},
+                        }
+                    ]
+                else:
+                    nodes = []
+                return {"data": {"node": {"projectItems": {"nodes": nodes}}}}
+
+            if "addProjectV2ItemById" in query:
+                if item_exists:
+                    raise AssertionError("must not add an item that already exists")
+                return {"data": {"addProjectV2ItemById": {"item": {"id": "NEW_ITEM"}}}}
+
+            if "updateProjectV2ItemFieldValue" in query:
+                if variables.get("fieldId") == pr_triage.TEAM_FIELD_ID:
+                    raise AssertionError("synchronize must never write the Team field")
+                return {"data": {"updateProjectV2ItemFieldValue": {"projectV2Item": {"id": "ITEM"}}}}
+
+            if "options { id name }" in query:
+                if variables["fieldId"] == pr_triage.STATUS_FIELD_ID:
+                    return {"data": {"node": {"options": LIVE_STATUS_OPTIONS}}}
+                raise AssertionError("synchronize must never fetch Team options")
+
+            raise AssertionError(f"unexpected call: {url} {query}")
+
+        with tempfile.TemporaryDirectory() as tmp_dir:
+            event_path = os.path.join(tmp_dir, "event.json")
+            with open(event_path, "w", encoding="utf-8") as handle:
+                json.dump(event, handle)
+            summary_path = os.path.join(tmp_dir, "summary.md")
+            open(summary_path, "w", encoding="utf-8").close()
+
+            env = {
+                "GITHUB_EVENT_PATH": event_path,
+                "PROJECT_BOARD_TOKEN": "board-token",
+                "GITHUB_STEP_SUMMARY": summary_path,
+            }
+
+            with mock.patch.dict(os.environ, env, clear=True), mock.patch.object(
+                pr_triage, "http_request", side_effect=fake_http_request
+            ):
+                pr_triage.main()
+
+            with open(summary_path, encoding="utf-8") as handle:
+                summary_text = handle.read()
+
+        return calls, summary_text
+
+    def _assert_no_forbidden_calls(self, calls):
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        self.assertFalse(any(call["url"].endswith("/assignees") for call in calls))
+        self.assertFalse(any("convertPullRequestToDraft" in query_of(call) for call in calls))
+        self.assertFalse(any(
+            "updateProjectV2ItemFieldValue" in query_of(call)
+            and call["body"]["variables"].get("fieldId") == pr_triage.TEAM_FIELD_ID
+            for call in calls
+        ))
+
+    def test_item_already_exists_does_nothing_at_all(self):
+        calls, summary_text = self._run_synchronize(is_draft=False, item_exists=True)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        self._assert_no_forbidden_calls(calls)
+        self.assertFalse(any("addProjectV2ItemById" in query_of(call) for call in calls))
+        self.assertFalse(any("updateProjectV2ItemFieldValue" in query_of(call) for call in calls))
+
+        self.assertIn("### PR triage", summary_text)
+        self.assertIn("no action", summary_text.lower())
+
+    def test_item_missing_and_draft_adds_and_boards_working(self):
+        calls, summary_text = self._run_synchronize(is_draft=True, item_exists=False)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        self._assert_no_forbidden_calls(calls)
+
+        add_item_calls = [call for call in calls if "addProjectV2ItemById" in query_of(call)]
+        self.assertEqual(len(add_item_calls), 1)
+        self.assertEqual(add_item_calls[0]["token"], "board-token")
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 1)
+        self.assertEqual(field_writes[0]["body"]["variables"]["fieldId"], pr_triage.STATUS_FIELD_ID)
+        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "47fc9ee4")
+        self.assertEqual(field_writes[0]["body"]["variables"]["itemId"], "NEW_ITEM")
+        self.assertEqual(field_writes[0]["token"], "board-token")
+
+        self.assertIn("### PR triage", summary_text)
+
+    def test_item_missing_and_ready_adds_and_boards_review(self):
+        calls, summary_text = self._run_synchronize(is_draft=False, item_exists=False)
+
+        def query_of(call):
+            return (call["body"] or {}).get("query", "")
+
+        self._assert_no_forbidden_calls(calls)
+
+        field_writes = [call for call in calls if "updateProjectV2ItemFieldValue" in query_of(call)]
+        self.assertEqual(len(field_writes), 1)
+        self.assertEqual(field_writes[0]["body"]["variables"]["optionId"], "879449e7")
 
 
 class MainWiringUnknownAuthorTest(unittest.TestCase):
@@ -893,8 +1175,8 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
         calls = []
 
         def fake_http_request(url, token, method="GET", body=None):
-            calls.append(url)
             query = (body or {}).get("query", "")
+            calls.append(query)
             if url.endswith("/assignees"):
                 return {"assignees": [{"login": "mswertz"}]}
             if "convertPullRequestToDraft" in query:
@@ -922,8 +1204,11 @@ class MainResolvesOptionsBeforeAddingBoardItemTest(unittest.TestCase):
             with mock.patch.dict(os.environ, env, clear=False), mock.patch.object(
                 pr_triage, "http_request", side_effect=fake_http_request
             ):
-                with self.assertRaises(ValueError):
+                with self.assertRaises(SystemExit) as context:
                     pr_triage.main()
+
+        self.assertNotEqual(context.exception.code, 0)
+        self.assertFalse(any("addProjectV2ItemById" in query for query in calls))
 
 
 LIVE_STATUS_OPTIONS = [
@@ -1224,7 +1509,7 @@ class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
         import tempfile
 
         event = {
-            "action": "synchronize",
+            "action": "labeled",
             "pull_request": {
                 "user": {"login": "mswertz"},
                 "head": {"ref": "feature/x"},
@@ -1257,7 +1542,7 @@ class MainIgnoresUnrecognizedActionTest(unittest.TestCase):
             with open(summary_path, encoding="utf-8") as handle:
                 summary_text = handle.read()
 
-        self.assertIn("synchronize", summary_text)
+        self.assertIn("labeled", summary_text)
         self.assertIn("no action", summary_text.lower())
 
 
@@ -1660,6 +1945,17 @@ class WorkflowHasAPerPrConcurrencyGroupTest(unittest.TestCase):
         self.assertIn("concurrency:", workflow_text)
         self.assertIn("github.event.pull_request.number", workflow_text)
         self.assertNotIn("cancel-in-progress: true", workflow_text)
+
+
+class WorkflowGithubTokenPermissionsAreNarrowedTest(unittest.TestCase):
+    def test_triage_job_no_longer_grants_pull_requests_write(self):
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+        workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
+        with open(workflow_path, encoding="utf-8") as handle:
+            workflow_text = handle.read()
+
+        self.assertIn("issues: write", workflow_text)
+        self.assertNotIn("pull-requests: write", workflow_text)
 
 
 if __name__ == "__main__":

--- a/.github/scripts/test_pr_triage_decide.py
+++ b/.github/scripts/test_pr_triage_decide.py
@@ -1,0 +1,432 @@
+"""Tests for pr_triage_decide — the pure verdicts.
+
+A test belongs here when the function it exercises needs no network, no clock and
+no environment. This file imports pr_triage_decide and nothing else of ours; if a
+test you are adding needs pr_triage or pr_triage_github, it belongs in their files.
+"""
+
+import datetime
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pr_triage_decide
+
+
+class DecidePrTriageTest(unittest.TestCase):
+    def test_known_author_is_assigned_drafted_and_boarded_working(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage_decide.decide(author_login="mswertz", is_draft=False, mapping=mapping)
+
+        self.assertTrue(decision["known"])
+        self.assertTrue(decision["force_draft"])
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_known_author_mapped_to_delivery_boards_under_delivery(self):
+        mapping = {"hslh": "Delivery"}
+
+        decision = pr_triage_decide.decide(author_login="hslh", is_draft=True, mapping=mapping)
+
+        self.assertTrue(decision["known"])
+        self.assertEqual(decision["team"], "Delivery")
+
+    def test_unknown_author_is_boarded_review_dev_without_assign_or_draft(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage_decide.decide(author_login="some-outside-contributor", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+        self.assertFalse(decision["force_draft"])
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_unknown_author_already_draft_is_still_not_touched(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage_decide.decide(author_login="some-outside-contributor", is_draft=True, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+        self.assertFalse(decision["force_draft"])
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_bot_author_is_unknown_regardless_of_login_shape(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage_decide.decide(author_login="dependabot[bot]", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_known_author_already_draft_is_not_re_converted(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage_decide.decide(author_login="mswertz", is_draft=True, mapping=mapping)
+
+        self.assertTrue(decision["known"])
+        self.assertFalse(decision["force_draft"])
+
+    def test_known_author_ready_for_review_is_converted_to_draft(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage_decide.decide(author_login="mswertz", is_draft=False, mapping=mapping)
+
+        self.assertTrue(decision["known"])
+        self.assertTrue(decision["force_draft"])
+
+    def test_empty_team_value_is_treated_as_unknown(self):
+        mapping = {"someuser": ""}
+
+        decision = pr_triage_decide.decide(author_login="someuser", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+        self.assertFalse(decision["force_draft"])
+        self.assertEqual(decision["team"], "Dev")
+
+    def test_whitespace_only_team_value_is_treated_as_unknown(self):
+        mapping = {"someuser": "   "}
+
+        decision = pr_triage_decide.decide(author_login="someuser", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+
+    def test_login_matching_is_exact_case_and_can_only_ever_miss(self):
+        mapping = {"mswertz": "Dev"}
+
+        decision = pr_triage_decide.decide(author_login="Mswertz", is_draft=False, mapping=mapping)
+
+        self.assertFalse(decision["known"])
+
+
+class DecideStatusTest(unittest.TestCase):
+    def test_blank_status_fills_from_draft_state(self):
+        self.assertEqual(pr_triage_decide.decide_status(True, None), "Working")
+        self.assertEqual(pr_triage_decide.decide_status(False, None), "Review")
+
+    def test_blank_string_status_counts_as_blank(self):
+        self.assertEqual(pr_triage_decide.decide_status(True, "   "), "Working")
+
+    def test_working_flips_to_review_when_pr_is_ready(self):
+        self.assertEqual(pr_triage_decide.decide_status(False, "Working"), "Review")
+
+    def test_review_flips_to_working_when_pr_is_draft(self):
+        self.assertEqual(pr_triage_decide.decide_status(True, "Review"), "Working")
+
+    def test_working_already_matching_draft_state_is_not_rewritten(self):
+        self.assertIsNone(pr_triage_decide.decide_status(True, "Working"))
+
+    def test_review_already_matching_ready_state_is_not_rewritten(self):
+        self.assertIsNone(pr_triage_decide.decide_status(False, "Review"))
+
+    def test_non_managed_statuses_are_never_touched_regardless_of_draft_state(self):
+        for status in ("Epic", "Blocked", "Backlog", "Done", "Inbox", "Icebox"):
+            with self.subTest(status=status):
+                self.assertIsNone(pr_triage_decide.decide_status(True, status))
+                self.assertIsNone(pr_triage_decide.decide_status(False, status))
+
+    def test_all_eight_real_board_option_names_behave_correctly_for_both_draft_states(self):
+        expected = {
+            "\U0001f4cb Epic": (None, None),
+            "⛔️ Blocked": (None, None),
+            "\U0001f4da Backlog": (None, None),
+            "\U0001f6e0️ Working": (None, "Review"),
+            "\U0001f50d Review": ("Working", None),
+            "✅ Done": (None, None),
+            "\U0001f4e5 Inbox": (None, None),
+            "Icebox": (None, None),
+        }
+
+        for real_name, (expected_draft, expected_ready) in expected.items():
+            with self.subTest(real_name=real_name):
+                self.assertEqual(pr_triage_decide.decide_status(True, real_name), expected_draft)
+                self.assertEqual(pr_triage_decide.decide_status(False, real_name), expected_ready)
+
+
+class DecideBoardUpdateTest(unittest.TestCase):
+    """decide_board_update takes no `action` argument, so a subTest loop over
+    BOARD_UPDATE_ACTIONS proved nothing beyond running the same assertion 5
+    times. Every other case this class used to cover that way is provably
+    redundant against MainWiringBoardUpdateTest and DecideStatusTest, per an
+    owner-approved mutation-tested trim. This one survives: without it, a
+    mutant that always overwrites a non-empty Sprint escapes every other test."""
+
+    def test_sprint_never_overwrites_a_non_empty_sprint(self):
+        for action in pr_triage_decide.BOARD_UPDATE_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage_decide.decide_board_update(
+                    is_draft=True,
+                    current_status="🔍 Review",
+                    current_team="Dev",
+                    mapped_team="Dev",
+                    current_sprint="Sprint 259",
+                    current_sprint_title="Sprint 260",
+                )
+                self.assertIsNone(fields["sprint"])
+
+
+class KeywordClosingIssuesTest(unittest.TestCase):
+    """Owner ruling, mid-ticket: only a KEYWORD-derived closing reference
+    redirects aim 6 -- a sidebar-only link (GitHub's Development panel, no
+    keyword in the body, e.g. this repo's `Addresses: <url>` habit) does not.
+    keyword_closing_issues = closingIssuesReferences minus its
+    userLinkedOnly=true counterpart, matched by node id. Verified against two
+    real PRs of each shape, see notes/github-facts.md §8."""
+
+    ISSUE_A = {"id": "ISSUE_A", "number": 1}
+    ISSUE_B = {"id": "ISSUE_B", "number": 2}
+
+    def test_a_keyword_only_link_counts(self):
+        result = pr_triage_decide.keyword_closing_issues([self.ISSUE_A], [])
+
+        self.assertEqual(result, [self.ISSUE_A])
+
+    def test_a_sidebar_only_link_does_not_count(self):
+        result = pr_triage_decide.keyword_closing_issues([self.ISSUE_A], [self.ISSUE_A])
+
+        self.assertEqual(result, [])
+
+    def test_both_sets_empty_means_no_redirection(self):
+        result = pr_triage_decide.keyword_closing_issues([], [])
+
+        self.assertEqual(result, [])
+
+    def test_a_keyword_link_and_a_separate_sidebar_link_keeps_only_the_keyword_one(self):
+        result = pr_triage_decide.keyword_closing_issues([self.ISSUE_A, self.ISSUE_B], [self.ISSUE_B])
+
+        self.assertEqual(result, [self.ISSUE_A])
+
+    def test_two_keyword_links_both_count(self):
+        result = pr_triage_decide.keyword_closing_issues([self.ISSUE_A, self.ISSUE_B], [])
+
+        self.assertEqual(result, [self.ISSUE_A, self.ISSUE_B])
+
+
+class DecideRedirectToIssuesTest(unittest.TestCase):
+    def test_true_when_the_pr_closes_one_issue(self):
+        self.assertTrue(pr_triage_decide.decide_redirect_to_issues([{"id": "ISSUE_A", "number": 1}]))
+
+    def test_true_when_the_pr_closes_two_issues(self):
+        self.assertTrue(
+            pr_triage_decide.decide_redirect_to_issues([{"id": "ISSUE_A", "number": 1}, {"id": "ISSUE_B", "number": 2}])
+        )
+
+    def test_false_when_the_pr_closes_no_issue(self):
+        self.assertFalse(pr_triage_decide.decide_redirect_to_issues([]))
+
+
+class DecideRemovePrCardTest(unittest.TestCase):
+    """Renamed from decide_delete_pr_item -- owner ruling: "delete" reads as
+    "delete the pull request", and it does not; this only removes a card
+    from board 15."""
+
+    def test_true_when_the_pr_closes_an_issue_and_already_has_a_card(self):
+        self.assertTrue(
+            pr_triage_decide.decide_remove_pr_card([{"id": "ISSUE_A", "number": 1}], {"id": "PR_ITEM", "status": None, "team": None, "sprint": None})
+        )
+
+    def test_false_when_the_pr_closes_an_issue_but_has_no_card_yet(self):
+        self.assertFalse(pr_triage_decide.decide_remove_pr_card([{"id": "ISSUE_A", "number": 1}], None))
+
+    def test_false_when_the_pr_closes_no_issue_even_if_it_has_a_card(self):
+        self.assertFalse(
+            pr_triage_decide.decide_remove_pr_card([], {"id": "PR_ITEM", "status": None, "team": None, "sprint": None})
+        )
+
+
+class DecideIssueCardUpdateTest(unittest.TestCase):
+    """Pure decision for one linked issue's card. mapped_team/current_sprint_title
+    are only ever consulted when a card is being added (existing_issue_item is
+    None); an existing card's Team and Sprint are never touched by any action."""
+
+    EXISTING_WORKING = {"id": "ISSUE_ITEM", "status": "🛠️ Working", "team": "Dev", "sprint": "Sprint 259"}
+    EXISTING_BLANK = {"id": "ISSUE_ITEM", "status": None, "team": None, "sprint": None}
+    EXISTING_PARKED = {"id": "ISSUE_ITEM", "status": "⛔️ Blocked", "team": "Dev", "sprint": "Sprint 259"}
+
+    # --- opened and the three transitions: Status only on an existing card ---
+
+    def test_opened_and_transitions_set_status_only_on_an_existing_card(self):
+        for action in pr_triage_decide.ISSUE_STATUS_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage_decide.decide_issue_card_update(action, False, self.EXISTING_WORKING, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": "Review", "team": None, "sprint": None})
+
+    def test_opened_and_transitions_fill_status_when_the_existing_card_is_blank(self):
+        for action in pr_triage_decide.ISSUE_STATUS_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage_decide.decide_issue_card_update(action, False, self.EXISTING_BLANK, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": "Review", "team": None, "sprint": None})
+
+    def test_opened_and_transitions_never_move_a_parked_status(self):
+        for action in pr_triage_decide.ISSUE_STATUS_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage_decide.decide_issue_card_update(action, False, self.EXISTING_PARKED, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": None, "team": None, "sprint": None})
+
+    def test_opened_and_transitions_add_and_fill_all_three_on_a_missing_card(self):
+        for action in pr_triage_decide.ISSUE_STATUS_ACTIONS:
+            with self.subTest(action=action):
+                fields = pr_triage_decide.decide_issue_card_update(action, True, None, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": "Working", "team": "Delivery", "sprint": "Sprint 260"})
+
+                fields = pr_triage_decide.decide_issue_card_update(action, False, None, "Delivery", "Sprint 260")
+                self.assertEqual(fields, {"status": "Review", "team": "Delivery", "sprint": "Sprint 260"})
+
+    # --- synchronize: never touches a linked issue's card, existing or missing ---
+
+    def test_synchronize_never_touches_an_existing_card(self):
+        fields = pr_triage_decide.decide_issue_card_update("synchronize", True, self.EXISTING_WORKING, "Delivery", "Sprint 260")
+        self.assertIsNone(fields)
+
+    def test_synchronize_never_touches_a_missing_card_either(self):
+        fields = pr_triage_decide.decide_issue_card_update("synchronize", True, None, "Delivery", "Sprint 260")
+        self.assertIsNone(fields)
+
+    # --- edited: adds and fills Team+Sprint on a missing card, but never
+    # touches an existing one, and never writes Status even on the card it adds ---
+
+    def test_edited_never_touches_an_existing_card(self):
+        fields = pr_triage_decide.decide_issue_card_update("edited", True, self.EXISTING_WORKING, "Delivery", "Sprint 260")
+        self.assertIsNone(fields)
+
+    def test_edited_adds_and_fills_team_and_sprint_on_a_missing_card_but_leaves_status_unwritten(self):
+        fields = pr_triage_decide.decide_issue_card_update("edited", True, None, "Delivery", "Sprint 260")
+        self.assertEqual(fields, {"status": None, "team": "Delivery", "sprint": "Sprint 260"})
+
+        fields = pr_triage_decide.decide_issue_card_update("edited", False, None, "Delivery", "Sprint 260")
+        self.assertEqual(fields, {"status": None, "team": "Delivery", "sprint": "Sprint 260"})
+
+
+class FindCurrentIterationTest(unittest.TestCase):
+    def test_returns_the_iteration_containing_today(self):
+
+        iterations = [
+            {"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21},
+            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21},
+        ]
+
+        iteration = pr_triage_decide.find_current_iteration(iterations, datetime.date(2026, 8, 8))
+
+        self.assertEqual(iteration["id"], "bd551114")
+        self.assertEqual(iteration["title"], "Sprint 260")
+
+    def test_start_date_itself_is_inside_the_iteration(self):
+
+        iterations = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
+
+        iteration = pr_triage_decide.find_current_iteration(iterations, datetime.date(2026, 8, 3))
+
+        self.assertEqual(iteration["id"], "bd551114")
+
+    def test_the_day_after_the_iteration_ends_is_not_inside_it(self):
+
+        iterations = [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}]
+
+        end_date = datetime.date(2026, 8, 3) + datetime.timedelta(days=21)
+        iteration = pr_triage_decide.find_current_iteration(iterations, end_date)
+
+        self.assertIsNone(iteration)
+
+    def test_returns_none_when_no_iteration_contains_the_date(self):
+
+        iterations = [{"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21}]
+
+        iteration = pr_triage_decide.find_current_iteration(iterations, datetime.date(2026, 9, 1))
+
+        self.assertIsNone(iteration)
+
+    def test_returns_none_for_an_empty_iteration_list(self):
+
+        self.assertIsNone(pr_triage_decide.find_current_iteration([], datetime.date(2026, 8, 8)))
+
+    def test_does_not_assume_the_first_entry_is_current(self):
+
+        iterations = [
+            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21},
+            {"id": "bd551113", "title": "Sprint 259", "startDate": "2026-07-13", "duration": 21},
+        ]
+
+        iteration = pr_triage_decide.find_current_iteration(iterations, datetime.date(2026, 7, 20))
+
+        self.assertEqual(iteration["id"], "bd551113")
+
+
+class CheckAssignmentSucceededTest(unittest.TestCase):
+    def test_raises_when_author_login_is_absent_from_the_assignees_response(self):
+        assign_result = {"assignees": []}
+
+        with self.assertRaises(pr_triage_decide.AssignmentDroppedError) as context:
+            pr_triage_decide.check_assignment_succeeded("someuser", assign_result)
+
+        self.assertIn("someuser", str(context.exception))
+        self.assertIn("pr-triage-teams.yml", str(context.exception))
+
+    def test_does_not_raise_when_author_login_is_present(self):
+        assign_result = {"assignees": [{"login": "someuser"}]}
+
+        pr_triage_decide.check_assignment_succeeded("someuser", assign_result)
+
+
+class StripEmojiPrefixTest(unittest.TestCase):
+    def test_strips_leading_emoji_and_whitespace(self):
+        self.assertEqual(pr_triage_decide.strip_emoji_prefix("\U0001f6e0️ Working"), "Working")
+
+    def test_leaves_plain_name_unchanged(self):
+        self.assertEqual(pr_triage_decide.strip_emoji_prefix("Icebox"), "Icebox")
+
+
+class FindOptionIdByNameTest(unittest.TestCase):
+    def test_matches_status_option_ignoring_emoji_prefix(self):
+        options = [
+            {"name": "\U0001f6e0️ Working", "id": "47fc9ee4"},
+            {"name": "\U0001f50d Review", "id": "879449e7"},
+        ]
+
+        option_id = pr_triage_decide.find_option_id_by_name(options, "Working", strip_emoji=True)
+
+        self.assertEqual(option_id, "47fc9ee4")
+
+    def test_matches_team_option_by_exact_name(self):
+        options = [{"name": "Dev", "id": "f2a5529c"}, {"name": "Delivery", "id": "34b176a9"}]
+
+        option_id = pr_triage_decide.find_option_id_by_name(options, "Delivery", strip_emoji=False)
+
+        self.assertEqual(option_id, "34b176a9")
+
+    def test_raises_with_full_option_list_when_name_does_not_resolve(self):
+        options = [{"name": "Dev", "id": "f2a5529c"}]
+
+        with self.assertRaises(ValueError) as context:
+            pr_triage_decide.find_option_id_by_name(options, "Nonexistent", strip_emoji=False)
+
+        self.assertIn("Dev", str(context.exception))
+        self.assertIn("Nonexistent", str(context.exception))
+
+
+class ParseTeamsMappingTest(unittest.TestCase):
+    def test_parses_flat_login_to_team_mapping(self):
+        text = (
+            "# header comment\n"
+            "teams:\n"
+            "  mswertz: Dev\n"
+            "  hslh: Delivery\n"
+        )
+
+        mapping = pr_triage_decide.parse_teams_mapping(text)
+
+        self.assertEqual(mapping, {"mswertz": "Dev", "hslh": "Delivery"})
+
+    def test_ignores_blank_lines_and_trailing_comments(self):
+        text = (
+            "teams:\n"
+            "\n"
+            "  mswertz: Dev\n"
+        )
+
+        mapping = pr_triage_decide.parse_teams_mapping(text)
+
+        self.assertEqual(mapping, {"mswertz": "Dev"})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/test_pr_triage_github.py
+++ b/.github/scripts/test_pr_triage_github.py
@@ -1,0 +1,102 @@
+"""Tests for pr_triage_github — the HTTP calls.
+
+A test belongs here when it exercises a request or a mutation, faked at
+pr_triage_github.http_request. Decisions are tested in test_pr_triage_decide.py.
+"""
+
+import os
+import sys
+import unittest
+from unittest import mock
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pr_triage_github
+
+
+class FetchProjectIterationsTest(unittest.TestCase):
+    def test_returns_the_not_yet_completed_iterations(self):
+        response = {
+            "data": {
+                "node": {
+                    "configuration": {
+                        "iterations": [
+                            {"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}
+                        ]
+                    }
+                }
+            }
+        }
+        with mock.patch.object(pr_triage_github, "http_request", return_value=response) as mock_request:
+            iterations = pr_triage_github.fetch_project_iterations(pr_triage_github.SPRINT_FIELD_ID, "board-token")
+
+        self.assertEqual(iterations, [{"id": "bd551114", "title": "Sprint 260", "startDate": "2026-08-03", "duration": 21}])
+        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
+        self.assertIn("iterations", called_body["query"])
+        self.assertNotIn("completedIterations", called_body["query"])
+
+
+class SetProjectFieldIterationTest(unittest.TestCase):
+    def test_writes_the_iteration_id_not_a_single_select_option(self):
+        with mock.patch.object(pr_triage_github, "http_request", return_value={"data": {}}) as mock_request:
+            pr_triage_github.set_project_field_iteration("ITEM_1", pr_triage_github.SPRINT_FIELD_ID, "bd551114", "board-token")
+
+        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
+        self.assertEqual(called_body["variables"]["iterationId"], "bd551114")
+        self.assertIn("iterationId", called_body["query"])
+        self.assertNotIn("singleSelectOptionId", called_body["query"])
+
+
+class RemoveItemFromBoardTest(unittest.TestCase):
+    """The story's one removal (aim 6): remove_item_from_board, called only
+    with the PR's own item id -- never an issue's. The GraphQL mutation
+    keeps GitHub's real name, deleteProjectV2Item; only our identifier
+    changed (owner ruling: "delete" reads as "delete the pull request")."""
+
+    def test_removes_the_given_item_from_board_15(self):
+        with mock.patch.object(
+            pr_triage_github, "http_request", return_value={"data": {"deleteProjectV2Item": {"deletedItemId": "PR_ITEM"}}}
+        ) as mock_request:
+            pr_triage_github.remove_item_from_board("PR_ITEM", "board-token")
+
+        called_body = mock_request.call_args.kwargs.get("body") or mock_request.call_args.args[-1]
+        self.assertIn("deleteProjectV2Item", called_body["query"])
+        self.assertEqual(called_body["variables"]["projectId"], pr_triage_github.BOARD_PROJECT_ID)
+        self.assertEqual(called_body["variables"]["itemId"], "PR_ITEM")
+        self.assertEqual(mock_request.call_args.kwargs.get("token") or mock_request.call_args.args[1], "board-token")
+
+
+class NullNodeIsRaisedActionablyTest(unittest.TestCase):
+    def test_fetch_project_field_options_raises_naming_the_field_id_when_node_is_null(self):
+        with mock.patch.object(pr_triage_github, "http_request", return_value={"data": {"node": None}}):
+            with self.assertRaises(pr_triage_github.GraphqlError) as context:
+                pr_triage_github.fetch_project_field_options("STALE_FIELD_ID", "board-token")
+
+        self.assertIn("STALE_FIELD_ID", str(context.exception))
+
+    def test_fetch_project_iterations_raises_naming_the_field_id_when_node_is_null(self):
+        with mock.patch.object(pr_triage_github, "http_request", return_value={"data": {"node": None}}):
+            with self.assertRaises(pr_triage_github.GraphqlError) as context:
+                pr_triage_github.fetch_project_iterations("STALE_SPRINT_FIELD_ID", "board-token")
+
+        self.assertIn("STALE_SPRINT_FIELD_ID", str(context.exception))
+
+
+class GraphqlRequestErrorHandlingTest(unittest.TestCase):
+    def test_raises_when_response_body_carries_errors_despite_http_200(self):
+        errors_payload = [{"message": "Resource not accessible - requires one of the following scopes: ['project']"}]
+        with mock.patch.object(pr_triage_github, "http_request", return_value={"data": None, "errors": errors_payload}):
+            with self.assertRaises(pr_triage_github.GraphqlError) as context:
+                pr_triage_github.graphql_request("query {}", {}, "token")
+
+        self.assertIn("requires one of the following scopes", str(context.exception))
+
+    def test_passes_through_a_clean_response(self):
+        with mock.patch.object(pr_triage_github, "http_request", return_value={"data": {"ok": True}}):
+            result = pr_triage_github.graphql_request("query {}", {}, "token")
+
+        self.assertEqual(result, {"data": {"ok": True}})
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/validate_pr_triage_teams.py
+++ b/.github/scripts/validate_pr_triage_teams.py
@@ -1,0 +1,155 @@
+"""Validation gates for .github/pr-triage-teams.yml, run as a workflow step.
+
+Pure checks (find_bot_or_machine_logins, find_unknown_team_values) take an
+already-parsed mapping and, for the team check, an already-resolved set of
+live board option names, so they are testable without a network. main() does
+the file read and the live GraphQL resolution, then calls the pure checks.
+"""
+
+import os
+import sys
+import urllib.error
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import pr_triage
+
+MACHINE_ACCOUNTS = {"JV-CI-CD", "molgenis-jenkins"}
+BANNED_WORKFLOW_TERMS = (
+    "author_association",
+    "user.type",
+    "/collaborators",
+    '["user"]["type"]',
+    "['user']['type']",
+)
+FILES_HOLDING_BANNED_TERMS_AS_LITERAL_FIXTURES = {os.path.basename(__file__), "test_pr_triage.py"}
+
+
+def is_bot_login(login):
+    return login.endswith("[bot]")
+
+
+def find_bot_or_machine_logins(mapping):
+    return [login for login in mapping if is_bot_login(login) or login in MACHINE_ACCOUNTS]
+
+
+def find_unknown_team_values(mapping, valid_team_names):
+    return [(login, team) for login, team in mapping.items() if team not in valid_team_names]
+
+
+def find_blank_team_values(mapping):
+    return [login for login, team in mapping.items() if not team.strip()]
+
+
+def find_missing_status_option(status_options, status_name):
+    for option in status_options:
+        if pr_triage.strip_emoji_prefix(option["name"]) == status_name:
+            return None
+    available = ", ".join(sorted(option["name"] for option in status_options))
+    return f"'{status_name}' is not a live Status option. Live Status options are: {available}"
+
+
+def find_missing_team_option(team_options, team_name):
+    valid_team_names = {option["name"] for option in team_options}
+    if team_name in valid_team_names:
+        return None
+    available = ", ".join(sorted(valid_team_names))
+    return f"'{team_name}' is not a live Team option. Live Team options are: {available}"
+
+
+def is_credential_error(http_error):
+    return getattr(http_error, "code", None) in (401, 403)
+
+
+def find_banned_terms_in_source(source_text, banned_terms=BANNED_WORKFLOW_TERMS):
+    return [term for term in banned_terms if term in source_text]
+
+
+def find_banned_terms_across_triage_source(repo_root):
+    findings = []
+
+    workflow_path = os.path.join(repo_root, ".github", "workflows", "pr-triage.yml")
+    with open(workflow_path, encoding="utf-8") as handle:
+        workflow_terms = find_banned_terms_in_source(handle.read())
+    if workflow_terms:
+        findings.append(("pr-triage.yml", workflow_terms))
+
+    scripts_dir = os.path.join(repo_root, ".github", "scripts")
+    for filename in sorted(os.listdir(scripts_dir)):
+        if not filename.endswith(".py") or filename in FILES_HOLDING_BANNED_TERMS_AS_LITERAL_FIXTURES:
+            continue
+        with open(os.path.join(scripts_dir, filename), encoding="utf-8") as handle:
+            terms = find_banned_terms_in_source(handle.read())
+        if terms:
+            findings.append((filename, terms))
+
+    return findings
+
+
+def main(repo_root=None):
+    if repo_root is None:
+        repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+    mapping_path = os.path.join(repo_root, ".github", "pr-triage-teams.yml")
+    mapping = pr_triage.load_teams_mapping(mapping_path)
+
+    errors = []
+
+    bad_logins = find_bot_or_machine_logins(mapping)
+    if bad_logins:
+        errors.append(f"bot or machine account login(s) present in pr-triage-teams.yml: {bad_logins}")
+
+    blank_team_logins = find_blank_team_values(mapping)
+    if blank_team_logins:
+        errors.append(f"login(s) with a blank Team value in pr-triage-teams.yml: {blank_team_logins}")
+
+    banned_terms_found = find_banned_terms_across_triage_source(repo_root)
+    if banned_terms_found:
+        errors.append(
+            f"reader-dependent decision term(s) found, never allowed in this workflow's logic: {banned_terms_found}"
+        )
+
+    board_token = os.environ["PROJECT_BOARD_TOKEN"]
+    try:
+        team_options = pr_triage.fetch_project_field_options(pr_triage.TEAM_FIELD_ID, board_token)
+        status_options = pr_triage.fetch_project_field_options(pr_triage.STATUS_FIELD_ID, board_token)
+    except urllib.error.HTTPError as error:
+        if is_credential_error(error):
+            print(f"ERROR: PROJECT_BOARD_TOKEN was rejected by GitHub (HTTP {error.code}). "
+                  "This is a credential problem: rotate the PROJECT_BOARD_TOKEN secret. "
+                  "It is not a problem with pr-triage-teams.yml.")
+        else:
+            print(f"ERROR: unexpected HTTP {error.code} resolving live board options: {error}")
+        sys.exit(1)
+
+    valid_team_names = {option["name"] for option in team_options}
+
+    unknown_team_values = find_unknown_team_values(mapping, valid_team_names)
+    if unknown_team_values:
+        available = ", ".join(sorted(valid_team_names))
+        errors.append(
+            f"unknown Team value(s) in pr-triage-teams.yml: {unknown_team_values}. "
+            f"Live Team options are: {available}"
+        )
+
+    missing_working_status = find_missing_status_option(status_options, pr_triage.KNOWN_AUTHOR_STATUS)
+    if missing_working_status:
+        errors.append(missing_working_status)
+
+    missing_review_status = find_missing_status_option(status_options, pr_triage.UNKNOWN_AUTHOR_STATUS)
+    if missing_review_status:
+        errors.append(missing_review_status)
+
+    missing_dev_team = find_missing_team_option(team_options, pr_triage.UNKNOWN_AUTHOR_TEAM)
+    if missing_dev_team:
+        errors.append(missing_dev_team)
+
+    if errors:
+        for error in errors:
+            print(f"ERROR: {error}")
+        sys.exit(1)
+
+    print(f"pr-triage-teams.yml is valid: {len(mapping)} authors, all Team values resolve to live board options")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/scripts/validate_pr_triage_teams.py
+++ b/.github/scripts/validate_pr_triage_teams.py
@@ -123,47 +123,64 @@ def main(repo_root=None):
             f"reader-dependent decision term(s) found, never allowed in this workflow's logic: {banned_terms_found}"
         )
 
-    board_token = os.environ["PROJECT_BOARD_TOKEN"]
-    try:
-        team_options = pr_triage.fetch_project_field_options(pr_triage.TEAM_FIELD_ID, board_token)
-        status_options = pr_triage.fetch_project_field_options(pr_triage.STATUS_FIELD_ID, board_token)
-    except urllib.error.HTTPError as error:
-        if is_credential_error(error):
-            print(f"ERROR: PROJECT_BOARD_TOKEN was rejected by GitHub (HTTP {error.code}). "
-                  "This is a credential problem: rotate the PROJECT_BOARD_TOKEN secret. "
-                  "It is not a problem with pr-triage-teams.yml.")
-        else:
-            print(f"ERROR: unexpected HTTP {error.code} resolving live board options: {error}")
-        sys.exit(1)
+    # Live board-option resolution (Team values, and Working/Review/Dev existing)
+    # needs PROJECT_BOARD_TOKEN, and this validator must not hold that secret:
+    # it runs against the PR's own edit to this very file, before review. So
+    # this step is offline-only here; the same check still happens, just later
+    # and loud: find_option_id_by_name raises with the full live option list
+    # when a value doesn't resolve, at write time in the triage job. Do not
+    # reinstate a token here to bring it back to validate time.
+    board_token = os.environ.get("PROJECT_BOARD_TOKEN")
+    if board_token:
+        try:
+            team_options = pr_triage.fetch_project_field_options(pr_triage.TEAM_FIELD_ID, board_token)
+            status_options = pr_triage.fetch_project_field_options(pr_triage.STATUS_FIELD_ID, board_token)
+        except urllib.error.HTTPError as error:
+            if is_credential_error(error):
+                print(f"ERROR: PROJECT_BOARD_TOKEN was rejected by GitHub (HTTP {error.code}). "
+                      "This is a credential problem: rotate the PROJECT_BOARD_TOKEN secret. "
+                      "It is not a problem with pr-triage-teams.yml.")
+            else:
+                print(f"ERROR: unexpected HTTP {error.code} resolving live board options: {error}")
+            sys.exit(1)
 
-    valid_team_names = {option["name"] for option in team_options}
+        valid_team_names = {option["name"] for option in team_options}
 
-    unknown_team_values = find_unknown_team_values(mapping, valid_team_names)
-    if unknown_team_values:
-        available = ", ".join(sorted(valid_team_names))
-        errors.append(
-            f"unknown Team value(s) in pr-triage-teams.yml: {unknown_team_values}. "
-            f"Live Team options are: {available}"
+        unknown_team_values = find_unknown_team_values(mapping, valid_team_names)
+        if unknown_team_values:
+            available = ", ".join(sorted(valid_team_names))
+            errors.append(
+                f"unknown Team value(s) in pr-triage-teams.yml: {unknown_team_values}. "
+                f"Live Team options are: {available}"
+            )
+
+        missing_working_status = find_missing_status_option(status_options, pr_triage.STATUS_WORKING)
+        if missing_working_status:
+            errors.append(missing_working_status)
+
+        missing_review_status = find_missing_status_option(status_options, pr_triage.STATUS_REVIEW)
+        if missing_review_status:
+            errors.append(missing_review_status)
+
+        missing_dev_team = find_missing_team_option(team_options, pr_triage.UNKNOWN_AUTHOR_TEAM)
+        if missing_dev_team:
+            errors.append(missing_dev_team)
+    else:
+        print(
+            "PROJECT_BOARD_TOKEN not present: skipping live board-option checks "
+            "(Team values, and Working/Review/Dev existing on the board). These "
+            "run at write time in the triage job instead."
         )
-
-    missing_working_status = find_missing_status_option(status_options, pr_triage.STATUS_WORKING)
-    if missing_working_status:
-        errors.append(missing_working_status)
-
-    missing_review_status = find_missing_status_option(status_options, pr_triage.STATUS_REVIEW)
-    if missing_review_status:
-        errors.append(missing_review_status)
-
-    missing_dev_team = find_missing_team_option(team_options, pr_triage.UNKNOWN_AUTHOR_TEAM)
-    if missing_dev_team:
-        errors.append(missing_dev_team)
 
     if errors:
         for error in errors:
             print(f"ERROR: {error}")
         sys.exit(1)
 
-    print(f"pr-triage-teams.yml is valid: {len(mapping)} authors, all Team values resolve to live board options")
+    if board_token:
+        print(f"pr-triage-teams.yml is valid: {len(mapping)} authors, all Team values resolve to live board options")
+    else:
+        print(f"pr-triage-teams.yml passes all offline checks: {len(mapping)} authors")
 
 
 if __name__ == "__main__":

--- a/.github/scripts/validate_pr_triage_teams.py
+++ b/.github/scripts/validate_pr_triage_teams.py
@@ -6,6 +6,7 @@ live board option names, so they are testable without a network. main() does
 the file read and the live GraphQL resolution, then calls the pure checks.
 """
 
+import collections
 import os
 import sys
 import urllib.error
@@ -38,32 +39,21 @@ def find_unknown_team_values(mapping, valid_team_names):
 
 
 def find_blank_team_values(mapping):
-    return [login for login, team in mapping.items() if not team.strip()]
+    return [login for login, team in mapping.items() if pr_triage.is_blank(team)]
 
 
 def find_duplicate_logins(text):
     logins = [login for login, _ in pr_triage.parse_teams_entries(text)]
-    duplicates = []
-    for login in logins:
-        if logins.count(login) > 1 and login not in duplicates:
-            duplicates.append(login)
-    return duplicates
+    counts = collections.Counter(logins)
+    return [login for login, count in counts.items() if count > 1]
 
 
-def find_missing_status_option(status_options, status_name):
-    for option in status_options:
-        if pr_triage.strip_emoji_prefix(option["name"]) == status_name:
-            return None
-    available = ", ".join(sorted(option["name"] for option in status_options))
-    return f"'{status_name}' is not a live Status option. Live Status options are: {available}"
-
-
-def find_missing_team_option(team_options, team_name):
-    valid_team_names = {option["name"] for option in team_options}
-    if team_name in valid_team_names:
+def find_missing_option(options, name, strip_emoji):
+    try:
+        pr_triage.find_option_id_by_name(options, name, strip_emoji=strip_emoji)
         return None
-    available = ", ".join(sorted(valid_team_names))
-    return f"'{team_name}' is not a live Team option. Live Team options are: {available}"
+    except ValueError as error:
+        return str(error)
 
 
 def is_credential_error(http_error):
@@ -154,15 +144,15 @@ def main(repo_root=None):
                 f"Live Team options are: {available}"
             )
 
-        missing_working_status = find_missing_status_option(status_options, pr_triage.STATUS_WORKING)
+        missing_working_status = find_missing_option(status_options, pr_triage.STATUS_WORKING, strip_emoji=True)
         if missing_working_status:
             errors.append(missing_working_status)
 
-        missing_review_status = find_missing_status_option(status_options, pr_triage.STATUS_REVIEW)
+        missing_review_status = find_missing_option(status_options, pr_triage.STATUS_REVIEW, strip_emoji=True)
         if missing_review_status:
             errors.append(missing_review_status)
 
-        missing_dev_team = find_missing_team_option(team_options, pr_triage.UNKNOWN_AUTHOR_TEAM)
+        missing_dev_team = find_missing_option(team_options, pr_triage.UNKNOWN_AUTHOR_TEAM, strip_emoji=False)
         if missing_dev_team:
             errors.append(missing_dev_team)
     else:

--- a/.github/scripts/validate_pr_triage_teams.py
+++ b/.github/scripts/validate_pr_triage_teams.py
@@ -13,7 +13,8 @@ import urllib.error
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-import pr_triage
+import pr_triage_decide
+import pr_triage_github
 
 MACHINE_ACCOUNTS = {"JV-CI-CD", "molgenis-jenkins"}
 BANNED_WORKFLOW_TERMS = (
@@ -39,18 +40,18 @@ def find_unknown_team_values(mapping, valid_team_names):
 
 
 def find_blank_team_values(mapping):
-    return [login for login, team in mapping.items() if pr_triage.is_blank(team)]
+    return [login for login, team in mapping.items() if pr_triage_decide.is_blank(team)]
 
 
 def find_duplicate_logins(text):
-    logins = [login for login, _ in pr_triage.parse_teams_entries(text)]
+    logins = [login for login, _ in pr_triage_decide.parse_teams_entries(text)]
     counts = collections.Counter(logins)
     return [login for login, count in counts.items() if count > 1]
 
 
 def find_missing_option(options, name, strip_emoji):
     try:
-        pr_triage.find_option_id_by_name(options, name, strip_emoji=strip_emoji)
+        pr_triage_decide.find_option_id_by_name(options, name, strip_emoji=strip_emoji)
         return None
     except ValueError as error:
         return str(error)
@@ -91,7 +92,7 @@ def main(repo_root=None):
     mapping_path = os.path.join(repo_root, ".github", "pr-triage-teams.yml")
     with open(mapping_path, encoding="utf-8") as handle:
         mapping_text = handle.read()
-    mapping = pr_triage.parse_teams_mapping(mapping_text)
+    mapping = pr_triage_decide.parse_teams_mapping(mapping_text)
 
     errors = []
 
@@ -123,8 +124,8 @@ def main(repo_root=None):
     board_token = os.environ.get("PROJECT_BOARD_TOKEN")
     if board_token:
         try:
-            team_options = pr_triage.fetch_project_field_options(pr_triage.TEAM_FIELD_ID, board_token)
-            status_options = pr_triage.fetch_project_field_options(pr_triage.STATUS_FIELD_ID, board_token)
+            team_options = pr_triage_github.fetch_project_field_options(pr_triage_github.TEAM_FIELD_ID, board_token)
+            status_options = pr_triage_github.fetch_project_field_options(pr_triage_github.STATUS_FIELD_ID, board_token)
         except urllib.error.HTTPError as error:
             if is_credential_error(error):
                 print(f"ERROR: PROJECT_BOARD_TOKEN was rejected by GitHub (HTTP {error.code}). "
@@ -144,15 +145,15 @@ def main(repo_root=None):
                 f"Live Team options are: {available}"
             )
 
-        missing_working_status = find_missing_option(status_options, pr_triage.STATUS_WORKING, strip_emoji=True)
+        missing_working_status = find_missing_option(status_options, pr_triage_decide.STATUS_WORKING, strip_emoji=True)
         if missing_working_status:
             errors.append(missing_working_status)
 
-        missing_review_status = find_missing_option(status_options, pr_triage.STATUS_REVIEW, strip_emoji=True)
+        missing_review_status = find_missing_option(status_options, pr_triage_decide.STATUS_REVIEW, strip_emoji=True)
         if missing_review_status:
             errors.append(missing_review_status)
 
-        missing_dev_team = find_missing_option(team_options, pr_triage.UNKNOWN_AUTHOR_TEAM, strip_emoji=False)
+        missing_dev_team = find_missing_option(team_options, pr_triage_decide.UNKNOWN_AUTHOR_TEAM, strip_emoji=False)
         if missing_dev_team:
             errors.append(missing_dev_team)
     else:

--- a/.github/scripts/validate_pr_triage_teams.py
+++ b/.github/scripts/validate_pr_triage_teams.py
@@ -41,6 +41,15 @@ def find_blank_team_values(mapping):
     return [login for login, team in mapping.items() if not team.strip()]
 
 
+def find_duplicate_logins(text):
+    logins = [login for login, _ in pr_triage.parse_teams_entries(text)]
+    duplicates = []
+    for login in logins:
+        if logins.count(login) > 1 and login not in duplicates:
+            duplicates.append(login)
+    return duplicates
+
+
 def find_missing_status_option(status_options, status_name):
     for option in status_options:
         if pr_triage.strip_emoji_prefix(option["name"]) == status_name:
@@ -90,9 +99,15 @@ def main(repo_root=None):
     if repo_root is None:
         repo_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
     mapping_path = os.path.join(repo_root, ".github", "pr-triage-teams.yml")
-    mapping = pr_triage.load_teams_mapping(mapping_path)
+    with open(mapping_path, encoding="utf-8") as handle:
+        mapping_text = handle.read()
+    mapping = pr_triage.parse_teams_mapping(mapping_text)
 
     errors = []
+
+    duplicate_logins = find_duplicate_logins(mapping_text)
+    if duplicate_logins:
+        errors.append(f"login(s) listed more than once in pr-triage-teams.yml: {duplicate_logins}")
 
     bad_logins = find_bot_or_machine_logins(mapping)
     if bad_logins:
@@ -131,11 +146,11 @@ def main(repo_root=None):
             f"Live Team options are: {available}"
         )
 
-    missing_working_status = find_missing_status_option(status_options, pr_triage.KNOWN_AUTHOR_STATUS)
+    missing_working_status = find_missing_status_option(status_options, pr_triage.STATUS_WORKING)
     if missing_working_status:
         errors.append(missing_working_status)
 
-    missing_review_status = find_missing_status_option(status_options, pr_triage.UNKNOWN_AUTHOR_STATUS)
+    missing_review_status = find_missing_status_option(status_options, pr_triage.STATUS_REVIEW)
     if missing_review_status:
         errors.append(missing_review_status)
 

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,39 @@
+name: PR triage
+on:
+  pull_request:
+    types: [ opened, reopened, ready_for_review, converted_to_draft ]
+jobs:
+  validate:
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+      - name: Validate pr-triage-teams.yml
+        env:
+          PROJECT_BOARD_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN }}
+        run: python3 .github/scripts/validate_pr_triage_teams.py
+      - name: Run unit tests
+        run: python3 .github/scripts/test_pr_triage.py
+
+  triage:
+    needs: validate
+    if: github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    # issues:write is needed because assignment goes through the
+    # /issues/{n}/assignees endpoint; pull-requests:write is needed to
+    # read/convert the pull request.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Triage pull request
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PROJECT_BOARD_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN }}
+        run: python3 .github/scripts/pr_triage.py

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -2,6 +2,8 @@ name: PR triage
 on:
   pull_request:
     types: [ opened, reopened, ready_for_review, converted_to_draft ]
+concurrency:
+  group: pr-triage-${{ github.event.pull_request.number }}
 jobs:
   validate:
     if: github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -14,15 +14,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate pr-triage-teams.yml
-        env:
-          PROJECT_BOARD_TOKEN: ${{ secrets.PROJECT_BOARD_TOKEN }}
         run: python3 .github/scripts/validate_pr_triage_teams.py
       - name: Run unit tests
         run: python3 .github/scripts/test_pr_triage.py
 
   triage:
     needs: validate
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # Assignment is GITHUB_TOKEN's only job here; the draft conversion and
@@ -40,7 +40,13 @@ jobs:
       issues: write
       pull-requests: write
     steps:
+      # Pin to the base commit, not the PR's own HEAD: this step runs with
+      # PROJECT_BOARD_TOKEN in its environment, and without this ref a PR
+      # could edit these scripts to exfiltrate that token and have its own
+      # edit run before any review. Looks removable; is not.
       - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
       - name: Triage pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,7 +1,7 @@
 name: PR triage
 on:
   pull_request:
-    types: [ opened, reopened, ready_for_review, converted_to_draft ]
+    types: [ opened, reopened, ready_for_review, converted_to_draft, synchronize ]
 concurrency:
   group: pr-triage-${{ github.event.pull_request.number }}
 jobs:
@@ -26,12 +26,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     # issues:write is needed because assignment goes through the
-    # /issues/{n}/assignees endpoint; pull-requests:write is needed to
-    # read/convert the pull request.
+    # /issues/{n}/assignees endpoint. GITHUB_TOKEN does nothing else here:
+    # the draft conversion and every board write use PROJECT_BOARD_TOKEN,
+    # since GitHub refuses convertPullRequestToDraft to GITHUB_TOKEN outright.
     permissions:
       contents: read
       issues: write
-      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Triage pull request

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Validate pr-triage-teams.yml
         run: python3 .github/scripts/validate_pr_triage_teams.py
       - name: Run unit tests
-        run: python3 .github/scripts/test_pr_triage.py
+        run: python3 -m unittest discover -s .github/scripts
 
   triage:
     needs: validate

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,7 +1,7 @@
 name: PR triage
 on:
   pull_request:
-    types: [ opened, reopened, ready_for_review, converted_to_draft, synchronize ]
+    types: [ opened, reopened, ready_for_review, converted_to_draft, synchronize, edited ]
 concurrency:
   group: pr-triage-${{ github.event.pull_request.number }}
 jobs:

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -25,13 +25,20 @@ jobs:
     if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     timeout-minutes: 5
-    # issues:write is needed because assignment goes through the
-    # /issues/{n}/assignees endpoint. GITHUB_TOKEN does nothing else here:
-    # the draft conversion and every board write use PROJECT_BOARD_TOKEN,
-    # since GitHub refuses convertPullRequestToDraft to GITHUB_TOKEN outright.
+    # Assignment is GITHUB_TOKEN's only job here; the draft conversion and
+    # every board write use PROJECT_BOARD_TOKEN, since GitHub refuses
+    # convertPullRequestToDraft to GITHUB_TOKEN outright.
+    #
+    # Do not narrow this block by reasoning. Assigning a PULL REQUEST needs
+    # pull-requests:write even though the endpoint path reads /issues/, and
+    # dropping it once already produced a 403 "Resource not accessible by
+    # integration" on the assignees call. This exact pair is the only
+    # combination observed to work; issues:write alone is observed to fail,
+    # and pull-requests:write alone has never been tried.
     permissions:
       contents: read
       issues: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
       - name: Triage pull request

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -40,13 +40,12 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      # Pin to the base commit, not the PR's own HEAD: this step runs with
-      # PROJECT_BOARD_TOKEN in its environment, and without this ref a PR
-      # could edit these scripts to exfiltrate that token and have its own
-      # edit run before any review. Looks removable; is not.
+      # This step runs the PR's own copy of .github/scripts/ with
+      # PROJECT_BOARD_TOKEN in its environment. Accepted: only trusted
+      # committers can push a branch here, and a same-repo PR supplies its
+      # own workflow file anyway, so pinning the checkout would not close the
+      # hole on its own.
       - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
       - name: Triage pull request
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Triage pull requests automatically

## Goal

A PR arrives already triaged: owned by its author, parked in the right column of the right team's board,
and in the state that says whether it wants eyes yet. Nobody sweeps for unassigned PRs, and nobody opens a review on something still being written.

## What changed

- **A PR from a known author is assigned to that author, put into draft, and lands on board 15 as
  `Working` under their team.** *(new)* Who counts as known is one file, `.github/pr-triage-teams.yml`,
  changed by a reviewable PR. 38 people are in it.
- **A PR that closes an issue gets no card of its own — the issue's card is the one that moves.**
  *(new)* One piece of work, one card. Mark that PR ready and the ISSUE moves to `Review`.
- **A PR from anyone not in that file is never assigned and never forced to draft**, and lands as
  `Review` under `Dev`. *(new)* That covers bots and outside contributors, so nothing here can assign a
  PR to someone outside the organisation.
- **Marking a PR ready for review moves it to `Review`; back to draft returns it to `Working`.** *(new)*
  The PR's draft state drives the board, never the reverse. Moving a card does not change the PR.
- **A parked card stays parked.** *(new)* `Epic`, `Blocked`, `Backlog`, `Done`, `Inbox` and `Icebox` are
  never touched by any event, so a PR you filed away survives any number of pushes.
- **Team and Sprint are filled once and never overwritten, and the assignee is never reconciled.**
  *(new)* Correct any of them by hand and the correction stands. Clearing an assignee during a holiday
  is supported by doing nothing.
- **A stacked PR — one based on another PR's branch — is left alone entirely.** *(new)* An N-deep stack
  puts one card on the board, not N.
- **A PR opened from a fork does nothing at all.** *(new)* GitHub withholds the board credential from a
  fork's run. Lifting this is a later ticket.

## How to verify

Everything below is **from `.plan/backlog/0087-pr-triage-automation/notes/first-real-pr-protocol.md`**.
Run them in this order and stop at the first surprise.

**None of these steps has been run as a clean pass against the real board**, because the workflow cannot
run until it is merged. Three real PRs did fire earlier commits of it — #6595, #6596 and #6597 — and each
one found a defect rather than confirming a behaviour: a half-failed board write, a PR force-drafted and
boarded while owned by nobody, and a stacked PR triaged when it should have been skipped. All three are
fixed here, and all three are why the rules read the way they do. Steps 4–6 have never run in any form.

1. **Open a draft PR from your own account.** Read the run's **step summary**, not the log — it is a
   table of what was decided. Expect: assigned to you, forced to draft, on the board as `🛠️ Working`
   under your team.
2. **Mark it ready for review.** The card moves to `🔍 Review`. Mark it draft again; it returns to
   `🛠️ Working`. Your Team and assignee do not change either time.
3. **Set the card's Status to `Blocked` by hand, then push a commit.** It must still say `Blocked`.
4. **Open a draft PR whose body says `closes #N`, against an issue already on the board.** Write down
   that issue's Status, Team and Sprint first. Expect: **your PR gets no card**, and issue N moves to
   `🛠️ Working` — with its Team and Sprint exactly as you wrote them down. Mark the PR ready; issue N
   moves to `🔍 Review`.
5. **Take a PR that has a card and edit its body to add `closes #N`.** Its card is **removed from the
   board**. The pull request itself is not closed and not changed, and the issue is untouched. The step
   summary's `PR card removed` row names the Status, Team and Sprint that card held — that row is the
   only record, so read it. Delete the `closes` line again and the PR is re-carded.
6. **Open a PR whose body says `Addresses: <issue url>` and link the issue in the Development sidebar
   instead.** Expect: **this PR IS carded, normally.** A sidebar link must not redirect. This is worth
   testing because it is the team's own habit, used deliberately to link an issue without closing it.

Automated: 176 offline tests at `466caaeb3`, none of which existed before this branch. They fake the GitHub API, so
they prove the decisions, not the network.

## Summary of code changes

You have the diff; this is the map, and the parts that look odd on purpose.

- **`.github/scripts/pr_triage.py`** — every decision is a pure function taking plain values and
  returning a verdict (`decide`, `decide_status`, `decide_board_update`, `keyword_closing_issues`,
  `decide_remove_pr_card`, `decide_issue_card_update`). All the I/O sits below them. That split is what
  makes a workflow nobody can run before merging testable at all.
- **Two tokens, on purpose.** Assignment uses the free `GITHUB_TOKEN`. The draft flip and every board
  write use a PAT, because GitHub refuses `convertPullRequestToDraft` to a GitHub App outright, and
  Projects v2 sits outside repo scope. Neither is a preference; both were measured.
- **Board options are matched by option **id**, and Status names have their emoji prefix stripped
  before comparison.** Seven of the eight live Status names carry an emoji and `Icebox` does not.
  Comparing against the bare word once made a whole rule a no-op in production while 133 offline tests
  stayed green — hence the test asserting all eight real names.
- **`deleteProjectV2Item` is called in exactly one place**, fed only by the pull request's own board
  lookup. It removes a card from the board; it does not delete anything else. Our own names for it say
  *remove*, not *delete*, so a run log cannot be misread. The card's field values are written to the run
  summary **before** the call, so a timeout cannot lose them.
- **Whether a PR closes an issue is GitHub's answer, not ours.** We ask for
  `closingIssuesReferences` twice — once plainly, once with `userLinkedOnly: true` — and subtract. No
  code here parses the PR body. Both ride the same query, so it costs no extra request.
- **`.github/scripts/test_pr_triage.py`** — test-heavy because there was no coverage of anything here
  before, and because this workflow cannot be exercised before it lands. Several tests assert the
  workflow YAML itself (its `types:`, its `permissions:`, its default-branch filter), since a config
  change is exactly how a rule becomes a silent no-op.
- **`.github/pr-triage-teams.yml`** — one key, `teams:`, answering both "assign?" and "which team?".
  A validator refuses duplicate logins and any `[bot]` or machine account, because this file is the only
  thing that can cause an assignment.

## Considered but out of scope

- **Moving a card on the board does not change the PR.** Considered and dropped: Actions has no trigger
  for a Projects v2 field change, and polling would ping-pong against the six parking columns.
- **Fork PRs**, which need the `pull_request_target` trigger and a different security posture.
- **PRs already open** are not backfilled. This is forward-only.
- **`Component` and `Priority`** stay for people to set.
- **Duplicate cards created before this landed** are left alone. Nothing here removes a card except the
  one narrow case above.

## Known limitations

- **The PAT carries `project` and `repo` scope**, which is broader than this workflow needs — `project`
  is not scoped to one board. Any of the 46 accounts that can push a branch here can read that secret,
  which is a standing property of GitHub Actions rather than something this PR introduces. A
  repository-limited fine-grained PAT was offered and declined as disproportionate. The privileged job
  checks out base-ref code, and the job that runs PR-authored code holds no credential.
- **`.github/pr-triage-teams.yml` goes stale**, and that is the accepted cost of not making an API call.
  A leaver keeps getting PRs assigned until someone edits the file.
- **An issue with two open PRs** takes its column from whichever PR transitioned last. Bounded: Status
  only ever moves between empty, `Working` and `Review`.
- **A red run does not block a merge.** `master` has no required status checks, so a failing run is
  something a person has to notice.
