### PR TITLE
fix: make useSession synchronous

### DIFF
--- a/apps/tailwind-components/app/components/form/DeleteModal.vue
+++ b/apps/tailwind-components/app/components/form/DeleteModal.vue
@@ -40,7 +40,7 @@ const visible = defineModel("visible", {
 const deleteErrorMessage = ref<string>("");
 const cascadeDeleteMsg = ref<string | null>(null);
 
-const session = await useSession();
+const session = useSession();
 const formMessage = ref<string>("");
 const showReAuthenticateButton = ref<boolean>(false);
 

--- a/apps/tailwind-components/app/components/form/EditModal.vue
+++ b/apps/tailwind-components/app/components/form/EditModal.vue
@@ -182,7 +182,7 @@ const visible = defineModel<boolean>("visible");
 // lazy init formContext (form) when modal is opened
 let form: UseForm | undefined;
 
-const session = await useSession(props.schemaId);
+const session = useSession(props.schemaId);
 
 const saveErrorMessage = ref<string>("");
 const formMessage = ref<string>("");

--- a/apps/tailwind-components/app/components/form/EditModalHeader.vue
+++ b/apps/tailwind-components/app/components/form/EditModalHeader.vue
@@ -18,7 +18,7 @@ const { formValues, schemaId } = defineProps<{
   isInsert: boolean;
 }>();
 
-const session = await useSession(schemaId);
+const session = useSession(schemaId);
 
 const selectedRole = ref<string>(getSelectedRole());
 

--- a/apps/tailwind-components/app/components/table/TableEMX2.vue
+++ b/apps/tailwind-components/app/components/table/TableEMX2.vue
@@ -479,7 +479,7 @@ const settings = defineModel<ITableSettings>("settings", {
   }),
 });
 
