### PR TITLE
fix(beacon): read filtering terms through the group by api

### DIFF
--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/endpoints/filteringterms/FilteringTermsFetcher.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/endpoints/filteringterms/FilteringTermsFetcher.java
@@ -1,13 +1,20 @@
 package org.molgenis.emx2.beaconv2.endpoints.filteringterms;
 
+import static org.molgenis.emx2.SelectColumn.s;
+
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.*;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.beaconv2.EntryType;
 
 @JsonAutoDetect(fieldVisibility = JsonAutoDetect.Visibility.ANY)
 public class FilteringTermsFetcher {
+
+  @JsonIgnore private static final ObjectMapper MAPPER = new ObjectMapper();
 
   @JsonIgnore
   public static final List<String> BEACON_TABLES =
@@ -56,8 +63,8 @@ public class FilteringTermsFetcher {
   }
 
   /**
-   * Check of a table is present in schema, add non-referencing terms immediately, launch native SQL
-   * query for others and loop over rows
+   * Check of a table is present in schema, add non-referencing terms immediately, query the terms
+   * occurring in the data for ontology columns
    *
    * @param schemaName
    * @param tableToQuery
@@ -75,52 +82,7 @@ public class FilteringTermsFetcher {
               new FilteringTerm("alphanumeric", column.getName(), tableToQuery);
           filteringTerms.add(filteringTerm);
         } else if (column.isOntology()) {
-          String schema = metadata.getSchemaName();
-          String refSchema = column.getRefTable().getSchemaName();
-          List<Row> rows;
-          String q =
-              "SELECT DISTINCT name,codesystem,code FROM \""
-                  + schema
-                  + "\".\""
-                  + tableToQuery
-                  + "\" INNER JOIN \""
-                  + refSchema
-                  + "\".\""
-                  + column.getRefTableName()
-                  + "\" ON \""
-                  + refSchema
-                  + "\".\""
-                  + column.getRefTableName()
-                  + (column.isArray()
-                      ? "\".\"name\" = ANY(\""
-                          + schema
-                          + "\".\""
-                          + tableToQuery
-                          + "\".\""
-                          + column.getName()
-                          + "\")"
-                      : "\".\"name\" = \""
-                          + schema
-                          + "\".\""
-                          + tableToQuery
-                          + "\".\""
-                          + column.getName()
-                          + "\"");
-          rows = database.getSchema(schemaName).retrieveSql(q);
-          for (Row row : rows) {
-            String codesystem = row.getString("codesystem");
-            codesystem = codesystem == null || codesystem.isBlank() ? "NULL" : codesystem;
-            String code = row.getString("code");
-            code = code == null || code.isBlank() ? "NULL" : code;
-            FilteringTerm filteringTerm =
-                new FilteringTerm(
-                    column,
-                    "ontology",
-                    codesystem + ":" + code,
-                    row.getString("name"),
-                    tableToQuery);
-            filteringTerms.add(filteringTerm);
-          }
+          filteringTerms.addAll(getOntologyTerms(schemaName, tableToQuery, metadata, column));
         } else {
           // ignore any non-atomic, non-ontology fields, which are headings, files and regular
           // (non-ontological) references
@@ -128,5 +90,57 @@ public class FilteringTermsFetcher {
       }
     }
     return filteringTerms;
+  }
+
+  /**
+   * Terms of an ontology column that occur in the data. Read through group by rather than a plain
+   * select, so a caller holding only aggregate permissions still gets terms; group by needs Range,
+   * tables below that are skipped instead of failing the whole response.
+   */
+  private Set<FilteringTerm> getOntologyTerms(
+      String schemaName, String tableToQuery, TableMetadata metadata, Column column) {
+    Schema schema = database.getSchema(schemaName);
+    if (!PermissionEvaluator.canRange(schema, metadata)) {
+      return Set.of();
+    }
+    Set<FilteringTerm> filteringTerms = new LinkedHashSet<>();
+    String groupBy = tableToQuery + "_groupBy";
+    String json =
+        schema
+            .query(groupBy, s("count"), s(column.getName(), s("name"), s("codesystem"), s("code")))
+            .retrieveJSON();
+    for (JsonNode group : readGroups(json, groupBy)) {
+      JsonNode term = group.get(column.getIdentifier());
+      if (term == null || term.isNull()) {
+        continue;
+      }
+      filteringTerms.add(
+          new FilteringTerm(
+              column,
+              "ontology",
+              orNull(term, "codesystem") + ":" + orNull(term, "code"),
+              text(term, "name"),
+              tableToQuery));
+    }
+    return filteringTerms;
+  }
+
+  private JsonNode readGroups(String json, String groupBy) {
+    try {
+      JsonNode groups = MAPPER.readTree(json).get(groupBy);
+      return groups == null || groups.isNull() ? MAPPER.createArrayNode() : groups;
+    } catch (JsonProcessingException e) {
+      throw new MolgenisException("Cannot read group by result of " + groupBy, e);
+    }
+  }
+
+  private static String orNull(JsonNode node, String field) {
+    String value = text(node, field);
+    return value == null || value.isBlank() ? "NULL" : value;
+  }
+
+  private static String text(JsonNode node, String field) {
+    JsonNode value = node.get(field);
+    return value == null || value.isNull() ? null : value.asText();
   }
 }

