### PR TITLE
refactor: encapsulate internal RLS_ role names in SqlRoleManager

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
@@ -31,6 +31,12 @@ public class SqlRoleManager {
   public static final String PG_ROLES = "pg_roles";
   public static final String ROLNAME = "rolname";
   public static final int PG_MAX_ID_LENGTH = 63;
+
+  /**
+   * Prefix of the internal roles that hold the row-restricted table grants. They are granted to
+   * their regular counterpart so privileges reach real users, which also makes them show up in
+   * every raw role listing. They are never assignable by a user.
+   */
   private static final String RLS_ROLE_PREFIX = "RLS_";
 
   enum RlsPolicy {
@@ -54,25 +60,20 @@ public class SqlRoleManager {
     this.database = database;
   }
 
-  /**
-   * RLS_ roles exist only to hold the row-restricted table grants; they are granted to their
-   * regular counterpart so privileges reach real users, which also makes them show up in every raw
-   * role listing. They are never assignable by a user.
-   */
-  private static boolean isInternalRole(String roleName) {
+  private static boolean isInternalRlsRole(String roleName) {
     return roleName != null && roleName.startsWith(RLS_ROLE_PREFIX);
   }
 
   static boolean isUserAssignableRole(String roleName) {
-    return !isInternalRole(roleName) && !Privileges.isSystemRole(roleName);
+    return !isInternalRlsRole(roleName) && !Privileges.isSystemRole(roleName);
   }
 
   private static List<String> withoutInternalRoles(List<String> roleNames) {
-    return roleNames.stream().filter(name -> !isInternalRole(name)).toList();
+    return roleNames.stream().filter(name -> !isInternalRlsRole(name)).toList();
   }
 
   private static void requireNotInternalRole(String roleName, String action) {
-    if (isInternalRole(roleName)) {
+    if (isInternalRlsRole(roleName)) {
       throw new MolgenisException(
           "Cannot "
               + action
@@ -154,7 +155,7 @@ public class SqlRoleManager {
     if (isSystemRole(roleName)) {
       throw new MolgenisException("Cannot create system role: " + roleName);
     }
-    if (isInternalRole(roleName)) {
+    if (isInternalRlsRole(roleName)) {
       throw new MolgenisException(
           "Cannot create role '"
               + roleName
@@ -488,7 +489,7 @@ public class SqlRoleManager {
   }
 
   public void addMember(String schemaName, Member member) {
-    if (isInternalRole(member.getRole())) {
+    if (isInternalRlsRole(member.getRole())) {
       throw new MolgenisException(
           "Add member(s) failed: Role '"
               + member.getRole()

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
@@ -58,7 +58,7 @@ public class SqlRoleManager {
    * regular counterpart so privileges reach real users, which also makes them show up in every raw
    * role listing. They are never assignable by a user.
    */
-  static boolean isInternalRole(String roleName) {
+  private static boolean isInternalRole(String roleName) {
     return roleName != null && roleName.startsWith(RLS_ROLE_PREFIX);
   }
 
@@ -66,7 +66,7 @@ public class SqlRoleManager {
     return !isInternalRole(roleName) && !Privileges.isSystemRole(roleName);
   }
 
-  static List<String> withoutInternalRoles(List<String> roleNames) {
+  private static List<String> withoutInternalRoles(List<String> roleNames) {
     return roleNames.stream().filter(name -> !isInternalRole(name)).toList();
   }
 

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
@@ -70,6 +70,17 @@ public class SqlRoleManager {
     return roleNames.stream().filter(name -> !isInternalRole(name)).toList();
   }
 
+  private static void requireNotInternalRole(String roleName, String action) {
+    if (isInternalRole(roleName)) {
+      throw new MolgenisException(
+          "Cannot "
+              + action
+              + " role '"
+              + roleName
+              + "': it is an internal row-level-security role");
+    }
+  }
+
   private DSLContext jooq() {
     return database.getJooq();
   }
@@ -103,6 +114,7 @@ public class SqlRoleManager {
     if (isSystemRole(roleName)) {
       throw new MolgenisException("Cannot delete system role: " + roleName);
     }
+    requireNotInternalRole(roleName, "delete");
     if (!roleExists(schemaName, roleName)) {
       throw new MolgenisException("Role does not exist: " + roleName);
     }
@@ -202,6 +214,7 @@ public class SqlRoleManager {
     if (isSystemRole(roleName)) {
       throw new MolgenisException("Cannot grant custom permissions to system role: " + roleName);
     }
+    requireNotInternalRole(roleName, "grant permissions to");
     if (!roleExists(schemaName, roleName)) {
       throw new MolgenisException("Role does not exist: " + roleName);
     }
@@ -254,6 +267,7 @@ public class SqlRoleManager {
     if (isSystemRole(roleName)) {
       throw new MolgenisException("Cannot revoke permissions from system role: " + roleName);
     }
+    requireNotInternalRole(roleName, "revoke permissions from");
     if (!roleExists(schemaName, roleName)) {
       throw new MolgenisException("Role does not exist: " + roleName);
     }
@@ -590,6 +604,7 @@ public class SqlRoleManager {
   }
 
   public Role getRole(String schemaName, String roleName) {
+    requireNotInternalRole(roleName, "inspect");
     boolean system = isSystemRole(roleName);
     List<TablePermission> permissions = getPermissions(schemaName, roleName);
     if (!system) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
@@ -56,7 +56,7 @@ public class SqlRoleManager {
   /**
    * RLS_ roles exist only to hold the row-restricted table grants; they are granted to their
    * regular counterpart so privileges reach real users, which also makes them show up in every raw
-   * role listing. They must never be created, joined or written into mg_roles by a user.
+   * role listing. They are never assignable by a user.
    */
   static boolean isInternalRole(String roleName) {
     return roleName != null && roleName.startsWith(RLS_ROLE_PREFIX);
@@ -560,7 +560,7 @@ public class SqlRoleManager {
     return withoutInternalRoles(getAllRoleNamesIncludingInternal(schemaName));
   }
 
-  /** Raw pg role listing, including the internal RLS_ roles; only for teardown and bookkeeping. */
+  /** Raw pg role listing, including the internal RLS_ roles; only for drop schema. */
   List<String> getAllRoleNamesIncludingInternal(String schemaName) {
     String rolePrefix = rolePrefix(schemaName);
     return jooq()
@@ -568,6 +568,21 @@ public class SqlRoleManager {
         .from(PG_ROLES)
         .where(field(ROLNAME).like(inline(rolePrefix + "%")))
         .fetch(r -> r.get(ROLNAME, String.class).substring(rolePrefix.length()));
+  }
+
+  public List<String> getInheritedRoleNamesForUser(String schemaName, String username) {
+    if (username == null) return List.of();
+    if (database.getUser(username).isAdmin()) {
+      return getRoleNames(schemaName);
+    }
+    List<String> result = new ArrayList<>();
+    // need elevated privileges, so clear user and run as root
+    database.getJooqAsAdmin(
+        adminJooq ->
+            result.addAll(
+                SqlSchemaMetadataExecutor.getInheritedRoleForUser(
+                    adminJooq, schemaName, username.trim())));
+    return withoutInternalRoles(result);
   }
 
   public List<Role> getRoles(String schemaName) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
@@ -24,6 +24,7 @@ import org.jooq.Table;
 import org.jooq.exception.DataAccessException;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.Role;
+import org.molgenis.emx2.User;
 
 public class SqlRoleManager {
 
@@ -586,7 +587,9 @@ public class SqlRoleManager {
 
   public List<String> getInheritedRoleNamesForUser(String schemaName, String username) {
     if (username == null) return List.of();
-    if (database.getUser(username).isAdmin()) {
+    User user = database.getUser(username);
+    if (user == null) return List.of();
+    if (user.isAdmin()) {
       return getRoleNames(schemaName);
     }
     List<String> result = new ArrayList<>();

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
@@ -30,7 +30,7 @@ public class SqlRoleManager {
   public static final String PG_ROLES = "pg_roles";
   public static final String ROLNAME = "rolname";
   public static final int PG_MAX_ID_LENGTH = 63;
-  public static final String RLS_ROLE_PREFIX = "RLS_";
+  private static final String RLS_ROLE_PREFIX = "RLS_";
 
   enum RlsPolicy {
     VIEWER_BYPASS("mg_roles_viewer_bypass", "SELECT"),
@@ -51,6 +51,23 @@ public class SqlRoleManager {
 
   public SqlRoleManager(SqlDatabase database) {
     this.database = database;
+  }
+
+  /**
+   * RLS_ roles exist only to hold the row-restricted table grants; they are granted to their
+   * regular counterpart so privileges reach real users, which also makes them show up in every raw
+   * role listing. They must never be created, joined or written into mg_roles by a user.
+   */
+  static boolean isInternalRole(String roleName) {
+    return roleName != null && roleName.startsWith(RLS_ROLE_PREFIX);
+  }
+
+  static boolean isUserAssignableRole(String roleName) {
+    return !isInternalRole(roleName) && !Privileges.isSystemRole(roleName);
+  }
+
+  static List<String> withoutInternalRoles(List<String> roleNames) {
+    return roleNames.stream().filter(name -> !isInternalRole(name)).toList();
   }
 
   private DSLContext jooq() {
@@ -124,7 +141,7 @@ public class SqlRoleManager {
     if (isSystemRole(roleName)) {
       throw new MolgenisException("Cannot create system role: " + roleName);
     }
-    if (roleName.startsWith(RLS_ROLE_PREFIX)) {
+    if (isInternalRole(roleName)) {
       throw new MolgenisException(
           "Cannot create role '"
               + roleName
@@ -456,7 +473,7 @@ public class SqlRoleManager {
   }
 
   public void addMember(String schemaName, Member member) {
-    if (member.getRole().startsWith(RLS_ROLE_PREFIX)) {
+    if (isInternalRole(member.getRole())) {
       throw new MolgenisException(
           "Add member(s) failed: Role '"
               + member.getRole()
@@ -540,6 +557,11 @@ public class SqlRoleManager {
   }
 
   public List<String> getRoleNames(String schemaName) {
+    return withoutInternalRoles(getAllRoleNamesIncludingInternal(schemaName));
+  }
+
+  /** Raw pg role listing, including the internal RLS_ roles; only for teardown and bookkeeping. */
+  List<String> getAllRoleNamesIncludingInternal(String schemaName) {
     String rolePrefix = rolePrefix(schemaName);
     return jooq()
         .select(field(ROLNAME))
@@ -549,10 +571,7 @@ public class SqlRoleManager {
   }
 
   public List<Role> getRoles(String schemaName) {
-    return getRoleNames(schemaName).stream()
-        .filter(name -> !name.startsWith(RLS_ROLE_PREFIX))
-        .map(name -> getRole(schemaName, name))
-        .toList();
+    return getRoleNames(schemaName).stream().map(name -> getRole(schemaName, name)).toList();
   }
 
   public Role getRole(String schemaName, String roleName) {
@@ -615,10 +634,7 @@ public class SqlRoleManager {
     if (roleNames.isEmpty()) return List.of();
 
     String customRoleName =
-        roleNames.stream()
-            .filter(r -> !r.startsWith(RLS_ROLE_PREFIX) && !isSystemRole(r))
-            .findFirst()
-            .orElse(null);
+        roleNames.stream().filter(SqlRoleManager::isUserAssignableRole).findFirst().orElse(null);
 
     TablePermission systemWildcard =
         roleNames.stream()

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRowOwnership.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRowOwnership.java
@@ -6,7 +6,6 @@ import java.util.Arrays;
 import java.util.List;
 import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.PermissionEvaluator;
-import org.molgenis.emx2.Privileges;
 import org.molgenis.emx2.Row;
 import org.molgenis.emx2.Schema;
 import org.molgenis.emx2.TableMetadata;
@@ -62,6 +61,12 @@ class SqlRowOwnership {
   }
 
   private void validateUserMayAssign(String role) {
+    if (!SqlRoleManager.isUserAssignableRole(role)) {
+      throw new MolgenisException(
+          "mg_roles value '"
+              + role
+              + "' is an internal or system role and cannot be assigned as row owner");
+    }
     if (!rolesInSchema().contains(role)) {
       throw new MolgenisException(
           "mg_roles value '"
@@ -79,8 +84,7 @@ class SqlRowOwnership {
   private String defaultRole() {
     if (!PermissionEvaluator.isRowLevelRestricted(schema, table)) return null;
     return rolesOfUser().stream()
-        .filter(role -> !role.startsWith(SqlRoleManager.RLS_ROLE_PREFIX))
-        .filter(role -> !Privileges.isSystemRole(role))
+        .filter(SqlRoleManager::isUserAssignableRole)
         .findFirst()
         .orElse(null);
   }

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -259,7 +259,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
                 result.addAll(
                     SqlSchemaMetadataExecutor.getInheritedRoleForUser(
                         adminJooq, getName(), username.trim())));
-    return result;
+    return SqlRoleManager.withoutInternalRoles(result);
   }
 
   public List<String> getInheritedRolesForActiveUser() {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -245,21 +245,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
   }
 
   public List<String> getInheritedRolesForUser(String username) {
-    if (username == null) return new ArrayList<>();
-    User user = getDatabase().getUser(username);
-    if (user.isAdmin()) {
-      // admin has all roles
-      return getDatabase().getRoleManager().getRoleNames(getName());
-    }
-    List<String> result = new ArrayList<>();
-    // need elevated privileges, so clear user and run as root
-    getDatabase()
-        .getJooqAsAdmin(
-            adminJooq ->
-                result.addAll(
-                    SqlSchemaMetadataExecutor.getInheritedRoleForUser(
-                        adminJooq, getName(), username.trim())));
-    return SqlRoleManager.withoutInternalRoles(result);
+    return getDatabase().getRoleManager().getInheritedRoleNamesForUser(getName(), username);
   }
 
   public List<String> getInheritedRolesForActiveUser() {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadataExecutor.java
@@ -143,7 +143,7 @@ class SqlSchemaMetadataExecutor {
       // drop schema
       db.getJooq().dropSchema(name(schemaName)).execute();
 
-      for (String role : db.getRoleManager().getRoleNames(schemaName)) {
+      for (String role : db.getRoleManager().getAllRoleNamesIncludingInternal(schemaName)) {
         db.getJooq().execute("DROP ROLE IF EXISTS {0}", name(getRolePrefix(schemaName) + role));
       }
       MetadataUtils.deleteSchema(db.getJooq(), schemaName);

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
@@ -159,6 +159,53 @@ class TestRowLevelSecurity {
   }
 
   @Test
+  void mgRolesRejectsInternalRlsRoleName() {
+    database.setActiveUser(USER_TEAM_A);
+    Table articles = database.getSchema(SCHEMA).getTable(ARTICLES);
+    Row row = new Row().setString("id", "mg_internal").set(MG_ROLES, new String[] {"RLS_TeamA"});
+    MolgenisException e = assertThrows(MolgenisException.class, () -> articles.insert(row));
+    assertTrue(e.getMessage().contains("internal"), e.getMessage());
+    database.becomeAdmin();
+  }
+
+  @Test
+  void mgRolesRejectsSystemRoleName() {
+    database.setActiveUser(USER_TEAM_A);
+    Table articles = database.getSchema(SCHEMA).getTable(ARTICLES);
+    Row row =
+        new Row()
+            .setString("id", "mg_system")
+            .set(MG_ROLES, new String[] {Privileges.VIEWER.toString()});
+    MolgenisException e = assertThrows(MolgenisException.class, () -> articles.insert(row));
+    assertTrue(e.getMessage().contains("system role"), e.getMessage());
+    database.becomeAdmin();
+  }
+
+  @Test
+  void schemaRolesExcludeInternalRlsRoles() {
+    database.becomeAdmin();
+    List<String> roles = database.getSchema(SCHEMA).getRoles();
+    assertTrue(roles.contains("TeamA"), roles.toString());
+    assertTrue(roles.stream().noneMatch(r -> r.startsWith("RLS_")), roles.toString());
+  }
+
+  @Test
+  void inheritedRolesForActiveUserExcludeInternalRlsRoles() {
+    database.setActiveUser(USER_TEAM_A);
+    List<String> roles = database.getSchema(SCHEMA).getInheritedRolesForActiveUser();
+    assertTrue(roles.contains("TeamA"), roles.toString());
+    assertTrue(roles.stream().noneMatch(r -> r.startsWith("RLS_")), roles.toString());
+    database.becomeAdmin();
+  }
+
+  @Test
+  void adminInheritedRolesExcludeInternalRlsRoles() {
+    database.becomeAdmin();
+    List<String> roles = database.getSchema(SCHEMA).getInheritedRolesForActiveUser();
+    assertTrue(roles.stream().noneMatch(r -> r.startsWith("RLS_")), roles.toString());
+  }
+
+  @Test
   void mgRolesEmptyArrayIsAllowedLikeNull() {
     database.becomeAdmin();
     String editorUser = "rls_user_editor_mgroles";

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
@@ -195,10 +195,9 @@ class TestRowLevelSecurity {
   void grantRejectsInternalRlsRoleName() {
     database.becomeAdmin();
     Schema schema = database.getSchema(SCHEMA);
+    TablePermission permission = new TablePermission(ARTICLES).select(true);
     MolgenisException e =
-        assertThrows(
-            MolgenisException.class,
-            () -> schema.grant("RLS_TeamA", new TablePermission(ARTICLES).select(true)));
+        assertThrows(MolgenisException.class, () -> schema.grant("RLS_TeamA", permission));
     assertTrue(e.getMessage().contains("internal"), e.getMessage());
   }
 

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
@@ -182,6 +182,45 @@ class TestRowLevelSecurity {
   }
 
   @Test
+  void deleteRoleRejectsInternalRlsRoleName() {
+    database.becomeAdmin();
+    Schema schema = database.getSchema(SCHEMA);
+    MolgenisException e =
+        assertThrows(MolgenisException.class, () -> schema.deleteRole("RLS_TeamA"));
+    assertTrue(e.getMessage().contains("internal"), e.getMessage());
+    assertTrue(schema.getRoles().contains("TeamA"), "TeamA must survive");
+  }
+
+  @Test
+  void grantRejectsInternalRlsRoleName() {
+    database.becomeAdmin();
+    Schema schema = database.getSchema(SCHEMA);
+    MolgenisException e =
+        assertThrows(
+            MolgenisException.class,
+            () -> schema.grant("RLS_TeamA", new TablePermission(ARTICLES).select(true)));
+    assertTrue(e.getMessage().contains("internal"), e.getMessage());
+  }
+
+  @Test
+  void revokeRejectsInternalRlsRoleName() {
+    database.becomeAdmin();
+    Schema schema = database.getSchema(SCHEMA);
+    MolgenisException e =
+        assertThrows(MolgenisException.class, () -> schema.revoke("RLS_TeamA", ARTICLES));
+    assertTrue(e.getMessage().contains("internal"), e.getMessage());
+  }
+
+  @Test
+  void getRoleInfoRejectsInternalRlsRoleName() {
+    database.becomeAdmin();
+    Schema schema = database.getSchema(SCHEMA);
+    MolgenisException e =
+        assertThrows(MolgenisException.class, () -> schema.getRoleInfo("RLS_TeamA"));
+    assertTrue(e.getMessage().contains("internal"), e.getMessage());
+  }
+
+  @Test
   void schemaRolesExcludeInternalRlsRoles() {
     database.becomeAdmin();
     List<String> roles = database.getSchema(SCHEMA).getRoles();


### PR DESCRIPTION
Note: This PR has `feat/rls-auto-apply-role` as base - the code it changes only exists in that PR. Merge #6566 first, or merge this into it.

## Why
While reviewing #6566, Claude noticed that an issue with the new `validateUserMayAssign` method: it does not check for `RLS_` prefixed (internal) rolenames. That allows an issue where `mg_roles` can have invalid values.
Looking closer, the filtering of internal roles is not centralized: several methods return unfiltered role lists, so every caller has to remember to filter them out. That leaves room for bugs in role-related code outside SqlRoleManager. This PR centralizes it.

## What changed

**1. Make the safe list the default** (`refactor: encapsulate internal RLS_ role names`)

- `RLS_ROLE_PREFIX` is now `private`. It appears in no other file.
- `getRoleNames()` excludes internal roles; the raw listing moved to package-private `getAllRoleNamesIncludingInternal()`, whose only caller is drop-schema teardown.
- `getInheritedRolesForUser()` filters both branches, so `Schema.getInheritedRolesForActiveUser()` no longer leaks internal names to core, analytics and graphql.
- New `isInternalRole()` / `isUserAssignableRole()` / `withoutInternalRoles()` replace five open-coded `startsWith("RLS_")` checks.
- `validateUserMayAssign` rejects internal **and** system roles, so `mg_roles` accepts only custom roles, as the docs describe.

**2. Move the inherited role lookup into `SqlRoleManager`** (`refactor: move inherited role lookup`)

`SqlSchemaMetadata` computed the admin shortcut, the elevated `pg_roles` query and the filtering itself. That is role vocabulary. The cache stays in `SqlSchemaMetadata`, because it is tied to the metadata reload lifecycle (`rolesCache` is cleared in `reload()`).

**3. Reject internal role names on the write paths** (`fix: reject internal RLS_ role names`)

`deleteRole`, `grant`, `revoke` and `getRole` checked only `isSystemRole` and `roleExists`, and an internal role passes both. All four confirmed accepting `RLS_TeamX` before the fix.

`deleteRole` was reachable from the graphql `drop` mutation, which passes the argument through unchecked. A manager dropping `RLS_TeamA` removed the internal role and its grants while the regular role and its row-level grants stayed — its members silently lost all access to the table.

## Behaviour changes to review
- Admin session roles no longer include `RLS_*` in the graphql response (`GraphqlSessionFieldFactory`). This is the intended fix, but it is user-visible; graphql tests pass.
- `mg_roles` now rejects system roles (e.g. `Viewer`), not only internal ones. Previously a user holding `Viewer` plus a row-level role could tag a row `{"Viewer"}` and widen its visibility. The old error message already said "custom role".

## Tests

9 new tests in `TestRowLevelSecurity`: `mg_roles` rejects internal and system role names; `deleteRole` / `grant` / `revoke` / `getRoleInfo` reject internal names (and `TeamA` survives the rejected delete); `getRoles()` and the inherited roles of both a normal user and an admin contain no `RLS_*`.

- `molgenis-emx2-sql`: 405 tests, 0 failures
- `molgenis-emx2-graphql`: 61 tests, 0 failures
- `spotlessCheck` passes