### PR TITLE
refactor: naming cleanups in the GraphQL query path

### DIFF
--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -658,33 +658,35 @@ public class GraphqlTableFieldFactory {
                   + entry.getKey()
                   + " unknown in table "
                   + table.getTableName());
-        Map value = new LinkedHashMap<>((Map) entry.getValue());
+        Map remainingOperators = new LinkedHashMap<>((Map) entry.getValue());
         // although nested, this should apply on this level, not sublevel
-        if (value.containsKey(FILTER_MATCH_INCLUDING_CHILDREN)) {
+        if (remainingOperators.containsKey(FILTER_MATCH_INCLUDING_CHILDREN)) {
           subFilters.add(
               f(
                   c.getName(),
                   Operator.MATCH_ANY_INCLUDING_CHILDREN,
-                  ((List) value.get(FILTER_MATCH_INCLUDING_CHILDREN)).toArray(new String[0])));
-          value.remove(FILTER_MATCH_INCLUDING_CHILDREN);
-        } else if (value.containsKey(FILTER_SEARCH_INCLUDING_PARENTS)) {
+                  ((List) remainingOperators.get(FILTER_MATCH_INCLUDING_CHILDREN))
+                      .toArray(new String[0])));
+          remainingOperators.remove(FILTER_MATCH_INCLUDING_CHILDREN);
+        } else if (remainingOperators.containsKey(FILTER_SEARCH_INCLUDING_PARENTS)) {
           subFilters.add(
               f(
                   c.getName(),
                   Operator.SEARCH_INCLUDING_PARENTS,
-                  ((List) value.get(FILTER_SEARCH_INCLUDING_PARENTS)).toArray(new String[0])));
-          value.remove(FILTER_SEARCH_INCLUDING_PARENTS);
-        } else if (value.containsKey(FILTER_MATCH_PATH)) {
+                  ((List) remainingOperators.get(FILTER_SEARCH_INCLUDING_PARENTS))
+                      .toArray(new String[0])));
+          remainingOperators.remove(FILTER_SEARCH_INCLUDING_PARENTS);
+        } else if (remainingOperators.containsKey(FILTER_MATCH_PATH)) {
           subFilters.add(
               f(
                   c.getName(),
                   Operator.MATCH_PATH,
-                  ((List) value.get(FILTER_MATCH_PATH)).toArray(new String[0])));
-          value.remove(FILTER_MATCH_PATH);
-        } else if (value.containsKey(FILTER_IS_NULL)) {
-          subFilters.add(f(c.getName(), IS_NULL, value.get(FILTER_IS_NULL)));
-          value.remove(FILTER_IS_NULL);
-        } else if (value.containsKey(FILTER_MATCH_ALL)) {
+                  ((List) remainingOperators.get(FILTER_MATCH_PATH)).toArray(new String[0])));
+          remainingOperators.remove(FILTER_MATCH_PATH);
+        } else if (remainingOperators.containsKey(FILTER_IS_NULL)) {
+          subFilters.add(f(c.getName(), IS_NULL, remainingOperators.get(FILTER_IS_NULL)));
+          remainingOperators.remove(FILTER_IS_NULL);
+        } else if (remainingOperators.containsKey(FILTER_MATCH_ALL)) {
           //  complex filter, should be an list of maps per graphql contract
           if (entry.getValue() != null && c.getReferences().size() > 1) {
             subFilters.add(
@@ -693,16 +695,19 @@ public class GraphqlTableFieldFactory {
                     Operator.MATCH_ALL,
                     convertToPrimaryKeyRows(
                             c.getRefTable(),
-                            (List<Map<String, Object>>) value.get(FILTER_MATCH_ALL))
+                            (List<Map<String, Object>>) remainingOperators.get(FILTER_MATCH_ALL))
                         .toArray()));
           } else if (entry.getValue() != null) {
             subFilters.add(
-                f(c.getName(), Operator.MATCH_ALL, (List<Object>) value.get(FILTER_MATCH_ALL)));
+                f(
+                    c.getName(),
+                    Operator.MATCH_ALL,
+                    (List<Object>) remainingOperators.get(FILTER_MATCH_ALL)));
           }
