### PR TITLE
chore: remove eddiewebb/queue orb from circle config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,6 @@ parameters:
 
 orbs:
   slack: circleci/slack@6.1.3
-  queue: eddiewebb/queue@3.3.3
 
 definitions:
   build_config: &build_config
@@ -437,11 +436,6 @@ jobs:
     <<: *release_config
 
     steps:
-    - queue/until_front_of_line:
-        limit-branch-name: main
-        max-wait-time: '25'
-        my-pipeline: <<pipeline.number>>
-        
     - pre_steps
     
     - run:


### PR DESCRIPTION
### What are the main changes you did

- the orb is no longer maintained
- due to a config issue the config probably had no effect on the circle jobs ( limit set to unused branch name)

### How to test

- inspect config 
- check on release ( hard to test as preview ) 

### Checklist

- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
