### PR TITLE
ref: pass schema and tables to RdfTransformer per run

### DIFF
--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/cli/commands/Harvest.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/cli/commands/Harvest.java
@@ -1,7 +1,6 @@
 package org.molgenis.emx2.fairmapper.cli.commands;
 
 import java.net.URI;
-import java.util.List;
 import java.util.UUID;
 import org.jetbrains.annotations.NotNull;
 import org.molgenis.emx2.*;
@@ -70,8 +69,7 @@ public class Harvest implements Runnable {
 
     RdfExtractor extractor = new CrawlingRdfExtractor().withCrawlSteps(CrawlSteps.FDP.steps());
     SparqlSelectRdfTransformer transformer =
-        new SparqlSelectRdfTransformer(
-            new TableQueryGenerator(), schema.getMetadata(), List.of(tables));
+        new SparqlSelectRdfTransformer(new TableQueryGenerator());
 
     HarvestingPipelineConfig.Builder builder =
         new HarvestingPipelineConfig.Builder(rdfURI, schema, extractor, transformer)

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/cli/commands/Harvest.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/cli/commands/Harvest.java
@@ -63,7 +63,7 @@ public class Harvest implements Runnable {
 
     Database database = setupDatabase();
     Schema schema = validateSchema(database);
-    String[] tables = validateTables(schema);
+    String[] tables = this.tablesArg.split(",");
 
     URI rdfURI = getRdf();
 
@@ -114,16 +114,5 @@ public class Harvest implements Runnable {
       throw new MolgenisException("Schema not found: " + schemaName);
     }
     return schema;
-  }
-
-  private String[] validateTables(Schema schema) {
-    logger.info("Validating table names: {}", tablesArg);
-    String[] tables = this.tablesArg.split(",");
-    for (String table : tables) {
-      if (schema.getTable(table) == null) {
-        throw new MolgenisException("Table not found: " + table);
-      }
-    }
-    return tables;
   }
 }

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/pipeline/HarvestingPipeline.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/pipeline/HarvestingPipeline.java
@@ -40,11 +40,11 @@ public class HarvestingPipeline {
 
   @SuppressWarnings("java:S2589")
   public void execute() {
+    logger.info("Starting harvesting pipeline: {}", harvestId);
+
     logger.info("Validating harvesting config");
     SchemaMetadata schema = config.schema().getMetadata();
     validateTables(schema);
-
-    logger.info("Starting harvesting pipeline: {}", harvestId);
 
     Repository repository = null;
     try {

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/pipeline/HarvestingPipeline.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/pipeline/HarvestingPipeline.java
@@ -4,6 +4,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 import org.eclipse.rdf4j.model.Statement;
 import org.eclipse.rdf4j.repository.Repository;
@@ -14,6 +15,7 @@ import org.eclipse.rdf4j.rio.RDFWriter;
 import org.eclipse.rdf4j.rio.Rio;
 import org.eclipse.rdf4j.sail.nativerdf.NativeStore;
 import org.molgenis.emx2.MolgenisException;
+import org.molgenis.emx2.SchemaMetadata;
 import org.molgenis.emx2.fairmapper.postprocessing.PostProcessor;
 import org.molgenis.emx2.fairmapper.preprocessing.RdfPreProcessor;
 import org.molgenis.emx2.io.ImportSchemaTask;
@@ -38,6 +40,10 @@ public class HarvestingPipeline {
 
   @SuppressWarnings("java:S2589")
   public void execute() {
+    logger.info("Validating harvesting config");
+    SchemaMetadata schema = config.schema().getMetadata();
+    validateTables(schema);
+
     logger.info("Starting harvesting pipeline: {}", harvestId);
 
     Repository repository = null;
@@ -58,7 +64,7 @@ public class HarvestingPipeline {
         preProcess(repository);
       }
 
-      InMemoryTableStore transformed = transform(repository);
+      InMemoryTableStore transformed = transform(repository, schema);
 
       if (!config.postProcessors().isEmpty()) {
         postProcess(transformed);
@@ -87,8 +93,9 @@ public class HarvestingPipeline {
     }
   }
 
-  private InMemoryTableStore transform(Repository extracted) {
-    InMemoryTableStore transformed = config.transformer().transform(extracted);
+  private InMemoryTableStore transform(Repository extracted, SchemaMetadata schema) {
+    InMemoryTableStore transformed =
+        config.transformer().transform(extracted, schema, config.tables());
 
     if (config.dumpEnabled()) {
       writeTableStoreToZip(transformed, config.tables(), "transformed.zip");
@@ -155,5 +162,16 @@ public class HarvestingPipeline {
 
   private Path outputDirectory() {
     return Path.of(config.outputPath()).resolve(OUTPUT_DIRECTORY_NAME + harvestId);
+  }
+
+  private void validateTables(SchemaMetadata schema) {
+    String missing =
+        config.tables().stream()
+            .filter(name -> schema.getTableMetadata(name) == null)
+            .collect(Collectors.joining(", "));
+    if (!missing.isBlank()) {
+      throw new MolgenisException(
+          "Unknown table(s) configured: " + missing + " for schema: " + schema.getName());
+    }
   }
 }

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/RdfTransformer.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/RdfTransformer.java
@@ -1,6 +1,8 @@
 package org.molgenis.emx2.fairmapper.transform;
 
+import java.util.List;
 import org.eclipse.rdf4j.repository.Repository;
+import org.molgenis.emx2.SchemaMetadata;
 import org.molgenis.emx2.io.tablestore.InMemoryTableStore;
 import org.molgenis.emx2.io.tablestore.TableStore;
 
@@ -9,7 +11,9 @@ import org.molgenis.emx2.io.tablestore.TableStore;
  * data.
  *
  * <p>Implementations query the repository and map the results onto a {@link TableStore}, bridging
- * the graph model to the row-column model expected by the rest of the EMX2 import pipeline.
+ * the graph model to the row-column model expected by the rest of the EMX2 import pipeline. The
+ * target {@code schema} and {@code tables} are passed in per call rather than fixed at construction
+ * time, so a single transformer instance can be reused across different schemas.
  */
 public interface RdfTransformer {
 
@@ -17,7 +21,9 @@ public interface RdfTransformer {
    * Transforms the RDF graph in {@code repository} into a {@link TableStore}.
    *
    * @param repository the RDF repository to query
+   * @param schema metadata describing the target tables to map onto
+   * @param tables names of the tables to populate
    * @return a {@link TableStore} containing the mapped tabular data
    */
-  InMemoryTableStore transform(Repository repository);
+  InMemoryTableStore transform(Repository repository, SchemaMetadata schema, List<String> tables);
 }

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformer.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformer.java
@@ -3,13 +3,11 @@ package org.molgenis.emx2.fairmapper.transform;
 import static org.molgenis.emx2.rdf.generators.query.SparqlVariableUtil.SUBJECT_NAME;
 
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.rdf4j.query.*;
 import org.eclipse.rdf4j.repository.Repository;
 import org.eclipse.rdf4j.repository.RepositoryConnection;
 import org.molgenis.emx2.*;
-import org.molgenis.emx2.MolgenisException;
 import org.molgenis.emx2.Row;
 import org.molgenis.emx2.SchemaMetadata;
 import org.molgenis.emx2.io.tablestore.InMemoryTableStore;
@@ -21,43 +19,26 @@ public class SparqlSelectRdfTransformer implements RdfTransformer {
   private static final String ARRAY_SEPARATOR_REGEX = "\\|";
 
   private final QueryGenerator queryGenerator;
-  private final SchemaMetadata schema;
-  private final List<String> tables;
 
-  public SparqlSelectRdfTransformer(
-      QueryGenerator queryGenerator, SchemaMetadata schema, List<String> tables) {
+  public SparqlSelectRdfTransformer(QueryGenerator queryGenerator) {
     this.queryGenerator = queryGenerator;
-    this.schema = schema;
-    this.tables = tables;
-
-    checkTableExistence(schema, tables);
-  }
-
-  private static void checkTableExistence(SchemaMetadata schema, List<String> tables) {
-    String missing =
-        tables.stream()
-            .filter(name -> null == schema.getTableMetadata(name))
-            .collect(Collectors.joining(", "));
-    if (!missing.isBlank()) {
-      throw new MolgenisException(
-          "Unknown table(s) provided to transformer: "
-              + missing
-              + " for schema: "
-              + schema.getName());
-    }
   }
 
   @Override
-  public InMemoryTableStore transform(Repository repository) {
+  public InMemoryTableStore transform(
+      Repository repository, SchemaMetadata schema, List<String> tables) {
     InMemoryTableStore tableStore = new InMemoryTableStore();
     try (RepositoryConnection conn = repository.getConnection()) {
-      tables.forEach(table -> addTableDataToStore(table, conn, tableStore));
+      tables.forEach(table -> addTableDataToStore(table, schema, conn, tableStore));
     }
     return tableStore;
   }
 
   private void addTableDataToStore(
-      String table, RepositoryConnection conn, InMemoryTableStore tableStore) {
+      String table,
+      SchemaMetadata schema,
+      RepositoryConnection conn,
+      InMemoryTableStore tableStore) {
     TableMetadata tableMetadata = schema.getTableMetadata(table);
     String query = queryGenerator.generate(tableMetadata);
     TupleQuery prepared = conn.prepareTupleQuery(QueryLanguage.SPARQL, query);

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformer.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformer.java
@@ -3,6 +3,7 @@ package org.molgenis.emx2.fairmapper.transform;
 import static org.molgenis.emx2.rdf.generators.query.SparqlVariableUtil.SUBJECT_NAME;
 
 import java.util.List;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.eclipse.rdf4j.query.*;
 import org.eclipse.rdf4j.repository.Repository;
@@ -27,6 +28,8 @@ public class SparqlSelectRdfTransformer implements RdfTransformer {
   @Override
   public InMemoryTableStore transform(
       Repository repository, SchemaMetadata schema, List<String> tables) {
+    checkTableExistence(schema, tables);
+
     InMemoryTableStore tableStore = new InMemoryTableStore();
     try (RepositoryConnection conn = repository.getConnection()) {
       tables.forEach(table -> addTableDataToStore(table, schema, conn, tableStore));
@@ -90,6 +93,20 @@ public class SparqlSelectRdfTransformer implements RdfTransformer {
         .filter(column -> column.isReference() && column.isArray() && !column.isOntology())
         .map(column -> SUBJECT_NAME + column.getName())
         .toList();
+  }
+
+  private static void checkTableExistence(SchemaMetadata schema, List<String> tables) {
+    String missing =
+        tables.stream()
+            .filter(name -> null == schema.getTableMetadata(name))
+            .collect(Collectors.joining(", "));
+    if (!missing.isBlank()) {
+      throw new MolgenisException(
+          "Unknown table(s) provided to transformer: "
+              + missing
+              + " for schema: "
+              + schema.getName());
+    }
   }
 
   private void splitArrayColumns(Row row, List<String> columnNames) {

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/cli/commands/HarvestTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/cli/commands/HarvestTest.java
@@ -117,16 +117,6 @@ class HarvestTest {
     assertEquals("Schema not found: NonExistingSchema", exception.getMessage());
   }
 
-  @Test
-  void shouldThrowWhenTableDoesNotExist() {
-    Harvest harvest = new Harvest();
-    new CommandLine(harvest)
-        .parseArgs("-r", RDF_ENDPOINT, "-s", schema.getName(), "-t", "NonExistingTable");
-
-    MolgenisException exception = assertThrows(MolgenisException.class, harvest::run);
-    assertEquals("Table not found: NonExistingTable", exception.getMessage());
-  }
-
   private HarvestingPipelineConfig runAndCaptureConfig(
       String rdf, String tables, String... extraArgs) {
     Harvest harvest = spy(new Harvest());

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/pipeline/HarvestingPipelineTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/pipeline/HarvestingPipelineTest.java
@@ -142,6 +142,22 @@ class HarvestingPipelineTest {
     assertEquals(1, Objects.requireNonNull(tempDir.toFile().list()).length);
   }
 
+  @Test
+  void shouldThrowBeforeExtractingWhenConfiguredTableDoesNotExistInSchema() {
+    StaticRdfExtractor extractor = new StaticRdfExtractor();
+    HarvestingPipelineConfig config =
+        new HarvestingPipelineConfig.Builder(FDP_URI, schema, extractor, transformer)
+            .setTables("names", "unknown-table")
+            .build();
+    HarvestingPipeline pipeline = new HarvestingPipeline(config);
+
+    MolgenisException exception = assertThrows(MolgenisException.class, pipeline::execute);
+
+    assertEquals(
+        "Unknown table(s) configured: unknown-table for schema: " + schema.getName(),
+        exception.getMessage());
+  }
+
   private static void assertFileContentMatches(String fileName, String fileContent) {
     try {
       String extracted = Files.readString(outputDirectory.resolve(fileName));
@@ -166,7 +182,8 @@ class HarvestingPipelineTest {
   private static class StaticRdfTransformer implements RdfTransformer {
 
     @Override
-    public InMemoryTableStore transform(Repository repository) {
+    public InMemoryTableStore transform(
+        Repository repository, SchemaMetadata schema, List<String> tables) {
       InMemoryTableStore store = new InMemoryTableStore();
       store.writeTable(
           "names", List.of("name"), List.of(Row.row("name", "foo"), Row.row("name", "bar")));

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/pipeline/HarvestingPipelineTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/pipeline/HarvestingPipelineTest.java
@@ -152,10 +152,10 @@ class HarvestingPipelineTest {
     HarvestingPipeline pipeline = new HarvestingPipeline(config);
 
     MolgenisException exception = assertThrows(MolgenisException.class, pipeline::execute);
-
     assertEquals(
         "Unknown table(s) configured: unknown-table for schema: " + schema.getName(),
         exception.getMessage());
+    assertFalse(extractor.called);
   }
 
   private static void assertFileContentMatches(String fileName, String fileContent) {
@@ -169,8 +169,11 @@ class HarvestingPipelineTest {
 
   private static class StaticRdfExtractor implements RdfExtractor {
 
+    private boolean called = false;
+
     @Override
     public void addRdfToRepository(Repository repository, URI rootToAdd) {
+      called = true;
       try (RepositoryConnection connection = repository.getConnection()) {
         connection.add(
             valueFactory.createStatement(

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlRdfTransformerTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlRdfTransformerTest.java
@@ -31,6 +31,10 @@ import org.molgenis.emx2.sql.TestDatabaseFactory;
 class SparqlRdfTransformerTest {
 
   public static final IRI SUBJECT = iri("https://example.com/bob");
+
+  private final SparqlSelectRdfTransformer transformer =
+      new SparqlSelectRdfTransformer(new TableQueryGenerator());
+
   private Database database;
   private SchemaMetadata schema;
 
@@ -39,19 +43,6 @@ class SparqlRdfTransformerTest {
     database = TestDatabaseFactory.getTestDatabase();
     String schemaName = SparqlRdfTransformerTest.class.getSimpleName();
     schema = database.dropCreateSchema(schemaName).getMetadata();
-  }
-
-  @Test
-  void givenUnknownTable_thenThrow() {
-    TableQueryGenerator generator = new TableQueryGenerator();
-    List<String> tables = List.of("unknown-1", "unknown-2");
-    MolgenisException exception =
-        assertThrows(
-            MolgenisException.class,
-            () -> new SparqlSelectRdfTransformer(generator, schema, tables));
-    assertEquals(
-        "Unknown table(s) provided to transformer: unknown-1, unknown-2 for schema: SparqlRdfTransformerTest",
-        exception.getMessage());
   }
 
   @Test
@@ -69,10 +60,7 @@ class SparqlRdfTransformerTest {
             statement(SUBJECT, FOAF.FIRST_NAME, literal("foo"), null),
             statement(SUBJECT, FOAF.FIRST_NAME, literal("bar"), null));
 
-    TableStore transform =
-        new SparqlSelectRdfTransformer(
-                new TableQueryGenerator(), schema, List.of("splitArrays_string"))
-            .transform(repository);
+    TableStore transform = transformer.transform(repository, schema, List.of("splitArrays_string"));
 
     Iterator<Row> iterator = transform.readTable("splitArrays_string").iterator();
     CompareTools.assertEquals(
@@ -97,9 +85,7 @@ class SparqlRdfTransformerTest {
             statement(SUBJECT, FOAF.FIRST_NAME, literal(2), null));
 
     TableStore transform =
-        new SparqlSelectRdfTransformer(
-                new TableQueryGenerator(), schema, List.of("splitArrays_integer"))
-            .transform(repository);
+        transformer.transform(repository, schema, List.of("splitArrays_integer"));
 
     Iterator<Row> iterator = transform.readTable("splitArrays_integer").iterator();
     Row next = iterator.next();
@@ -129,9 +115,7 @@ class SparqlRdfTransformerTest {
             statement(SUBJECT, FOAF.KNOWS, tag1, null), statement(SUBJECT, FOAF.KNOWS, tag2, null));
 
     TableStore transform =
-        new SparqlSelectRdfTransformer(
-                new TableQueryGenerator(), schema, List.of("splitRefArrays_owner"))
-            .transform(repository);
+        transformer.transform(repository, schema, List.of("splitRefArrays_owner"));
 
     Iterator<Row> iterator = transform.readTable("splitRefArrays_owner").iterator();
     Row row = iterator.next();
@@ -148,14 +132,10 @@ class SparqlRdfTransformerTest {
         .getImportTask(database, schemaName, "RDF data transformation test", false)
         .run();
 
-    SparqlSelectRdfTransformer transformer =
-        new SparqlSelectRdfTransformer(
-            new TableQueryGenerator(),
-            database.getSchema(schemaName).getMetadata(),
-            List.of("Pet"));
-
     SailRepository repository = readPetStoreTtl();
-    TableStore store = transformer.transform(repository);
+    TableStore store =
+        transformer.transform(
+            repository, database.getSchema(schemaName).getMetadata(), List.of("Pet"));
 
     StringWriter writer = new StringWriter();
     CsvTableWriter.write(
@@ -204,12 +184,8 @@ class SparqlRdfTransformerTest {
 
     @BeforeAll
     void queryTestData() {
-      // Set up a SailRepository with a single statement to test against
       SailRepository repository = setupRepository();
-      SparqlSelectRdfTransformer transformer =
-          new SparqlSelectRdfTransformer(
-              new TableQueryGenerator(), setupSchema(), List.of("testTable"));
-      TableStore transform = transformer.transform(repository);
+      TableStore transform = transformer.transform(repository, setupSchema(), List.of("testTable"));
       testData = transform.readTable("testTable").iterator().next();
     }
 

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlRdfTransformerTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlRdfTransformerTest.java
@@ -145,6 +145,18 @@ class SparqlRdfTransformerTest {
     assertEquals(expected, writer.toString());
   }
 
+  @Test
+  void givenUnknownTable_thenThrow() {
+    SailRepository repository = readPetStoreTtl();
+    List<String> tables = List.of("unknown-1", "unknown-2");
+    MolgenisException exception =
+        assertThrows(
+            MolgenisException.class, () -> transformer.transform(repository, schema, tables));
+    assertEquals(
+        "Unknown table(s) provided to transformer: unknown-1, unknown-2 for schema: SparqlRdfTransformerTest",
+        exception.getMessage());
+  }
+
   private SailRepository createRepositoryWithStatements(Statement... statements) {
     SailRepository repository = new SailRepository(new MemoryStore());
 

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerDataTypeMappingTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/transform/SparqlSelectRdfTransformerDataTypeMappingTest.java
@@ -149,8 +149,8 @@ class SparqlSelectRdfTransformerDataTypeMappingTest {
 
   private Row transformAndGetFirstRow(SchemaMetadata schema, SailRepository repo) {
     SparqlSelectRdfTransformer transformer =
-        new SparqlSelectRdfTransformer(new TableQueryGenerator(), schema, List.of(TABLE));
-    TableStore store = transformer.transform(repo);
+        new SparqlSelectRdfTransformer(new TableQueryGenerator());
+    TableStore store = transformer.transform(repo, schema, List.of(TABLE));
     return store.readTable(TABLE).iterator().next();
   }
 }


### PR DESCRIPTION
Addresses: https://github.com/molgenis/molgenis-emx2/issues/6658

### What are the main changes you did

Changes `RdfTransformer.transform(...)` to take the target `SchemaMetadata` and the list of tables to harvest as parameters on each call, instead of baking them into the transformer instance at construction time. This makes transformer instances stateless/reusable, which is needed now that the schema is fetched via a `SchemaFetcher` rather than known up front.

Also moves table-existence validation to the start of `HarvestingPipeline.execute()`, so a harvest fails fast on an unknown table name instead of partway through the pipeline.

### How to test

- Existing `HarvestingPipeline`/`SparqlSelectRdfTransformer` unit tests updated to the new signature.

### Checklist

- [x] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [x] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)