### PR TITLE
perf(ci): split the gradle cache into dependencies and build cache

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,15 +107,15 @@ commands:
         command: find . -name 'build.gradle' -type f -exec cat {} \; > concatenated-build-gradle
     - restore_cache:
         keys:
-          - gradle-deps-v1-{{ checksum "concatenated-build-gradle" }}
-          - gradle-deps-v1-
+          - gradle-deps-v4-{{ checksum "concatenated-build-gradle" }}
+          - gradle-deps-v4-
 
   save_gradle_deps:
     steps:
     - save_cache:
         paths:
           - /tmp/ci-cache/gradle
-        key: gradle-deps-v1-{{ checksum "concatenated-build-gradle" }}
+        key: gradle-deps-v4-{{ checksum "concatenated-build-gradle" }}
 
   restore_gradle_build_cache:
     steps:
@@ -129,12 +129,12 @@ commands:
         steps:
         - restore_cache:
             keys:
-              - gradle-buildcache-v1-master-
+              - gradle-buildcache-v4-master-
     - restore_cache:
         keys:
-          - gradle-buildcache-v1-{{ .Branch }}-
-          - gradle-buildcache-v1-master-
-          - gradle-buildcache-v1-
+          - gradle-buildcache-v4-{{ .Branch }}-
+          - gradle-buildcache-v4-master-
+          - gradle-buildcache-v4-
 
   save_gradle_build_cache:
     steps:
@@ -153,7 +153,7 @@ commands:
     - save_cache:
         paths:
           - /tmp/ci-cache/gradle-build-cache
-        key: gradle-buildcache-v1-{{ .Branch }}-{{ .Revision }}
+        key: gradle-buildcache-v4-{{ .Branch }}-{{ .Revision }}
         when: always
 
   restore_turbo_cache:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,6 +22,7 @@ definitions:
   # test-e2e's image than on the other jobs', so both need this same explicit path.
   cache_env: &cache_env
     GRADLE_USER_HOME: /tmp/ci-cache/gradle
+    GRADLE_BUILD_CACHE_DIR: /tmp/ci-cache/gradle-build-cache
     TURBO_CACHE_DIR: /tmp/ci-cache/turbo
 
   build_config: &build_config
@@ -97,19 +98,30 @@ commands:
     - run:
         name: Sign in to docker
         command: docker login -u $DOCKER_USER -p $DOCKER_PASS
+    - restore_gradle_deps
 
-  restore_gradle_cache:
+  restore_gradle_deps:
     steps:
+    - run:
+        name: Concatenate build files as the dependency cache key
+        command: find . -name 'build.gradle' -type f -exec cat {} \; > concatenated-build-gradle
     - restore_cache:
-        # Own branch first, its last save holds master's pool plus this branch's work.
         keys:
-          - gradle-v1-{{ .Branch }}-
-          - gradle-v1-master-
-          - gradle-v1-
-    # A restore takes the FIRST key that matches, so the step above never reaches master's pool
-    # on a branch that has run before. After a merge from master the branch's own pool has no
-    # entry for the code it just took in, and master's has all of them, so restore that too.
-    # Skipped on master, where the step above already restored this exact key.
+          - gradle-deps-v1-{{ checksum "concatenated-build-gradle" }}
+          - gradle-deps-v1-
+
+  save_gradle_deps:
+    steps:
+    - save_cache:
+        paths:
+          - /tmp/ci-cache/gradle
+        key: gradle-deps-v1-{{ checksum "concatenated-build-gradle" }}
+
+  restore_gradle_build_cache:
+    steps:
+    # A restore takes the FIRST key that matches, so a branch that has run before never reaches
+    # master's pool. After a merge from master the branch's own pool has no entry for the code it
+    # just took in, and master's has all of them, so restore both, least specific first.
     - when:
         condition:
           not:
@@ -117,18 +129,20 @@ commands:
         steps:
         - restore_cache:
             keys:
