### PR TITLE
perf(ci): skip the unused remote docker engine in test-e2e

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,9 @@ commands:
       gradle_cache:
         type: boolean
         default: true
+      remote_docker:
+        type: boolean
+        default: true
     steps:
     - run:
         name: Fresh Git Checkout to prevent missing objects
@@ -112,11 +115,14 @@ commands:
             paths:
               - ~/.gradle/caches
             key: gradle-{{ checksum "concatenated-build-gradle" }}
-    - setup_remote_docker:
-        docker_layer_caching: true
-    - run:
-        name: Sign in to docker
-        command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+    - when:
+        condition: << parameters.remote_docker >>
+        steps:
+        - setup_remote_docker:
+            docker_layer_caching: true
+        - run:
+            name: Sign in to docker
+            command: docker login -u $DOCKER_USER -p $DOCKER_PASS
 
   post_steps:
     steps:
@@ -191,8 +197,11 @@ jobs:
           name: Enable pnpm
           command: sudo corepack enable
 
+      # No image is built here, so the layer cache has nothing to keep and its
+      # teardown is pure overhead at the end of the job.
       - pre_steps:
           gradle_cache: false
+          remote_docker: false
 
       - restore_cache:
           keys:


### PR DESCRIPTION
Stacked on #6721 — please merge that one first.

## What

`test-e2e` never touches Docker, but `pre_steps` provisions a remote engine with layer caching for it anyway. This gates those two steps behind a `remote_docker` parameter, mirroring the `gradle_cache` parameter #6721 already added. Every other caller keeps the default `true` and is unchanged.

## Why

From a green `test-e2e` run on this branch ([88862](https://app.circleci.com/jobs/github/molgenis/molgenis-emx2/88862)):

| step | time |
|---|---|
| Setup a remote Docker engine | 0.0s |
| Sign in to docker | 0.1s |
| **DLC Teardown** | **23.3s** |

The setup is free; the layer cache teardown at the end of the job is not. That is ~3% of the 12m36s run, for a resource the job does not use. The `test` job pays the same 24.8s.

## Why it is safe

- `shadowJar -x test ci` builds a jar plus `build/ci.properties` — `ci` is a `WriteProperties` task (`build.gradle:139`), not a docker task.
- `-x test` means no Testcontainers.
- postgres is a service container, provided by the executor, not by the remote engine.
- The executor pulls its own images before any step runs, so the in-job `docker login` cannot affect them.

## Note on the earlier attempt

`53028c862` on the base branch removed this and was reverted by `be7e104a6`. Its build ([88760](https://app.circleci.com/jobs/github/molgenis/molgenis-emx2/88760)) failed for an unrelated reason — the postgres service container was killed part-way through the job:

```
2026-08-31 19:13:47.580 UTC [6] LOG:  database system is ready to accept connections
exited with error (exited with 137)
```

and the next step then reported:

```
psql: error: connection to server at "127.0.0.1", port 5432 failed: Connection refused
```

Exit 137 is SIGKILL — postgres was OOM-killed while the Gradle and Nuxt builds were running. Neither log mentions a docker daemon, socket or login. That commit also dropped the gradle cache and split `pre_steps` into `checkout_steps`; `933d5299c` has since settled the gradle side separately.

This change is deliberately narrower: `pre_steps` keeps its shape, the gradle cache is untouched, and only the two docker steps move behind a flag. If CI disagrees, reverting this single commit costs nothing.

## Possible follow-ups

`test` and `emx2-pyclient` also call `pre_steps` and may not need the engine either — not touched here, since only `test-e2e` was measured.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J4JKofJm98vsT3rm9DHQRF

