### PR TITLE
perf(ci): turn off postgres durability for the throwaway CI databases

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -35,6 +35,9 @@ definitions:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres
         POSTGRES_DB: postgres
+      # This database is thrown away with the job, so durability buys nothing and only costs
+      # write throughput. A crash here loses a container nobody restarts.
+      command: ["postgres", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off"]
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -176,6 +179,9 @@ jobs:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres
         POSTGRES_DB: postgres
+      # This database is thrown away with the job, so durability buys nothing and only costs
+      # write throughput. A crash here loses a container nobody restarts.
+      command: ["postgres", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off"]
     working_directory: ~/repo
     resource_class: large
     environment:


### PR DESCRIPTION
Alternative to #6715 that attacks the same cost with three words of config instead of a cache.

## Why

The e2e job spends **87s of 612s** waiting for the application to boot, and nearly all of that is the demo import writing to Postgres ([build 89396](https://app.circleci.com/pipelines/gh/molgenis/molgenis-emx2)):

```
  233s  build the application without running tests to speed up the e2e tests
   38s  build ssr catalogue
   21s  Install e2e deps and playwright browser
   87s  Wait for application to be up, poll every 5 seconds   <-- the demo import
   51s  Test tailwind components
   ...
```

Bulk import into Postgres is usually dominated by WAL flushing. Both CI databases are service containers that are deleted with the job, so `fsync`, `synchronous_commit` and `full_page_writes` protect nothing here — a crash loses a container nobody restarts.

Applied to both Postgres services: the `test_config` executor (backend tests) and `test-e2e`.

## Trade-offs

- **No staleness risk.** Unlike a cached database, this cannot serve a green run against wrong data. The import still happens, it is just cheaper.
- **Helps every run**, not only cache hits.
- If Postgres is killed mid-job the data directory can be corrupt. That is exactly what we want to happen to it anyway.

## Measurement

The real number has to come from CI, so this is a draft until it has run.

Local indication only, 20k auto-committed inserts against `postgres:15-alpine`, macOS Docker Desktop:

| | time |
|---|---|
| default | 1.9s |
| `fsync=off synchronous_commit=off full_page_writes=off` | 1.0s |

Docker Desktop's fsync is already partly virtualised, so the gap on the CI Linux runners is usually larger. But only part of the 87s is writes — JVM startup, CSV parsing and DDL are unaffected — so I would not expect the full factor to land on the wall clock.

I verified the `command:` override does not break the image's init: `docker-entrypoint.sh` still runs `initdb` and applies `POSTGRES_USER`/`POSTGRES_PASSWORD`/`POSTGRES_DB` because `postgres` is still the first argument.

## Stack

1. **this PR**
2. 6743 — overlap the e2e node installs with the boot

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uR2G2mXDndUSnW7qUagdd
