### PR TITLE
feat(cms): add option to emphasize sections using bg color

### DIFF
--- a/apps/tailwind-components/app/components/cms/ComponentDropZone.vue
+++ b/apps/tailwind-components/app/components/cms/ComponentDropZone.vue
@@ -5,7 +5,7 @@ import { ref, useTemplateRef } from "vue";
 import { useWindowScroll } from "@vueuse/core";
 import { useRafFn as useAnimationFrame } from "@vueuse/core";
 import { addBlock, addComponent } from "../../utils/cms";
-import type { IDraggingInfo } from "../../../types/cms";
+import type { IDraggingInfo } from "../../../types/CmsComponents";
 const scroll = useWindowScroll();
 const dropzone = useTemplateRef("dropzone");
 

--- a/apps/tailwind-components/app/components/cms/ConfigurablePage.vue
+++ b/apps/tailwind-components/app/components/cms/ConfigurablePage.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { IConfigurablePages } from "../../../types/cms";
 import type { ITableMetaData } from "../../../../metadata-utils/src";
-import type { IDraggingInfo } from "../../../types/cms";
+import type { IDraggingInfo } from "../../../types/CmsComponents";
 
 import PageComponent from "./PageComponent.vue";
 import TextParagraph from "./Paragraph.vue";

--- a/apps/tailwind-components/app/components/cms/DraggableComponent.vue
+++ b/apps/tailwind-components/app/components/cms/DraggableComponent.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import type { IDraggingInfo } from "../../../types/cms";
+import type { IDraggingInfo } from "../../../types/CmsComponents";
 import Button from "../Button.vue";
 
 const props = withDefaults(

--- a/apps/tailwind-components/app/components/cms/PageComponent.vue
+++ b/apps/tailwind-components/app/components/cms/PageComponent.vue
@@ -112,6 +112,7 @@ async function doDelete(): Promise<void> {
     v-else-if="mg_tableclass.endsWith('.Sections')"
     :id="component.id"
     :enable-full-screen-width="component.enableFullScreenWidth"
+    :applyShadedBackground="component.applyShadedBackground"
     :isEditable="editingIsEnabled"
     @edit="showEditModal = true"
     @delete="onDelete"

--- a/apps/tailwind-components/app/components/cms/Section.vue
+++ b/apps/tailwind-components/app/components/cms/Section.vue
@@ -3,8 +3,9 @@ import { ref } from "vue";
 import type { ISections } from "../../../types/cms";
 import ComponentActions from "./ComponentActions.vue";
 
-const props = withDefaults(defineProps<ISections>(), {
+const props = withDefaults(defineProps<ISections & { isEditable: boolean }>(), {
   enableFullScreenWidth: false,
+  applyShadedBackground: false,
   isEditable: false,
 });
 
@@ -45,7 +46,12 @@ const showMenu = ref<boolean>(false);
       </div>
     </VMenu>
 
-    <div class="w-full py-8 justify-center items-center">
+    <div
+      class="w-full py-8 justify-center items-center"
+      :class="{
+        'bg-form-legend': applyShadedBackground,
+      }"
+    >
       <div
         class="m-auto"
         :class="{

--- a/apps/tailwind-components/app/components/cms/Section.vue
+++ b/apps/tailwind-components/app/components/cms/Section.vue
@@ -3,11 +3,14 @@ import { ref } from "vue";
 import type { ISections } from "../../../types/cms";
 import ComponentActions from "./ComponentActions.vue";
 
-const props = withDefaults(defineProps<ISections & { isEditable: boolean }>(), {
-  enableFullScreenWidth: false,
-  applyShadedBackground: false,
-  isEditable: false,
-});
+const props = withDefaults(
+  defineProps<ISections & { isEditable?: boolean }>(),
+  {
+    enableFullScreenWidth: false,
+    applyShadedBackground: false,
+    isEditable: false,
+  }
+);
 
 const emit = defineEmits(["edit", "delete"]);
 const showMenu = ref<boolean>(false);

--- a/apps/tailwind-components/app/gql/cmsPages.ts
+++ b/apps/tailwind-components/app/gql/cmsPages.ts
@@ -30,8 +30,11 @@ export const getContainersQuery = `query getContainers($filter:ContainersFilter)
             order
             block {
                 id
-                enableFullScreenWidth
                 mg_tableclass
+                
+                # ui settings for blocks: settings
+                enableFullScreenWidth
+                applyShadedBackground
                 
                 # page headings
                 title

--- a/apps/tailwind-components/app/pages/cms/Section.story.vue
+++ b/apps/tailwind-components/app/pages/cms/Section.story.vue
@@ -1,0 +1,37 @@
+<script setup lang="ts">
+import Section from "../../components/cms/Section.vue";
+import Heading from "../../components/cms/Heading.vue";
+import Paragraph from "../../components/cms/Paragraph.vue";
+</script>
+
+<template>
+  <Section id="section-default">
+    <Heading id="section-default-heading" :level="3" text="Default section" />
+    <Paragraph
+      id="section-default-paragraph"
+      text="This is the default status of the section component. Content has a fixed width and left aligned."
+    />
+  </Section>
+  <Section id="section-full-width" :enableFullScreenWidth="true">
+    <Heading
+      id="section-full-width-heading"
+      :level="3"
+      text="Full width section"
+    />
+    <Paragraph
+      id="section-full-width-paragraph"
+      text="Sections can also fit the entire width if the page using the 'enable full screen width' setting. This may be useful if you need more space for content (e.g., images, visualisations, etc.)."
+    />
+  </Section>
+  <Section id="section-visually-emphasized" :applyShadedBackground="true">
+    <Heading
+      id="section-visually-emphasized-heading"
+      :level="3"
+      text="Section with visual emphasis"
+    />
+    <Paragraph
+      id="section-visually-emphasized-paragraph"
+      text="The 'apply shaded background' setting can be used to add visual distinction between sections. This may be useful if you have pages with a lot of content."
+    />
+  </Section>
+</template>

--- a/apps/tailwind-components/types/CmsComponents.ts
+++ b/apps/tailwind-components/types/CmsComponents.ts
@@ -52,3 +52,9 @@ export interface ICmsOrder {
 }
 
 export type ICmsPageTypes = "ConfigurablePage" | "DeveloperPage";
+
+export interface IDraggingInfo {
+  dragging: boolean;
+  componentName: string;
+  componentType: string;
+}

--- a/apps/tailwind-components/types/cms.ts
+++ b/apps/tailwind-components/types/cms.ts
@@ -1,4 +1,4 @@
-// Generated (on: 2026-04-13T16:07:28.658752) from Generator.java for schema: cms
+// Generated (on: 2026-08-21T10:23:03.961841) from Generator.java for schema: cms
 
 export interface IMgTableClass {
   mg_tableclass?: string;
@@ -47,6 +47,7 @@ export interface IBlocks extends IMgTableClass {
   subtitle?: string;
   backgroundImage?: any;
   titleIsCentered?: boolean;
+  applyShadedBackground?: boolean;
 }
 
 export interface IBlocks_agg {
@@ -81,11 +82,11 @@ export interface IComponents extends IMgTableClass {
   headingIsHidden?: boolean;
   title?: string;
   description?: string;
-  url?: string;
+  url: string;
   urlLabel?: string;
   urlIsExternal?: boolean;
   displayedInNavigationGroup?: any;
-  order?: number;
+  order: number;
   items?: string[];
 }
 
@@ -265,8 +266,10 @@ export interface IParagraphs_agg {
 
 export interface ISections extends IMgTableClass {
   enableFullScreenWidth?: boolean;
+  applyShadedBackground?: boolean;
   inContainer?: any;
-  isEditable?: boolean;
+  components?: IComponents[];
+  componentOrder?: IComponentOrders[];
   id: string;
 }
 
@@ -313,10 +316,4 @@ export interface IWebFetchPriorities extends IMgTableClass {
 
 export interface IWebFetchPriorities_agg {
   count: number;
-}
-
-export interface IDraggingInfo {
-  dragging: boolean;
-  componentName: string;
-  componentType: string;
 }

--- a/data/_demodata/applications/pages/Sections.csv
+++ b/data/_demodata/applications/pages/Sections.csv
@@ -1,4 +1,4 @@
-id,in container
-home-section-features,home
-home-section-applications,home
-home-section-navigation,home
+id,in container,apply shaded background
+home-section-features,home,
+home-section-applications,home,true
+home-section-navigation,home,

--- a/data/_models/specific/Pages.csv
+++ b/data/_models/specific/Pages.csv
@@ -65,6 +65,7 @@ Navigation cards,,order,int,,TRUE,,,,,,0,,Order the card should appear in when u
 Blocks,,Configuration,section,,,,,,,,,,,pages
 Blocks,,UI settings,heading,,,,,,,,,,,pages
 Blocks,,enable full screen width,bool,,,,,,,,FALSE,,"If true, content will be expanded to the fit the full width of the screen",pages
+Sections,,apply shaded background,bool,,,,,,,,FALSE,,"If true, a light background color will be applied to provide visual distinction between blocks",pages
 Blocks,,Component connections,heading,,,,,,,,,,Link components and set the order in which they display on page. ,pages
 Blocks,,in container,multiselect,,,Configurable pages,,,,,,,A link to the configurable page where the block is displayed,pages
 Blocks,,components,refback,,,Components,in block,,,,,,The elements that are displayed in a block,pages


### PR DESCRIPTION
### What are the main changes you did

One of the features that exists in the ERN applications&mdash;that would be useful for the page builder&mdash;is the ability to distinguish sections visually, i.e., apply a shaded background any section. To reduce the number of tailwind classes, the shaded background colour aligns with the form/sidebar background colors. (Ideally, we would want a better system for background colours, but that's for another story.)

- [x] Data model: 
    - [x] Added new column `apply shaded background`
    - [x] Added example in the demo data
- [x]  Page builder
    - [x] Regenerated types
    - [x] Added new column in the page builder query
    - [x] Integrated `apply shaded background` into components: PageComponent, Section, etc.

This PR is part of molgenis/GCC#1143

### How to test

- Go the preview server and sign in as admin
- Go the [page gallery](https://preview-emx2-pr-6676.dev.molgenis.org/apps/ui/cms/pages) and view the "Home" page
- The "Applications" section is now shaded (a light background color is applied)
- Go back to the page gallery and click the edit button for the demo page
- In the Applications section, click the edit section button and set `apply shaded background` to `false`. 
- Refresh the page to view the changes

### Checklist

- [x] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [x] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