-          value.remove(FILTER_MATCH_ALL);
+          remainingOperators.remove(FILTER_MATCH_ALL);
         }
 
-        if (value.size() == 0) continue;
+        if (remainingOperators.size() == 0) continue;
         if (c.isReference()) {
           subFilters.add(
               f(
@@ -714,7 +719,7 @@ public class GraphqlTableFieldFactory {
                           .getSchema(c.getRefTable().getSchemaName())
                           .getTable(c.getRefTableName())
                           .getMetadata(),
-                      value)));
+                      remainingOperators)));
         } else {
           subFilters.add(convertMapToFilter(c.getName(), (Map<String, Object>) entry.getValue()));
         }
@@ -749,15 +754,15 @@ public class GraphqlTableFieldFactory {
 
   private static Filter convertMapToFilter(String name, Map<String, Object> subFilter) {
     int count = 0;
-    for (Map.Entry<String, Object> entry2 : subFilter.entrySet()) {
+    for (Map.Entry<String, Object> operatorEntry : subFilter.entrySet()) {
       count++;
       if (count > 1)
         throw new MolgenisException("Can only have one operator, found multiple for " + name);
-      Operator op = Operator.fromAbbreviation(entry2.getKey());
-      if (entry2.getValue() instanceof List) {
-        return f(name, op, (List) entry2.getValue());
+      Operator op = Operator.fromAbbreviation(operatorEntry.getKey());
+      if (operatorEntry.getValue() instanceof List) {
+        return f(name, op, (List) operatorEntry.getValue());
       } else {
-        return f(name, op, entry2.getValue());
+        return f(name, op, operatorEntry.getValue());
       }
     }
     return null;

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -760,8 +760,9 @@ public class GraphqlTableFieldFactory {
       if (count > 1)
         throw new MolgenisException("Can only have one operator, found multiple for " + name);
       Operator op = Operator.fromAbbreviation(operatorEntry.getKey());
-      if (operatorEntry.getValue() instanceof List) {
-        return f(name, op, (List) operatorEntry.getValue());
+      if (operatorEntry.getValue() instanceof List<?> values) {
+        // cast selects the List overload of f instead of wrapping the list in varargs
+        return f(name, op, (List<Object>) values);
       } else {
         return f(name, op, operatorEntry.getValue());
       }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/graphql/GraphqlTableFieldFactory.java
@@ -30,7 +30,7 @@ public class GraphqlTableFieldFactory {
           .value(Order.ASC.name(), Order.ASC)
           .value(Order.DESC.name(), Order.DESC)
           .build();
-  private static GraphQLObjectType fileDownload =
+  private static final GraphQLObjectType FILE_DOWNLOAD =
       GraphQLObjectType.newObject()
           .name("MolgenisFileDownload")
           .field(GraphQLFieldDefinition.newFieldDefinition().name("id").type(Scalars.GraphQLString))
@@ -46,7 +46,7 @@ public class GraphqlTableFieldFactory {
           .field(
               GraphQLFieldDefinition.newFieldDefinition().name("url").type(Scalars.GraphQLString))
           .build();
-  final List<String> agg_fields = List.of("max", "min", SUM_FIELD, "avg");
+  private static final List<String> AGG_FIELDS = List.of("max", "min", SUM_FIELD, "avg");
   private final Schema schema;
 
   // cache so we can reuse types between tables
@@ -171,7 +171,8 @@ public class GraphqlTableFieldFactory {
         // nothing to do
         break;
       case FILE:
-        tableBuilder.field(GraphQLFieldDefinition.newFieldDefinition().name(id).type(fileDownload));
+        tableBuilder.field(
+            GraphQLFieldDefinition.newFieldDefinition().name(id).type(FILE_DOWNLOAD));
         break;
       case BOOL:
         tableBuilder.field(
@@ -832,7 +833,7 @@ public class GraphqlTableFieldFactory {
           }
           result.add(nested);
 
-        } else if (agg_fields.contains(name)) {
+        } else if (AGG_FIELDS.contains(name)) {
           // --- Aggregate pseudo-field ---
           result.add(new SelectColumn(name, convertMapSelection(table, s.getSelectionSet())));
         }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -219,13 +219,13 @@ public class SqlQuery extends QueryBean {
           fields.add(field(name(alias(tableAlias), column.getName() + "_extension")));
         }
       } else if (column.isRef() || column.isRefArray()) {
-        shouldNotExpandBeyondPkey(select, column);
+        checkNotExpandedBeyondPkey(select, column);
         fields.addAll(
             column.getReferences().stream()
                 .map(ref -> field(name(alias(tableAlias), ref.getColumnName())))
                 .toList());
       } else if (column.isRefback()) {
-        shouldNotExpandBeyondPkey(select, column);
+        checkNotExpandedBeyondPkey(select, column);
         // will come from refJoin table
         fields.addAll(
             column.getReferences().stream()
@@ -243,7 +243,7 @@ public class SqlQuery extends QueryBean {
     return fields;
   }
 
-  private static void shouldNotExpandBeyondPkey(SelectColumn select, Column column) {
+  private static void checkNotExpandedBeyondPkey(SelectColumn select, Column column) {
     select
         .getSubselect()
         .forEach(

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -490,7 +490,7 @@ public class SqlQuery extends QueryBean {
         SEARCH_INCLUDING_PARENTS:
           // check for table level filter for ontologies (weird getColumn), apply to "name" columm
           if (filter.getOperator().getName().equals(filter.getColumn())) {
-            return whereCondition(
+            return whereColumnOperator(
                 tableAlias,
                 // use the table itself
                 new Column("name")
@@ -503,7 +503,7 @@ public class SqlQuery extends QueryBean {
         // else use default
         default:
           // then it must be a column filter
-          return whereCondition(
+          return whereColumnOperator(
               subAlias,
               getColumnByName(table, filter.getColumn()),
               filter.getOperator(),
@@ -1169,13 +1169,13 @@ public class SqlQuery extends QueryBean {
         }
       } else {
         conditions.add(
-            whereCondition(tableAlias, column, filters.getOperator(), filters.getValues()));
+            whereColumnOperator(tableAlias, column, filters.getOperator(), filters.getValues()));
       }
     }
     return conditions.isEmpty() ? null : and(conditions);
   }
 
-  private Condition whereCondition(
+  private Condition whereColumnOperator(
       String tableAlias, Column column, org.molgenis.emx2.Operator operator, Object[] values) {
     Name columnName = name(alias(tableAlias), column.getName());
     ColumnType columnType = column.getColumnType();

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -94,7 +94,7 @@ public class SqlQuery extends QueryBean {
 
     // if empty selection, we will add the default selection here, incl File and Refback
     // will generally be all you need
-    if (select == null || select.getColumNames().isEmpty()) {
+    if (select == null || select.getColumnNames().isEmpty()) {
       for (Column c :
           table.getColumns().stream()
               .filter(
@@ -128,10 +128,10 @@ public class SqlQuery extends QueryBean {
 
     // we don't accept '.' notation in query select anymore
     else {
-      if (select.getColumNames().stream().anyMatch(name -> name.contains("."))) {
+      if (select.getColumnNames().stream().anyMatch(name -> name.contains("."))) {
         throw new MolgenisException(
             "select columns cannot contain dot. Use subselects. Error: "
-                + (select.getColumNames().stream()
+                + (select.getColumnNames().stream()
                     .filter(name -> name.contains("."))
                     .collect(Collectors.joining(","))));
       }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SelectColumn.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/SelectColumn.java
@@ -62,7 +62,7 @@ public class SelectColumn {
     return children.values();
   }
 
-  public Collection<String> getColumNames() {
+  public Collection<String> getColumnNames() {
     return children.keySet();
   }
 


### PR DESCRIPTION
### What are the main changes you did

Naming cleanups in the GraphQL → `Query` → SQL read path (`GraphqlTableFieldFactory`, `SqlQuery`, `SelectColumn`). **All five commits are pure renames — no behaviour change.** One `final` was added to a static field that was never reassigned.

Each commit is self-contained and compiles on its own, so they can be reviewed or reverted individually:

| Commit | Change | Why |
|---|---|---|
| `17aca2b` | `SelectColumn.getColumNames()` → `getColumnNames()` | typo in a public method; only 4 call sites |
| `43548c6` | `entry2` → `operatorEntry`, `Map value` → `remainingOperators` | in `convertMapToFilterArray` the copied operator map was called `value`, which hid that it *shrinks* as operators are handled |
| `386f463` | `agg_fields` → `AGG_FIELDS`, `fileDownload` → `FILE_DOWNLOAD` | `agg_fields` was snake_case, non-static and package-private; `fileDownload` was a non-final static |
| `f02e397` | `shouldNotExpandBeyondPkey` → `checkNotExpandedBeyondPkey` | since this is a validate+throw function, match the `check*` convention similar to `checkHasViewPermission` in the same class |
| `f089f6d` | `whereCondition` → `whereColumnOperator` | it is the entry point of the `whereColumn*` family (`whereColumnBetween`, `whereColumnLike`, …) that it dispatches to, and it sat one word away from `whereConditions` / `whereConditionsFilter` |

`AGG_FIELDS` becoming `static` is safe: the value is an immutable `List.of(...)`, so nothing mutable is now shared between the per-schema `GraphqlTableFieldFactory` instances.

Some diff lines are **spotless output, not hand edits**: `remainingOperators` is 13 characters longer than `value`, so google-java-format re-wrapped several chained calls in `convertMapToFilterArray`.

### How to test

Covered by the existing suites — no new tests, since no behaviour changed:

- `./gradlew :backend:molgenis-emx2-graphql:test` — 74 tests, all pass. Includes `testTableQueries`, `testGroupBy`, `testNullAndNotNull`, `testMatchInParentsAndChildren` and `testAggFilterNotMutatedByMatchIncludingChildren`, which exercise the renamed filter-conversion path.
- `./gradlew :backend:molgenis-emx2-sql:test` — 412 tests, all pass.

Also verified that each of the five commits compiles main **and** test sources on its own (`compileTestJava` for both modules), so `git bisect` stays usable across the series.

### Follow-up (not in this PR)

* Bugfix: `GraphqlTableFieldFactory.convertMapToFilterArray` passes the **uncleaned** `entry.getValue()` to `convertMapToFilter` for non-reference columns, instead of the `remainingOperators` copy it just stripped. Combining e.g. `_is_null` with another operator on a non-reference column therefore fails with *"Can only have one operator"*, while the same filter on a reference column works. The rename in `43548c6` makes the mismatch visible but deliberately does not fix it, so the fix can land as a one-line diff with its own test.

* Suggestion: I would suggest to rename `SelectColumn` to `SelectNode`, as that class represents a tree node, not a column. Its root instance holds a table name ("Pet", "Pet_agg"), so SelectNode would name what the class actually is. (The current name confused me while trying to understand the `SqlQuery` code.) That change is larger and warrants its own PR.

### Checklist

- [x] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md) — n/a, backend only
- [ ] updated docs in case of new feature — n/a, no feature
- [ ] added/updated tests — n/a, pure renames covered by existing tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation — n/a, no bug fixed here

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
