### PR TITLE
feat(email): bound the SMTP connect and read timeouts and provide setting to change them

### DIFF
--- a/backend/molgenis-emx2-email/src/main/java/org/molgenis/emx2/email/EmailService.java
+++ b/backend/molgenis-emx2-email/src/main/java/org/molgenis/emx2/email/EmailService.java
@@ -31,6 +31,8 @@ public class EmailService {
     props.put("mail.smtp.socketFactory.port", settings.getSocketFactoryPort());
     props.put("mail.smtp.socketFactory.class", settings.getSocketFactoryClass());
     props.put("mail.smtp.socketFactory.fallback", settings.getSocketFactoryFallback());
+    props.put("mail.smtp.connectiontimeout", settings.getConnectionTimeout());
+    props.put("mail.smtp.timeout", settings.getReadTimeout());
 
     props.put("mail.debug", settings.getDebug());
 

--- a/backend/molgenis-emx2-email/src/main/java/org/molgenis/emx2/email/EmailSettings.java
+++ b/backend/molgenis-emx2-email/src/main/java/org/molgenis/emx2/email/EmailSettings.java
@@ -7,6 +7,8 @@ public class EmailSettings {
   private final String host;
 
   private final String port;
+  private final String connectionTimeout;
+  private final String readTimeout;
   private final String starttlsEnable;
   private final String sslProtocols;
   private final String socketFactoryPort;
@@ -21,6 +23,8 @@ public class EmailSettings {
   private EmailSettings(EmailSettingsBuilder builder) {
     host = builder.host;
     port = builder.port;
+    connectionTimeout = builder.connectionTimeout;
+    readTimeout = builder.readTimeout;
 
     starttlsEnable = builder.starttlsEnable;
     sslProtocols = builder.sslProtocols;
@@ -49,6 +53,14 @@ public class EmailSettings {
 
   public String getPort() {
     return port;
+  }
+
+  public String getConnectionTimeout() {
+    return connectionTimeout;
+  }
+
+  public String getReadTimeout() {
+    return readTimeout;
   }
 
   public String getStarttlsEnable() {
@@ -82,6 +94,8 @@ public class EmailSettings {
   public static class EmailSettingsBuilder {
     private String host = "smtpout1.molgenis.net";
     private String port = "25"; // / 587 / 2525
+    private String connectionTimeout = "10000";
+    private String readTimeout = "10000";
     private String starttlsEnable = Boolean.FALSE.toString();
     private String sslProtocols = "TLSv1.2";
     private String socketFactoryPort = Strings.EMPTY;
@@ -104,6 +118,16 @@ public class EmailSettings {
 
     public EmailSettingsBuilder port(String port) {
       this.port = port;
+      return this;
+    }
+
+    public EmailSettingsBuilder connectionTimeout(String connectionTimeout) {
+      this.connectionTimeout = connectionTimeout;
+      return this;
+    }
+
+    public EmailSettingsBuilder readTimeout(String readTimeout) {
+      this.readTimeout = readTimeout;
       return this;
     }
 

--- a/backend/molgenis-emx2-email/src/test/java/org/molgenis/emx2/email/EmailServiceTest.java
+++ b/backend/molgenis-emx2-email/src/test/java/org/molgenis/emx2/email/EmailServiceTest.java
@@ -2,6 +2,9 @@ package org.molgenis.emx2.email;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Optional;
 import javax.mail.internet.AddressException;
@@ -44,5 +47,32 @@ class EmailServiceTest {
             Optional.of(bccAddress));
     boolean isSuccess = emailService.send(message);
     assertTrue(isSuccess);
+  }
+
+  @Test
+  public void sendGivesUpWhenTheServerNeverReplies() throws IOException {
+    try (ServerSocket silentServer = new ServerSocket(0)) {
+      EmailSettings settings =
+          new EmailSettings.EmailSettingsBuilder()
+              .host("127.0.0.1")
+              .port(String.valueOf(silentServer.getLocalPort()))
+              .connectionTimeout("200")
+              .readTimeout("200")
+              .build();
+      EmailService emailService = new EmailService(settings);
+      EmailMessage message =
+          new EmailMessage(
+              Collections.singletonList("test@test.com"), "subject", "text", Optional.empty());
+
+      assertFalse(
+          assertTimeoutPreemptively(Duration.ofSeconds(5), () -> emailService.send(message)));
+    }
+  }
+
+  @Test
+  public void defaultsBoundTheWaitOnAnUnresponsiveServer() {
+    EmailSettings settings = new EmailSettings.EmailSettingsBuilder().build();
+    assertTrue(Integer.parseInt(settings.getConnectionTimeout()) > 0);
+    assertTrue(Integer.parseInt(settings.getReadTimeout()) > 0);
   }
 }


### PR DESCRIPTION
# Bound the SMTP connect and read timeouts

Split out of #6718, which carried this fix inside a `build(ci):` change. On a squash merge that type produces no changelog entry and no version bump, so a real runtime fix would have shipped invisibly — the Nyx `changelog` config in `settings.gradle` only renders `^feat$` and `^fix$`.

## The problem

`EmailService` sets nine JavaMail properties and leaves `mail.smtp.connectiontimeout` and `mail.smtp.timeout` unset. Both default to infinite.

That matters because of who calls it:

```
MessageApi.java:119    EmailService emailService = new EmailService(settings);
MessageApi.java:142    EmailSettings.EmailSettingsBuilder builder = new EmailSettings.EmailSettingsBuilder();
```

`MessageApi` builds the settings from schema settings and calls `send()` on a request thread. `send()` catches everything and returns `false`, so a host that accepts the TCP connection and then never speaks did not fail — it held the thread until the socket died on its own. Enough concurrent requests against such a host exhaust the Javalin thread pool.

## The change

Both timeouts become `EmailSettings` fields with a 10s default:

```java
    private String connectionTimeout = "10000";
    private String readTimeout = "10000";
```

That matches how every other JavaMail property in this class is already handled — all eleven have a builder setter, and hardcoding these two would have been the only exception. It also lets an operator behind a slow relay raise the value, which is worth having since `MessageApi` populates these settings per schema.

## Tests

`sendGivesUpWhenTheServerNeverReplies` opens a `ServerSocket` and never accepts. The connection still completes the TCP handshake via the accept backlog, so the client hangs waiting for the SMTP greeting — which is the read timeout, the case that actually bit.

Because the timeouts are configurable, the test sets 200ms rather than waiting out the production default:

```
0.248s  sendGivesUpWhenTheServerNeverReplies()
0.001s  defaultsBoundTheWaitOnAnUnresponsiveServer()
```

Verified it is a real regression test — with the two `props.put` lines removed it fails as expected:

```
EmailServiceTest > sendGivesUpWhenTheServerNeverReplies() FAILED
    org.opentest4j.AssertionFailedError: execution timed out after 5000 ms
```

`defaultsBoundTheWaitOnAnUnresponsiveServer` covers the other half: the shipped default has to be finite. JavaMail reads zero or less as infinite, so it asserts `> 0` rather than pinning the exact value.

## How to test

1. `./gradlew :backend:molgenis-emx2-email:test` — all pass, whole class runs in under half a second.
2. Delete the two `props.put` lines in `EmailService` and run it again. `sendGivesUpWhenTheServerNeverReplies` fails on the 5s preemptive timeout.
3. `./gradlew :backend:molgenis-emx2-email:spotlessCheck pmdMain pmdTest` — clean.

## Before merging #6718

Drop `EmailService.java` and `EmailServiceTest.java` from that branch and rebase it, so it stays a pure CI change.
