### PR TITLE
fix(graphql): pass Boolean variable with GraphQL Java 26

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -59,7 +59,7 @@ subprojects {
         implementation 'com.fasterxml.jackson.core:jackson-databind:2.22.1'
         implementation 'com.fasterxml.jackson.core:jackson-core:2.22.1'
         implementation 'com.fasterxml.jackson.core:jackson-annotations:2.22'
-        implementation 'com.graphql-java:graphql-java:21.5'
+        implementation 'com.graphql-java:graphql-java:26.1'
         implementation 'com.graphql-java:graphql-java-extended-scalars:20.2'
         implementation 'org.pac4j:pac4j-core:6.5.5'
         implementation 'org.pac4j:pac4j-oidc:6.5.5'

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlAdminFields.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlAdminFields.java
@@ -206,7 +206,7 @@ class TestGraphqlAdminFields {
     Map<String, Object> updateUser = new HashMap<>();
     updateUser.put("email", TEST_PERSOON);
     updateUser.put("password", "12345678");
-    updateUser.put("enabled", "false");
+    updateUser.put("enabled", false);
 
     ArrayList<Map<String, String>> revokedRoles = new ArrayList<>();
     Map<String, String> revokedRole = new HashMap<>();


### PR DESCRIPTION
## Summary

- keep Renovate's GraphQL Java 21.5 → 26.1 upgrade intact
- pass the `enabled` update-user variable as a Boolean instead of a string
- unblock the failing `TestGraphqlAdminFields.testUpdateUser` regression in #6687

## Why

GraphQL Java 26 rejects a string value for a variable declared as `Boolean`. The schema already declares `enabled` as `GraphQLBoolean`, and the update-user data fetcher consumes it as `Boolean`, so the test fixture should supply `false` with the same type.

This is based on Renovate head `c924363fcb350b7ac05e7601b48c0672ef3a5919` and changes no production code or dependency metadata.

## Verification

- JDK 21.0.9, Gradle 9.7.1, PostgreSQL 15.19
- focused `TestGraphqlAdminFields.testUpdateUser`: passed
- complete `molgenis-emx2-graphql` suite: 74 tests passed
- `spotlessCheck`, `pmdTest`, and `compileTestJava`: passed
- `git diff --check`: passed

For local test execution only, an external Gradle init script supplied JUnit Platform Launcher 1.14.4 to match the repository's JUnit Jupiter 5.14.4. This works around the source branch's unrelated versionless `testRuntimeOnly` declaration and is not part of this patch.

Built and verified with [JAIPilot](https://github.com/JAIPilot/jaipilot):
- Skills: `jaipilot-maintainer-intent`, `jaipilot-fast-execution`, and `jaipilot-review-diff`
- Execution profile: `gpt-5.6-sol · xhigh · fast`
