### PR TITLE
docs: fix broken relative links to dev guidelines

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,8 @@
 
 ### Checklist
 
-- [ ] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
-- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
+- [ ] checked that code complies with the [dev guidelines](https://molgenis.github.io/molgenis-emx2/#/molgenis/dev_guidelines)
+- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://molgenis.github.io/molgenis-emx2/#/molgenis/dev_accessibility)
 - [ ] updated docs in case of new feature
 - [ ] added/updated tests
 - [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,8 +8,8 @@
 
 ### Checklist
 
-- [ ] checked that code complies with the [dev guidelines](https://molgenis.github.io/molgenis-emx2/#/molgenis/dev_guidelines)
-- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://molgenis.github.io/molgenis-emx2/#/molgenis/dev_accessibility)
+- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
+- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
 - [ ] updated docs in case of new feature
 - [ ] added/updated tests
 - [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

--- a/docs/molgenis/dev.md
+++ b/docs/molgenis/dev.md
@@ -7,6 +7,7 @@ There are a number of guides available to help you get started with EMX2. We enc
     - [Principles](./dev_principles.md)
     - [MOLGENIS Architecture](./dev_architecture.md)
     - [Developer guidelines](./dev_guidelines.md)
+    - [Accessibility guidelines](./dev_accessibility.md)
     - [Quickstart](./dev_quickstart.md)
     - [Migration guidelines](./dev_migrations.md)
     - [Technologies used](./dev_technologies.md)

--- a/docs/molgenis/dev_guidelines.md
+++ b/docs/molgenis/dev_guidelines.md
@@ -84,7 +84,7 @@ Good semantic html practices covers a lot of areas. In principle, it is importan
 - Text elements use clear, concise language. It is recommended to avoid using technical jargon in the UI. When writing text, keep in mind that they are two terms: the internal, technical word and the public-facing term.
 - Error messages clearly describe the issue and inform users how to resolve it. Do not use phrases such as "Oops! Something went wrong".
 
-There are additional things to consider. Please refer to the [Accessibility guidelines](docs/molgenis/dev_accessibility.md) page for more information and instructions on how to review PRs.
+There are additional things to consider. Please refer to the [Accessibility guidelines](./dev_accessibility.md) page for more information and instructions on how to review PRs.
 
 ### 6. Naming conventions
 


### PR DESCRIPTION
### What are the main changes you did

The `dev guidelines` and `Accessibility guide` links in the PR template were relative paths (`docs/molgenis/dev_guidelines.md`). GitHub rewrites relative links when rendering **files**, but not when rendering **PR or issue bodies** — the href stays relative and the browser resolves it against the page URL:

| Where you click | Resolves to |
|---|---|
| `/pull/1234` (Conversation) | `/molgenis-emx2/pull/docs/molgenis/dev_guidelines.md` ❌ |
| `/pull/1234/files` | `/molgenis-emx2/pull/1234/docs/molgenis/dev_guidelines.md` ❌ |
| email notification, mobile app, `gh pr view`, IDE | no repo context at all ❌ |

Because resolution depends on the page you are on, the link fails differently in different places — which is why it looked flaky rather than plainly broken. The `contributor terms` link in the same template already uses an absolute URL and has always worked.

Changes:

- **`.github/pull_request_template.md`** — both checklist links now use absolute `blob/master` URLs, so reviewers stay on GitHub and the style matches the `contributor terms` link right below them.
- **`docs/molgenis/dev_guidelines.md`** — the same bug in reverse: the accessibility link used a repo-root-relative path inside a docs page, so it resolved to `docs/molgenis/docs/molgenis/dev_accessibility.md`. Now `./dev_accessibility.md`, matching `dev.md`. Links inside docs pages stay relative on purpose — there GitHub *does* rewrite them, and docsify resolves them too.
- **`docs/molgenis/dev.md`** — `dev_accessibility.md` was not listed in any index or sidebar, so it was only reachable via a direct link. Added it under "Concepts and guidelines".

### How to test

Docs-only change, no tests. To verify:

1. Click the two links in the checklist below — they should open the guidelines and accessibility pages in this repo.
2. Compare with an older open PR, where the same links 404.
3. Check the rendered href is absolute:
   `gh api repos/molgenis/molgenis-emx2/pulls/6660 -H "Accept: application/vnd.github.html+json" --jq '.body_html' | grep dev_guidelines`

### Checklist

- [x] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [x] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)