### PR TITLE
fix(rls): switch grants instead of adding when rls flag is set

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
@@ -193,26 +193,44 @@ public class SqlRoleManager {
       throw new MolgenisException("Table name is required for table-level grant");
     }
     TableMetadata tableMetadata = requireRootTable(schemaName, tableName);
-    boolean isRowLevel = permission.hasRowLevel();
-    String grantRoleName = isRowLevel ? RLS_ROLE_PREFIX + roleName : roleName;
+    Boolean requestedRowLevel = permission.isRowLevel();
+    boolean isRowLevel =
+        requestedRowLevel != null
+            ? requestedRowLevel
+            : hasRowLevelGrant(schemaName, roleName, tableName);
+    String plainFullRole = fullRoleName(schemaName, roleName);
+    String rlsFullRole = fullRoleName(schemaName, RLS_ROLE_PREFIX + roleName);
     if (isRowLevel) {
       createRlsRole(schemaName, roleName);
       if (tableMetadata.getColumn(MG_ROLES) == null) {
         tableMetadata.add(column(MG_ROLES).setType(STRING_ARRAY));
       }
     }
-    String fullRole = fullRoleName(schemaName, grantRoleName);
+    String fullRole = isRowLevel ? rlsFullRole : plainFullRole;
+    String supersededRole = isRowLevel ? plainFullRole : rlsFullRole;
+    boolean supersededRoleExists = isRowLevel || roleExists(rlsFullRole);
     database.tx(
         db -> {
           DSLContext jooq = ((SqlDatabase) db).getJooq();
           for (TableMetadata tableInTree : tableMetadata.getInheritanceTree()) {
-            applyPgGrants(jooq, schemaName, fullRole, tableInTree.getTableName(), permission);
+            String tableInTreeName = tableInTree.getTableName();
+            if (supersededRoleExists) {
+              revokeAll(jooq, table(name(schemaName, tableInTreeName)), name(supersededRole));
+            }
+            applyPgGrants(jooq, schemaName, fullRole, tableInTreeName, permission);
           }
           if (isRowLevel) {
             enableRowLevelSecurityOnTree(jooq, schemaName, tableMetadata);
+          } else {
+            disableRowLevelSecurityIfUnused(jooq, schemaName, tableMetadata);
           }
         });
     database.getListener().onSchemaChange();
