### PR TITLE
fix(sql): check the caller's roles before running raw sql

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchema.java
@@ -75,7 +75,7 @@ public class SqlSchema implements Schema {
   }
 
   @Override
-  public List<String> getRoles() {
+  public List<String> getAllRoles() {
     return roleManager().getRoleNames(getName());
   }
 
@@ -89,7 +89,7 @@ public class SqlSchema implements Schema {
     // moved implementation to SqlSchemaMetadata so can be cached
     // while being reloaded in case of transactions
     if (user == null || user.equals(ADMIN_USER)) {
-      return getRoles();
+      return getAllRoles();
     } else {
       return getMetadata().getInheritedRolesForUser(user);
     }
@@ -143,11 +143,10 @@ public class SqlSchema implements Schema {
 
   @Override
   public List<Row> retrieveSql(String sql, Map<String, ?> parameters) {
-    if (getRoles().contains("Viewer")) {
-      return new SqlRawQueryForSchema(this).executeSql(sql, parameters);
-    } else {
+    if (!getInheritedRolesForActiveUser().contains(Privileges.VIEWER.toString())) {
       throw new MolgenisException("No view permissions on this schema");
     }
+    return new SqlRawQueryForSchema(this).executeSql(sql, parameters);
   }
 
   @Override

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTable.java
@@ -94,7 +94,7 @@ public class SqlTable implements Table {
     if (metadata.getColumn(MG_ROLES) == null) return;
 
     List<String> userRoles = getSchema().getInheritedRolesForActiveUser();
-    List<String> rolesInSchema = getSchema().getRoles();
+    List<String> rolesInSchema = getSchema().getAllRoles();
 
     for (Row row : rows) {
       String[] mgRoles = row.getStringArray(MG_ROLES);

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestEricRowLevel.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestEricRowLevel.java
@@ -51,7 +51,7 @@ class TestEricRowLevel {
         "Expected " + EXPECTED_COUNTRY_COUNT + " distinct countries in Biobanks");
 
     for (String country : countries) {
-      if (!schema.getRoles().contains(country)) {
+      if (!schema.getAllRoles().contains(country)) {
         schema.createRole(country);
       }
       schema.grant(
@@ -72,7 +72,7 @@ class TestEricRowLevel {
               .rowLevel(true));
     }
 
-    List<String> roles = schema.getRoles();
+    List<String> roles = schema.getAllRoles();
     for (String country : countries) {
       assertTrue(roles.contains(country), "Role should exist for country: " + country);
     }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestGrantRolesToUsers.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestGrantRolesToUsers.java
@@ -30,7 +30,7 @@ public class TestGrantRolesToUsers {
     List<String> first =
         Arrays.asList(
             "Exists", "Range", "Aggregator", "Count", "Viewer", "Editor", "Manager", "Owner");
-    List<String> second = schema.getRoles();
+    List<String> second = schema.getAllRoles();
     assertTrue(
         first.size() == second.size() && first.containsAll(second) && second.containsAll(first));
 

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRetrieveSqlPermission.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRetrieveSqlPermission.java
@@ -1,0 +1,76 @@
+package org.molgenis.emx2.sql;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.molgenis.emx2.Column.column;
+import static org.molgenis.emx2.TableMetadata.table;
+
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.*;
+
+class TestRetrieveSqlPermission {
+
+  private static final String SCHEMA = TestRetrieveSqlPermission.class.getSimpleName();
+  private static final String ARTICLES = "Articles";
+  private static final String SQL = "SELECT \"title\" FROM \"" + SCHEMA + "\".\"" + ARTICLES + "\"";
+
+  private static final String USER_VIEWER = "raw_sql_viewer";
+  private static final String USER_AGGREGATOR = "raw_sql_aggregator";
+  private static final String USER_COUNT = "raw_sql_count";
+
+  private static Database database;
+
+  @BeforeAll
+  static void setUp() {
+    database = TestDatabaseFactory.getTestDatabase();
+    database.becomeAdmin();
+
+    for (String user : List.of(USER_VIEWER, USER_AGGREGATOR, USER_COUNT)) {
+      if (!database.hasUser(user)) database.addUser(user);
+    }
+
+    Schema schema = database.dropCreateSchema(SCHEMA);
+    schema.create(table(ARTICLES).add(column("id").setPkey()).add(column("title")));
+    schema.getTable(ARTICLES).insert(new Row("id", "a1", "title", "secret"));
+
+    schema.addMember(USER_VIEWER, Privileges.VIEWER.toString());
+    schema.addMember(USER_AGGREGATOR, Privileges.AGGREGATOR.toString());
+    schema.addMember(USER_COUNT, Privileges.COUNT.toString());
+  }
+
+  @AfterEach
+  void becomeAdminAgain() {
+    database.becomeAdmin();
+  }
+
+  @Test
+  void aggregatorCannotRunRawSql() {
+    database.setActiveUser(USER_AGGREGATOR);
+    Schema schema = database.getSchema(SCHEMA);
+    assertThrows(MolgenisException.class, () -> schema.retrieveSql(SQL));
+  }
+
+  @Test
+  void countCannotRunRawSql() {
+    database.setActiveUser(USER_COUNT);
+    Schema schema = database.getSchema(SCHEMA);
+    assertThrows(MolgenisException.class, () -> schema.retrieveSql(SQL));
+  }
+
+  @Test
+  void viewerCanRunRawSql() {
+    database.setActiveUser(USER_VIEWER);
+    List<Row> rows = database.getSchema(SCHEMA).retrieveSql(SQL);
+    assertEquals(1, rows.size());
+    assertEquals("secret", rows.get(0).getString("title"));
+  }
+
+  @Test
+  void adminCanRunRawSql() {
+    database.becomeAdmin();
+    List<Row> rows = database.getSchema(SCHEMA).retrieveSql(SQL);
+    assertEquals(1, rows.size());
+  }
+}

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Schema.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Schema.java
@@ -52,7 +52,7 @@ public interface Schema {
 
   void removeMember(String user);
 
-  List<String> getRoles();
+  List<String> getAllRoles();
 
   String getRoleForUser(String user);
 


### PR DESCRIPTION
### What are the main changes you did

`Schema.retrieveSql` gated raw sql on `getRoles()`, which returns the roles **defined on the schema**, not the roles the **caller holds**. Every schema defines a `Viewer` role and `pg_roles` is world readable, so `getRoles().contains("Viewer")` was always true and the check never rejected anyone.

- Gate on `getInheritedRolesForActiveUser()` instead.
- Rename `Schema.getRoles()` to `getAllRoles()`. It returns every role under the schema prefix, internal `RLS_` proxies included, so the name now states its scope instead of reading like the roles that apply to you. `SqlTable.validateMgRoles` legitimately uses both lists and already named its variable `rolesInSchema`.

> [!NOTE]
> Worth settling separately: `SqlRoleManager.getRoles()` filters the `RLS_` proxies out and `getRoleNames()` does not, so those two differ in **contents**, not just representation. Naming across the role API deserves its own pass.

Two features reach `retrieveSql`: the `_reports` GraphQL field and beacon filtering terms. Any schema member — including an `Exists` only user — could run their sql against every table in the schema.

For an aggregate role this matters more since #6612, which gives `Exists` and up an RLS bypass for SELECT. Before that a report over an RLS table returned no rows to them; after it, all of them.

> [!NOTE]
> This lands a behaviour change for beacon: filtering terms now need `Viewer`. That is fixed in the stacked PR on top of this one, which should land with it.

### How to test

New `TestRetrieveSqlPermission`: `Aggregator` refused, `Count` refused, `Viewer` allowed, admin allowed.

Confirmed the tests have teeth — with the old check restored, `aggregatorCannotRunRawSql` and `countCannotRunRawSql` both fail.

| suite | result |
|---|---|
| `molgenis-emx2-sql` | 420/420 (master baseline 416; delta is the 4 new tests) |
| `molgenis-emx2-graphql` | 74/74 |
| all backend modules | compile, test sources included |

### Checklist

- [x] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)

### Known flaky neighbour

`ChangeLogExecutorTest` fails intermittently in a full parallel run (`expected: <1> but was: <0>`) and passes in isolation. It asserts on **database-wide deltas** — `executeLastUpdates` and `getSchemasWithChangeLog` scan the whole database, and the test snapshots a count, mutates, then asserts the difference. Under `maxParallelForks` against one Postgres that is not stable. This PR does not touch changelog code, but it does add test classes that create and drop schemas, so it plausibly makes the existing fragility fire more often. Flagging rather than fixing — it deserves its own change.
