### PR TITLE
fix: added an extended timeout to cleandb

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/AToolToCleanDatabase.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/AToolToCleanDatabase.java
@@ -13,7 +13,7 @@ public class AToolToCleanDatabase {
 
   public static void deleteAll() {
     SqlDatabase db = new SqlDatabase(true);
-    DSLContext jooq = db.getJooq();
+    DSLContext jooq = db.getJooqWithExtendedTimeout();
     db.becomeAdmin();
     try {
       String sql =


### PR DESCRIPTION
Fixes #6690

### What are the main changes you did

- Gave the jooq context inside AToolToCleanTheDatabase an extended timeout

### How to test

- explain here what to do to test this (or point to unit tests)

### Checklist

- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