+  }
+
+  private boolean hasRowLevelGrant(String schemaName, String roleName, String tableName) {
+    return getPermissions(schemaName, roleName).stream()
+        .anyMatch(p -> tableName.equals(p.table()) && p.hasRowLevel());
   }
 
   public void revoke(String schemaName, String roleName, String tableName) {

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
@@ -6,6 +6,7 @@ import static org.molgenis.emx2.Constants.MG_ROLES;
 import static org.molgenis.emx2.TableMetadata.table;
 
 import java.util.List;
+import org.jooq.Record;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 import org.molgenis.emx2.*;
@@ -13,7 +14,7 @@ import org.molgenis.emx2.*;
 class TestRowLevelSecurity {
 
   private static Database database;
-  private static final String SCHEMA = "TestRowLevelSecurity";
+  private static final String SCHEMA = TestRowLevelSecurity.class.getSimpleName();
   private static final String ARTICLES = "Articles";
 
   private static final String USER_TEAM_A = "rls_user_team_a";
@@ -462,6 +463,189 @@ class TestRowLevelSecurity {
     schema.revoke("MixedPlainRole", table);
     schema.deleteRole("MixedRlsRole");
     schema.deleteRole("MixedPlainRole");
+  }
+
+  @Test
+  void switchingGrantToRowLevelEnforcesRlsForThatRole() {
+    database.becomeAdmin();
+    Schema schema = database.getSchema(SCHEMA);
+    String table = "FlipOnTable";
+    String role = "FlipOnRole";
+    String user = "rls_user_flip_on";
+    if (!database.hasUser(user)) database.addUser(user);
+
+    schema.create(table(table).add(column("id").setPkey()).add(column("title")));
+    schema.createRole(role);
+    schema.grant(
+        role, new TablePermission(table).select(true).insert(true).update(true).delete(true));
+    schema.grant(
+        role,
+        new TablePermission(table)
+            .select(true)
+            .insert(true)
+            .update(true)
+            .delete(true)
+            .rowLevel(true));
+
+    schema
+        .getTable(table)
+        .insert(
+            new Row()
+                .setString("id", "f1")
+                .setString("title", "owned")
+                .set(MG_ROLES, new String[] {role}));
+    schema.getTable(table).insert(new Row().setString("id", "f2").setString("title", "unowned"));
+    schema.addMember(user, role);
+
+    assertTrue(
+        schema.getRoleInfo(role).permissions().stream()
+            .anyMatch(p -> table.equals(p.table()) && p.hasRowLevel()),
+        "permission should report row level after the switch");
+
+    database.setActiveUser(user);
+    database.tx(
+        db -> {
+          List<String> ids =
+              db.getSchema(SCHEMA).getTable(table).retrieveRows().stream()
+                  .map(r -> r.getString("id"))
+                  .toList();
+          assertTrue(ids.contains("f1"), "should see own row");
+          assertFalse(
+              ids.contains("f2"), "should NOT see unowned row after switching to row level");
+        });
+
+    // Cleanup
+    database.becomeAdmin();
+    schema.getTable(table).delete(new Row().setString("id", "f1"));
+    schema.removeMember(user);
+    schema.revoke(role, table);
+    schema.deleteRole(role);
+  }
+
+  @Test
+  void switchingGrantOffRowLevelRestoresFullTableAccess() {
+    database.becomeAdmin();
+    Schema schema = database.getSchema(SCHEMA);
+    String table = "FlipOffTable";
+    String role = "FlipOffRole";
+    String user = "rls_user_flip_off";
+    if (!database.hasUser(user)) database.addUser(user);
+
+    schema.create(table(table).add(column("id").setPkey()).add(column("title")));
+    schema.createRole(role);
+    schema.grant(
+        role,
+        new TablePermission(table)
+            .select(true)
+            .insert(true)
+            .update(true)
+            .delete(true)
+            .rowLevel(true));
+
+    schema
+        .getTable(table)
+        .insert(
+            new Row()
+                .setString("id", "g1")
+                .setString("title", "owned")
+                .set(MG_ROLES, new String[] {role}));
+    schema.getTable(table).insert(new Row().setString("id", "g2").setString("title", "unowned"));
+    schema.addMember(user, role);
+
+    database.setActiveUser(user);
+    database.tx(
+        db ->
+            assertFalse(
+                db.getSchema(SCHEMA).getTable(table).retrieveRows().stream()
+                    .anyMatch(r -> "g2".equals(r.getString("id"))),
+                "unowned row should be hidden while row level is on"));
+
+    database.becomeAdmin();
+    schema.grant(
+        role,
+        new TablePermission(table)
+            .select(true)
+            .insert(true)
+            .update(true)
+            .delete(true)
+            .rowLevel(false));
+
+    assertTrue(
+        schema.getRoleInfo(role).permissions().stream()
+            .noneMatch(p -> table.equals(p.table()) && p.hasRowLevel()),
+        "permission should no longer report row level");
+    assertFalse(
+        rowLevelSecurityEnabled(table),
+        "row level security should be disabled once the last row level grant is gone");
+
+    database.setActiveUser(user);
+    database.tx(
+        db -> {
+          List<String> ids =
+              db.getSchema(SCHEMA).getTable(table).retrieveRows().stream()
+                  .map(r -> r.getString("id"))
+                  .toList();
+          assertTrue(ids.contains("g1"), "should see own row");
+          assertTrue(ids.contains("g2"), "should see unowned row after switching row level off");
+        });
+  }
+
+  @Test
+  void omittedIsRowLevelKeepsTheExistingMode() {
+    database.becomeAdmin();
+    Schema schema = database.getSchema(SCHEMA);
+    String table = "KeepModeTable";
+    String role = "KeepModeRole";
+    String user = "rls_user_keep_mode";
+    if (!database.hasUser(user)) database.addUser(user);
+
+    schema.create(table(table).add(column("id").setPkey()).add(column("title")));
+    schema.createRole(role);
+    schema.grant(role, new TablePermission(table).select(true).rowLevel(true));
+    // isRowLevel not specified: this only adds insert, it must not downgrade to a plain grant
+    schema.grant(role, new TablePermission(table).insert(true));
+
+    schema
+        .getTable(table)
+        .insert(
+            new Row()
+                .setString("id", "k1")
+                .setString("title", "owned")
+                .set(MG_ROLES, new String[] {role}));
+    schema.getTable(table).insert(new Row().setString("id", "k2").setString("title", "unowned"));
+    schema.addMember(user, role);
+
+    assertTrue(
+        schema.getRoleInfo(role).permissions().stream()
+            .anyMatch(p -> table.equals(p.table()) && p.hasRowLevel()),
+        "row level should be preserved when isRowLevel is not specified");
+
+    database.setActiveUser(user);
+    database.tx(
+        db -> {
+          List<String> ids =
+              db.getSchema(SCHEMA).getTable(table).retrieveRows().stream()
+                  .map(r -> r.getString("id"))
+                  .toList();
+          assertTrue(ids.contains("k1"), "should see own row");
+          assertFalse(ids.contains("k2"), "should NOT see unowned row");
+        });
+
+    database.becomeAdmin();
+    schema.getTable(table).delete(new Row().setString("id", "k1"));
+    schema.removeMember(user);
+    schema.revoke(role, table);
+    schema.deleteRole(role);
+  }
+
+  private static boolean rowLevelSecurityEnabled(String tableName) {
+    Record record =
+        ((SqlDatabase) database)
+            .getJooq()
+            .fetchOne(
+                "select relrowsecurity as rls from pg_class where oid = cast(? as regclass)",
+                "\"" + SCHEMA + "\".\"" + tableName + "\"");
+    return Boolean.TRUE.equals(record.get("rls", Boolean.class));
   }
 
   @Test


### PR DESCRIPTION
### What are the main changes you did

Fixes https://github.com/molgenis/GCC/issues/3380

- There was no check if a row level role was already present for a role table combination. Therefor table-level roles were never disabled when a row level role was added.

### How to test

- See unit test
Or:
- Go to the preview server add a table level row:
```
   mutation {
  change(
    roles: [
      {
        name: "TeamB"
        permissions: [
          {
            table: "Pet"
            select: true
            insert: true
            update: true
            delete: true
            isRowLevel: false // or ommit
          }
        ]
      }
    ]
  ) {
    message
  }
}
```
No switch is to row level:
```
mutation {
  change(
    roles: [
      {
        name: "TeamB"
        permissions: [
          {
            table: "Pet"
            select: true
            insert: true
            update: true
            delete: true
            isRowLevel: true
          }
        ]
      }
    ]
  ) {
    message
  }
}
```
Now check the permission:
```
query {
  _schema {
    roles {
      name
      permissions {
        table
        select
        insert
        isRowLevel
      }
    }
  }
}
```
See that TeamB has a row level security grant for pets (succes)

### Checklist

- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
