### PR TITLE
feat: add SchemaFetcher interface

### DIFF
--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/schemas/DatabaseSchemaFetcher.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/schemas/DatabaseSchemaFetcher.java
@@ -1,0 +1,20 @@
+package org.molgenis.emx2.fairmapper.schemas;
+
+import java.util.Optional;
+import org.molgenis.emx2.Database;
+import org.molgenis.emx2.Schema;
+import org.molgenis.emx2.SchemaMetadata;
+
+public class DatabaseSchemaFetcher implements SchemaFetcher {
+
+  private final Database database;
+
+  public DatabaseSchemaFetcher(Database database) {
+    this.database = database;
+  }
+
+  @Override
+  public Optional<SchemaMetadata> fetch(String schemaName) {
+    return Optional.ofNullable(database.getSchema(schemaName)).map(Schema::getMetadata);
+  }
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/schemas/GraphqlSchemaFetcher.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/schemas/GraphqlSchemaFetcher.java
@@ -1,0 +1,44 @@
+package org.molgenis.emx2.fairmapper.schemas;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Optional;
+import org.molgenis.emx2.MolgenisException;
+import org.molgenis.emx2.SchemaMetadata;
+import org.molgenis.emx2.graphql.GraphqlClient;
+import org.molgenis.emx2.json.JsonUtil;
+
+public class GraphqlSchemaFetcher implements SchemaFetcher {
+
+  private final GraphqlClient client;
+
+  public GraphqlSchemaFetcher(GraphqlClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public Optional<SchemaMetadata> fetch(String schemaName) {
+    String query = readFile("schema-query.graphql");
+    JsonNode result = client.sendSchemaQuery(schemaName, query);
+    if (!result.has("_schema")) {
+      throw new MolgenisException("No schema returned in graphql response: " + result);
+    }
+
+    try {
+      SchemaMetadata schema = JsonUtil.jsonToSchema(result.get("_schema").toString());
+      return Optional.of(schema);
+    } catch (IOException e) {
+      throw new MolgenisException("Unable to map query result to SchemaMetaData", e);
+    }
+  }
+
+  private String readFile(String fileName) {
+    try (InputStream inputStream = GraphqlSchemaFetcher.class.getResourceAsStream(fileName)) {
+      return new String(Objects.requireNonNull(inputStream).readAllBytes());
+    } catch (IOException e) {
+      throw new MolgenisException("Unable to read query from file: " + fileName, e);
+    }
+  }
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/schemas/SchemaFetcher.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/schemas/SchemaFetcher.java
@@ -1,0 +1,9 @@
+package org.molgenis.emx2.fairmapper.schemas;
+
+import java.util.Optional;
+import org.molgenis.emx2.SchemaMetadata;
+
+public interface SchemaFetcher {
+
+  Optional<SchemaMetadata> fetch(String schemaName);
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/schemas/schema-query.graphql
+++ b/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/schemas/schema-query.graphql
@@ -1,0 +1,70 @@
+query {
+    _schema {
+        tables {
+            schemaId
+            name
+            label
+            description
+            inheritId
+            inheritName
+            inheritSchemaName
+            semantics
+            id
+            tableType
+            labels {
+                locale
+                value
+            }
+            descriptions {
+                locale
+                value
+            }
+            columns {
+                table
+                id
+                name
+                label
+                section
+                heading
+                description
+                formLabel
+                key
+                required
+                readonly
+                defaultValue
+                refSchemaId
+                refSchemaName
+                refTableId
+                refTableName
+                refLinkId
+                refLinkName
+                refBackId
+                refBackName
+                refLabel
+                refLabelDefault
+                position
+                validation
+                visible
+                computed
+                labels {
+                    locale
+                    value
+                }
+                descriptions {
+                    locale
+                    value
+                }
+                columnType
+                semantics
+            }
+            settings {
+                key
+                value
+            }
+        }
+        settings {
+            key
+            value
+        }
+    }
+}

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/schemas/DatabaseSchemaFetcherTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/schemas/DatabaseSchemaFetcherTest.java
@@ -1,0 +1,36 @@
+package org.molgenis.emx2.fairmapper.schemas;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.Database;
+import org.molgenis.emx2.SchemaMetadata;
+import org.molgenis.emx2.sql.TestDatabaseFactory;
+
+class DatabaseSchemaFetcherTest {
+
+  private static final String SCHEMA_NAME = DatabaseSchemaFetcherTest.class.getSimpleName();
+  private static final Database DATABASE = TestDatabaseFactory.getTestDatabase();
+
+  private static DatabaseSchemaFetcher fetcher;
+
+  @BeforeAll
+  static void setupSchema() {
+    DATABASE.createSchema(SCHEMA_NAME);
+    fetcher = new DatabaseSchemaFetcher(DATABASE);
+  }
+
+  @Test
+  void givenSchemaName_whenExists_thenReturn() {
+    Optional<SchemaMetadata> fetch = fetcher.fetch(SCHEMA_NAME);
+    assertTrue(fetch.isPresent());
+    assertEquals(SCHEMA_NAME, fetch.get().getName());
+  }
+
+  @Test
+  void givenSchemaName_whenNoSchemaExists_thenReturnEmpty() {
+    assertTrue(fetcher.fetch("non-existent-schema").isEmpty());
+  }
+}

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/schemas/GraphqlSchemaFetcherTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/schemas/GraphqlSchemaFetcherTest.java
@@ -1,0 +1,132 @@
+package org.molgenis.emx2.fairmapper.schemas;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.*;
+import org.molgenis.emx2.graphql.GraphqlClient;
+import org.molgenis.emx2.sql.JWTgenerator;
+import org.molgenis.emx2.sql.TestDatabaseFactory;
+import org.molgenis.emx2.web.ApiTestBase;
+
+class GraphqlSchemaFetcherTest extends ApiTestBase {
+
+  private static final String SCHEMA_NAME = GraphqlSchemaFetcherTest.class.getSimpleName();
+  private static final Database DATABASE = TestDatabaseFactory.getTestDatabase();
+  public static final ObjectMapper MAPPER = new ObjectMapper();
+
+  @BeforeAll
+  static void setupSchema() {
+    SchemaMetadata schema = DATABASE.dropCreateSchema(SCHEMA_NAME).getMetadata();
+    TableMetadata person =
+        schema.create(
+            TableMetadata.table("Person").add(Column.column("name", ColumnType.STRING).setPkey()));
+
+    schema.create(
+        TableMetadata.table("Product").add(Column.column("name", ColumnType.STRING).setPkey()),
+        TableMetadata.table("Order")
+            .add(
+                Column.column("orderId", ColumnType.INT).setPkey(),
+                Column.column("person", ColumnType.REF).setRefTable("Person"),
+                Column.column("products", ColumnType.REF_ARRAY).setRefTable("Product")));
+
+    person.add(
+        Column.column("orders")
+            .setType(ColumnType.REFBACK)
+            .setRefTable("Order")
+            .setRefBack("person"));
+  }
+
+  @Test
+  void shouldHandleRealResponse() {
+    String token = JWTgenerator.createTemporaryToken(database);
+    GraphqlClient graphqlClient = new GraphqlClient("http://localhost:" + port, token);
+    GraphqlSchemaFetcher fetcher = new GraphqlSchemaFetcher(graphqlClient);
+
+    Optional<SchemaMetadata> result = fetcher.fetch(SCHEMA_NAME);
+
+    assertTrue(result.isPresent());
+    assertMatchesPersonProductOrderSchema(result.get());
+  }
+
+  @Test
+  void givenGraphqlResponseWithSchema_whenFetch_thenMapsResponseToSchemaMetadata()
+      throws IOException {
+    GraphqlClient client = staticClient(readSchemaResponse());
+    GraphqlSchemaFetcher fetcherWithMock = new GraphqlSchemaFetcher(client);
+
+    Optional<SchemaMetadata> result = fetcherWithMock.fetch(SCHEMA_NAME);
+
+    assertTrue(result.isPresent());
+    assertMatchesPersonProductOrderSchema(result.get());
+  }
+
+  @Test
+  void givenGraphqlResponseWithoutSchemaField_whenFetch_thenThrows()
+      throws JsonProcessingException {
+    GraphqlClient client = staticClient(MAPPER.readTree("{\"notSchema\": {}}"));
+    GraphqlSchemaFetcher fetcherWithMock = new GraphqlSchemaFetcher(client);
+
+    MolgenisException exception =
+        assertThrows(MolgenisException.class, () -> fetcherWithMock.fetch(SCHEMA_NAME));
+    assertTrue(exception.getMessage().contains("No schema returned"));
+  }
+
+  private void assertMatchesPersonProductOrderSchema(SchemaMetadata schema) {
+    assertEquals(Set.of("Person", "Product", "Order"), schema.getTableNames());
+
+    TableMetadata order = schema.getTableMetadata("Order");
+    Column orderId = order.getColumn("orderId");
+    assertEquals(ColumnType.INT, orderId.getColumnType());
+    assertEquals(1, orderId.getKey());
+
+    Column orderPerson = order.getColumn("person");
+    assertEquals(ColumnType.REF, orderPerson.getColumnType());
+    assertEquals("Person", orderPerson.getRefTableName());
+
+    Column orderProducts = order.getColumn("products");
+    assertEquals(ColumnType.REF_ARRAY, orderProducts.getColumnType());
+    assertEquals("Product", orderProducts.getRefTableName());
+
+    TableMetadata personTable = schema.getTableMetadata("Person");
+    Column personName = personTable.getColumn("name");
+    assertEquals(ColumnType.STRING, personName.getColumnType());
+    assertEquals(1, personName.getKey());
+
+    Column personOrders = personTable.getColumn("orders");
+    assertEquals(ColumnType.REFBACK, personOrders.getColumnType());
+    assertEquals("Order", personOrders.getRefTableName());
+    assertEquals("person", personOrders.getRefBack());
+
+    TableMetadata productTable = schema.getTableMetadata("Product");
+    Column productName = productTable.getColumn("name");
+    assertEquals(ColumnType.STRING, productName.getColumnType());
+    assertEquals(1, productName.getKey());
+  }
+
+  private GraphqlClient staticClient(JsonNode response) {
+    GraphqlClient client = mock(GraphqlClient.class);
+    when(client.sendSchemaQuery(anyString(), anyString())).thenReturn(response);
+    return client;
+  }
+
+  private JsonNode readSchemaResponse() throws IOException {
+    try (InputStream inputStream =
+        GraphqlSchemaFetcherTest.class.getResourceAsStream("expected-schema.json")) {
+      String rawSchema = new String(Objects.requireNonNull(inputStream).readAllBytes());
+      return new ObjectMapper().readTree("{\"_schema\":" + rawSchema + "}");
+    }
+  }
+}

--- a/backend/molgenis-emx2-fairmapper/src/test/resources/org/molgenis/emx2/fairmapper/schemas/expected-schema.json
+++ b/backend/molgenis-emx2-fairmapper/src/test/resources/org/molgenis/emx2/fairmapper/schemas/expected-schema.json
@@ -1,0 +1,265 @@
+{
+  "tables": [
+    {
+      "schemaId": "GraphqlSchemaFetcherTest",
+      "name": "Order",
+      "label": "Order",
+      "id": "Order",
+      "tableType": "DATA",
+      "columns": [
+        {
+          "table": "Order",
+          "id": "mg_top_of_form",
+          "name": "mg_top_of_form",
+          "label": "_top",
+          "section": "mg_top_of_form",
+          "columnType": "SECTION"
+        },
+        {
+          "table": "Order",
+          "id": "orderId",
+          "name": "orderId",
+          "label": "orderId",
+          "section": "mg_top_of_form",
+          "key": 1,
+          "required": "true",
+          "columnType": "INT"
+        },
+        {
+          "table": "Order",
+          "id": "person",
+          "name": "person",
+          "label": "person",
+          "section": "mg_top_of_form",
+          "refSchemaId": "GraphqlSchemaFetcherTest",
+          "refSchemaName": "GraphqlSchemaFetcherTest",
+          "refTableId": "Person",
+          "refTableName": "Person",
+          "refLabelDefault": "${name}",
+          "position": 1,
+          "columnType": "REF"
+        },
+        {
+          "table": "Order",
+          "id": "products",
+          "name": "products",
+          "label": "products",
+          "section": "mg_top_of_form",
+          "refSchemaId": "GraphqlSchemaFetcherTest",
+          "refSchemaName": "GraphqlSchemaFetcherTest",
+          "refTableId": "Product",
+          "refTableName": "Product",
+          "refLabelDefault": "${name}",
+          "position": 2,
+          "columnType": "REF_ARRAY"
+        },
+        {
+          "table": "Order",
+          "id": "mg_draft",
+          "name": "mg_draft",
+          "label": "mg_draft",
+          "section": "mg_top_of_form",
+          "position": -5,
+          "columnType": "BOOL"
+        },
+        {
+          "table": "Order",
+          "id": "mg_insertedBy",
+          "name": "mg_insertedBy",
+          "label": "mg_insertedBy",
+          "section": "mg_top_of_form",
+          "position": -4,
+          "columnType": "STRING"
+        },
+        {
+          "table": "Order",
+          "id": "mg_insertedOn",
+          "name": "mg_insertedOn",
+          "label": "mg_insertedOn",
+          "section": "mg_top_of_form",
+          "position": -3,
+          "columnType": "DATETIME"
+        },
+        {
+          "table": "Order",
+          "id": "mg_updatedBy",
+          "name": "mg_updatedBy",
+          "label": "mg_updatedBy",
+          "section": "mg_top_of_form",
+          "position": -2,
+          "columnType": "STRING"
+        },
+        {
+          "table": "Order",
+          "id": "mg_updatedOn",
+          "name": "mg_updatedOn",
+          "label": "mg_updatedOn",
+          "section": "mg_top_of_form",
+          "position": -1,
+          "columnType": "DATETIME"
+        }
+      ]
+    },
+    {
+      "schemaId": "GraphqlSchemaFetcherTest",
+      "name": "Person",
+      "label": "Person",
+      "id": "Person",
+      "tableType": "DATA",
+      "columns": [
+        {
+          "table": "Person",
+          "id": "mg_top_of_form",
+          "name": "mg_top_of_form",
+          "label": "_top",
+          "section": "mg_top_of_form",
+          "columnType": "SECTION"
+        },
+        {
+          "table": "Person",
+          "id": "name",
+          "name": "name",
+          "label": "name",
+          "section": "mg_top_of_form",
+          "key": 1,
+          "required": "true",
+          "columnType": "STRING"
+        },
+        {
+          "table": "Person",
+          "id": "orders",
+          "name": "orders",
+          "label": "orders",
+          "section": "mg_top_of_form",
+          "refSchemaId": "GraphqlSchemaFetcherTest",
+          "refSchemaName": "GraphqlSchemaFetcherTest",
+          "refTableId": "Order",
+          "refTableName": "Order",
+          "refBackId": "person",
+          "refBackName": "person",
+          "refLabelDefault": "${orderId}",
+          "position": 3,
+          "columnType": "REFBACK"
+        },
+        {
+          "table": "Person",
+          "id": "mg_draft",
+          "name": "mg_draft",
+          "label": "mg_draft",
+          "section": "mg_top_of_form",
+          "position": -5,
+          "columnType": "BOOL"
+        },
+        {
+          "table": "Person",
+          "id": "mg_insertedBy",
+          "name": "mg_insertedBy",
+          "label": "mg_insertedBy",
+          "section": "mg_top_of_form",
+          "position": -4,
+          "columnType": "STRING"
+        },
+        {
+          "table": "Person",
+          "id": "mg_insertedOn",
+          "name": "mg_insertedOn",
+          "label": "mg_insertedOn",
+          "section": "mg_top_of_form",
+          "position": -3,
+          "columnType": "DATETIME"
+        },
+        {
+          "table": "Person",
+          "id": "mg_updatedBy",
+          "name": "mg_updatedBy",
+          "label": "mg_updatedBy",
+          "section": "mg_top_of_form",
+          "position": -2,
+          "columnType": "STRING"
+        },
+        {
+          "table": "Person",
+          "id": "mg_updatedOn",
+          "name": "mg_updatedOn",
+          "label": "mg_updatedOn",
+          "section": "mg_top_of_form",
+          "position": -1,
+          "columnType": "DATETIME"
+        }
+      ]
+    },
+    {
+      "schemaId": "GraphqlSchemaFetcherTest",
+      "name": "Product",
+      "label": "Product",
+      "id": "Product",
+      "tableType": "DATA",
+      "columns": [
+        {
+          "table": "Product",
+          "id": "mg_top_of_form",
+          "name": "mg_top_of_form",
+          "label": "_top",
+          "section": "mg_top_of_form",
+          "columnType": "SECTION"
+        },
+        {
+          "table": "Product",
+          "id": "name",
+          "name": "name",
+          "label": "name",
+          "section": "mg_top_of_form",
+          "key": 1,
+          "required": "true",
+          "columnType": "STRING"
+        },
+        {
+          "table": "Product",
+          "id": "mg_draft",
+          "name": "mg_draft",
+          "label": "mg_draft",
+          "section": "mg_top_of_form",
+          "position": -5,
+          "columnType": "BOOL"
+        },
+        {
+          "table": "Product",
+          "id": "mg_insertedBy",
+          "name": "mg_insertedBy",
+          "label": "mg_insertedBy",
+          "section": "mg_top_of_form",
+          "position": -4,
+          "columnType": "STRING"
+        },
+        {
+          "table": "Product",
+          "id": "mg_insertedOn",
+          "name": "mg_insertedOn",
+          "label": "mg_insertedOn",
+          "section": "mg_top_of_form",
+          "position": -3,
+          "columnType": "DATETIME"
+        },
+        {
+          "table": "Product",
+          "id": "mg_updatedBy",
+          "name": "mg_updatedBy",
+          "label": "mg_updatedBy",
+          "section": "mg_top_of_form",
+          "position": -2,
+          "columnType": "STRING"
+        },
+        {
+          "table": "Product",
+          "id": "mg_updatedOn",
+          "name": "mg_updatedOn",
+          "label": "mg_updatedOn",
+          "section": "mg_top_of_form",
+          "position": -1,
+          "columnType": "DATETIME"
+        }
+      ]
+    }
+  ],
+  "settings": []
+}

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Column.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Column.java
@@ -3,7 +3,9 @@ package org.molgenis.emx2.json;
 import static java.util.Arrays.stream;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.molgenis.emx2.ColumnType;
 import org.molgenis.emx2.MolgenisException;
@@ -446,5 +448,84 @@ public class Column {
 
   public void setFormLabel(String formLabel) {
     this.formLabel = formLabel;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Column column = (Column) o;
+    return drop == column.drop
+        && inherited == column.inherited
+        && Objects.equals(table, column.table)
+        && Objects.equals(id, column.id)
+        && Objects.equals(name, column.name)
+        && Objects.equals(label, column.label)
+        && Objects.equals(section, column.section)
+        && Objects.equals(heading, column.heading)
+        && Objects.equals(description, column.description)
+        && Objects.equals(labels, column.labels)
+        && Objects.equals(formLabel, column.formLabel)
+        && Objects.equals(oldName, column.oldName)
+        && Objects.equals(key, column.key)
+        && Objects.equals(required, column.required)
+        && Objects.equals(readonly, column.readonly)
+        && Objects.equals(defaultValue, column.defaultValue)
+        && Objects.equals(refSchemaId, column.refSchemaId)
+        && Objects.equals(refSchemaName, column.refSchemaName)
+        && Objects.equals(refTableId, column.refTableId)
+        && Objects.equals(refTableName, column.refTableName)
+        && Objects.equals(refLinkId, column.refLinkId)
+        && Objects.equals(refLinkName, column.refLinkName)
+        && Objects.equals(refBackId, column.refBackId)
+        && Objects.equals(refBackName, column.refBackName)
+        && Objects.equals(refLabel, column.refLabel)
+        && Objects.equals(refLabelDefault, column.refLabelDefault)
+        && Objects.equals(position, column.position)
+        && Objects.equals(validation, column.validation)
+        && Objects.equals(visible, column.visible)
+        && Objects.equals(computed, column.computed)
+        && Objects.equals(descriptions, column.descriptions)
+        && columnType == column.columnType
+        && Objects.deepEquals(semantics, column.semantics)
+        && Objects.deepEquals(profiles, column.profiles);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        table,
+        id,
+        name,
+        label,
+        section,
+        heading,
+        description,
+        labels,
+        formLabel,
+        drop,
+        oldName,
+        key,
+        required,
+        readonly,
+        defaultValue,
+        refSchemaId,
+        refSchemaName,
+        refTableId,
+        refTableName,
+        refLinkId,
+        refLinkName,
+        refBackId,
+        refBackName,
+        refLabel,
+        refLabelDefault,
+        position,
+        validation,
+        visible,
+        computed,
+        descriptions,
+        columnType,
+        Arrays.hashCode(semantics),
+        Arrays.hashCode(profiles),
+        inherited);
   }
 }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Schema.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Schema.java
@@ -95,4 +95,16 @@ public class Schema {
   public void setSettings(List<Setting> settings) {
     this.settings = settings;
   }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Schema schema = (Schema) o;
+    return Objects.equals(tables, schema.tables) && Objects.equals(settings, schema.settings);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(tables, settings);
+  }
 }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Table.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Table.java
@@ -3,9 +3,7 @@ package org.molgenis.emx2.json;
 import static java.util.Arrays.stream;
 import static org.molgenis.emx2.utils.TypeUtils.convertToPascalCase;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import org.molgenis.emx2.*;
 
 public class Table {
@@ -19,15 +17,16 @@ public class Table {
   private String inheritId;
   private String inheritName;
   private String inheritSchemaName;
+  private String[] semantics;
+  private String id;
+  private TableType tableType;
+
   private List<LanguageValue> labels = new ArrayList<>();
   private List<LanguageValue> descriptions = new ArrayList<>();
   private Collection<String[]> unique = new ArrayList<>();
   private List<Column> columns = new ArrayList<>();
   private List<Setting> settings = new ArrayList<>();
-  private String[] semantics;
   private String[] profiles = null;
-  private String id;
-  private TableType tableType;
 
   public Table() {
     // for json serialisation
@@ -248,5 +247,54 @@ public class Table {
 
   public void setSchemaId(String schemaId) {
     this.schemaId = schemaId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Table table = (Table) o;
+    return drop == table.drop
+        && Objects.equals(schemaId, table.schemaId)
+        && Objects.equals(name, table.name)
+        && Objects.equals(label, table.label)
+        && Objects.equals(description, table.description)
+        && Objects.equals(oldName, table.oldName)
+        && Objects.deepEquals(pkey, table.pkey)
+        && Objects.equals(inheritId, table.inheritId)
+        && Objects.equals(inheritName, table.inheritName)
+        && Objects.equals(inheritSchemaName, table.inheritSchemaName)
+        && Objects.deepEquals(semantics, table.semantics)
+        && Objects.equals(id, table.id)
+        && tableType == table.tableType
+        && Objects.equals(labels, table.labels)
+        && Objects.equals(descriptions, table.descriptions)
+        && Objects.equals(unique, table.unique)
+        && Objects.equals(columns, table.columns)
+        && Objects.equals(settings, table.settings)
+        && Objects.deepEquals(profiles, table.profiles);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        schemaId,
+        name,
+        label,
+        description,
+        oldName,
+        drop,
+        Arrays.hashCode(pkey),
+        inheritId,
+        inheritName,
+        inheritSchemaName,
+        Arrays.hashCode(semantics),
+        id,
+        tableType,
+        labels,
+        descriptions,
+        unique,
+        columns,
+        settings,
+        Arrays.hashCode(profiles));
   }
 }


### PR DESCRIPTION
Addresses: https://github.com/molgenis/molgenis-emx2/issues/6658
Stacked on #6706.

### What are the main changes you did

Part 2 of the remote-harvesting stack. Introduces a `SchemaFetcher` abstraction so the harvesting pipeline can look up a target schema's metadata without caring whether it lives in a local database or on a remote EMX2 instance:

- `SchemaFetcher` interface, with `DatabaseSchemaFetcher` as the local-database-backed implementation.
- `GraphqlSchemaFetcher`, which fetches schema metadata from a remote EMX2 instance via the `GraphqlClient` added in #6706.

### How to test

- Unit tests for both `DatabaseSchemaFetcher` and `GraphqlSchemaFetcher`.

### Checklist

- [x] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)