### PR TITLE
build(gradle): speed up builds accross different worktrees by keeping .env out of gradle cache keys.

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -14,14 +14,19 @@
 #
 # Who reads this file:
 #   - Gradle AUTO-READS it (straight from disk at configuration time, so it is
-#     daemon-safe) and applies EVERY key as a system property to the forked
-#     test/run/dev/cleandb JVMs - postgres settings, feature flags, anything the code
-#     reads via EnvironmentProperty. No `source` needed.
+#     daemon-safe) and forwards EVERY key to the JVMs it forks. `run`, `dev`, `cleandb`
+#     and `generateTypes` get them as system properties; test tasks get them as
+#     environment variables. EnvironmentProperty reads either, so the code sees no
+#     difference. No `source` needed.
 #   - the frontend dev servers read it via apps/dev-env.js (the Nuxt `dev` scripts pass
 #     `--dotenv=../../.env`).
 #   - IntelliJ does NOT. Gradle's forwarding only reaches JVMs Gradle forks, so an IDE
 #     run configuration needs these set by hand as env vars or -D VM options, or it
 #     silently targets the DEFAULT database on :5432 and port :8080.
+#
+# Keep to keys that say WHERE things run - hosts, ports, credentials. A test task's
+# environment is not in its cache key, so a key that changes what the code DOES can get
+# you a cached PASS without a single test running. `--rerun` forces a real run.
 
 # --- database [BACKEND-ONLY] ----------------------------------------------------------
 # Stand new postgres up (for example using Postgres.app), then seed the molgenis db/user:

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -70,10 +70,11 @@ tasks.register('pnpm_install', PnpmTask) {
     outputs.file("${project.projectDir}/node_modules/.pnpm-workspace-state-v1.json")
 }
 
+// .env is not an input here: apps/dev-env.js only loads it when npm_lifecycle_event is "dev", so a
+// build never sees it. Tracking it gave every worktree its own cache entry.
 tasks.register('pnpm_build', PnpmTask) {
     dependsOn 'pnpm_install'
     args = ['run', 'build']
-    inputs.property('molgenisDotenv', rootProject.ext.molgenisDotenv)
     registerAppInputsOutputs(delegate, workspaceDirs, excludeFolders)
 }
 

--- a/apps/build.gradle
+++ b/apps/build.gradle
@@ -70,8 +70,6 @@ tasks.register('pnpm_install', PnpmTask) {
     outputs.file("${project.projectDir}/node_modules/.pnpm-workspace-state-v1.json")
 }
 
-// .env is not an input here: apps/dev-env.js only loads it when npm_lifecycle_event is "dev", so a
-// build never sees it. Tracking it gave every worktree its own cache entry.
 tasks.register('pnpm_build', PnpmTask) {
     dependsOn 'pnpm_install'
     args = ['run', 'build']

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -150,7 +150,7 @@ subprojects {
         }
     }
 
-    tasks.withType(Test).configureEach { rootProject.ext.forwardDotenvProps(it) }
+    tasks.withType(Test).configureEach { rootProject.ext.forwardDotenvPropsToTest(it) }
     tasks.withType(JavaExec).configureEach { rootProject.ext.forwardDotenvProps(it) }
 
     test.dependsOn ":backend:molgenis-emx2-sql:initDatabase"

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -150,8 +150,8 @@ subprojects {
         }
     }
 
-    tasks.withType(Test).configureEach { rootProject.ext.forwardDotenvPropsToTest(it) }
-    tasks.withType(JavaExec).configureEach { rootProject.ext.forwardDotenvProps(it) }
+    tasks.withType(Test).configureEach { rootProject.ext.forwardDotenvAsEnvironment(it) }
+    tasks.withType(JavaExec).configureEach { rootProject.ext.forwardDotenvAsSystemProperties(it) }
 
     test.dependsOn ":backend:molgenis-emx2-sql:initDatabase"
 

--- a/build.gradle
+++ b/build.gradle
@@ -16,45 +16,45 @@ ext {
     javaVersion = JavaVersion.VERSION_21
 }
 
-// Settings such as MOLGENIS_POSTGRES_URI/USER/PASS, MOLGENIS_HTTP_PORT or feature flags
-// are read inside the Java code (EnvironmentProperty.getParameter). A running Gradle
-// daemon does not pass command-line -D system properties to forked JVMs, so they are
-// forwarded explicitly onto every forked Test/JavaExec task (test, run, dev, cleandb,
-// generateTypes).
-// Every key of a repo-root .env file is forwarded, read straight from disk once at
-// configuration time (daemon-safe, no `source` needed), as is every MOLGENIS_ system property
-// given on the command line. Precedence per key: a -D CLI system property wins; otherwise the
-// .env value; otherwise nothing (Java default applies).
-// Whitespace is trimmed the way JavaScript String.trim() does it, so that this parser and the
-// one in apps/dev-env.js read the same keys out of the same file.
+// A warm Gradle daemon does not pass -D to forked JVMs, so .env is read here and forwarded instead.
+// Mirror apps/dev-env.js: it parses the same file and the two must agree.
 def javascriptTrim = { String text -> text.replaceAll('^[\\s\\u00A0\\uFEFF]+|[\\s\\u00A0\\uFEFF]+$', '') }
