### PR TITLE
chore(e2e): add env option to disable e2e reporter

### DIFF
--- a/apps/ui/playwright.config.ts
+++ b/apps/ui/playwright.config.ts
@@ -1,6 +1,18 @@
 import { defineConfig, devices } from "@playwright/test";
 import type { ConfigOptions } from "@nuxt/test-utils/playwright";
 
+const reporter = setReporter();
+
+function setReporter() {
+  if (process.env.CI) {
+    return [["list"], ["junit", { outputFile: "results.xml" }]];
+  } else if (process.env.E2E_NO_REPORTER === "true") {
+    return undefined;
+  } else {
+    return "html";
+  }
+}
+
 export default defineConfig<ConfigOptions>({
   testDir: "./tests/e2e",
   /* Run tests in files in parallel */
@@ -12,9 +24,7 @@ export default defineConfig<ConfigOptions>({
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
-  reporter: process.env.CI
-    ? [["list"], ["junit", { outputFile: "results.xml" }]]
-    : "html",
+  reporter: reporter,
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */
   use: {
     /* Base URL to use in actions like `await page.goto('/')`. */


### PR DESCRIPTION
### What are the main changes you did

- Adds option to disable the playwright reporter from env
- Done because when debugging e2e tests it gets real annoying real fast when every run opens a browser tab, which (for me) contains no useful information, as the same report gets shown in the console.

### How to test

- set in env `E2E_NO_REPORTER="true"`
- run e2e tests
- See that now tab in the browser opens with the test resulsts

### Checklist

- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
