### PR TITLE
fix: close the download transaction before writing to the client

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
@@ -50,6 +51,11 @@ public class TableStoreForXlsxFile implements TableStore {
 
   @Override
   public void writeTable(String name, List<String> columnNames, Iterable<Row> rows) {
+    writeTableStreaming(name, columnNames, rows::forEach);
+  }
+
+  @Override
+  public void writeTableStreaming(String name, List<String> columnNames, RowProducer rows) {
     SXSSFWorkbook wb;
     try {
       if (name.length() > 30)
@@ -64,11 +70,7 @@ public class TableStoreForXlsxFile implements TableStore {
             Files.move(excelFilePath, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         wb = new SXSSFWorkbook(new XSSFWorkbook(temp.toFile()), ROW_ACCESS_WINDOW_SIZE);
       }
-      if (rows.iterator().hasNext()) {
-        writeRowsToSheet(name, columnNames, rows, wb);
-      } else {
-        writeHeaderOnlyToSheet(name, columnNames, wb);
-      }
+      writeRowsToSheet(name, columnNames, rows, wb);
       // write contents to a temp file and overwrite original
       try (FileOutputStream outputStream = new FileOutputStream(excelFilePath.toFile())) {
         wb.write(outputStream);
@@ -80,16 +82,8 @@ public class TableStoreForXlsxFile implements TableStore {
     }
   }
 
-  private void writeHeaderOnlyToSheet(String name, List<String> columnNames, Workbook wb) {
-    Sheet sheet = wb.createSheet(name);
-    org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(0);
-    for (int i = 0; i < columnNames.size(); i++) {
-      excelRow.createCell(i).setCellValue(columnNames.get(i));
-    }
-  }
-
   private void writeRowsToSheet(
-      String name, List<String> columnNames, Iterable<Row> rows, SXSSFWorkbook wb)
+      String name, List<String> columnNames, RowProducer rows, SXSSFWorkbook wb)
       throws IOException {
 
     // create the sheet
@@ -97,44 +91,39 @@ public class TableStoreForXlsxFile implements TableStore {
     // buffer the row so it gets flushed
     sheet.setRandomAccessWindowSize(wb.getRandomAccessWindowSize());
     Map<String, Integer> columnNameIndexMap = new LinkedHashMap<>();
-    int rowNum = 0;
-
-    // write the data
-    for (Row row : rows) {
-      // create header row
-      if (rowNum == 0) {
-        int columnIndex = 0;
-        // define the column indexes
-        for (String columnName : columnNames) {
-          columnNameIndexMap.put(columnName, columnIndex++);
-        }
-        // write a header row
-        org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(rowNum);
-        for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
-          excelRow.createCell(entry.getValue()).setCellValue(entry.getKey());
-        }
-        rowNum++;
-      }
-      // write a contents row
-      org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(rowNum);
-      for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
-        try {
-          String cellValue = ExcelIOUtil.toExcelFormat(row, entry.getKey());
-          excelRow.createCell(entry.getValue()).setCellValue(cellValue);
-        } catch (IllegalArgumentException e) {
-          throw new MolgenisException(
-              "Error writing table '"
-                  + name
-                  + "', column '"
-                  + entry.getKey()
-                  + "', at row "
-                  + rowNum
-                  + ": "
-                  + e.getMessage());
-        }
-      }
-      rowNum++;
+    int columnIndex = 0;
+    for (String columnName : columnNames) {
+      columnNameIndexMap.put(columnName, columnIndex++);
     }
+
+    // write a header row
+    org.apache.poi.ss.usermodel.Row headerRow = sheet.createRow(0);
+    for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
+      headerRow.createCell(entry.getValue()).setCellValue(entry.getKey());
+    }
+
+    AtomicInteger rowNum = new AtomicInteger(1);
+    rows.produce(
+        row -> {
+          int currentRow = rowNum.getAndIncrement();
+          org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(currentRow);
+          for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
+            try {
+              String cellValue = ExcelIOUtil.toExcelFormat(row, entry.getKey());
+              excelRow.createCell(entry.getValue()).setCellValue(cellValue);
+            } catch (IllegalArgumentException e) {
+              throw new MolgenisException(
+                  "Error writing table '"
+                      + name
+                      + "', column '"
+                      + entry.getKey()
+                      + "', at row "
+                      + currentRow
+                      + ": "
+                      + e.getMessage());
+            }
+          }
+        });
     sheet.flushRows();
   }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
@@ -11,13 +11,15 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.javalin.Javalin;
 import io.javalin.http.Context;
-import java.io.BufferedWriter;
 import java.io.IOException;
-import java.io.OutputStreamWriter;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.StringReader;
 import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.List;
@@ -221,19 +223,29 @@ public class CsvApi {
     List<Column> columns = table.getMetadata().getColumns();
     Query query = getDownloadQuery(ctx, table);
 
-    ctx.contentType(ACCEPT_CSV);
-    ctx.header("Content-Disposition", "attachment; filename=\"" + table.getName() + ".csv\"");
-    ctx.status(200);
-    ctx.res().setCharacterEncoding("UTF-8");
+    // The cursor's transaction holds an ACCESS SHARE lock that blocks ALTER TABLE, so it is
+    // closed before the client, whose speed we do not control, is written to.
+    Path csv = Files.createTempFile("emx2-download-", ".csv");
+    try {
+      try (Writer writer = Files.newBufferedWriter(csv, StandardCharsets.UTF_8)) {
+        Consumer<Row> rowWriter = CsvTableWriter.rowWriter(columnNames, writer, getSeparator(ctx));
+        query.retrieveRowsStreaming(
+            row -> {
+              ResolveComputedValue.apply(columns, List.of(row));
+              rowWriter.accept(row);
+            });
+      }
 
-    try (Writer writer =
-        new BufferedWriter(new OutputStreamWriter(ctx.outputStream(), StandardCharsets.UTF_8))) {
-      Consumer<Row> rowWriter = CsvTableWriter.rowWriter(columnNames, writer, getSeparator(ctx));
-      query.retrieveRowsStreaming(
-          row -> {
-            ResolveComputedValue.apply(columns, List.of(row));
-            rowWriter.accept(row);
-          });
+      ctx.contentType(ACCEPT_CSV);
+      ctx.header("Content-Disposition", "attachment; filename=\"" + table.getName() + ".csv\"");
+      ctx.status(200);
+      ctx.res().setCharacterEncoding("UTF-8");
+      try (InputStream in = Files.newInputStream(csv);
+          OutputStream out = ctx.outputStream()) {
+        in.transferTo(out);
+      }
+    } finally {
+      Files.deleteIfExists(csv);
     }
   }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
@@ -264,7 +264,7 @@ public class CsvApi {
         .toList();
   }
 
-  private static Query getDownloadQuery(Context ctx, Table table) throws JsonProcessingException {
+  static Query getDownloadQuery(Context ctx, Table table) throws JsonProcessingException {
     Query query = table.query();
     // extract filter argument if exists
     if (ctx.queryParam(GraphqlConstants.FILTER_ARGUMENT) != null) {
@@ -277,13 +277,6 @@ public class CsvApi {
                   .readValue(ctx.queryParam(GraphqlConstants.FILTER_ARGUMENT), Map.class)));
     }
     return query;
-  }
-
-  public static List<Row> getDownloadRows(Context ctx, Table table) throws JsonProcessingException {
-    List<Row> rows = getDownloadQuery(ctx, table).retrieveRows();
-    List<Column> columns = table.getMetadata().getColumns();
-    ResolveComputedValue.apply(columns, rows);
-    return rows;
   }
 
   private static void tableUpdate(Context ctx) {

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
@@ -225,7 +225,9 @@ public class CsvApi {
 
     // The cursor's transaction holds an ACCESS SHARE lock that blocks ALTER TABLE, so it is
     // closed before the client, whose speed we do not control, is written to.
-    Path csv = Files.createTempFile(MolgenisWebservice.TEMPFILES_DELETE_ON_EXIT, ".csv");
+    // the enclosing directory is created private to this user, the temp file alone would not be
+    Path tempDir = Files.createTempDirectory(MolgenisWebservice.TEMPFILES_DELETE_ON_EXIT);
+    Path csv = tempDir.resolve("download.csv");
     try {
       try (Writer writer = Files.newBufferedWriter(csv, StandardCharsets.UTF_8)) {
         Consumer<Row> rowWriter = CsvTableWriter.rowWriter(columnNames, writer, getSeparator(ctx));
@@ -246,6 +248,7 @@ public class CsvApi {
       }
     } finally {
       Files.deleteIfExists(csv);
+      Files.deleteIfExists(tempDir);
     }
   }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
@@ -247,8 +247,12 @@ public class CsvApi {
         in.transferTo(out);
       }
     } finally {
-      Files.deleteIfExists(csv);
-      Files.deleteIfExists(tempDir);
+      // nested: a failure to delete the file must not skip the directory
+      try {
+        Files.deleteIfExists(csv);
+      } finally {
+        Files.deleteIfExists(tempDir);
+      }
     }
   }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
@@ -225,7 +225,7 @@ public class CsvApi {
 
     // The cursor's transaction holds an ACCESS SHARE lock that blocks ALTER TABLE, so it is
     // closed before the client, whose speed we do not control, is written to.
-    Path csv = Files.createTempFile("emx2-download-", ".csv");
+    Path csv = Files.createTempFile(MolgenisWebservice.TEMPFILES_DELETE_ON_EXIT, ".csv");
     try {
       try (Writer writer = Files.newBufferedWriter(csv, StandardCharsets.UTF_8)) {
         Consumer<Row> rowWriter = CsvTableWriter.rowWriter(columnNames, writer, getSeparator(ctx));

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ExcelApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ExcelApi.java
@@ -2,7 +2,7 @@ package org.molgenis.emx2.web;
 
 import static org.molgenis.emx2.io.FileUtils.getTempFile;
 import static org.molgenis.emx2.web.CsvApi.getDownloadColumns;
-import static org.molgenis.emx2.web.CsvApi.getDownloadRows;
+import static org.molgenis.emx2.web.CsvApi.getDownloadQuery;
 import static org.molgenis.emx2.web.DownloadApiUtils.includeSystemColumns;
 import static org.molgenis.emx2.web.MolgenisWebservice.getSchema;
 import static org.molgenis.emx2.web.ZipApi.generateReportsToStore;
@@ -18,11 +18,13 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.io.ImportExcelTask;
 import org.molgenis.emx2.io.MolgenisIO;
 import org.molgenis.emx2.io.tablestore.TableStore;
 import org.molgenis.emx2.io.tablestore.TableStoreForXlsxFile;
+import org.molgenis.emx2.sql.row.resolvers.ResolveComputedValue;
 import org.molgenis.emx2.tasks.Task;
 
 public class ExcelApi {
@@ -102,8 +104,17 @@ public class ExcelApi {
     tempDir.toFile().deleteOnExit();
     Path excelFile = tempDir.resolve("download.xlsx");
     TableStore excelStore = new TableStoreForXlsxFile(excelFile);
-    excelStore.writeTable(
-        table.getName(), getDownloadColumns(ctx, table), getDownloadRows(ctx, table));
+    List<Column> columns = table.getMetadata().getColumns();
+    Query query = getDownloadQuery(ctx, table);
+    excelStore.writeTableStreaming(
+        table.getName(),
+        getDownloadColumns(ctx, table),
+        consumer ->
+            query.retrieveRowsStreaming(
+                row -> {
+                  ResolveComputedValue.apply(columns, List.of(row));
+                  consumer.accept(row);
+                }));
     try (OutputStream outputStream = ctx.res().getOutputStream()) {
       ctx.contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
       ctx.header(
@@ -114,7 +125,7 @@ public class ExcelApi {
               + table.getName()
               + System.currentTimeMillis()
               + ".xlsx");
-      outputStream.write(Files.readAllBytes(excelFile));
+      Files.copy(excelFile, outputStream);
       ctx.result("Export success");
     }
   }


### PR DESCRIPTION
Suggestion on top of #6703, not a replacement. Merge it into `fix/download-heap` or take the idea, whichever suits.

### What this changes

`CsvApi.tableRetrieve` writes the rows to a temp file, closes the transaction, then streams that file to the response. Heap stays constant on both halves, which is what #6703 is for.

### Why

Driving the cursor straight into the client socket keeps the query's transaction open for as long as the download takes, and the client controls that. The `SELECT` holds an `ACCESS SHARE` lock, which does not block inserts or updates, but does block `ALTER TABLE`. EMX2 issues `ALTER TABLE` at runtime whenever someone adds or drops a column, so a slow download of a large table can stall a schema change. Postgres queues locks first-in-first-out, so the queries that arrive after the blocked `ALTER TABLE` queue behind it too.

Writing to disk first keeps the transaction as short as the query, instead of as long as the transfer.

Three further effects, all from the same move:

- Compression comes back on. The response body now goes out after the query, through `ctx.outputStream()`.
- A failing query returns an error. Nothing is committed to the response until the CSV is complete, so a mid-query failure no longer produces HTTP 200 with a truncated file that looks whole.
- The size is known before the first byte, so a `Content-Length` becomes possible. I have not added one, because I have not checked whether Javalin manages that header itself when it compresses.

### Cost

A disk round-trip, and time-to-first-byte becomes the full query time rather than the first row. For a browser download that seems the better trade: a correct error beats a fast start.

`ZipApi` and `ExcelApi` already build a temp file, so this follows the existing shape. They then read it back with `Files.readAllBytes`, which this does not.

### Testing

`spotlessApply` and `compileJava` are green for `molgenis-emx2-webapi`. There is no existing test for `tableRetrieve`, and a real one needs a running backend, so I have not added one.
