### PR TITLE
perf(ci): overlap the e2e node installs with the application boot

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -312,16 +312,8 @@ jobs:
           name: prepare sql test database
           command: psql -h 127.0.0.1 -p 5432 -U postgres < .circleci/initdb.sql
 
-      # Only chromium: every playwright.config.ts uses devices["Desktop Chrome"], and no config sets channel.
-      # Installed from e2e/, which pins @playwright/test 1.62.0; the browser cache is shared with the apps suites.
-      - run:
-          name: Install e2e deps and playwright browser
-          command: |
-            pnpm install
-            npx playwright install --with-deps chromium
-          working_directory: e2e
-          no_output_timeout: 5m
-
+      # The demo import runs inside the application boot, so everything below that does not
+      # need a running application is placed between the start and the wait for it.
       - run:
           name: start the application in the background
           command: |
@@ -342,6 +334,21 @@ jobs:
             ps -p $(cat application.pid) || echo "❌ Process died immediately"
             echo "Last logs:"
             tail -200 application.log
+
+      # Only chromium: every playwright.config.ts uses devices["Desktop Chrome"], and no config sets channel.
+      # Installed from e2e/, which pins @playwright/test 1.62.0; the browser cache is shared with the apps suites.
+      - run:
+          name: Install e2e deps and playwright browser
+          command: |
+            pnpm install
+            npx playwright install --with-deps chromium
+          working_directory: e2e
+          no_output_timeout: 5m
+
+      - run:
+          name: Install app dependencies
+          command: pnpm install
+          working_directory: apps
 
       - run:
           name: Wait for application to be up, poll every 5 seconds
@@ -370,11 +377,6 @@ jobs:
 
               sleep 1
             done
-
-      - run:
-          name: Install app dependencies
-          command: pnpm install
-          working_directory: apps
 
       - run:
           name: Test tailwind components

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -40,6 +40,9 @@ definitions:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres
         POSTGRES_DB: postgres
+      # This database is thrown away with the job, so durability buys nothing and only costs
+      # write throughput. A crash here loses a container nobody restarts.
+      command: ["postgres", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off"]
     working_directory: ~/repo
     resource_class: large
     environment: *job_env
@@ -260,6 +263,9 @@ jobs:
         POSTGRES_USER: postgres
         POSTGRES_PASSWORD: postgres
         POSTGRES_DB: postgres
+      # This database is thrown away with the job, so durability buys nothing and only costs
+      # write throughput. A crash here loses a container nobody restarts.
+      command: ["postgres", "-c", "fsync=off", "-c", "synchronous_commit=off", "-c", "full_page_writes=off"]
     working_directory: ~/repo
     resource_class: large
     environment: *job_env


### PR DESCRIPTION
## Why

The e2e job boots the application, then waits ~87s for the demo import to finish. Both `pnpm install` steps sat *before* that wait in the queue, even though neither needs a running application:

```
   21s  Install e2e deps and playwright browser
    5s  start the application in the background
   87s  Wait for application to be up, poll every 5 seconds
    6s  Install app dependencies
```

Starting the application first puts both installs inside the window the job was already going to spend waiting. **Expected saving: ~27s**, for a step reorder and no new code.

## What changed

Order only. Verified as a pure move — the sole content added is the two comment lines:

```
- Put custom app next to jar
- install postgres client
- prepare sql test database
- start the application in the background      <- moved up
- Install e2e deps and playwright browser         (now overlaps the boot)
- Install app dependencies                     <- moved up, overlaps the boot
- Wait for application to be up
- Test tailwind components
```

The boot's prerequisites are all still ahead of it: the jar and `build/ci.properties` from the Gradle build, `custom-app` beside the jar, and the database prepared by `initdb.sql`.

## Not done here

`build ssr catalogue` (38s) could overlap too, which would take the total saving to ~65s. I left it out on purpose: it is a Nuxt build with a 2GB node heap, and running it next to the EMX2 JVM and a Postgres doing a bulk import in one 8GB container is a plausible OOM. Worth trying separately, where a failure is easy to attribute.

## Trade-off

If the application dies during boot, the job now notices at the wait step rather than ~27s earlier. The `sleep 5` and `tail -200 application.log` in the start step still catch an immediate crash.

## Stack

1. #6742 — turn off postgres durability for the throwaway CI databases
2. **this PR**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011uR2G2mXDndUSnW7qUagdd