-              - gradle-v1-master-
+              - gradle-buildcache-v1-master-
+    - restore_cache:
+        keys:
+          - gradle-buildcache-v1-{{ .Branch }}-
+          - gradle-buildcache-v1-master-
+          - gradle-buildcache-v1-
 
-  save_gradle_cache:
+  save_gradle_build_cache:
     steps:
     - run:
-        # The du below reports build-cache-1 alone, so it reads far smaller than the size the
-        # save step uploads: that covers all of GRADLE_USER_HOME, dependencies and the gradle
-        # distribution included. Only build-cache-1 grows without bound, so only it is capped.
         name: Cap the gradle build cache at 2GB, dropping the oldest entries first
         command: |
-          if [ -d /tmp/ci-cache/gradle/caches/build-cache-1 ]; then
-            cd /tmp/ci-cache/gradle/caches/build-cache-1
+          if [ -d "$GRADLE_BUILD_CACHE_DIR" ]; then
+            cd "$GRADLE_BUILD_CACHE_DIR"
             ls -lt | awk -v limit=2147483648 '$NF ~ /^[0-9a-f]{32}$/ { total += $5; if (total > limit) print $NF }' |
               while read -r entry; do rm -f "$entry"; done
             du -sh .
@@ -138,8 +152,8 @@ commands:
         when: always
     - save_cache:
         paths:
-          - /tmp/ci-cache/gradle
-        key: gradle-v1-{{ .Branch }}-{{ .Revision }}
+          - /tmp/ci-cache/gradle-build-cache
+        key: gradle-buildcache-v1-{{ .Branch }}-{{ .Revision }}
         when: always
 
   restore_turbo_cache:
@@ -204,7 +218,7 @@ jobs:
 
     - pre_steps
 
-    - restore_gradle_cache
+    - restore_gradle_build_cache
     - restore_turbo_cache
 
     - run:
@@ -258,7 +272,7 @@ jobs:
       - pre_steps:
           layer_cache: false
 
-      - restore_gradle_cache
+      - restore_gradle_build_cache
       - restore_turbo_cache
 
       - run:
@@ -426,7 +440,7 @@ jobs:
     steps:
     - pre_steps
 
-    - restore_gradle_cache
+    - restore_gradle_build_cache
     - restore_turbo_cache
 
     - run:
@@ -457,7 +471,7 @@ jobs:
 
     # No turbo restore: `:apps` is a runtimeOnly dependency, so a dry run of this job's
     # gradle call schedules no `:apps:*` task and nothing here reads the turbo cache.
-    - restore_gradle_cache
+    - restore_gradle_build_cache
 
     - run:
         name: prepare sql test database
@@ -486,8 +500,9 @@ jobs:
           $SONAR_PR_ARGS
 
     # Every backend module compiles and every backend test runs here, plus pmd and
-    # spotless. The only writer of this cache.
-    - save_gradle_cache
+    # spotless. The only writer of these caches.
+    - save_gradle_deps
+    - save_gradle_build_cache
 
     - post_steps
 

--- a/settings.gradle
+++ b/settings.gradle
@@ -68,6 +68,15 @@ gradle.beforeProject { Project p ->
     }
 }
 
+buildCache {
+    local {
+        String override = System.getenv('GRADLE_BUILD_CACHE_DIR')
+        if (override) {
+            directory = new File(override)
+        }
+    }
+}
+
 rootProject.name = 'emx2'
 include(':apps')
 include(':docs')


### PR DESCRIPTION
Stacked on #6624 — base is `perf/build_cache_2_base`, so the diff here is only the split. Draft until #6624 settles.

## Why

`gradle-v1-{{ .Branch }}-{{ .Revision }}` covers all of `GRADLE_USER_HOME`. That folds together two things with different properties:

| | Safe to reuse? | Changes how often? |
|---|---|---|
| `wrapper/`, `caches/modules-2` | Yes — remote artifacts identified by coordinate and checksum | When a `build.gradle` does |
| `caches/build-cache-1` | Only as far as our own input declarations go | Every commit |