+def stripSurroundingQuotes = { String value ->
+    def quoted = value.length() >= 2 &&
+            ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'")))
+    quoted ? value.substring(1, value.length() - 1) : value
+}
+def parseDotenvLine = { String line, Map into ->
+    def trimmed = javascriptTrim(line)
+    if (trimmed.isEmpty() || trimmed.startsWith('#')) return
+    def separator = trimmed.indexOf('=')
+    if (separator < 0) return
+    into[javascriptTrim(trimmed.substring(0, separator))] =
+            stripSurroundingQuotes(javascriptTrim(trimmed.substring(separator + 1)))
+}
 ext.molgenisDotenv = { ->
     def envFile = new File(rootDir, '.env')
     def result = [:]
-    if (envFile.exists()) {
-        envFile.eachLine { line ->
-            def trimmed = javascriptTrim(line)
-            if (trimmed.isEmpty() || trimmed.startsWith('#')) return
-            def idx = trimmed.indexOf('=')
-            if (idx < 0) return
-            def key = javascriptTrim(trimmed.substring(0, idx))
-            def value = javascriptTrim(trimmed.substring(idx + 1))
-            if (value.length() >= 2 &&
-                    ((value.startsWith('"') && value.endsWith('"')) ||
-                     (value.startsWith("'") && value.endsWith("'")))) {
-                value = value.substring(1, value.length() - 1)
-            }
-            result[key] = value
-        }
-    }
+    if (envFile.exists()) envFile.eachLine { parseDotenvLine(it, result) }
     result
 }()
-ext.forwardDotenvProps = { task ->
+ext.dotenvValuesForForkedJvms = { ->
     def commandLineKeys = System.getProperties().stringPropertyNames().findAll { it.startsWith('MOLGENIS_') }
+    def values = new TreeMap<String, String>()
     (rootProject.molgenisDotenv.keySet() + commandLineKeys).each { key ->
         def value = System.getProperty(key) ?: rootProject.molgenisDotenv[key]
-        if (value != null) task.systemProperty key, value
+        if (value != null) values[key] = String.valueOf(value)
     }
+    values
+}
+ext.forwardDotenvProps = { task ->
+    rootProject.ext.dotenvValuesForForkedJvms().each { key, value -> task.systemProperty key, value }
+}
+
+// .env says where to run, not what to run, so it stays out of a Test task's cache key: Gradle marks
+// systemProperties @Input but environment @Internal, and EnvironmentProperty reads either.
+ext.forwardDotenvPropsToTest = { task ->
+    task.environment rootProject.ext.dotenvValuesForForkedJvms()
 }
 ext.resolveDotenvValue = { key ->
     System.getProperty(key) ?: rootProject.molgenisDotenv[key] ?: System.getenv(key)

--- a/build.gradle
+++ b/build.gradle
@@ -47,13 +47,13 @@ ext.dotenvValuesForForkedJvms = { ->
     }
     values
 }
-ext.forwardDotenvProps = { task ->
+ext.forwardDotenvAsSystemProperties = { task ->
     rootProject.ext.dotenvValuesForForkedJvms().each { key, value -> task.systemProperty key, value }
 }
 
 // .env says where to run, not what to run, so it stays out of a Test task's cache key: Gradle marks
 // systemProperties @Input but environment @Internal, and EnvironmentProperty reads either.
-ext.forwardDotenvPropsToTest = { task ->
+ext.forwardDotenvAsEnvironment = { task ->
     task.environment rootProject.ext.dotenvValuesForForkedJvms()
 }
 ext.resolveDotenvValue = { key ->
@@ -215,7 +215,7 @@ application {
     mainClass.set(javaMainClass)
 }
 
-tasks.withType(JavaExec).configureEach { forwardDotenvProps(it) }
+tasks.withType(JavaExec).configureEach { forwardDotenvAsSystemProperties(it) }
 
 tasks.named('run') { rootProject.ext.applyDotenvHeap(it) }
 


### PR DESCRIPTION
Keep .env out of gradle cache keys; 
simplify the .env forwarding code.

## Before

Open another worktree, give it its own `.env` with its own database port, run the backend tests, and every one of them runs again. The code is identical.

## After

`.env` no longer decides the cache key, so the second worktree reuses the first one's results. On `3ec36d323e`, `:backend:molgenis-emx2:test` drops from 19s to 1s.

## How to test

1. Check this branch out in a second worktree at the same commit. Edit that worktree's `.env` and set `MOLGENIS_POSTGRES_URI` to a different port. Run `./gradlew :backend:molgenis-emx2:test` in the first worktree, then the same task in the second. The second prints `> Task :backend:molgenis-emx2:test FROM-CACHE` and finishes in about a second, without reaching a database.
2. Repeat both runs with `./gradlew :apps:pnpm_build`. It prints `FROM-CACHE` the same way.

## Changes

1. **Tests you already ran do not run again in another worktree.** `build.gradle` hands `.env` to a Test task through `environment` instead of `systemProperty`, and `backend/build.gradle` points Test tasks at the new forwarder. Gradle annotates a fork's `systemProperties` as `@Input` and its `environment` as `@Internal`, and `EnvironmentProperty` reads a system property or an environment variable, so the values still arrive in the test JVM. The `.env` parsing moves into `stripSurroundingQuotes` and `parseDotenvLine`, named after their counterparts in `apps/dev-env.js`, which parses the same file.
2. **The frontend build is reused the same way.** `apps/build.gradle` drops `inputs.property('molgenisDotenv', ...)` from `pnpm_build`. That map cannot change what the task builds, because `apps/dev-env.js` loads `.env` only when `npm_lifecycle_event` is `dev`.

## Out of scope

CircleCI is untouched. Judge this from the two-worktree run, not from a green pipeline.
