### PR TITLE
perf(ci): build each docker image once instead of twice

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -251,41 +251,6 @@ commands:
 
 # jobs for pull request and master
 jobs:
-  build-preview-images:
-    <<: *build_config
-
-    steps:
-    - run: |
-        echo "PR number: ${CIRCLE_PULL_REQUEST##*/}"
-
-    - pre_steps
-
-    - run:
-        name: build and push emx2 java docker images for the preview
-        command: ./gradlew -s --no-daemon dockerPush ci -x test
-
-    - persist_to_workspace:
-        root: .
-        paths:
-          - build/ci.properties
-
-    - run:
-        name: push ssr-catalogue docker images
-        command: |
-          export $( cat build/ci.properties | xargs )
-          docker build apps/catalogue/ -t molgenis/ssr-catalogue-snapshot:latest -t molgenis/ssr-catalogue-snapshot:${TAG_NAME}
-          docker push molgenis/ssr-catalogue-snapshot --all-tags
-
-    - run:
-        name: Docker-Scout scanning on cve's, break on critical.
-        command: |
-          export $( cat build/ci.properties | xargs )
-          curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s
-          docker scout cves molgenis/molgenis-emx2-snapshot:${TAG_NAME} --only-severity critical --ignore-suppressed --only-fixed --exit-code
-
-    - post_steps
-
-
   build:
     <<: *build_config
 
@@ -297,7 +262,7 @@ jobs:
           tree: apps
       - run:
           name: build the application without running tests to speed up the e2e tests
-          command: ./gradlew shadowJar -x test ci --no-daemon
+          command: ./gradlew shadowJar dockerPrepare -x test ci --no-daemon
 
       - run:
           name: build ssr catalogue
@@ -312,6 +277,8 @@ jobs:
           paths:
             - build/libs
             - build/ci.properties
+            - build/docker/deps
+            - build/docker/app
             - apps/catalogue
             - custom-app/
 
@@ -653,7 +620,7 @@ jobs:
 
     - post_steps
 
-  pr-preview:
+  preview:
     <<: *build_config
 
     steps:
@@ -661,6 +628,27 @@ jobs:
 
     - attach_workspace:
         at: .
+
+    - run:
+        name: build and push emx2 java docker image
+        command: |
+          export $( cat build/ci.properties | xargs )
+          docker build . -t ${IMAGE_NAME}:${TAG_NAME} -t ${IMAGE_NAME}:latest
+          docker push ${IMAGE_NAME} --all-tags
+
+    - run:
+        name: push ssr-catalogue docker images
+        command: |
+          export $( cat build/ci.properties | xargs )
+          docker build apps/catalogue/ -t molgenis/ssr-catalogue-snapshot:latest -t molgenis/ssr-catalogue-snapshot:${TAG_NAME}
+          docker push molgenis/ssr-catalogue-snapshot --all-tags
+
+    - run:
+        name: Docker-Scout scanning on cve's, break on critical.
+        command: |
+          export $( cat build/ci.properties | xargs )
+          curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s
+          docker scout cves molgenis/molgenis-emx2-snapshot:${TAG_NAME} --only-severity critical --ignore-suppressed --only-fixed --exit-code
 
     - run:
         name: Start preview in limited resources mode
@@ -796,13 +784,9 @@ workflows:
     unless:
       equal: [ "delete-pr-preview", << pipeline.parameters.GHA_Action >> ]
     jobs:
-    - build-preview-images:
-        filters:
-          branches:
-            ignore: master
-    - pr-preview:
+    - preview:
         requires:
-          - build-preview-images
+          - build
         filters:
           branches:
             ignore: master

--- a/build.gradle
+++ b/build.gradle
@@ -139,6 +139,7 @@ if (version.toString().endsWith('-SNAPSHOT')) {
 tasks.register('ci', WriteProperties) {
     destinationFile.set(file('build/ci.properties'))
     property 'TAG_NAME', tagName
+    property 'IMAGE_NAME', imageName
 }
 
 tasks.register('dockerPrepare') {


### PR DESCRIPTION
Summary:
- move duplicated stuff from preview builds into build
- move remaining preview stuff to preview task, and make it depend on build.

# Goal: build each docker image once

The preview image is built by the job that already built the application, instead of a second job
building the whole thing again.

## What it does, and how to check each one

1. **`./gradlew ci` publishes the image name alongside the tag**, so nothing downstream has to
   reconstruct the coordinate.
   *Check:* run `./gradlew ci` and read `build/ci.properties`. See both
   `IMAGE_NAME=docker.io/molgenis/molgenis-emx2-snapshot` and `TAG_NAME=…`. On the branch below this
   one the same file holds `TAG_NAME` alone.

2. **One `preview` job builds and pushes the image**, from the docker context the `build` job
   prepared and the coordinate it wrote. `build-preview-images` and `pr-preview` are gone.
   *Check:* read the workflow. `preview` requires `build`; no job named `build-preview-images` or
   `pr-preview` exists. In the job, `docker build .` runs against `build/docker/deps` and
   `build/docker/app` restored from the workspace, and tags come from `build/ci.properties`.

3. **The `build` job prepares the docker context in the same invocation that builds the jar** —
   `./gradlew shadowJar dockerPrepare -x test ci` — and persists it.
   *Check:* read the `build` job's `persist_to_workspace` list: `build/docker/deps`,
   `build/docker/app` and `build/ci.properties` beside what it carried before.

4. **The ssr-catalogue image build, the docker-scout scan, the azure preview start, the poll and the
   slack message run exactly as they did**, in the new job.
   *Check:* compare those steps against the branch below this one; they are unchanged.

## Code map

- **`build.gradle`** — one line: the `ci` task writes `IMAGE_NAME` from the same `imageName` the
  docker tasks use, on both the snapshot and the release branch of that condition.
- **`.circleci/config.yml`** — the new `preview` job is the two deleted jobs' steps in one place. The
  old job passed a `--build-arg JAR_FILE`; the root `Dockerfile` declares no such `ARG` and copies
  only the prepared context, so that argument was already doing nothing.
- **`preview` still runs `pre_steps`**, which fetches gradle dependencies it does not use. Splitting
  `pre_steps` would touch every job in the file, which is a bigger change than this one earns.

## Known limitations

- The docker-scout scan names `molgenis/molgenis-emx2-snapshot:${TAG_NAME}` literally rather than the
  `IMAGE_NAME` this PR publishes, so a release image is scanned under the snapshot name.