One key cannot express both, which costs three things:

1. **Release gives up dependencies to give up task outputs.** Opting `release` out of cached task outputs is right. Opting it out of the Gradle distribution and ~1.3GB of Maven artifacts buys no safety — a wrong dependency would be a different coordinate, so a different entry.
2. **The master-pool restore overlays more than it means to.** Unioning two pools is sound for `build-cache-1/<hash>`. The same archive also carries `journal-1/file-access.bin`, `modules-2/metadata-2.107/*.bin` and `caches/<version>/fileContent/*.bin`, and those are replaced wholesale by whichever restore lands last.
3. **Storage.** A per-revision key creates one new object per commit. Only `build-cache-1` needs that; the dependency jars do not.

## What changed

`GRADLE_BUILD_CACHE_DIR` moves the local build cache out of `GRADLE_USER_HOME`, so `caches/` holds only downloads again and the two can be saved separately.

- `settings.gradle` — `buildCache { local { … } }`, applied only when the env var is set, so local development is unchanged.
- `restore_gradle_deps` / `save_gradle_deps` — whole `/tmp/ci-cache/gradle`, keyed on `checksum "concatenated-build-gradle"`. Restored in `pre_steps`, so every job gets it, `release` included. Written by `test-backend`, after the build, so it holds what the build actually pulled rather than what `./gradlew dependencies` alone resolved.
- `restore_gradle_build_cache` / `save_gradle_build_cache` — `/tmp/ci-cache/gradle-build-cache`, keyed per revision and capped at 2GB. Restored only by the jobs that already opted in. `release` has no such line, so it still consumes none of our task outputs.
- The master restore now runs **first**, so the branch's own pool lands on top. With the cache scoped to content-addressed entries the order no longer changes anything, but least-specific-first is the right default if the scope ever widens.
- Dropped the note explaining why `du -sh` under-reported the upload — it now measures exactly what is saved.

No job gains or loses a cache it did not already have, apart from `release` and the other `pre_steps`-only jobs regaining the dependency cache they had on master.

## Verified locally

`GRADLE_BUILD_CACHE_DIR` genuinely relocates the cache, and leaving it unset keeps Gradle's default:

```
$ GRADLE_BUILD_CACHE_DIR=/tmp/gbc ./gradlew :backend:molgenis-emx2-email:compileJava --rerun
--- relocated dir: 1 entries
--- default dir:   157 -> 157 entries (unchanged = relocation worked)

$ ./gradlew :backend:molgenis-emx2-email:compileJava     # env var unset
exit=0
```

`.circleci/config.yml` parses, and the resulting wiring is:

```
release                ['pre_steps', 'post_steps']                                   # deps only, via pre_steps
test-backend           ['pre_steps', 'restore_gradle_build_cache', …,
                        'save_gradle_deps', 'save_gradle_build_cache', 'post_steps']
test-apps              ['pre_steps', 'restore_gradle_build_cache', 'restore_turbo_cache', 'save_turbo_cache', …]
test-e2e               ['pre_steps', 'restore_gradle_build_cache', 'restore_turbo_cache']
build-preview-images   ['pre_steps', 'restore_gradle_build_cache', 'restore_turbo_cache', …]
```

`release` keeps `-Dorg.gradle.caching=false` and `requires: [test-apps, test-backend]`.

## How to test

1. First pipeline is cold for both keys. Second pipeline on this branch: `test-backend` should restore `gradle-deps-v1-…` in `pre_steps` and `gradle-buildcache-v1-…` after it, as two separate restores.
2. `release` on master should restore `gradle-deps-v1-…` and no build cache, and its gradle steps should still show no `FROM-CACHE`.
3. Compare the sizes reported by the two `save_cache` steps against the single one on #6624 — the per-commit object should now be the capped build cache alone.
