### PR TITLE
fix(rls): validate mg_role column for admins

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/RowOwnership.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/RowOwnership.java
@@ -22,12 +22,12 @@ class RowOwnership {
   }
 
   void validateAndAssignOwnerWhenOmitted(Iterable<Row> rows) {
-    if (!ownershipApplies()) return;
+    if (!hasMgRoleColumn()) return;
     apply(rows, defaultRoleForActiveUser());
   }
 
   void validateOwners(Iterable<Row> rows) {
-    if (!ownershipApplies()) return;
+    if (!hasMgRoleColumn()) return;
     apply(rows, null);
   }
 
@@ -39,14 +39,14 @@ class RowOwnership {
           row.set(MG_ROLES, new String[] {defaultRole});
         }
       } else {
-        validateUserMayAssign(owner);
+        validateRoleIsAssignable(owner);
+        if (PermissionEvaluator.isRowLevelRestricted(schema, table)) validateUserMayAssign(owner);
       }
     }
   }
 
-  private boolean ownershipApplies() {
-    return table.getColumn(MG_ROLES) != null
-        && PermissionEvaluator.isRowLevelRestricted(schema, table);
+  private boolean hasMgRoleColumn() {
+    return table.getColumn(MG_ROLES) != null;
   }
 
   private static String ownerOf(Row row) {
@@ -60,7 +60,7 @@ class RowOwnership {
     return mgRoles[0];
   }
 
-  private void validateUserMayAssign(String role) {
+  private void validateRoleIsAssignable(String role) {
     if (!SqlRoleManager.isUserAssignableRole(role)) {
       throw new MolgenisException(
           "mg_roles value '"
@@ -75,6 +75,9 @@ class RowOwnership {
               + table.getSchemaName()
               + "'");
     }
+  }
+
+  private void validateUserMayAssign(String role) {
     if (!schema.getInheritedRolesForActiveUser().contains(role)) {
       throw new MolgenisException(
           "Permission denied: you must be Manager or hold the role '" + role + "' to set mg_roles");

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestRowLevelSecurity.java
@@ -79,14 +79,6 @@ class TestRowLevelSecurity {
                 .setString("id", "b1")
                 .setString("title", "Team B only")
                 .set(MG_ROLES, new String[] {"TeamB"}));
-    // Row visible to both teams
-    schema
-        .getTable(ARTICLES)
-        .insert(
-            new Row()
-                .setString("id", "ab1")
-                .setString("title", "Both teams")
-                .set(MG_ROLES, new String[] {"TeamA", "TeamB"}));
     // Row with no mg_roles assigned (visible only to VIEWER and above, not to custom role users)
     schema
         .getTable(ARTICLES)
@@ -168,6 +160,74 @@ class TestRowLevelSecurity {
     MolgenisException e = assertThrows(MolgenisException.class, () -> articles.insert(row));
     assertTrue(e.getMessage().contains("is not a valid custom role"), e.getMessage());
     database.becomeAdmin();
+  }
+
+  @Test
+  void mgRolesRejectsNonExistentRoleForAdmin() {
+    database.becomeAdmin();
+    Table articles = database.getSchema(SCHEMA).getTable(ARTICLES);
+    Row row =
+        new Row().setString("id", "mg_nosuch_admin").set(MG_ROLES, new String[] {"IkBestaNiet"});
+    MolgenisException e = assertThrows(MolgenisException.class, () -> articles.insert(row));
+    assertTrue(e.getMessage().contains("is not a valid custom role"), e.getMessage());
+  }
+
+  @Test
+  void mgRolesRejectsNonExistentRoleForManager() {
+    database.becomeAdmin();
+    String managerUser = "rls_user_manager_mgroles";
+    if (!database.hasUser(managerUser)) database.addUser(managerUser);
+    database.getSchema(SCHEMA).addMember(managerUser, Privileges.MANAGER.toString());
+
+    database.setActiveUser(managerUser);
+    Table articles = database.getSchema(SCHEMA).getTable(ARTICLES);
+    Row row =
+        new Row().setString("id", "mg_nosuch_manager").set(MG_ROLES, new String[] {"IkBestaNiet"});
+    MolgenisException e = assertThrows(MolgenisException.class, () -> articles.insert(row));
+    assertTrue(e.getMessage().contains("is not a valid custom role"), e.getMessage());
+    database.becomeAdmin();
+  }
+
+  @Test
+  void mgRolesRejectsNonExistentRoleOnUpdate() {
+    database.becomeAdmin();
+    Table articles = database.getSchema(SCHEMA).getTable(ARTICLES);
+    articles.insert(
+        new Row().setString("id", "mg_nosuch_update").set(MG_ROLES, new String[] {"TeamA"}));
+
+    Row update =
+        new Row().setString("id", "mg_nosuch_update").set(MG_ROLES, new String[] {"IkBestaNiet"});
+    MolgenisException e = assertThrows(MolgenisException.class, () -> articles.update(update));
+    assertTrue(e.getMessage().contains("is not a valid custom role"), e.getMessage());
+
+    assertArrayEquals(
+        new String[] {"TeamA"}, retrieveArticle("mg_nosuch_update").getStringArray(MG_ROLES));
+    articles.delete(new Row().setString("id", "mg_nosuch_update"));
+  }
+
+  @Test
+  void mgRolesAcceptsExistingRole() {
+    database.becomeAdmin();
+    String managerUser = "rls_user_manager_assigns";
+    if (!database.hasUser(managerUser)) database.addUser(managerUser);
+    database.getSchema(SCHEMA).addMember(managerUser, Privileges.MANAGER.toString());
+
+    database.setActiveUser(managerUser);
+    Table articles = database.getSchema(SCHEMA).getTable(ARTICLES);
+    assertDoesNotThrow(
+        () ->
+            articles.insert(
+                new Row()
+                    .setString("id", "mg_manager_assign")
+                    .set(MG_ROLES, new String[] {"TeamA"})));
+
+    database.becomeAdmin();
+    assertArrayEquals(
+        new String[] {"TeamA"}, retrieveArticle("mg_manager_assign").getStringArray(MG_ROLES));
+    database
+        .getSchema(SCHEMA)
+        .getTable(ARTICLES)
+        .delete(new Row().setString("id", "mg_manager_assign"));
   }
 
   @Test
@@ -474,7 +534,6 @@ class TestRowLevelSecurity {
           List<Row> rows = db.getSchema(SCHEMA).getTable(ARTICLES).retrieveRows();
           List<String> ids = rows.stream().map(r -> r.getString("id")).toList();
           assertTrue(ids.contains("a1"), "should see TeamA row");
-          assertTrue(ids.contains("ab1"), "should see row shared with TeamB");
           assertFalse(ids.contains("open"), "should NOT see row with no mg_roles assigned");
           assertFalse(ids.contains("b1"), "should NOT see TeamB-only row");
         });
@@ -488,7 +547,6 @@ class TestRowLevelSecurity {
           List<Row> rows = db.getSchema(SCHEMA).getTable(ARTICLES).retrieveRows();
           List<String> ids = rows.stream().map(r -> r.getString("id")).toList();
           assertTrue(ids.contains("b1"), "should see TeamB row");
-          assertTrue(ids.contains("ab1"), "should see row shared with TeamA");
           assertFalse(ids.contains("open"), "should NOT see row with no mg_roles assigned");
           assertFalse(ids.contains("a1"), "should NOT see TeamA-only row");
         });
@@ -507,7 +565,7 @@ class TestRowLevelSecurity {
   void adminSeesAllRows() {
     database.becomeAdmin();
     List<Row> rows = database.getSchema(SCHEMA).getTable(ARTICLES).retrieveRows();
-    assertEquals(4, rows.size());
+    assertEquals(3, rows.size());
   }
 
   @Test
@@ -977,7 +1035,6 @@ class TestRowLevelSecurity {
           List<String> ids = rows.stream().map(r -> r.getString("id")).toList();
           assertTrue(ids.contains("a1"), "Viewer should see TeamA row");
           assertTrue(ids.contains("b1"), "Viewer should see TeamB row");
-          assertTrue(ids.contains("ab1"), "Viewer should see shared row");
           assertTrue(ids.contains("open"), "Viewer should see public row");
         });
   }
@@ -993,7 +1050,7 @@ class TestRowLevelSecurity {
               () -> schema.getTable(ARTICLES).retrieveRows(),
               "Count role must not be able to read rows");
           assertEquals(
-              4,
+              3,
               aggregateCount(schema),
               "Count role should count every row, row level security must not filter aggregates");
         });
@@ -1018,7 +1075,7 @@ class TestRowLevelSecurity {
     database.tx(
         db ->
             assertEquals(
-                2,
+                1,
                 aggregateCount(db.getSchema(SCHEMA)),
                 "TeamA should only count the rows it is allowed to see"));
   }


### PR DESCRIPTION
Fixes #6661 

### What are the main changes you did

- Changed to flow of the validation of mg_role runs properly for managers+ 

### How to test

- For admin users it was possible the put in any value inside mg_role because validation was skipped
- See issue.. Query will work on dev and will appropriately fail on this preview

### Checklist

- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