-const { isAdmin, isOwner, isManager } = await useSession(props.schemaId);
+const { isAdmin, isOwner, isManager } = useSession(props.schemaId);
 
 const filters: UseFilters | null = props.enableFilters
   ? useFilters(

--- a/apps/tailwind-components/app/components/table/control/DeleteRows.vue
+++ b/apps/tailwind-components/app/components/table/control/DeleteRows.vue
@@ -13,7 +13,7 @@ import BaseIcon from "../../BaseIcon.vue";
 import Modal from "../../Modal.vue";
 import { isMgError } from "../../../utils/typeUtils";
 
-const session = await useSession();
+const session = useSession();
 
 const props = defineProps<{
   schemaId: string;

--- a/apps/tailwind-components/app/composables/useForm.ts
+++ b/apps/tailwind-components/app/composables/useForm.ts
@@ -566,7 +566,7 @@ export default function useForm(
 
   async function handleFetchError(error: any, message: string) {
     if (error.statusCode && error.statusCode >= 400) {
-      const { hasSessionTimeout } = await useSession();
+      const { hasSessionTimeout } = useSession();
       if (await hasSessionTimeout()) {
         console.log("Session has timed out, ask for re-authentication");
         throw new SessionExpiredError(

--- a/apps/tailwind-components/app/composables/useLayoutState.ts
+++ b/apps/tailwind-components/app/composables/useLayoutState.ts
@@ -8,7 +8,7 @@ import { useLayoutMenu } from "./useLayoutMenu";
 export async function useLayoutState() {
   const route = useRoute();
   const schema = computed(() => route.params.schema as string);
-  const { session, signOut } = await useSession(schema.value);
+  const { session, signOut } = useSession(schema.value);
   const logoUrl = ref<string | undefined>(undefined);
 
   watch(

--- a/apps/tailwind-components/app/composables/useSession.ts
+++ b/apps/tailwind-components/app/composables/useSession.ts
@@ -8,7 +8,7 @@ import type {
 } from "../../types/types";
 import { openReAuthenticationWindow } from "../utils/openReAuthenticationWindow";
 
-export const useSession = async (schemaId?: string) => {
+export const useSession = (schemaId?: string) => {
   const router = useRouter();
   const session = useState("session", () => null as ISession | null);
 
@@ -17,17 +17,24 @@ export const useSession = async (schemaId?: string) => {
   const isAdmin = computed(() => session.value?.admin || false);
   const isOwner = computed(() => hasRole("Owner"));
   const isManager = computed(() => hasRole("Manager"));
-  const rowLevelRoles = ref<string[]>(await getRowLevelRoles());
+  const rowLevelRoles = ref<string[]>([]);
+  const isInitialized = ref(false);
 
   const tablePermissions = computed<ITablePermission[]>(() =>
     schemaId ? session.value?.tablePermissions?.[schemaId] ?? [] : []
   );
 
-  if (
-    !session.value ||
-    (schemaId && session.value.roles?.[schemaId] === undefined)
-  ) {
-    await loadSession();
+  initializeSession();
+
+  async function initializeSession() {
+    if (
+      !session.value ||
+      (schemaId && session.value.roles?.[schemaId] === undefined)
+    ) {
+      await loadSession();
+    }
+    rowLevelRoles.value = await getRowLevelRoles();
+    isInitialized.value = true;
   }
 
   function hasRole(role: string): boolean {
@@ -218,6 +225,7 @@ export const useSession = async (schemaId?: string) => {
     rowLevelRoles,
     session,
     tablePermissions,
+    isInitialized,
 
     getTablePermission,
     reload,

--- a/apps/tailwind-components/app/composables/useTable.ts
+++ b/apps/tailwind-components/app/composables/useTable.ts
@@ -121,7 +121,7 @@ export const useTable = (schemaId: string, tableId: string) => {
 
   async function handleFetchError(error: any, message: string) {
     if (error.statusCode && error.statusCode >= 400) {
-      const { hasSessionTimeout } = await useSession();
+      const { hasSessionTimeout } = useSession();
       if (await hasSessionTimeout()) {
         console.log("Session has timed out, ask for re-authentication");
         throw new SessionExpiredError(

--- a/apps/tailwind-components/app/pages/Session.story.vue
+++ b/apps/tailwind-components/app/pages/Session.story.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import { useSession } from "../composables/useSession";
-const { isAdmin, session, reload, hasSessionTimeout } = await useSession();
+const { isAdmin, session, reload, hasSessionTimeout } = useSession();
 import Field from "../components/Field.vue";
 
 const timeoutCheckResponse = ref("unknown");

--- a/apps/tailwind-components/tests/vitest/composables/useSession.test.ts
+++ b/apps/tailwind-components/tests/vitest/composables/useSession.test.ts
@@ -34,7 +34,9 @@ describe("useSession", () => {
         pending: ref(false),
       });
 
-      const session = await useSession();
+      const session = useSession();
+
+      await vi.waitFor(() => expect(session.isInitialized.value).toBe(true));
 
       expect(session.isAdmin.value).toEqual(true);
       expect(session.session.value).toEqual({
@@ -73,7 +75,9 @@ describe("useSession", () => {
           pending: ref(false),
         });
 
-      const session = await useSession("abc");
+      const session = useSession("abc");
+
+      await vi.waitFor(() => expect(session.isInitialized.value).toBe(true));
 
       expect(session.session.value?.roles).toEqual({
         abc: ["Editor"],
@@ -98,7 +102,9 @@ describe("useSession", () => {
         pending: ref(false),
       });
 
-      const session = await useSession();
+      const session = useSession();
+
+      await vi.waitFor(() => expect(session.isInitialized.value).toBe(true));
 
       expect(session.session.value?.roles).toBeUndefined();
       expect(session.session.value?.tablePermissions).toBeUndefined();
@@ -150,7 +156,9 @@ describe("useSession", () => {
           .mockResolvedValueOnce(permissionsResult)
           .mockResolvedValueOnce(sessionResult);
 
-        const session = await useSession("pet store");
+        const session = useSession("pet store");
+
+        await vi.waitFor(() => expect(session.isInitialized.value).toBe(true));
 
         expect(session.session.value?.roles).toEqual({ "pet store": roles });
         expect(session.session.value?.tablePermissions).toEqual({

--- a/apps/ui/app/middleware/adminOnly.ts
+++ b/apps/ui/app/middleware/adminOnly.ts
@@ -5,7 +5,7 @@ import { useRoute } from "#app";
 export default defineNuxtRouteMiddleware(async () => {
   const route = useRoute();
   const schema = route.params.schema as string;
-  const { isAdmin } = await useSession(schema);
+  const { isAdmin } = useSession(schema);
   if (!isAdmin.value) {
     return navigateTo("/login");
   }

--- a/apps/ui/app/pages/[schema]/[table]/[entity].vue
+++ b/apps/ui/app/pages/[schema]/[table]/[entity].vue
@@ -46,7 +46,7 @@ try {
   // If the query parameter is malformed JSON, fall back to an empty object
   entityKeysObject = {};
 }
-const { isAdmin, session } = await useSession(schemaId);
+const { isAdmin, session } = useSession(schemaId);
 
 const tableMetadata = await fetchTableMetadata(schemaId, tableId);
 const { data: rowData, refresh } = await useAsyncData(

--- a/apps/ui/app/pages/[schema]/[table]/index.vue
+++ b/apps/ui/app/pages/[schema]/[table]/index.vue
@@ -119,7 +119,7 @@ const currentBreadCrumb = computed(
 
 watch(tableSettings, handleSettingsUpdate, { deep: true });
 
-const { session } = await useSession(schemaId);
+const { session } = useSession(schemaId);
 const { canView, canInsert, canUpdate, canDelete, isRowLevel, userRoles } =
   useTablePermission(session, schemaId, tableId, tableMetadata.tableType);
 const enableFilters = true;

--- a/apps/ui/app/pages/[schema]/index.vue
+++ b/apps/ui/app/pages/[schema]/index.vue
@@ -73,7 +73,7 @@ const ontologies = computed<ITableMetaData[]>(
       ) ?? []
 );
 
-const { tablePermissions, getTablePermission } = await useSession(schema);
+const { tablePermissions, getTablePermission } = useSession(schema);
 
 // no permissions at all means the backend did not supply them; fall back to
 // showing every table rather than ghosting the whole list

--- a/apps/ui/app/pages/[schema]/pages/[page]/configure.vue
+++ b/apps/ui/app/pages/[schema]/pages/[page]/configure.vue
@@ -30,7 +30,7 @@ const crumbs: Crumb[] = [
   { label: page as string, url: "" },
 ];
 
-const { isAdmin, session } = await useSession(schema);
+const { isAdmin, session } = useSession(schema);
 const enableEditing = computed(() => {
   return (
     session.value?.roles?.[schema as string]?.includes("Manager") ||

--- a/apps/ui/app/pages/[schema]/pages/[page]/editor.vue
+++ b/apps/ui/app/pages/[schema]/pages/[page]/editor.vue
@@ -39,7 +39,7 @@ const schema = Array.isArray(route.params.schema)
   ? route.params.schema[0]
   : route.params.schema ?? "";
 const page = route.params.page as string;
-const { isAdmin } = await useSession(schema);
+const { isAdmin } = useSession(schema);
 
 useHead({ title: `Edit - ${page} - Pages - ${schema} - Molgenis` });
 

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -48,7 +48,7 @@ const formType = ref<ICmsPageTypes | undefined>();
 const showFormModal = ref<boolean>(false);
 const showPageDropdown = ref<boolean>(false);
 
-const { isAdmin, session } = await useSession(schema);
+const { isAdmin, session } = useSession(schema);
 const enableEditing = computed(() => {
   return (
     session.value?.roles?.[schema as string]?.includes("Manager") ||

--- a/apps/ui/app/pages/account.vue
+++ b/apps/ui/app/pages/account.vue
@@ -8,7 +8,7 @@ import Button from "../../../tailwind-components/app/components/Button.vue";
 
 const route = useRoute();
 const router = useRouter();
-const { session, reload: reloadSession } = await useSession(
+const { session, reload: reloadSession } = useSession(
   route.params.schema as string
 );
 

--- a/apps/ui/app/pages/login.vue
+++ b/apps/ui/app/pages/login.vue
@@ -74,7 +74,7 @@ async function signin() {
     loading.value = false;
 
     if (signinResp?.data.signin.status === "SUCCESS") {
-      await (await useSession(route.query.schema as string)).reload();
+      await useSession(route.query.schema as string).reload();
 
       // Send a message to the opener
       if (window && window.opener) {


### PR DESCRIPTION
### What are the main changes you did

- made the useSession synchronous, because vue 3 and nuxt do not allow async composables. This caused issues for the tailwind-components app, making it throw nuxt error during runtime due to changes in #6621.

### How to test

- tailwind componets e2e tests should run correctly

### Checklist

- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
