### PR TITLE
fix(cms): show message when blank dev pages are created

### DIFF
--- a/apps/tailwind-components/app/components/editor/HtmlPreview.vue
+++ b/apps/tailwind-components/app/components/editor/HtmlPreview.vue
@@ -2,6 +2,9 @@
 import { useTemplateRef, watch } from "vue";
 import type { IDeveloperPages } from "../../../types/cms";
 import { generateHtmlPreview } from "../../utils/cms";
+import { useRoute } from "#app";
+
+const route = useRoute();
 
 const props = defineProps<{
   content: IDeveloperPages;
@@ -28,6 +31,21 @@ watch(
 </script>
 
 <template>
+  <div
+    v-if="!content.html && !route.fullPath.endsWith('/editor')"
+    role="banner"
+    class="emx2__page_preview w-[80%] mx-auto"
+  >
+    <p class="text-title-contrast text-center">
+      No content to display. Start building your page in the
+      <NuxtLink
+        :to="`${route.fullPath}editor`"
+        class="underline text-link-inverted"
+      >
+        Page Editor
+      </NuxtLink>
+    </p>
+  </div>
   <div
     class="emx2__page_preview"
     :class="{

--- a/apps/ui/app/pages/[schema]/pages/[page]/editor.vue
+++ b/apps/ui/app/pages/[schema]/pages/[page]/editor.vue
@@ -69,27 +69,35 @@ async function saveSetting() {
   statusModalData.value.message = "";
   isSaving.value = true;
 
+  const query = `mutation saveDeveloperPage($page: [DeveloperPagesInput]) {
+    save(DeveloperPages: $page) {
+      status
+      message
+    }
+  }`;
+
   const response = await $fetch(`/${schema}/graphql`, {
     method: "POST",
     body: {
-      query: `mutation save($page:[DeveloperPageInput]){save(DeveloperPage:$page){status message}}`,
+      query: query,
       variables: { page: pageData.value },
     },
   }).catch((err) => {
     statusModalData.value = {
       type: "error",
-      message: err.error ? err.error[0].message : err,
+      message: err?.errors?.[0].message || err,
     };
     console.error(statusModalData.value.message);
+    showStatusModal.value = true;
   });
 
-  if (response.data?.save) {
+  if (response?.data?.save) {
     statusModalData.value = {
       type: "success",
       message: `Updated "${page}"`,
     };
+    showStatusModal.value = true;
   }
-  showStatusModal.value = true;
 }
 
 const enableSaveButton = computed<boolean>(

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -87,9 +87,7 @@ function onAddNewPageClick(type: ICmsPageTypes) {
     formMetadata.value = data.value?.configurablePageMetadata;
   } else {
     formMetadata.value = data.value?.developerPageMetadata;
-    const newPage = newDeveloperPage(
-      "<h2>My new page</h2>\n<p>This is a demo page</p>"
-    );
+    const newPage = newDeveloperPage();
     formValues.value = newPage;
   }
   showFormModal.value = true;


### PR DESCRIPTION
### What are the main changes you did

The purpose of this PR is to improve the UX of creating new dev pages. Currently, when a new dev page is created without content, no message is displayed when the page is viewed and there's no indication what needs to be done. Instead, I would like to display a message that informs the user the current state is and instruct them on what they need to do.

- [x] Add a message that is shown when a dev page is viewed but there is nothing to display (i.e., no html)
- [x] Remove default html when a new dev page is created
- [x] Fixed a bug in the graphql query that was thrown when dev page content was saved

This PR is part of molgenis/GCC#1143.

### How to test

- Go the preview and sign in as admin
- Go to the new UI and open the page gallery (`cms/pages`)
- Click the "Add new page" button, and then select "Developer page".
- In the form that opens, enter only the name of the page and save.
- View the new page. See message
- Click the "Page Editor" link to go to the editor. The message on the view-only page should not be shown in the editor
- Add some html e.g., `<p>This is my page</p>` and save
- View the page. Message is now gone and your html should be shown instead

### Checklist

- [x] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [x] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
