### PR TITLE
refactor(catalogue): use status instead of statusCode in createError

### DIFF
--- a/apps/catalogue/app/pages/[catalogue]/index.vue
+++ b/apps/catalogue/app/pages/[catalogue]/index.vue
@@ -210,7 +210,7 @@ const network = computed(() => {
   const catalogues = data.value.data?.Catalogues;
   if (scoped && (!catalogues || catalogues.length === 0)) {
     throw createError({
-      statusCode: 404,
+      status: 404,
       statusMessage: 'Catalogue "' + catalogueRouteParam + '" Not Found.',
     });
   }

--- a/apps/catalogue/app/pages/[catalogue]/variables/index.vue
+++ b/apps/catalogue/app/pages/[catalogue]/variables/index.vue
@@ -405,7 +405,7 @@ const {
 
 if (error.value) {
   throw createError({
-    statusCode: error.value.statusCode || 500,
+    status: error.value.statusCode || 500,
     message: error.value.message || "An error occurred while fetching data.",
   });
 }

--- a/apps/tailwind-components/app/composables/fetchTableMetadata.ts
+++ b/apps/tailwind-components/app/composables/fetchTableMetadata.ts
@@ -17,7 +17,7 @@ export default async (
     console.error(message);
     throw createError({
       message,
-      statusCode: 404,
+      status: 404,
     });
   } else {
     return tableMetadata;

--- a/apps/tailwind-components/app/utils/fetchErrorToNuxtError.ts
+++ b/apps/tailwind-components/app/utils/fetchErrorToNuxtError.ts
@@ -4,7 +4,7 @@ import { errorToMessage } from "./errorToMessage";
 
 export function fetchErrorToNuxtError(error: unknown, fallbackMessage: string) {
   return createError({
-    statusCode: error instanceof FetchError ? error.statusCode ?? 500 : 500,
+    status: error instanceof FetchError ? error.statusCode ?? 500 : 500,
     message: errorToMessage(error, fallbackMessage),
     cause: error,
   });


### PR DESCRIPTION
## What

Fixes `createError` calls with deprecated parameter name: PR #6515 inadvertently added `createError` calls with `statusCode` instead of `status`.

## Why

`status` is the canonical name in h3 v2. Our codebase is using `status` already in other callsites.

## No behaviour change

h3 v1 accepts `status` as an alias and routes both keys through the same `sanitizeStatusCode`, storing the result under `statusCode` on the resulting error:

```js
if (input.statusCode) { err.statusCode = sanitizeStatusCode(input.statusCode, err.statusCode); }
else if (input.status) { err.statusCode = sanitizeStatusCode(input.status, err.statusCode); }
```

## Note for reviewers

In `variables/index.vue` only the **written** key changed:

```diff
-    statusCode: error.value.statusCode || 500,
+    status: error.value.statusCode || 500,
```

The right-hand side is a **read** off `IMgError` (`apps/catalogue/interfaces/types.ts`), which declares `statusCode` — and h3 stores the resolved value under `statusCode` regardless of which input alias was used. Renaming the read too would yield `undefined` and silently downgrade every error to 500.