### PR TITLE
chore(cms): refactor cms graphql queries

### DIFF
--- a/apps/tailwind-components/app/utils/cms.ts
+++ b/apps/tailwind-components/app/utils/cms.ts
@@ -77,13 +77,14 @@ export async function deleteComponent(
       message
     }
   }`;
-  const orderVars = { orderId: [{ id: `${componentOrderid}` }] };
 
   const componentQuery = `mutation delete($componentId:[ComponentsInput]) {
     delete(Components:$componentId) {
       message
     }
   }`;
+
+  const orderVars = { orderId: [{ id: `${componentOrderid}` }] };
   const componentVars = { componentId: [{ id: `${componentId}` }] };
 
   await cmsFetch(schema, orderQuery, orderVars);
@@ -135,10 +136,19 @@ export async function deleteBlock(
 ) {
   await deleteAllComponentsFromBlock(schema, blockId);
 
-  const orderQuery = `mutation delete($pkey:[BlockOrdersInput]){delete(BlockOrders:$pkey){message}}`;
-  const orderVar = { pkey: [{ id: `${blockOrderid}` }] };
+  const orderQuery = `mutation delete($pkey:[BlockOrdersInput]){
+    delete(BlockOrders:$pkey) {
+      message
+    }
+  }`;
 
-  const blockQuery = `mutation delete($pkey:[BlocksInput]){delete(Blocks:$pkey){message}}`;
+  const blockQuery = `mutation delete($pkey:[BlocksInput]){
+    delete(Blocks:$pkey) {
+      message
+    }
+  }`;
+
+  const orderVar = { pkey: [{ id: `${blockOrderid}` }] };
   const blockVars = { pkey: [{ id: `${blockId}` }] };
 
   await cmsFetch(schema, orderQuery, orderVar);
@@ -184,13 +194,22 @@ export async function addBlock(
 }
 
 async function AddSection(schema: string, id: string) {
-  const query = `mutation insert($section:[SectionsInput]){insert(Sections:$section){ message }}`;
+  const query = `mutation insert($section:[SectionsInput]) {
+    insert(Sections:$section) {
+      message
+    }
+  }`;
   const variables = { section: [{ id: `${id}` }] };
   await cmsFetch(schema, query, variables);
 }
 
 async function AddHeader(schema: string, id: string) {
-  const query = `mutation insert($header:[HeadersInput]){insert(Headers:$header){ message }}`;
+  const query = `mutation insert($header:[HeadersInput]) {
+    insert(Headers:$header) {
+      message
+    }
+  }`;
+
   const variables = {
     header: [
       {
@@ -252,11 +271,18 @@ async function fullReorder(
     };
   }
 
-  const query = `query get${type}s($filter: ${type}OrdersFilter){${type}Orders(filter:$filter){id,order}}`;
-  const variables = { filter: filter, orderby: [{ order: "ASC" }] };
-  const { data } = await cmsFetch(schema, query, variables);
+  const query = `query get${type}s($filter: ${type}OrdersFilter) {
+    ${type}Orders(filter:$filter) {
+      id
+      order
+    }
+  }`;
 
+  const variables = { filter: filter, orderby: [{ order: "ASC" }] };
+
+  const { data } = await cmsFetch(schema, query, variables);
   const items = type === "Block" ? data?.BlockOrders : data?.ComponentOrders;
+
   if (items) {
     let order: number = 0;
     const itemsToUpdate = (items as ICmsOrder[])
@@ -266,7 +292,11 @@ async function fullReorder(
       });
 
     if (itemsToUpdate.length) {
-      const query = `mutation update($value:[${type}OrdersInput]){update(${type}Orders:$value){message}}`;
+      const query = `mutation update($value:[${type}OrdersInput]) {
+        update(${type}Orders:$value){
+          message
+        }
+      }`;
       const variables = { value: itemsToUpdate };
       await cmsFetch(schema, query, variables);
     }
@@ -274,7 +304,12 @@ async function fullReorder(
 }
 
 async function prepareOrder(schema: string, order: number, block: string) {
-  const query = `query getComponents($filter:ComponentOrdersFilter){ComponentOrders(filter:$filter){id,order}}`;
+  const query = `query getComponents($filter:ComponentOrdersFilter) {
+    ComponentOrders(filter:$filter) {
+      id
+      order
+    }
+  }`;
   const variables = {
     filter: {
       block: { id: { equals: block } },
@@ -293,7 +328,11 @@ async function prepareOrder(schema: string, order: number, block: string) {
     );
 
     if (componentsToUpdate.length) {
-      const updateQuery = `mutation update($value:[ComponentOrdersInput]){update(ComponentOrders:$value){message}}`;
+      const updateQuery = `mutation update($value:[ComponentOrdersInput]) {
+        update(ComponentOrders:$value) {
+          message
+        }
+      }`;
       const updateVars = { value: componentsToUpdate };
       await cmsFetch(schema, updateQuery, updateVars);
     }
@@ -301,7 +340,13 @@ async function prepareOrder(schema: string, order: number, block: string) {
 }
 
 async function prepareBlockOrder(schema: string, order: number, page: string) {
-  const query = `query getBlocks($filter: BlockOrdersFilter){BlockOrders(filter:$filter){id,order}}`;
+  const query = `query getBlocks($filter: BlockOrdersFilter) {
+    BlockOrders(filter:$filter) {
+      id
+      order
+    }
+  }`;
+
   const variables = {
     filter: {
       configurablePage: { equals: [{ name: page }] },
@@ -309,6 +354,7 @@ async function prepareBlockOrder(schema: string, order: number, page: string) {
     },
     orderby: [{ order: "ASC" }],
   };
+
   const { data } = await cmsFetch(schema, query, variables);
 
   if (data?.BlockOrders) {
@@ -319,7 +365,12 @@ async function prepareBlockOrder(schema: string, order: number, page: string) {
     );
 
     if (blocksToUpdate.length) {
-      const updateQuery = `mutation update($value:[BlockOrdersInput]){update(BlockOrders:$value){message}}`;
+      const updateQuery = `mutation update($value:[BlockOrdersInput]) {
+        update(BlockOrders:$value) {
+          message
+        }
+      }`;
+
       const updateVars = { value: blocksToUpdate };
       await cmsFetch(schema, updateQuery, updateVars);
     }
@@ -332,7 +383,12 @@ async function AddOrder(
   order: number,
   parentBlock: string
 ) {
-  const query = `mutation insert($value:[ComponentOrdersInput]){insert(ComponentOrders:$value){message}}`;
+  const query = `mutation insert($value:[ComponentOrdersInput]) {
+    insert(ComponentOrders:$value) {
+      message
+    }
+  }`;
+
   const variables = {
     value: [
       {
@@ -356,7 +412,12 @@ async function AddBlockOrder(
   order: number,
   page: string
 ) {
-  const query = `mutation insert($value:[BlockOrdersInput]){insert(BlockOrders:$value){message}}`;
+  const query = `mutation insert($value:[BlockOrdersInput]) {
+    insert(BlockOrders:$value) {
+      message
+    }
+  }`;
+
   const variables = {
     value: [
       {

--- a/apps/tailwind-components/app/utils/cms.ts
+++ b/apps/tailwind-components/app/utils/cms.ts
@@ -10,6 +10,7 @@ import { getContainersQuery } from "../gql/cmsPages";
 import type {
   IContainerMetadata,
   ICmsJsFetchPriority,
+  FetchGraphqlResponse,
 } from "../../types/CmsComponents";
 
 export function newDeveloperPage(): IDeveloperPages {
@@ -45,6 +46,24 @@ export async function getPage(
   return { page: currentPage, metadata: data._schema.tables };
 }
 
+async function cmsFetch(
+  schema: string,
+  query: string,
+  variables?: any
+): Promise<FetchGraphqlResponse> {
+  const url: string = `/${schema}/graphql`;
+  const response = (await $fetch(url, {
+    method: "POST",
+    body: { query: query, variables: variables },
+  })) as unknown as FetchGraphqlResponse;
+
+  if (response?.errors?.[0]?.message) {
+    console.error(response.errors[0].message);
+  }
+
+  return response;
+}
+
 export async function deleteComponent(
   schema: string,
   componentId: string,
@@ -52,50 +71,49 @@ export async function deleteComponent(
   block: string,
   reorder: boolean = true
 ) {
-  const dataOrder = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation delete($pkey:[ComponentOrdersInput]){delete(ComponentOrders:$pkey){message}}`,
-      variables: {
-        pkey: [
-          {
-            id: `${componentOrderid}`,
-          },
-        ],
-      },
-    },
-  });
-  const dataComponent = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation delete($pkey:[ComponentsInput]){delete(Components:$pkey){message}}`,
-      variables: {
-        pkey: [
-          {
-            id: `${componentId}`,
-          },
-        ],
-      },
-    },
-  });
+  const orderQuery = `mutation delete($orderId:[ComponentOrdersInput]) {
+    delete(ComponentOrders:$orderId){
+      message
+    }
+  }`;
+  const orderVars = { orderId: [{ id: `${componentOrderid}` }] };
+
+  const componentQuery = `mutation delete($componentId:[ComponentsInput]) {
+    delete(Components:$componentId) {
+      message
+    }
+  }`;
+  const componentVars = { componentId: [{ id: `${componentId}` }] };
+
+  await cmsFetch(schema, orderQuery, orderVars);
+  await cmsFetch(schema, componentQuery, componentVars);
+
   if (reorder) {
     await fullReorder(schema, block, "Component");
   }
 }
 
 async function deleteAllComponentsFromBlock(schema: string, blockId: string) {
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `query getComponents($filter: ComponentOrdersFilter){ComponentOrders(filter:$filter){id,order, component{id}}}`,
-      variables: {
-        filter: {
-          block: { id: { equals: blockId } },
-        },
-        orderby: [{ order: "ASC" }],
-      },
-    },
-  });
+  const query = `query getComponents($filter: ComponentOrdersFilter) {
+    ComponentOrders(filter:$filter) {
+      id
+      order
+      component {
+        id
+      }
+    }
+  }`;
+
+  const variables = {
+    filter: { block: { id: { equals: blockId } } },
+    orderby: [{ order: "ASC" }],
+  };
+
+  const { data } = (await cmsFetch(
+    schema,
+    query,
+    variables
+  )) as FetchGraphqlResponse;
 
   if (data?.ComponentOrders) {
     const itemsToRemove = data.ComponentOrders as {
@@ -116,32 +134,14 @@ export async function deleteBlock(
 ) {
   await deleteAllComponentsFromBlock(schema, blockId);
 
-  const dataOrder = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation delete($pkey:[BlockOrdersInput]){delete(BlockOrders:$pkey){message}}`,
-      variables: {
-        pkey: [
-          {
-            id: `${blockOrderid}`,
-          },
-        ],
-      },
-    },
-  });
-  const dataComponent = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation delete($pkey:[BlocksInput]){delete(Blocks:$pkey){message}}`,
-      variables: {
-        pkey: [
-          {
-            id: `${blockId}`,
-          },
-        ],
-      },
-    },
-  });
+  const orderQuery = `mutation delete($pkey:[BlockOrdersInput]){delete(BlockOrders:$pkey){message}}`;
+  const orderVar = { pkey: [{ id: `${blockOrderid}` }] };
+
+  const blockQuery = `mutation delete($pkey:[BlocksInput]){delete(Blocks:$pkey){message}}`;
+  const blockVars = { pkey: [{ id: `${blockId}` }] };
+
+  await cmsFetch(schema, orderQuery, orderVar);
+  await cmsFetch(schema, blockQuery, blockVars);
   await fullReorder(schema, page, "Block");
 }
 
@@ -183,100 +183,58 @@ export async function addBlock(
 }
 
 async function AddSection(schema: string, id: string) {
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation insert($value:[SectionsInput]){insert(Sections:$value){message}}`,
-      variables: {
-        value: [
-          {
-            enableFullScreenWidth: false,
-            id: `${id}`,
-          },
-        ],
-      },
-    },
-  });
+  const query = `mutation insert($section:[SectionsInput]){insert(Sections:$section){ message }}`;
+  const variables = { section: [{ id: `${id}` }] };
+  await cmsFetch(schema, query, variables);
 }
 
 async function AddHeader(schema: string, id: string) {
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation insert($value:[HeadersInput]){insert(Headers:$value){message}}`,
-      variables: {
-        value: [
-          {
-            titleIsCentered: false,
-            enableFullScreenWidth: false,
-            title: "Header",
-            subtitle: "Add a nice subtitle here",
-            backgroundImage: {
-              id: "penguins",
-            },
-            id: `${id}`,
-            mg_draft: false,
-          },
-        ],
+  const query = `mutation insert($header:[HeadersInput]){insert(Headers:$header){ message }}`;
+  const variables = {
+    header: [
+      {
+        id: `${id}`,
+        title: "Title",
+        subtitle: "A subtitle here",
+        backgroundImage: { id: "penguins" },
       },
-    },
-  });
+    ],
+  };
+
+  await cmsFetch(schema, query, variables);
 }
 
 async function AddImage(schema: string, id: string) {
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation insert($value:[ImagesInput]){insert(Images:$value){message}}`,
-      variables: {
-        value: [
-          {
-            id: `${id}`,
-            width: "325px",
-            imageIsCentered: true,
-          },
-        ],
-      },
-    },
-  });
+  const query = `mutation insert($image:[ImagesInput]) {
+    insert(Images:$image) {
+      status
+      message
+    }
+  }`;
+  const variables = { image: [{ id: `${id}` }] };
+  await cmsFetch(schema, query, variables);
 }
 
 async function AddHeading(schema: string, id: string) {
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation insert($value:[HeadingsInput]){insert(Headings:$value){message}}`,
-      variables: {
-        value: [
-          {
-            id: `${id}`,
-            headingIsCentered: false,
-            headingIsHidden: false,
-            text: "Heading",
-            level: 2,
-          },
-        ],
-      },
-    },
-  });
+  const query = `mutation insert($heading:[HeadingsInput]) {
+    insert(Headings:$heading) {
+      status
+      message
+    }
+  }`;
+  const variables = { heading: [{ id: `${id}`, text: "Section Heading" }] };
+  await cmsFetch(schema, query, variables);
 }
 
 async function AddParagraph(schema: string, id: string) {
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation insert($value:[ParagraphsInput]){insert(Paragraphs:$value){message}}`,
-      variables: {
-        value: [
-          {
-            paragraphIsCentered: false,
-            text: "Add your text here.",
-            id: `${id}`,
-          },
-        ],
-      },
-    },
-  });
+  const query = `mutation insert($paragraph:[ParagraphsInput]){
+    insert(Paragraphs:$paragraph){
+      status
+      message
+    }
+  }`;
+  const variables = { paragraph: [{ id: `${id}`, text: "My new paragraph" }] };
+  await cmsFetch(schema, query, variables);
 }
 
 async function fullReorder(

--- a/apps/tailwind-components/app/utils/cms.ts
+++ b/apps/tailwind-components/app/utils/cms.ts
@@ -11,6 +11,7 @@ import type {
   IContainerMetadata,
   ICmsJsFetchPriority,
   FetchGraphqlResponse,
+  ICmsOrder,
 } from "../../types/CmsComponents";
 
 export function newDeveloperPage(): IDeveloperPages {
@@ -250,126 +251,77 @@ async function fullReorder(
       configurablePage: { name: { equals: parent } },
     };
   }
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `query get${type}s($filter: ${type}OrdersFilter){${type}Orders(filter:$filter){id,order}}`,
-      variables: {
-        filter,
-        orderby: [{ order: "ASC" }],
-      },
-    },
-  });
+
+  const query = `query get${type}s($filter: ${type}OrdersFilter){${type}Orders(filter:$filter){id,order}}`;
+  const variables = { filter: filter, orderby: [{ order: "ASC" }] };
+  const { data } = await cmsFetch(schema, query, variables);
+
   const items = type === "Block" ? data?.BlockOrders : data?.ComponentOrders;
   if (items) {
-    const itemsToUpdate = items as {
-      id: string;
-      order: number;
-    }[];
-
-    itemsToUpdate.sort((a, b) => a.order - b.order);
-
-    let values: { id: string; order: number }[] = [];
     let order: number = 0;
-    for (const item of itemsToUpdate) {
-      values.push({
-        id: item.id,
-        order: order++,
+    const itemsToUpdate = (items as ICmsOrder[])
+      .sort((a: ICmsOrder, b: ICmsOrder) => a.order - b.order)
+      .map((item: ICmsOrder) => {
+        return { id: item.id, order: order++ };
       });
-    }
-    if (values.length) {
-      await $fetch(`/${schema}/graphql`, {
-        method: "POST",
-        body: {
-          query: `mutation update($value:[${type}OrdersInput]){update(${type}Orders:$value){message}}`,
-          variables: {
-            value: values,
-          },
-        },
-      });
+
+    if (itemsToUpdate.length) {
+      const query = `mutation update($value:[${type}OrdersInput]){update(${type}Orders:$value){message}}`;
+      const variables = { value: itemsToUpdate };
+      await cmsFetch(schema, query, variables);
     }
   }
 }
 
 async function prepareOrder(schema: string, order: number, block: string) {
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `query getComponents($filter: ComponentOrdersFilter){ComponentOrders(filter:$filter){id,order}}`,
-      variables: {
-        filter: {
-          block: { id: { equals: block } },
-          order: { between: [order, null] },
-        },
-        orderby: [{ order: "ASC" }],
-      },
+  const query = `query getComponents($filter:ComponentOrdersFilter){ComponentOrders(filter:$filter){id,order}}`;
+  const variables = {
+    filter: {
+      block: { id: { equals: block } },
+      order: { between: [order, null] },
     },
-  });
-  if (data?.ComponentOrders) {
-    const componentsToUpdate = data.ComponentOrders as {
-      id: string;
-      order: number;
-    }[];
+    orderby: [{ order: "ASC" }],
+  };
 
-    let values: { id: string; order: number }[] = [];
-    for (const component of componentsToUpdate) {
-      values.push({
-        id: component.id,
-        order: component.order + 1,
-      });
-    }
-    if (values.length) {
-      await $fetch(`/${schema}/graphql`, {
-        method: "POST",
-        body: {
-          query: `mutation update($value:[ComponentOrdersInput]){update(ComponentOrders:$value){message}}`,
-          variables: {
-            value: values,
-          },
-        },
-      });
+  const { data } = await cmsFetch(schema, query, variables);
+
+  if (data?.ComponentOrders) {
+    const componentsToUpdate = (data.ComponentOrders as ICmsOrder[]).map(
+      (item: ICmsOrder) => {
+        return { id: item.id, order: item.order + 1 };
+      }
+    );
+
+    if (componentsToUpdate.length) {
+      const updateQuery = `mutation update($value:[ComponentOrdersInput]){update(ComponentOrders:$value){message}}`;
+      const updateVars = { value: componentsToUpdate };
+      await cmsFetch(schema, updateQuery, updateVars);
     }
   }
 }
 
 async function prepareBlockOrder(schema: string, order: number, page: string) {
-  const { data } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `query getBlocks($filter: BlockOrdersFilter){BlockOrders(filter:$filter){id,order}}`,
-      variables: {
-        filter: {
-          configurablePage: { equals: [{ name: page }] },
-          order: { between: [order, null] },
-        },
-        orderby: [{ order: "ASC" }],
-      },
+  const query = `query getBlocks($filter: BlockOrdersFilter){BlockOrders(filter:$filter){id,order}}`;
+  const variables = {
+    filter: {
+      configurablePage: { equals: [{ name: page }] },
+      order: { between: [order, null] },
     },
-  });
+    orderby: [{ order: "ASC" }],
+  };
+  const { data } = await cmsFetch(schema, query, variables);
 
   if (data?.BlockOrders) {
-    const blocksToUpdate = data.BlockOrders as {
-      id: string;
-      order: number;
-    }[];
+    const blocksToUpdate = (data.BlockOrders as ICmsOrder[]).map(
+      (block: ICmsOrder) => {
+        return { id: block.id, order: block.order + 1 };
+      }
+    );
 
-    let values: { id: string; order: number }[] = [];
-    for (const block of blocksToUpdate) {
-      values.push({
-        id: block.id,
-        order: block.order + 1,
-      });
-    }
-    if (values.length) {
-      await $fetch(`/${schema}/graphql`, {
-        method: "POST",
-        body: {
-          query: `mutation update($value:[BlockOrdersInput]){update(BlockOrders:$value){message}}`,
-          variables: {
-            value: values,
-          },
-        },
-      });
+    if (blocksToUpdate.length) {
+      const updateQuery = `mutation update($value:[BlockOrdersInput]){update(BlockOrders:$value){message}}`;
+      const updateVars = { value: blocksToUpdate };
+      await cmsFetch(schema, updateQuery, updateVars);
     }
   }
 }
@@ -380,27 +332,22 @@ async function AddOrder(
   order: number,
   parentBlock: string
 ) {
-  const { data_order } = await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation insert($value:[ComponentOrdersInput]){insert(ComponentOrders:$value){message}}`,
-      variables: {
-        value: [
-          {
-            id: `${id}-order`,
-            block: {
-              id: parentBlock,
-            },
-            component: {
-              id: `${id}`,
-            },
-            order: order,
-          },
-        ],
+  const query = `mutation insert($value:[ComponentOrdersInput]){insert(ComponentOrders:$value){message}}`;
+  const variables = {
+    value: [
+      {
+        id: `${id}-order`,
+        block: {
+          id: parentBlock,
+        },
+        component: {
+          id: `${id}`,
+        },
+        order: order,
       },
-    },
-  });
-  return true;
+    ],
+  };
+  await cmsFetch(schema, query, variables);
 }
 
 async function AddBlockOrder(
@@ -409,27 +356,22 @@ async function AddBlockOrder(
   order: number,
   page: string
 ) {
-  await $fetch(`/${schema}/graphql`, {
-    method: "POST",
-    body: {
-      query: `mutation insert($value:[BlockOrdersInput]){insert(BlockOrders:$value){message}}`,
-      variables: {
-        value: [
-          {
-            id: `${id}-order`,
-            configurablePage: {
-              name: page,
-            },
-            block: {
-              id: `${id}`,
-            },
-            order: order,
-          },
-        ],
+  const query = `mutation insert($value:[BlockOrdersInput]){insert(BlockOrders:$value){message}}`;
+  const variables = {
+    value: [
+      {
+        id: `${id}-order`,
+        configurablePage: {
+          name: page,
+        },
+        block: {
+          id: `${id}`,
+        },
+        order: order,
       },
-    },
-  });
-  return true;
+    ],
+  };
+  await cmsFetch(schema, query, variables);
 }
 
 export function generateHtmlPreview(

--- a/apps/tailwind-components/types/CmsComponents.ts
+++ b/apps/tailwind-components/types/CmsComponents.ts
@@ -7,6 +7,7 @@ import type {
   INavigationGroups,
   IDeveloperPages,
   IConfigurablePages,
+  IComponentOrders,
   IFile,
 } from "./cms.ts";
 
@@ -30,3 +31,18 @@ export interface IContainerMetadata {
 }
 
 export type ICmsJsFetchPriority = "high" | "low" | "auto";
+
+export interface FetchGraphqlBody {
+  status?: string;
+  message: string;
+}
+
+export interface FetchGraphqlResponse {
+  data?: {
+    insert?: FetchGraphqlBody;
+    delete?: FetchGraphqlBody;
+    query?: FetchGraphqlBody;
+    ComponentOrders?: IComponentOrders[];
+  };
+  errors?: FetchGraphqlBody[];
+}

--- a/apps/tailwind-components/types/CmsComponents.ts
+++ b/apps/tailwind-components/types/CmsComponents.ts
@@ -7,6 +7,7 @@ import type {
   INavigationGroups,
   IDeveloperPages,
   IConfigurablePages,
+  IBlockOrders,
   IComponentOrders,
   IFile,
 } from "./cms.ts";
@@ -39,10 +40,13 @@ export interface FetchGraphqlBody {
 
 export interface FetchGraphqlResponse {
   data?: {
-    insert?: FetchGraphqlBody;
-    delete?: FetchGraphqlBody;
-    query?: FetchGraphqlBody;
     ComponentOrders?: IComponentOrders[];
+    BlockOrders?: IBlockOrders[];
   };
   errors?: FetchGraphqlBody[];
+}
+
+export interface ICmsOrder {
+  id: string;
+  order: number;
 }

--- a/data/_demodata/applications/pages/Images.csv
+++ b/data/_demodata/applications/pages/Images.csv
@@ -1,4 +1,4 @@
-id,in block,display name,alt,width,height,image,image is centered
-molgenis-default-banner-img,,,a person pointing at a computer screen,,,molgenis-banner,
-molgenis-logo,,,MOLGENIS open source software,,,molgenis-logo-blue-text,
-penguins,,,two penguins walking in the grass,,,penguins,
+id,alt,image
+molgenis-default-banner-img,a person pointing at a computer screen,molgenis-banner
+molgenis-logo,MOLGENIS open source software,molgenis-logo-blue-text
+penguins,two penguins walking in the grass,penguins

--- a/data/_demodata/applications/pages/Paragraphs.csv
+++ b/data/_demodata/applications/pages/Paragraphs.csv
@@ -1,4 +1,4 @@
-id,in block,text,paragraph is centered
-home-section-features-p,home-section-features,"[MOLGENIS](https://molgenis.org) helps to find, capture, exchange, manage and analyse scientific data. It is fully customizable: data structure, user interface and layout can be fully changed and you can plug-in your own (bioinformatics) scripts to make your MOLGENIS very special.",
+id,in block,text
+home-section-features-p,home-section-features,"[MOLGENIS](https://molgenis.org) helps to find, capture, exchange, manage and analyse scientific data. It is fully customizable: data structure, user interface and layout can be fully changed and you can plug-in your own (bioinformatics) scripts to make your MOLGENIS very special."
 home-section-applications-p,home-section-applications,"MOLGENIS was born from molecular genetics research and is now a broadly applicable data tool thanks to many sponsors and contributors. It is used in many scientific areas such as biobanking, rare disease research, patient registries and other scientific organisations all around the world."
 home-section-applications-p-2,home-section-applications,"Discover more tools on our [website](https://molgenis.org/tools.html)."

--- a/data/_models/specific/Pages.csv
+++ b/data/_models/specific/Pages.csv
@@ -65,15 +65,15 @@ Navigation cards,,order,int,,TRUE,,,,,,0,,Order the card should appear in when u
 Blocks,,Configuration,section,,,,,,,,,,,pages
 Blocks,,UI settings,heading,,,,,,,,,,,pages
 Blocks,,enable full screen width,bool,,,,,,,,FALSE,,"If true, content will be expanded to the fit the full width of the screen",pages
-Blocks,,Component connections,heading,,,,,,"mg_tableclass && mg_tableclass.endsWith("".Headers"") ? false : true",,,,Link components and set the order in which they display on page. ,pages
-Blocks,,in container,multiselect,,,Configurable pages,,,"mg_tableclass && mg_tableclass.endsWith("".Headers"") ? false : true",,,,A link to the configurable page where the block is displayed,pages
-Blocks,,components,refback,,,Components,in block,,"mg_tableclass && mg_tableclass.endsWith("".Headers"") ? false : true",,,,The elements that are displayed in a block,pages
-Blocks,,component order,refback,,,Component orders,block,,"mg_tableclass && mg_tableclass.endsWith("".Headers"") ? false : true",,,,,pages
+Blocks,,Component connections,heading,,,,,,,,,,Link components and set the order in which they display on page. ,pages
+Blocks,,in container,multiselect,,,Configurable pages,,,,,,,A link to the configurable page where the block is displayed,pages
+Blocks,,components,refback,,,Components,in block,,,,,,The elements that are displayed in a block,pages
+Blocks,,component order,refback,,,Component orders,block,,,,,,,pages
 Blocks,,Metadata,heading,,,,,,,,,,,pages
 Blocks,,id,auto_id,1,TRUE,,,,,,,,An auto ID used to generate UI elements,pages
 Components,,Configuration,section,,,,,,,,,,,pages
-Components,,Component connections,heading,,,,,,FALSE,,,,Create links between components and blocks,pages
-Components,,in block,multiselect,,,Blocks,,,FALSE,,,,A link to the block where the component is used,pages
+Components,,Component connections,heading,,,,,,,,,,Create links between components and blocks,pages
+Components,,in block,multiselect,,,Blocks,,,,,,,A link to the block where the component is used,pages
 Components,,Metadata,heading,,,,,,,,,,,pages
 Components,,id,auto_id,1,TRUE,,,,,,,,An auto ID used to generate UI elements,pages
 Block orders,,,,,,,,,,,,,"The order blocks (headers, sections, etc.) appear on a page",pages

--- a/data/_models/specific/Pages.csv
+++ b/data/_models/specific/Pages.csv
@@ -36,7 +36,7 @@ Headers,,title is centered,bool,,,,,,,,FALSE,,"If true, the title and subtitle w
 Text elements,Components,,,,,,,,,,,,All text elements,pages
 Text elements,,text,text,,,,,,,,,,"The content to display. URLs can be generated using markdown format ""[label](url)"". This also works for emails if ""mailto"" is defined ""[user@website.com](mailto:user@website.com)"".",pages
 Headings,Text elements,,,,,,,,,,,,<h*> elements,pages
-Headings,,level,int,,,,,,,"if (level && (level < 1 || level > 6)) ""Level must corresponding to an HTML heading element. Use a level from 1 to 6.""",,,Enter an HTML Heading element level (1-6). Please note that heading levels corresponds to page hierarchy and it should not be used to style headings; this should be done elsewhere. ,pages
+Headings,,level,int,,,,,,,"if (level && (level < 1 || level > 6)) ""Level must corresponding to an HTML heading element. Use a level from 1 to 6.""",2,,Enter an HTML Heading element level (1-6). Please note that heading levels corresponds to page hierarchy and it should not be used to style headings; this should be done elsewhere. ,pages
 Headings,,heading is centered,bool,,,,,,,,FALSE,,"If true, the heading will be center aligned",pages
 Headings,,heading is hidden,bool,,,,,,,,FALSE,,"If true, the heading will be visually hidden",pages
 Paragraphs,Text elements,,,,,,,,,,,,<p> elements,pages
@@ -72,8 +72,8 @@ Blocks,,component order,refback,,,Component orders,block,,"mg_tableclass && mg_t
 Blocks,,Metadata,heading,,,,,,,,,,,pages
 Blocks,,id,auto_id,1,TRUE,,,,,,,,An auto ID used to generate UI elements,pages
 Components,,Configuration,section,,,,,,,,,,,pages
-Components,,Component connections,heading,,,,,,false,,,,Create links between components and blocks,pages
-Components,,in block,multiselect,,,Blocks,,,false,,,,A link to the block where the component is used,pages
+Components,,Component connections,heading,,,,,,FALSE,,,,Create links between components and blocks,pages
+Components,,in block,multiselect,,,Blocks,,,FALSE,,,,A link to the block where the component is used,pages
 Components,,Metadata,heading,,,,,,,,,,,pages
 Components,,id,auto_id,1,TRUE,,,,,,,,An auto ID used to generate UI elements,pages
 Block orders,,,,,,,,,,,,,"The order blocks (headers, sections, etc.) appear on a page",pages


### PR DESCRIPTION
### What are the main changes you did

The aim of this PR is to refactor the graphql-related functions that were introduced in the recent CMS PRs. The idea was to merge the PRs and refactor once we had added the create and delete functionality. 

- [x] Create a generic function for handling graphql requests
- [x] Refactor add, delete, and order functions using the generic function to reduce duplication. Further revise functions for simplicity and readability 
- [x] Move extra query variables to default values in the data model

This PR is part of molgenis/GCC#1143

### How to test

- explain here what to do to test this (or point to unit tests)

### Checklist

- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
