### PR TITLE
fix(apps): minor changes NESTOR dashboard

### DIFF
--- a/apps/nestor-public/public/css/index.css
+++ b/apps/nestor-public/public/css/index.css
@@ -152,3 +152,7 @@
     max-width: var(--max-width);
   }
 }
+
+#registryHighlights .data-highlight {
+ flex: 0 0 calc(50% - 0.5em);
+}

--- a/apps/nestor-public/src/pages/view-dashboard.vue
+++ b/apps/nestor-public/src/pages/view-dashboard.vue
@@ -64,7 +64,7 @@ async function loadData() {
   );
   const enrollmentResponse = await getComponentStats(
     "../api/graphql",
-    "enrollmentByDiseaseGroup"
+    "enrollmentBySyndromeGroup"
   );
   const organisationsResponse = await getOrganisations("../api/graphql");
 
@@ -99,7 +99,7 @@ function prepareData() {
     .map((row: IStatistics) => {
       return {
         ...row,
-        "Thematic Disease Group": row.label,
+        "Thematic Syndrome Group": row.label,
         "Number of Patients": row.value,
       };
     })
@@ -190,10 +190,10 @@ function prepareData() {
         </DashboardChart>
         <DashboardChart>
           <DataTable
-            tableId="diseaseGroupEnrollment"
-            caption="Summary of patients enrolled by thematic disease group"
+            tableId="syndromeGroupEnrollment"
+            caption="Summary of patients enrolled by thematic syndrome group"
             :data="enrollmentData"
-            :columnOrder="['Thematic Disease Group', 'Number of Patients']"
+            :columnOrder="['Thematic Syndrome Group', 'Number of Patients']"
             :enableRowHighlighting="true"
           />
         </DashboardChart>


### PR DESCRIPTION
### What are the main changes you did
- Renamed Disease to Syndrome on the NESTOR dashboard (see Thematic group counts chart)
- Data-highlights only consists of two elements instead of three (no country data), which resulted in an unequal alignment of the two blocks compared to the other chart elements (see https://demo-nestor.molgenis.net)

### How to test

- Go to https://preview-emx2-pr-6645.dev.molgenis.org/NESTOR/nestor-public/#/dashboard and see that the names in the Thematic groups overview include Syndrome instead of Disease and that the blocks with # Patients and # HCPs are equal aligned to the chart blocks. (see original:  https://demo-nestor.molgenis.net/NESTOR/nestor-public/#/dashboard)

### Checklist

- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
