### PR TITLE
perf(build): enable caching also when tests were run on different backends when you work on multiple worktree

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -122,6 +122,15 @@ subprojects {
         sourceCompatibility = rootProject.ext.javaVersion
     }
 
+    normalization {
+        runtimeClasspath {
+            metaInf {
+                ignoreAttribute("Implementation-Version")
+                ignoreAttribute("Build-OS")
+            }
+        }
+    }
+
     jar {
         reproducibleFileOrder = true
         manifest {
@@ -150,7 +159,7 @@ subprojects {
         }
     }
 
-    tasks.withType(Test).configureEach { rootProject.ext.forwardDotenvProps(it) }
+    tasks.withType(Test).configureEach { rootProject.ext.forwardDotenvPropsToTest(it) }
     tasks.withType(JavaExec).configureEach { rootProject.ext.forwardDotenvProps(it) }
 
     test.dependsOn ":backend:molgenis-emx2-sql:initDatabase"

--- a/build.gradle
+++ b/build.gradle
@@ -16,53 +16,7 @@ ext {
     javaVersion = JavaVersion.VERSION_21
 }
 
-// Settings such as MOLGENIS_POSTGRES_URI/USER/PASS, MOLGENIS_HTTP_PORT or feature flags
-// are read inside the Java code (EnvironmentProperty.getParameter). A running Gradle
-// daemon does not pass command-line -D system properties to forked JVMs, so they are
-// forwarded explicitly onto every forked Test/JavaExec task (test, run, dev, cleandb,
-// generateTypes).
-// Every key of a repo-root .env file is forwarded, read straight from disk once at
-// configuration time (daemon-safe, no `source` needed), as is every MOLGENIS_ system property
-// given on the command line. Precedence per key: a -D CLI system property wins; otherwise the
-// .env value; otherwise nothing (Java default applies).
-// Whitespace is trimmed the way JavaScript String.trim() does it, so that this parser and the
-// one in apps/dev-env.js read the same keys out of the same file.
-def javascriptTrim = { String text -> text.replaceAll('^[\\s\\u00A0\\uFEFF]+|[\\s\\u00A0\\uFEFF]+$', '') }
-ext.molgenisDotenv = { ->
-    def envFile = new File(rootDir, '.env')
-    def result = [:]
-    if (envFile.exists()) {
-        envFile.eachLine { line ->
-            def trimmed = javascriptTrim(line)
-            if (trimmed.isEmpty() || trimmed.startsWith('#')) return
-            def idx = trimmed.indexOf('=')
-            if (idx < 0) return
-            def key = javascriptTrim(trimmed.substring(0, idx))
-            def value = javascriptTrim(trimmed.substring(idx + 1))
-            if (value.length() >= 2 &&
-                    ((value.startsWith('"') && value.endsWith('"')) ||
-                     (value.startsWith("'") && value.endsWith("'")))) {
-                value = value.substring(1, value.length() - 1)
-            }
-            result[key] = value
-        }
-    }
-    result
-}()
-ext.forwardDotenvProps = { task ->
-    def commandLineKeys = System.getProperties().stringPropertyNames().findAll { it.startsWith('MOLGENIS_') }
-    (rootProject.molgenisDotenv.keySet() + commandLineKeys).each { key ->
-        def value = System.getProperty(key) ?: rootProject.molgenisDotenv[key]
-        if (value != null) task.systemProperty key, value
-    }
-}
-ext.resolveDotenvValue = { key ->
-    System.getProperty(key) ?: rootProject.molgenisDotenv[key] ?: System.getenv(key)
-}
-ext.applyDotenvHeap = { task ->
-    def heap = rootProject.ext.resolveDotenvValue('MOLGENIS_JVM_XMX')
-    if (heap) task.maxHeapSize = heap
-}
+apply from: "$rootDir/gradle/dotenv.gradle"
 
 allprojects {
     if(rootProject.nyxState.releaseScope.previousVersion == rootProject.version) {
@@ -227,7 +181,7 @@ tasks.register('printDevConfig') {
     description = 'Prints the realized dev task system properties and heap without starting the application'
     def devTask = project(':backend:molgenis-emx2-webapi').tasks.named('dev', JavaExec).get()
     def devSystemProperties = new TreeMap<String, String>(devTask.systemProperties.collectEntries { key, value ->
-        [key, key.toUpperCase() =~ /PASS|SECRET|TOKEN/ ? '<HIDDEN>' : String.valueOf(value)]
+        [key, rootProject.ext.isSecretDotenvKey(key) ? '<HIDDEN>' : String.valueOf(value)]
     })
     def devHeap = devTask.maxHeapSize ?: 'unbounded'
     doLast {

--- a/gradle/dotenv.gradle
+++ b/gradle/dotenv.gradle
@@ -1,0 +1,95 @@
+// Settings such as MOLGENIS_POSTGRES_URI/USER/PASS, MOLGENIS_HTTP_PORT or feature flags
+// are read inside the Java code (EnvironmentProperty.getParameter). A running Gradle
+// daemon does not pass command-line -D system properties to forked JVMs, so they are
+// forwarded explicitly onto every forked Test/JavaExec task (test, run, dev, cleandb,
+// generateTypes).
+// Every key of a repo-root .env file is forwarded, read straight from disk once at
+// configuration time (daemon-safe, no `source` needed), as is every MOLGENIS_ system property
+// given on the command line. Precedence per key: a -D CLI system property wins; otherwise the
+// .env value; otherwise nothing (Java default applies).
+// Whitespace is trimmed the way JavaScript String.trim() does it, so that this parser and the
+// one in apps/dev-env.js read the same keys out of the same file.
+class DotenvSystemProperties implements org.gradle.process.CommandLineArgumentProvider {
+    private final Map<String, String> values
+
+    DotenvSystemProperties(Map<String, String> values) {
+        this.values = values
+    }
+
+    @Override
+    Iterable<String> asArguments() {
+        values.collect { key, value -> "-D${key}=${value}".toString() }
+    }
+}
+
+def javascriptTrim = { String text -> text.replaceAll('^[\\s\\u00A0\\uFEFF]+|[\\s\\u00A0\\uFEFF]+$', '') }
+ext.molgenisDotenv = { ->
+    def envFile = new File(rootDir, '.env')
+    def result = [:]
+    if (envFile.exists()) {
+        envFile.eachLine { line ->
+            def trimmed = javascriptTrim(line)
+            if (trimmed.isEmpty() || trimmed.startsWith('#')) return
+            def idx = trimmed.indexOf('=')
+            if (idx < 0) return
+            def key = javascriptTrim(trimmed.substring(0, idx))
+            def value = javascriptTrim(trimmed.substring(idx + 1))
+            if (value.length() >= 2 &&
+                    ((value.startsWith('"') && value.endsWith('"')) ||
+                     (value.startsWith("'") && value.endsWith("'")))) {
+                value = value.substring(1, value.length() - 1)
+            }
+            result[key] = value
+        }
+    }
+    result
+}()
+ext.dotenvValuesForForkedJvms = { ->
+    def commandLineKeys = System.getProperties().stringPropertyNames().findAll { it.startsWith('MOLGENIS_') }
+    def values = new TreeMap<String, String>()
+    (rootProject.molgenisDotenv.keySet() + commandLineKeys).each { key ->
+        def value = System.getProperty(key) ?: rootProject.molgenisDotenv[key]
+        if (value != null) values[key] = String.valueOf(value)
+    }
+    values
+}
+ext.secretDotenvKeyNameFragments = /PASS|PW|SECRET|TOKEN|KEY|CREDENTIAL/
+ext.isSecretDotenvKey = { String key -> key.toUpperCase() =~ rootProject.ext.secretDotenvKeyNameFragments }
+ext.dotenvKeysNotReadByTests = ['MOLGENIS_HTTP_PORT', 'MOLGENIS_JVM_XMX',
+                                'MOLGENIS_APPS_HOST', 'MOLGENIS_APPS_SCHEMA',
+                                'NUXT_PUBLIC_API_BASE'].toSet()
+ext.secretDotenvKeysReadByTests = ['MOLGENIS_POSTGRES_PASS', 'MOLGENIS_ADMIN_PW',
+                                   'MOLGENIS_JWT_SHARED_SECRET', 'MOLGENIS_OIDC_CLIENT_SECRET',
+                                   'MOLGENIS_OIDC_UNSIGNED_TOKEN', 'MOLGENIS_TOKEN',
+                                   'CV_CLIENT_SECRET', 'EMX2_TEST_EMAIL_PASSWORD',
+                                   'EMAIL_SMTP_AUTHENTICATOR_SENDER_PASSWORD'].toSet()
+ext.sha256Hex = { String text ->
+    java.security.MessageDigest.getInstance('SHA-256').digest(text.getBytes('UTF-8')).encodeHex().toString()
+}
+ext.dotenvKeysWhosePortIsNotReadByTests = ['MOLGENIS_POSTGRES_URI'].toSet()
+ext.withoutPort = { String uri -> uri.replaceFirst('(//[^/:]+):\\d+', '$1') }
+ext.forwardDotenvProps = { task ->
+    rootProject.ext.dotenvValuesForForkedJvms().each { key, value -> task.systemProperty key, value }
+}
+ext.declareTestDotenvInput = { task, String key, String value ->
+    if (rootProject.ext.dotenvKeysNotReadByTests.contains(key)) return
+    if (rootProject.ext.dotenvKeysWhosePortIsNotReadByTests.contains(key)) {
+        task.inputs.property("molgenisDotenv.${key}.portless", rootProject.ext.withoutPort(value))
+    } else if (!rootProject.ext.isSecretDotenvKey(key)) {
+        task.inputs.property("molgenisDotenv.${key}", value)
+    } else if (rootProject.ext.secretDotenvKeysReadByTests.contains(key)) {
+        task.inputs.property("molgenisDotenv.${key}.sha256", rootProject.ext.sha256Hex(value))
+    }
+}
+ext.forwardDotenvPropsToTest = { task ->
+    def values = rootProject.ext.dotenvValuesForForkedJvms()
+    task.jvmArgumentProviders.add(new DotenvSystemProperties(values))
+    values.each { key, value -> rootProject.ext.declareTestDotenvInput(task, key, value) }
+}
+ext.resolveDotenvValue = { key ->
+    System.getProperty(key) ?: rootProject.molgenisDotenv[key] ?: System.getenv(key)
+}
+ext.applyDotenvHeap = { task ->
+    def heap = rootProject.ext.resolveDotenvValue('MOLGENIS_JVM_XMX')
+    if (heap) task.maxHeapSize = heap
+}


### PR DESCRIPTION
# Goal: let test ran in different worktree share each other's cached test results so you don't run them all twice

Two developers, or two worktrees on one machine, run the backend tests against different postgres
ports. Today that alone gives each of them a different cache key, so neither can reuse anything the
other built. After this change they compute the same key and share the result.

Gradle's local build cache lives in `~/.gradle/caches/build-cache-1`, which is shared across every
project and worktree on a machine — so this is what makes the caches the earlier PRs in this stack
turn on reusable, rather than merely present.

## What it does, and how to check each one

1. **A `.env` key no test reads no longer invalidates test results.** `MOLGENIS_HTTP_PORT`,
   `MOLGENIS_JVM_XMX`, `MOLGENIS_APPS_HOST`, `MOLGENIS_APPS_SCHEMA` and `NUXT_PUBLIC_API_BASE` do not
   enter a `Test` task's cache key at all.
   *Check:* run `./gradlew :backend:molgenis-emx2-analytics:test --build-cache
   -Dorg.gradle.caching.debug=true` and note the line `Build cache key for task … is …`. Change
   `MOLGENIS_HTTP_PORT` in your `.env` and run it again: the key is identical.

2. **The postgres port is normalised out, so a colleague on another port shares your key.** The rest
   of `MOLGENIS_POSTGRES_URI` still counts.
   *Check:* change only the port in `MOLGENIS_POSTGRES_URI` — the key holds. Change the host — the key
   moves.

3. **A secret's value never reaches a cache key.** A key whose name matches
   `PASS|PW|SECRET|TOKEN|KEY|CREDENTIAL` enters as a SHA-256 digest, and only when it is one the tests
   actually read.
   *Check:* change `MOLGENIS_POSTGRES_PASS` and see the key move; then search the debug log for the
   value itself and find nothing.

4. **The jar manifest's git hash no longer invalidates every test on every commit.** Each jar's
   manifest carries `Implementation-Version` (the git hash) and `Build-OS`, so each commit changed
   every jar's bytes and with it the cache key of every test whose classpath holds one.
   *Check:* build with `-Dos.name=Linux` and again without it, which changes only that manifest
   attribute. The key is the same both times. Remove the `normalization` block from
   `backend/build.gradle` and the two differ.

5. **`printDevConfig` stops printing `MOLGENIS_ADMIN_PW` in clear.** It shares the secret-name rule
   with the cache-key logic instead of carrying a narrower one of its own.
   *Check:* run `./gradlew printDevConfig` with an admin password set and see `<HIDDEN>`.

## Code map

- **`gradle/dotenv.gradle` is the old block from `build.gradle`, moved.** The one deliberate change
  inside it: the forwarding is split so the test path and the `JavaExec` path share one map.
- **Test JVMs get their configuration through a `CommandLineArgumentProvider`**, not
  `task.systemProperty`. Arguments supplied that way reach the JVM without entering the task's cache
  key, which is what allows the key to be declared deliberately, one rule at a time. `run`, `dev`,
  `cleandb` and `generateTypes` keep the plain forwarding, since a `JavaExec` has no cache key to
  protect.
- **`backend/build.gradle`** gains the manifest `normalization` block and the one-line switch to the
  test-specific forwarding.

## Known limitations

- **A secret-named key that no test reads is left out of the cache key entirely.** If a test later
  starts reading one and nobody adds it to the listed set, that test can reuse a stale result. The
  set covers every secret-like key the backend source reads today; the guard that would keep it
  honest is deliberately not in this PR.
- **A value still appears in a `-i` gradle log**, in gradle's own "Starting process … `-DKEY=VALUE`"
  line. That is unchanged from before and is unavoidable while values are forwarded as `-D` at all.
- **An IPv6 postgres host is not port-normalised**, so two developers using one would still not share
  a key.