--- a/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/endpoints/filteringterms/FilteringTermsFetcherTest.java
+++ b/backend/molgenis-emx2-beacon-v2/src/test/java/org/molgenis/emx2/beaconv2/endpoints/filteringterms/FilteringTermsFetcherTest.java
@@ -1,0 +1,89 @@
+package org.molgenis.emx2.beaconv2.endpoints.filteringterms;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.molgenis.emx2.Constants.ANONYMOUS;
+import static org.molgenis.emx2.datamodels.DataModels.Profile.PET_STORE;
+
+import java.util.List;
+import java.util.Set;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.Database;
+import org.molgenis.emx2.Privileges;
+import org.molgenis.emx2.Schema;
+import org.molgenis.emx2.sql.TestDatabaseFactory;
+
+class FilteringTermsFetcherTest {
+
+  private static final String SCHEMA = FilteringTermsFetcherTest.class.getSimpleName();
+  private static final String PET = "Pet";
+
+  private static final String USER_AGGREGATOR = "filtering_terms_aggregator";
+  private static final String USER_EXISTS = "filtering_terms_exists";
+
+  private static Database database;
+
+  @BeforeAll
+  static void setUp() {
+    database = TestDatabaseFactory.getTestDatabase();
+    database.becomeAdmin();
+
+    for (String user : List.of(USER_AGGREGATOR, USER_EXISTS)) {
+      if (!database.hasUser(user)) database.addUser(user);
+    }
+
+    database.dropSchemaIfExists(SCHEMA);
+    PET_STORE.getImportTask(database, SCHEMA, "", true).run();
+
+    Schema schema = database.getSchema(SCHEMA);
+    schema.removeMember(ANONYMOUS);
+    // pet store puts row level security on Pet; that interaction is covered elsewhere
+    schema.revoke("DragonKeeper", PET);
+    schema.addMember(USER_AGGREGATOR, Privileges.AGGREGATOR.toString());
+    schema.addMember(USER_EXISTS, Privileges.EXISTS.toString());
+  }
+
+  @AfterEach
+  void becomeAdminAgain() {
+    database.becomeAdmin();
+  }
+
+  @Test
+  void adminGetsOntologyTerms() {
+    assertFalse(ontologyLabels().isEmpty());
+  }
+
+  @Test
+  void aggregatorGetsSameOntologyTermsAsAdmin() {
+    Set<String> asAdmin = ontologyLabels();
+
+    database.setActiveUser(USER_AGGREGATOR);
+    assertEquals(
+        asAdmin, ontologyLabels(), "aggregate roles must keep the filtering terms they had");
+  }
+
+  @Test
+  void existsGetsAlphanumericTermsWithoutFailing() {
+    database.setActiveUser(USER_EXISTS);
+    Set<FilteringTerm> terms = assertDoesNotThrow(this::petFilteringTerms);
+
+    assertTrue(terms.stream().anyMatch(term -> "alphanumeric".equals(term.getType())));
+    assertTrue(
+        terms.stream().noneMatch(term -> "ontology".equals(term.getType())),
+        "grouping needs Range, so ontology terms are skipped rather than throwing");
+  }
+
+  private Set<String> ontologyLabels() {
+    return petFilteringTerms().stream()
+        .filter(term -> "ontology".equals(term.getType()))
+        .map(FilteringTerm::getLabel)
+        .collect(java.util.stream.Collectors.toSet());
+  }
+
+  private Set<FilteringTerm> petFilteringTerms() {
+    Schema schema = database.getSchema(SCHEMA);
+    return new FilteringTermsFetcher(database)
+        .getFilteringTermsFromOneTable(SCHEMA, PET, schema.getTableNames());
+  }
+}


### PR DESCRIPTION
> [!IMPORTANT]
> Stacked on #6694 — base is `fix/raw-sql-viewer-check`, review that one first. These two should land together: #6694 alone leaves beacon filtering terms needing `Viewer`.

### What are the main changes you did

`FilteringTermsFetcher` read the ontology terms occurring in the data with hand built sql through `retrieveSql`, which needs view permission on the whole schema. Aggregate roles are exactly who beacon serves, so they lost their filtering terms once #6694 makes that check real.

Group by already carries the right rules for this: `SqlQuery` permits grouping on **ontology** columns without view permission, precisely so aggregate roles can use it. Routing through it makes the permission behaviour correct for free, and removes the second raw sql door in the codebase.

Two things fall out of the rewrite:

- **It fixes an existing crash.** The old query was `SELECT DISTINCT name, codesystem, code FROM <table> INNER JOIN <ontology> ON <ontology>."name" = ...`, with `name` unqualified in the select list. Any table with a `name` column of its own — pet store's `Pet`, for one — fails with `column reference "name" is ambiguous`. Reproduced on master as admin.
- **The permission floor moves from `Viewer` to `Range`,** since group by needs a count. Tables below `Range` are skipped rather than failing the whole response, so a user with mixed roles across schemas still gets an answer.

### How to test

New `FilteringTermsFetcherTest`, the first tests in this module: admin gets ontology terms, an `Aggregator` gets the same set, an `Exists` user gets alphanumeric terms and no error.

Confirmed the tests have teeth — against the base branch alone all three fail: the `Exists` case with `No view permissions on this schema`, the other two with the ambiguous column error above.

The test revokes `DragonKeeper` on `Pet` first, because pet store puts RLS there and on master aggregates over an RLS table return nothing — that is #6612, kept out of scope here.

| suite | result |
|---|---|
| `molgenis-emx2-beacon-v2` | 3/3 |
| `molgenis-emx2-sql` | 420/420 |
| `molgenis-emx2-graphql` | 74/74 |

### Checklist

- [x] checked that code complies with the [dev guidelines](docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)