### PR TITLE
refactor(backend): tighten the QueryBean base class and drop dead code

### DIFF
--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlQuery.java
@@ -94,7 +94,7 @@ public class SqlQuery extends QueryBean {
 
     // if empty selection, we will add the default selection here, incl File and Refback
     // will generally be all you need
-    if (select == null || select.getColumnNames().isEmpty()) {
+    if (select.getColumnNames().isEmpty()) {
       for (Column c :
           table.getColumns().stream()
               .filter(

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/QueryBean.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/QueryBean.java
@@ -11,12 +11,12 @@ public abstract class QueryBean implements Query {
   private Filter filter;
   private String[] searchTerms = new String[0];
 
-  public QueryBean() {
+  protected QueryBean() {
     this.select = new SelectColumn(null);
     this.filter = new FilterBean(AND);
   }
 
-  public QueryBean(String field) {
+  protected QueryBean(String field) {
     this.select = new SelectColumn(field);
     this.filter = new FilterBean(AND);
   }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/QueryBean.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/QueryBean.java
@@ -3,11 +3,10 @@ package org.molgenis.emx2;
 import static org.molgenis.emx2.Operator.AND;
 
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
-public class QueryBean implements Query {
+public abstract class QueryBean implements Query {
   private SelectColumn select;
   private Filter filter;
   private String[] searchTerms = new String[0];
@@ -32,16 +31,6 @@ public class QueryBean implements Query {
   public Query where(Filter... filters) {
     this.filter.addSubfilters(filters);
     return this;
-  }
-
-  @Override
-  public List<Row> retrieveRows(Option... options) {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
-  public String retrieveJSON() {
-    throw new UnsupportedOperationException();
   }
 
   @Override

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/QueryBean.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/QueryBean.java
@@ -11,11 +11,6 @@ public abstract class QueryBean implements Query {
   private Filter filter;
   private String[] searchTerms = new String[0];
 
-  protected QueryBean() {
-    this.select = new SelectColumn(null);
-    this.filter = new FilterBean(AND);
-  }
-
   protected QueryBean(String field) {
     this.select = new SelectColumn(field);
     this.filter = new FilterBean(AND);


### PR DESCRIPTION
## Why

Two small cleanups I ran into while reading `SqlQuery.retrieveRows`.

1. `QueryBean` is designed abstract but isn't

`Query` declares 15 methods. `QueryBean` implements 13 and stubs `retrieveRows` and `retrieveJSON` by throwing `UnsupportedOperationException`.

This appears to me as if QueryBean is designed as an absract superclass; this PR declares it such to clarify the class hierarchy.
Call site check:

| | count |
|---|---|
| `new QueryBean(...)` call sites, repo-wide | **0** |
| `extends QueryBean` | **1** (`SqlQuery`) |
| Methods `SqlQuery` overrides | exactly those 2 |

Marking the class `abstract` turns that latent runtime failure into a compile error, and the two throwing bodies can go: the interface already declares them for subclasses to implement.

Its constructors are narrowed to `protected` in the same spirit: once the class is abstract, only a subclass can
reach them via `super()`, so `public` overstated the contract. `protected` is the only available narrowing —
`SqlQuery` sits in a different package, so package-private would break the `super(field)` calls.

The no-arg `QueryBean()` constructor is removed as dead code. `SqlQuery` is the only subclass and both its
constructors call `super(field)` explicitly, so nothing reached it — not even an implicit `super()` — and it
is named in no reflective or configured lookup. It built a `SelectColumn(null)` no code path asked for.

2. An unreachable null check.**

```java
if (select == null || select.getColumnNames().isEmpty()) {
```

`select` can never be null there. Both `QueryBean` constructors assign one, the field is `private` with no setter, and `retrieveRows` already dereferences `select.getColumn()` 14 lines earlier — a null would have thrown before reaching this branch.

## Testing
- All unit tests pass

`abstract` narrows a `public` type, so any out-of-tree subclass that instantiated `QueryBean` directly would break. Nothing in this repo does.

