### PR TITLE
refactor(fairmapper): make FDP crawl steps explicit configuration

### DIFF
--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/cli/commands/Harvest.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/cli/commands/Harvest.java
@@ -1,5 +1,10 @@
 package org.molgenis.emx2.fairmapper.cli.commands;
 
+import static org.molgenis.emx2.fairmapper.extractors.FdpCrawlSteps.CATALOGS;
+import static org.molgenis.emx2.fairmapper.extractors.FdpCrawlSteps.CSVW;
+import static org.molgenis.emx2.fairmapper.extractors.FdpCrawlSteps.DATASETS;
+import static org.molgenis.emx2.fairmapper.extractors.FdpCrawlSteps.DISTRIBUTIONS;
+
 import java.net.URI;
 import java.util.List;
 import java.util.UUID;
@@ -67,7 +72,9 @@ public class Harvest implements Runnable {
 
     URI rdfURI = getRdf();
 
-    RdfExtractor extractor = new FdpRdfExtractor(new RemoteRdfExtractor(), rdfURI);
+    RdfExtractor extractor =
+        new FdpRdfExtractor(new RemoteRdfExtractor())
+            .withCrawlSteps(CATALOGS, DATASETS, DISTRIBUTIONS, CSVW);
     SparqlSelectRdfTransformer transformer =
         new SparqlSelectRdfTransformer(
             new TableQueryGenerator(), schema.getMetadata(), List.of(tables));

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/CrawlStep.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/CrawlStep.java
@@ -1,0 +1,12 @@
+package org.molgenis.emx2.fairmapper.extractors;
+
+import org.eclipse.rdf4j.model.IRI;
+
+/**
+ * One level of a linked data crawl: follow {@code predicate} from every subject found by the
+ * previous step. Steps form a chain, so their order has to match the structure of the source.
+ *
+ * @param name used in logging to identify the level
+ * @param predicate links a subject to the resources fetched by this step
+ */
+public record CrawlStep(String name, IRI predicate) {}

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FDPO.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FDPO.java
@@ -1,0 +1,14 @@
+package org.molgenis.emx2.fairmapper.extractors;
+
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.util.Values;
+
+/** Constants for the FAIR Data Point Ontology, which RDF4J does not ship a vocabulary for. */
+public final class FDPO {
+
+  public static final String NAMESPACE = "https://w3id.org/fdp/fdp-o#";
+
+  public static final IRI METADATA_CATALOG = Values.iri(NAMESPACE, "metadataCatalog");
+
+  private FDPO() {}
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FdpCrawlSteps.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FdpCrawlSteps.java
@@ -2,6 +2,7 @@ package org.molgenis.emx2.fairmapper.extractors;
 
 import java.util.List;
 import org.eclipse.rdf4j.model.vocabulary.DCAT;
+import org.molgenis.emx2.rdf.vocabulary.FDPO;
 
 /**
  * The levels a FAIR Data Point exposes, in the order they have to be followed.

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FdpCrawlSteps.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FdpCrawlSteps.java
@@ -1,0 +1,24 @@
+package org.molgenis.emx2.fairmapper.extractors;
+
+import java.util.List;
+import org.eclipse.rdf4j.model.vocabulary.DCAT;
+
+/**
+ * The levels a FAIR Data Point exposes, in the order they have to be followed.
+ *
+ * <p>Note that RDF4J's {@code DCAT.DATASET} and {@code DCAT.DISTRIBUTION} are the classes {@code
+ * dcat:Dataset} and {@code dcat:Distribution}; the linking properties are {@code HAS_DATASET} and
+ * {@code HAS_DISTRIBUTION}.
+ */
+public final class FdpCrawlSteps {
+
+  public static final CrawlStep CATALOGS = new CrawlStep("catalog", FDPO.METADATA_CATALOG);
+  public static final CrawlStep DATASETS = new CrawlStep("dataset", DCAT.HAS_DATASET);
+  public static final CrawlStep DISTRIBUTIONS =
+      new CrawlStep("distribution", DCAT.HAS_DISTRIBUTION);
+  public static final CrawlStep CSVW = new CrawlStep("csvw", DCAT.DOWNLOAD_URL);
+
+  public static final List<CrawlStep> DEFAULT = List.of(CATALOGS, DATASETS, DISTRIBUTIONS, CSVW);
+
+  private FdpCrawlSteps() {}
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FdpRdfExtractor.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FdpRdfExtractor.java
@@ -3,205 +3,103 @@ package org.molgenis.emx2.fairmapper.extractors;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.rdf4j.model.Value;
-import org.eclipse.rdf4j.query.TupleQuery;
-import org.eclipse.rdf4j.query.TupleQueryResult;
+import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import org.eclipse.rdf4j.model.IRI;
+import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+/**
+ * Extracts RDF from a FAIR Data Point by walking its levels one at a time.
+ *
+ * <p>Each step queries the repository for the resources it links to and then fetches those into the
+ * same repository, so that the next step has triples to query. Fetching and querying therefore have
+ * to alternate; a single SPARQL property path would find nothing beyond the first level.
+ */
 public class FdpRdfExtractor implements RdfExtractor {
 
   private static final Logger logger = LoggerFactory.getLogger(FdpRdfExtractor.class);
 
-  private static final String CATALOG_QUERY =
-      """
-      SELECT ?catalog
-      WHERE {
-        <%s> <https://w3id.org/fdp/fdp-o#metadataCatalog> ?catalog .
-      }
-      """;
-
-  private static final String DATASET_QUERY =
-      """
-      PREFIX dcat: <http://www.w3.org/ns/dcat#>
-
-      SELECT ?dataset
-      WHERE {
-        <%s> dcat:dataset ?dataset .
-      }
-      """;
-
-  private static final String DISTRIBUTION_QUERY =
-      """
-          PREFIX dcat: <http://www.w3.org/ns/dcat#>
-          SELECT ?distribution
-          WHERE {
-              <%s> dcat:distribution ?distribution .
-          }
-          """;
-
-  private static final String CSVW_QUERY =
-      """
-          PREFIX dcat: <http://www.w3.org/ns/dcat#>
-          SELECT ?csvw
-          WHERE {
-              <%s> dcat:downloadURL ?csvw .
-          }
-          """;
-
   private final RdfExtractor rdfExtractor;
-  private final URI endpoint;
+  private final List<CrawlStep> crawlSteps;
 
-  public FdpRdfExtractor(RdfExtractor rdfExtractor, URI endpoint) {
-    this.rdfExtractor = rdfExtractor;
-    this.endpoint = normalize(endpoint);
+  public FdpRdfExtractor(RdfExtractor rdfExtractor) {
+    this(rdfExtractor, FdpCrawlSteps.DEFAULT);
   }
 
-  private static URI normalize(URI uri) {
-    if (uri.toString().endsWith("/")) {
-      return URI.create(uri.toString().replaceAll("/$", ""));
+  private FdpRdfExtractor(RdfExtractor rdfExtractor, List<CrawlStep> crawlSteps) {
+    this.rdfExtractor = rdfExtractor;
+    this.crawlSteps = crawlSteps;
+  }
+
+  public FdpRdfExtractor withCrawlSteps(CrawlStep... crawlSteps) {
+    return new FdpRdfExtractor(rdfExtractor, List.of(crawlSteps));
+  }
+
+  @Override
+  public void addRdfToRepository(Repository repository, URI rootToAdd) {
+    IRI root = Values.iri(stripTrailingSlashes(rootToAdd));
+    logger.info("Crawling FAIR Data Point: {}", root);
+    rdfExtractor.addRdfToRepository(repository, root.stringValue());
+
+    List<IRI> frontier = List.of(root);
+    for (CrawlStep step : crawlSteps) {
+      frontier = follow(repository, frontier, step);
+    }
+  }
+
+  private List<IRI> follow(Repository repository, List<IRI> subjects, CrawlStep step) {
+    List<IRI> found = objectsOf(repository, subjects, step.predicate());
+
+    logger.info("Found {} {}(s): {}", found.size(), step.name(), found);
+    if (found.isEmpty()) {
+      logger.warn(
+          "Crawl step '{}' found nothing for {} subject(s); check the step order and whether the"
+              + " source uses {}",
+          step.name(),
+          subjects.size(),
+          step.predicate());
     }
 
-    return uri;
+    found.forEach(iri -> fetchSkippingFailures(repository, iri));
+    return found;
   }
 
-  public void addRdfToRepository(Repository repository) {
-    addRdfToRepository(repository, endpoint);
+  private static List<IRI> objectsOf(Repository repository, List<IRI> subjects, IRI predicate) {
+    List<IRI> objects = new ArrayList<>();
+    try (RepositoryConnection connection = repository.getConnection()) {
+      for (IRI subject : subjects) {
+        try (CloseableIteration<Statement> statements =
+            connection.getStatements(subject, predicate, null)) {
+          statements.stream()
+              .map(Statement::getObject)
+              .filter(IRI.class::isInstance)
+              .map(IRI.class::cast)
+              .forEach(objects::add);
+        }
+      }
+    }
+
+    return objects.stream().distinct().toList();
   }
 
   /**
-   * Extracts RDF data from a FAIR Data Point by querying its metadata catalogs and, for each
-   * catalog, its datasets, then fetching the RDF for each catalog and dataset into the provided
-   * repository.
-   *
-   * @param repository RDF repository that the query results are written to.
-   * @param rootToAdd the URI identifying the FAIR Data Point to extract catalogs and datasets from
+   * A FAIR Data Point links to resources it does not control, so a download URL may well point at a
+   * CSV or ZIP rather than at RDF. One unreadable resource should not end the harvest.
    */
-  @Override
-  public void addRdfToRepository(Repository repository, URI rootToAdd) {
-    rdfExtractor.addRdfToRepository(repository, endpoint);
-
-    List<String> catalogs = queryCatalogs(repository, rootToAdd);
-    for (String catalog : catalogs) {
-      rdfExtractor.addRdfToRepository(repository, catalog);
-    }
-
-    List<String> datasets = queryDatasets(repository, catalogs);
-    for (String dataset : datasets) {
-      rdfExtractor.addRdfToRepository(repository, dataset);
-    }
-
-    List<String> distributions = queryDistributions(repository, datasets);
-    for (String distribution : distributions) {
-      rdfExtractor.addRdfToRepository(repository, distribution);
-    }
-
-    List<String> csvwResults = queryCsvw(repository, distributions);
-    for (String csvw : csvwResults) {
-      rdfExtractor.addRdfToRepository(repository, csvw);
+  private void fetchSkippingFailures(Repository repository, IRI iri) {
+    try {
+      rdfExtractor.addRdfToRepository(repository, iri.stringValue());
+    } catch (RuntimeException e) {
+      logger.warn("Skipping {}: {}", iri, e.toString());
+      logger.debug("Could not add RDF from {}", iri, e);
     }
   }
 
-  private static List<String> queryDatasets(Repository sail, List<String> catalogs) {
-    List<String> datasets = new ArrayList<>();
-    try (RepositoryConnection connection = sail.getConnection()) {
-      for (String catalog : catalogs) {
-        logger.info("Querying for datasets in catalog: {}", catalog);
-        TupleQuery tupleQuery = connection.prepareTupleQuery(DATASET_QUERY.formatted(catalog));
-        try (TupleQueryResult evaluate = tupleQuery.evaluate()) {
-          List<String> results =
-              evaluate.stream()
-                  .map(result -> result.getValue("dataset"))
-                  .map(Value::stringValue)
-                  .toList();
-
-          logger.info(
-              "Found the following dataset{} for catalog {}: {}",
-              datasets.size() == 1 ? "" : "s",
-              catalog,
-              results);
-          results.stream().map(dataset -> "dataset : " + dataset).forEach(logger::info);
-          datasets.addAll(results);
-        }
-      }
-    }
-
-    return datasets;
-  }
-
-  private List<String> queryCatalogs(Repository repository, URI fdpIdentifier) {
-    logger.info("Querying for catalogs from FDP with identifier: {}", fdpIdentifier);
-    try (RepositoryConnection connection = repository.getConnection()) {
-      TupleQuery tupleQuery = connection.prepareTupleQuery(CATALOG_QUERY.formatted(fdpIdentifier));
-      try (TupleQueryResult evaluate = tupleQuery.evaluate()) {
-        List<String> catalogs =
-            evaluate.stream()
-                .map(result -> result.getValue("catalog"))
-                .map(Value::stringValue)
-                .toList();
-
-        logger.info("Found {} catalog{}", catalogs.size(), catalogs.size() == 1 ? "" : "s");
-        catalogs.stream().map(catalog -> "catalog : " + catalog).forEach(logger::info);
-        return catalogs;
-      }
-    }
-  }
-
-  private static List<String> queryDistributions(Repository sail, List<String> datasets) {
-    List<String> distributions = new ArrayList<>();
-    try (RepositoryConnection connection = sail.getConnection()) {
-      for (String dataset : datasets) {
-        logger.info("Querying for distributions in dataset: {}", dataset);
-        TupleQuery tupleQuery = connection.prepareTupleQuery(DISTRIBUTION_QUERY.formatted(dataset));
-        try (TupleQueryResult evaluate = tupleQuery.evaluate()) {
-          List<String> results =
-              evaluate.stream()
-                  .map(result -> result.getValue("distribution"))
-                  .map(Value::stringValue)
-                  .toList();
-
-          logger.info(
-              "Found the following distribution{} for dataset {}: {}",
-              distributions.size() == 1 ? "" : "s",
-              dataset,
-              results);
-          results.stream()
-              .map(distribution -> "distribution : " + distribution)
-              .forEach(logger::info);
-          distributions.addAll(results);
-        }
-      }
-    }
-
-    return distributions;
-  }
-
-  private static List<String> queryCsvw(Repository sail, List<String> distributions) {
-    List<String> csvwResults = new ArrayList<>();
-    try (RepositoryConnection connection = sail.getConnection()) {
-      for (String distribution : distributions) {
-        logger.info("Querying for distributions in distribution: {}", distribution);
-        TupleQuery tupleQuery = connection.prepareTupleQuery(CSVW_QUERY.formatted(distribution));
-        try (TupleQueryResult evaluate = tupleQuery.evaluate()) {
-          List<String> results =
-              evaluate.stream()
-                  .map(result -> result.getValue("csvw"))
-                  .map(Value::stringValue)
-                  .toList();
-
-          logger.info(
-              "Found the following csvw result{} for distribution {}: {}",
-              csvwResults.size() == 1 ? "" : "s",
-              distribution,
-              results);
-          results.stream().map(result -> "csvw : " + result).forEach(logger::info);
-          csvwResults.addAll(results);
-        }
-      }
-    }
-
-    return csvwResults;
+  private static String stripTrailingSlashes(URI uri) {
+    return uri.toString().replaceAll("/+$", "");
   }
 }

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FdpRdfExtractor.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/extractors/FdpRdfExtractor.java
@@ -1,14 +1,16 @@
 package org.molgenis.emx2.fairmapper.extractors;
 
 import java.net.URI;
-import java.util.ArrayList;
 import java.util.List;
-import org.eclipse.rdf4j.common.iteration.CloseableIteration;
+import java.util.Set;
+import java.util.stream.Collectors;
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.Statement;
+import org.eclipse.rdf4j.model.Value;
 import org.eclipse.rdf4j.model.util.Values;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
+import org.molgenis.emx2.MolgenisException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -25,18 +27,24 @@ public class FdpRdfExtractor implements RdfExtractor {
 
   private final RdfExtractor rdfExtractor;
   private final List<CrawlStep> crawlSteps;
+  private final boolean strict;
 
   public FdpRdfExtractor(RdfExtractor rdfExtractor) {
-    this(rdfExtractor, FdpCrawlSteps.DEFAULT);
+    this(rdfExtractor, FdpCrawlSteps.DEFAULT, false);
   }
 
-  private FdpRdfExtractor(RdfExtractor rdfExtractor, List<CrawlStep> crawlSteps) {
+  private FdpRdfExtractor(RdfExtractor rdfExtractor, List<CrawlStep> crawlSteps, boolean strict) {
     this.rdfExtractor = rdfExtractor;
     this.crawlSteps = crawlSteps;
+    this.strict = strict;
   }
 
   public FdpRdfExtractor withCrawlSteps(CrawlStep... crawlSteps) {
-    return new FdpRdfExtractor(rdfExtractor, List.of(crawlSteps));
+    return new FdpRdfExtractor(rdfExtractor, List.of(crawlSteps), strict);
+  }
+
+  public FdpRdfExtractor withStrict() {
+    return new FdpRdfExtractor(rdfExtractor, crawlSteps, true);
   }
 
   @Override
@@ -45,57 +53,48 @@ public class FdpRdfExtractor implements RdfExtractor {
     logger.info("Crawling FAIR Data Point: {}", root);
     rdfExtractor.addRdfToRepository(repository, root.stringValue());
 
-    List<IRI> frontier = List.of(root);
+    Set<IRI> frontier = Set.of(root);
     for (CrawlStep step : crawlSteps) {
-      frontier = follow(repository, frontier, step);
+      frontier = executeStep(repository, frontier, step);
     }
   }
 
-  private List<IRI> follow(Repository repository, List<IRI> subjects, CrawlStep step) {
-    List<IRI> found = objectsOf(repository, subjects, step.predicate());
+  private Set<IRI> executeStep(Repository repository, Set<IRI> subjects, CrawlStep step) {
+    Set<IRI> results = objectsOf(repository, subjects, step.predicate());
 
-    logger.info("Found {} {}(s): {}", found.size(), step.name(), found);
-    if (found.isEmpty()) {
+    logger.info("Found {} {}(s): {}", results.size(), step.name(), results);
+    if (results.isEmpty()) {
       logger.warn(
-          "Crawl step '{}' found nothing for {} subject(s); check the step order and whether the"
+          "Crawl step '{}' results nothing for {} subject(s); check the step order and whether the"
               + " source uses {}",
           step.name(),
           subjects.size(),
           step.predicate());
     }
 
-    found.forEach(iri -> fetchSkippingFailures(repository, iri));
-    return found;
+    results.forEach(iri -> fetch(repository, iri));
+    return results;
   }
 
-  private static List<IRI> objectsOf(Repository repository, List<IRI> subjects, IRI predicate) {
-    List<IRI> objects = new ArrayList<>();
+  private static Set<IRI> objectsOf(Repository repository, Set<IRI> subjects, IRI predicate) {
     try (RepositoryConnection connection = repository.getConnection()) {
-      for (IRI subject : subjects) {
-        try (CloseableIteration<Statement> statements =
-            connection.getStatements(subject, predicate, null)) {
-          statements.stream()
-              .map(Statement::getObject)
-              .filter(IRI.class::isInstance)
-              .map(IRI.class::cast)
-              .forEach(objects::add);
-        }
-      }
+      return subjects.stream()
+          .flatMap(subject -> connection.getStatements(subject, predicate, null).stream())
+          .map(Statement::getObject)
+          .filter(Value::isIRI)
+          .map(IRI.class::cast)
+          .collect(Collectors.toSet());
     }
-
-    return objects.stream().distinct().toList();
   }
 
-  /**
-   * A FAIR Data Point links to resources it does not control, so a download URL may well point at a
-   * CSV or ZIP rather than at RDF. One unreadable resource should not end the harvest.
-   */
-  private void fetchSkippingFailures(Repository repository, IRI iri) {
+  private void fetch(Repository repository, IRI iri) {
     try {
       rdfExtractor.addRdfToRepository(repository, iri.stringValue());
     } catch (RuntimeException e) {
-      logger.warn("Skipping {}: {}", iri, e.toString());
-      logger.debug("Could not add RDF from {}", iri, e);
+      logger.error("Could not add RDF from {}", iri, e);
+      if (strict) {
+        throw new MolgenisException("Unable to add RDF from " + iri, e);
+      }
     }
   }
 

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/extractors/FdpRdfExtractorTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/extractors/FdpRdfExtractorTest.java
@@ -99,7 +99,7 @@ class FdpRdfExtractorTest {
 
     extracted = new SailRepository(new MemoryStore());
     valueFactory = extracted.getValueFactory();
-    new FdpRdfExtractor(new RemoteRdfExtractor(), rootUri).addRdfToRepository(extracted);
+    new FdpRdfExtractor(new RemoteRdfExtractor()).addRdfToRepository(extracted, rootUri);
   }
 
   @Test
@@ -183,32 +183,133 @@ class FdpRdfExtractorTest {
     Repository extract = new SailRepository(new MemoryStore());
     Assertions.assertDoesNotThrow(
         () ->
-            new FdpRdfExtractor(new RemoteRdfExtractor(), URI.create(endpoint))
-                .addRdfToRepository(extract));
+            new FdpRdfExtractor(new RemoteRdfExtractor())
+                .addRdfToRepository(extract, URI.create(endpoint)));
     try (RepositoryConnection connection = extract.getConnection()) {
       connection.getStatements(null, null, null).forEach(System.out::println);
     }
   }
 
+  /**
+   * The pipeline passes the URI the user typed, so the trailing slash has to be stripped from the
+   * URI the crawl queries with, not only from the one it fetches.
+   */
   @Test
-  void shouldRemoveTrailingSlash(@TempDir Path tempDir) throws IOException {
+  void shouldCrawlOnWhenRootHasTrailingSlash(@TempDir Path tempDir) throws IOException {
     SailRepository repository = new SailRepository(new MemoryStore());
 
     Path root = tempDir.resolve("root.ttl");
+    Path catalog = tempDir.resolve("catalog.ttl");
+
     Files.writeString(
         root,
         """
-            @prefix dcterms: <http://purl.org/dc/terms/> .
-            <https://example.org> dcterms:title "root" .
-            """);
+        @prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+        <%s> fdpo:metadataCatalog <%s> .
+        """
+            .formatted(root.toUri(), catalog.toUri()));
+    Files.writeString(
+        catalog,
+        """
+        @prefix dcterms: <http://purl.org/dc/terms/> .
+        <%s> dcterms:title "catalog" .
+        """
+            .formatted(catalog.toUri()));
 
-    new FdpRdfExtractor(new RemoteRdfExtractor(), URI.create(root.toUri() + "/"))
+    new FdpRdfExtractor(new RemoteRdfExtractor())
+        .addRdfToRepository(repository, URI.create(root.toUri() + "//"));
+
+    try (RepositoryConnection connection = repository.getConnection()) {
+      assertHasStatements(
+          connection,
+          statement(
+              Values.iri(catalog.toUri().toString()), DCTERMS.TITLE, Values.literal("catalog")));
+    }
+  }
+
+  @Test
+  void shouldFollowConfiguredStepsOnly(@TempDir Path tempDir) throws IOException {
+    SailRepository repository = new SailRepository(new MemoryStore());
+    IRI partOf = Values.iri("https://example.org/ns#part");
+
+    Path root = tempDir.resolve("root.ttl");
+    Path part = tempDir.resolve("part.ttl");
+
+    Files.writeString(root, "<%s> <%s> <%s> .%n".formatted(root.toUri(), partOf, part.toUri()));
+    Files.writeString(
+        part,
+        """
+        @prefix dcterms: <http://purl.org/dc/terms/> .
+        <%s> dcterms:title "part" .
+        """
+            .formatted(part.toUri()));
+
+    new FdpRdfExtractor(new RemoteRdfExtractor())
+        .withCrawlSteps(new CrawlStep("part", partOf))
         .addRdfToRepository(repository, root.toUri());
 
     try (RepositoryConnection connection = repository.getConnection()) {
       assertHasStatements(
           connection,
-          statement(Values.iri("https://example.org"), DCTERMS.TITLE, Values.literal("root")));
+          statement(Values.iri(part.toUri().toString()), DCTERMS.TITLE, Values.literal("part")));
+    }
+  }
+
+  /** A download URL usually points at the data itself, which is rarely RDF. */
+  @Test
+  void shouldContinueWhenALinkedResourceIsNotRdf(@TempDir Path tempDir) throws IOException {
+    SailRepository repository = new SailRepository(new MemoryStore());
+
+    Path root = tempDir.resolve("root.ttl");
+    Path catalog = tempDir.resolve("catalog.ttl");
+    Path dataset = tempDir.resolve("dataset.ttl");
+    Path distribution = tempDir.resolve("distribution.ttl");
+    Path data = tempDir.resolve("data.csv");
+
+    Files.writeString(
+        root,
+        """
+        @prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
+        <%s> fdpo:metadataCatalog <%s> .
+        """
+            .formatted(root.toUri(), catalog.toUri()));
+    Files.writeString(
+        catalog,
+        """
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        <%s> dcat:dataset <%s> .
+        """
+            .formatted(catalog.toUri(), dataset.toUri()));
+    Files.writeString(
+        dataset,
+        """
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        <%s> dcat:distribution <%s> .
+        """
+            .formatted(dataset.toUri(), distribution.toUri()));
+    Files.writeString(
+        distribution,
+        """
+        @prefix dcat: <http://www.w3.org/ns/dcat#> .
+        @prefix dcterms: <http://purl.org/dc/terms/> .
+        <%s> dcterms:title "distribution" ;
+            dcat:downloadURL <%s> .
+        """
+            .formatted(distribution.toUri(), data.toUri()));
+    Files.writeString(data, "id,name%n1,first%n".formatted());
+
+    Assertions.assertDoesNotThrow(
+        () ->
+            new FdpRdfExtractor(new RemoteRdfExtractor())
+                .addRdfToRepository(repository, root.toUri()));
+
+    try (RepositoryConnection connection = repository.getConnection()) {
+      assertHasStatements(
+          connection,
+          statement(
+              Values.iri(distribution.toUri().toString()),
+              DCTERMS.TITLE,
+              Values.literal("distribution")));
     }
   }
 }

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/extractors/FdpRdfExtractorTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/extractors/FdpRdfExtractorTest.java
@@ -1,7 +1,6 @@
 package org.molgenis.emx2.fairmapper.extractors;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 
 import java.io.IOException;
 import java.net.URI;
@@ -9,13 +8,17 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import org.eclipse.rdf4j.model.*;
 import org.eclipse.rdf4j.model.util.Values;
+import org.eclipse.rdf4j.model.vocabulary.DCAT;
 import org.eclipse.rdf4j.model.vocabulary.DCTERMS;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.eclipse.rdf4j.repository.sail.SailRepository;
+import org.eclipse.rdf4j.repository.sail.SailRepositoryConnection;
 import org.eclipse.rdf4j.sail.memory.MemoryStore;
 import org.junit.jupiter.api.*;
 import org.junit.jupiter.api.io.TempDir;
+import org.molgenis.emx2.MolgenisException;
+import org.molgenis.emx2.rdf.vocabulary.FDPO;
 
 class FdpRdfExtractorTest {
 
@@ -104,10 +107,7 @@ class FdpRdfExtractorTest {
 
   @Test
   void shouldHaveNoMoreStatementsThanNeeded() {
-    try (RepositoryConnection connection = extracted.getConnection()) {
-      long nrStatements = connection.getStatements(null, null, null).stream().count();
-      assertEquals(11, nrStatements);
-    }
+    assertStatementCount(extracted, 11);
   }
 
   @Test
@@ -116,17 +116,17 @@ class FdpRdfExtractorTest {
         statement(Values.iri(rootUri.toString()), DCTERMS.TITLE, Values.literal("root")),
         statement(
             Values.iri(rootUri.toString()),
-            Values.iri("https://w3id.org/fdp/fdp-o#metadataCatalog"),
+            FDPO.METADATA_CATALOG,
             Values.iri(catalog1Uri.toString())),
         statement(
             Values.iri(rootUri.toString()),
-            Values.iri("https://w3id.org/fdp/fdp-o#metadataCatalog"),
+            FDPO.METADATA_CATALOG,
             Values.iri(catalog2Uri.toString())),
         statement(Values.iri(catalog1Uri.toString()), DCTERMS.TITLE, Values.literal("catalog-1")),
         statement(Values.iri(catalog2Uri.toString()), DCTERMS.TITLE, Values.literal("catalog-2")),
         statement(
             Values.iri(catalog1Uri.toString()),
-            Values.iri("http://www.w3.org/ns/dcat#dataset"),
+            DCAT.HAS_DATASET,
             Values.iri(datasetUri.toString())));
   }
 
@@ -136,7 +136,7 @@ class FdpRdfExtractorTest {
         statement(Values.iri(datasetUri.toString()), DCTERMS.TITLE, Values.literal("dataset")),
         statement(
             Values.iri(datasetUri.toString()),
-            Values.iri("http://www.w3.org/ns/dcat#distribution"),
+            DCAT.HAS_DISTRIBUTION,
             Values.iri(distributionUri.toString())));
   }
 
@@ -149,7 +149,7 @@ class FdpRdfExtractorTest {
             Values.literal("distribution 1")),
         statement(
             Values.iri(distributionUri.toString()),
-            Values.iri("http://www.w3.org/ns/dcat#downloadURL"),
+            DCAT.DOWNLOAD_URL,
             Values.iri(csvwUri.toString())));
   }
 
@@ -173,6 +173,13 @@ class FdpRdfExtractorTest {
       RepositoryConnection connection, Statement... statements) {
     for (Statement statement : statements) {
       assertTrue(connection.hasStatement(statement, false));
+    }
+  }
+
+  private static void assertStatementCount(SailRepository repository, int expectedNrStatement) {
+    try (SailRepositoryConnection connection = repository.getConnection()) {
+      long nrStatements = connection.getStatements(null, null, null, false).stream().count();
+      assertEquals(expectedNrStatement, nrStatements);
     }
   }
 
@@ -228,7 +235,7 @@ class FdpRdfExtractorTest {
   }
 
   @Test
-  void shouldFollowConfiguredStepsOnly(@TempDir Path tempDir) throws IOException {
+  void shouldExecuteStepConfiguredStepsOnly(@TempDir Path tempDir) throws IOException {
     SailRepository repository = new SailRepository(new MemoryStore());
     IRI partOf = Values.iri("https://example.org/ns#part");
 
@@ -255,61 +262,62 @@ class FdpRdfExtractorTest {
     }
   }
 
-  /** A download URL usually points at the data itself, which is rarely RDF. */
-  @Test
-  void shouldContinueWhenALinkedResourceIsNotRdf(@TempDir Path tempDir) throws IOException {
-    SailRepository repository = new SailRepository(new MemoryStore());
+  @Nested
+  class StrictModeTest {
 
-    Path root = tempDir.resolve("root.ttl");
-    Path catalog = tempDir.resolve("catalog.ttl");
-    Path dataset = tempDir.resolve("dataset.ttl");
-    Path distribution = tempDir.resolve("distribution.ttl");
-    Path data = tempDir.resolve("data.csv");
+    private final IRI partOf = Values.iri("https://example.org/ns#part");
+    private SailRepository repository;
+    private Path root;
+    private Path data;
 
-    Files.writeString(
-        root,
-        """
-        @prefix fdpo: <https://w3id.org/fdp/fdp-o#> .
-        <%s> fdpo:metadataCatalog <%s> .
-        """
-            .formatted(root.toUri(), catalog.toUri()));
-    Files.writeString(
-        catalog,
-        """
-        @prefix dcat: <http://www.w3.org/ns/dcat#> .
-        <%s> dcat:dataset <%s> .
-        """
-            .formatted(catalog.toUri(), dataset.toUri()));
-    Files.writeString(
-        dataset,
-        """
-        @prefix dcat: <http://www.w3.org/ns/dcat#> .
-        <%s> dcat:distribution <%s> .
-        """
-            .formatted(dataset.toUri(), distribution.toUri()));
-    Files.writeString(
-        distribution,
-        """
-        @prefix dcat: <http://www.w3.org/ns/dcat#> .
-        @prefix dcterms: <http://purl.org/dc/terms/> .
-        <%s> dcterms:title "distribution" ;
-            dcat:downloadURL <%s> .
-        """
-            .formatted(distribution.toUri(), data.toUri()));
-    Files.writeString(data, "id,name%n1,first%n".formatted());
+    @BeforeEach
+    void setUp(@TempDir Path tempDir) throws IOException {
+      repository = new SailRepository(new MemoryStore());
+      root = tempDir.resolve("root.ttl");
+      data = tempDir.resolve("data.csv");
+      Files.writeString(data, "id,name%n1,first%n".formatted());
+    }
 
-    Assertions.assertDoesNotThrow(
-        () ->
-            new FdpRdfExtractor(new RemoteRdfExtractor())
-                .addRdfToRepository(repository, root.toUri()));
+    @Test
+    void whenNotStrictMode_thenContinue() throws IOException {
+      Path part = root.resolveSibling("part.ttl");
+      Files.writeString(
+          root,
+          "<%s> <%s> <%s>, <%s> .%n".formatted(root.toUri(), partOf, part.toUri(), data.toUri()));
+      Files.writeString(
+          part,
+          """
+          @prefix dcterms: <http://purl.org/dc/terms/> .
+          <%s> dcterms:title "part" .
+          """
+              .formatted(part.toUri()));
 
-    try (RepositoryConnection connection = repository.getConnection()) {
-      assertHasStatements(
-          connection,
-          statement(
-              Values.iri(distribution.toUri().toString()),
-              DCTERMS.TITLE,
-              Values.literal("distribution")));
+      Assertions.assertDoesNotThrow(
+          () ->
+              new FdpRdfExtractor(new RemoteRdfExtractor())
+                  .withCrawlSteps(new CrawlStep("part", partOf))
+                  .addRdfToRepository(repository, root.toUri()));
+
+      try (RepositoryConnection connection = repository.getConnection()) {
+        assertStatementCount(repository, 3);
+        assertHasStatements(
+            connection,
+            statement(Values.iri(part.toUri().toString()), DCTERMS.TITLE, Values.literal("part")));
+      }
+    }
+
+    @Test
+    void whenStrictMode_thenThrow() throws IOException {
+      Files.writeString(root, "<%s> <%s> <%s> .%n".formatted(root.toUri(), partOf, data.toUri()));
+
+      FdpRdfExtractor extractor =
+          new FdpRdfExtractor(new RemoteRdfExtractor())
+              .withCrawlSteps(new CrawlStep("part", partOf))
+              .withStrict();
+
+      URI uri = root.toUri();
+      assertThrows(
+          MolgenisException.class, () -> extractor.addRdfToRepository(repository, uri));
     }
   }
 }

--- a/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/vocabulary/FDPO.java
+++ b/backend/molgenis-emx2-rdf/src/main/java/org/molgenis/emx2/rdf/vocabulary/FDPO.java
@@ -1,4 +1,4 @@
-package org.molgenis.emx2.fairmapper.extractors;
+package org.molgenis.emx2.rdf.vocabulary;
 
 import org.eclipse.rdf4j.model.IRI;
 import org.eclipse.rdf4j.model.util.Values;


### PR DESCRIPTION
> **Proposal, stacked on #6652.** Base is `feat/fairmapper/csvw-extract`, so this diff shows only the refactor. Draft on purpose — it's meant as a concrete alternative to discuss, not as something to merge over #6652.

## Why

`FdpRdfExtractor` now has four query methods — `queryCatalogs`, `queryDatasets`, `queryDistributions`, `queryCsvw`. They are the same ~22 lines four times, differing in **one predicate** and **one noun in a log message**:

| Method | Predicate | Log noun |
|---|---|---|
| `queryCatalogs` | `fdpo:metadataCatalog` | "catalog" |
| `queryDatasets` | `dcat:dataset` | "dataset" |
| `queryDistributions` | `dcat:distribution` | "distribution" |
| `queryCsvw` | `dcat:downloadURL` | "csvw result" |

Adding a level means writing a new method *and* editing `addRdfToRepository`. Every other stage in this module works the other way round — `withPreProcessors(...)` / `withPostProcessors(...)` let you add behaviour without touching existing code.

## What

The crawl becomes one fold over a list of named steps, configured where the pipeline is composed:

```java
// Harvest.run()
RdfExtractor extractor =
    new FdpRdfExtractor(new RemoteRdfExtractor())
        .withCrawlSteps(CATALOGS, DATASETS, DISTRIBUTIONS, CSVW);
```

Sitting directly above the existing:

```java
new HarvestingPipelineConfig.Builder(rdfURI, schema, extractor, transformer)
    .setTables(tables)
    .withPostProcessors(new DCATPostProcessor(schema.getMetadata()))
    .withPreProcessors(new TemporalRdfPreProcessor(), new TypicalAgeRdfPreProcessor());
```

New files, all small:

- `CrawlStep` — `record CrawlStep(String name, IRI predicate)`
- `FdpCrawlSteps` — the four named constants plus `DEFAULT`
- `FDPO` — `fdpo:metadataCatalog`, since RDF4J ships no FDP-O vocabulary

A different FDP shape is now one argument, not a code change to the crawler:

```java
.withCrawlSteps(CATALOGS, DATASETS, DISTRIBUTIONS, CSVW_VIA_ACCESS_URL)
```

The steps live on `FdpRdfExtractor`, deliberately **not** on `HarvestingPipelineConfig.Builder` — the pipeline should not need to know what a DCAT predicate is.

## Three defects that fall out of the structure

These were found while reviewing #6652. Each is fixed by having one code path rather than by a separate patch. I reproduced both of the first two against the #6652 code with a throwaway test before writing the fix:

**1. The trailing-slash fix does not reach the production path.**

`addRdfToRepository` fetches the normalized `endpoint` field but queries with the raw `rootToAdd` parameter. `HarvestingPipeline:47` passes `config.rdf()`, which is `URI.create(rdf)` straight from the CLI — so with `-r https://fdp.example.org/` the query becomes `<https://fdp.example.org/> fdpo:metadataCatalog ?catalog` while the document says `<https://fdp.example.org>`. Zero catalogs, empty harvest, no error.

```
ScratchProofTest > trailingSlashInProductionCallShape(Path) FAILED
  org.opentest4j.AssertionFailedError: catalog was never reached ==> expected: <true> but was: <false>
```

The existing `shouldRemoveTrailingSlash` can't catch this: it passes the *clean* URI as `rootToAdd`, and every other test uses the one-argument `addRdfToRepository(repository)` overload, which fills in `endpoint` for both the fetch and the query. The tests take the consistent path; production takes the divergent one.

There is now a single root, normalized once at the entry point, so the two cannot drift apart.

**2. A non-RDF `dcat:downloadURL` aborts the whole harvest.**

`dcat:downloadURL` conventionally points at the data file. `RemoteRdfExtractor` catches only `IOException`, but RDF4J throws `UnsupportedRDFormatException` / `RDFParseException`, which are `RuntimeException`s:

```
ScratchProofTest > nonRdfDownloadUrlAbortsHarvest(Path) FAILED
  Unexpected exception thrown: org.eclipse.rdf4j.rio.UnsupportedRDFormatException:
  Could not find RDF format for URL: .../data.csv
```

Any FDP that harvested fine before now dies on the first distribution whose download URL is a `.csv` or `.zip`. Fetch failures are now isolated per resource: warn and continue.

**3. Repeated URLs were fetched once per occurrence.** Two datasets pointing at the same distribution meant two downloads into the in-memory store. `distinct()` on the frontier.

Smaller things that disappear with the duplication: the pluralization used the accumulator instead of `results.size()` (`distributions.size() == 1 ? "" : "s"`), the copy-pasted `"Querying for distributions in distribution"`, non-IRI objects reaching `new URI(...)`, and `replaceAll("/$", "")` only stripping a single slash.

## Also

A step that finds nothing now logs a warning. A silently empty harvest is the shared failure mode of a wrong root, a wrong step order, and an FDP that uses different predicates — worth a signal rather than a clean "Finished harvesting pipeline" with no data.

## A trap worth knowing

RDF4J's `DCAT.DATASET` and `DCAT.DISTRIBUTION` are the **classes** `dcat:Dataset` and `dcat:Distribution`. The linking **properties** are `DCAT.HAS_DATASET` and `DCAT.HAS_DISTRIBUTION`. Picking the wrong one gives — again — a silently empty crawl.

## Tests

Module suite is green (`:backend:molgenis-emx2-fairmapper:test`), including `HarvestTest.shouldConfigureFdpExtractorAndSparqlTransformer` which covers the CLI wiring.

The existing extractor tests are unchanged in intent but now call the two-argument `addRdfToRepository(repository, rootUri)` — the shape the pipeline actually uses. Three tests added:

- `shouldCrawlOnWhenRootHasTrailingSlash` — production call shape; fails on the current code
- `shouldContinueWhenALinkedResourceIsNotRdf` — a `.csv` download URL; fails on the current code
- `shouldFollowConfiguredStepsOnly` — a made-up predicate, showing the crawl is not FDP-specific and can be tested without a DCAT fixture

## Deliberately not done
- **No per-step follow policy.** A `Predicate<Value>` field on `CrawlStep` would be the seam for "only follow download URLs that conform to CSVW" — but all four steps would pass the same value today, so it would be dead flexibility. When you know the rule, it's one extra field and no change to the crawler. Whether `dcat:mediaType` or `dcterms:conformsTo` is the right test is a domain call I'd leave to you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)