### PR TITLE
fix: stream the excel table download instead of buffering every row

### DIFF
--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
@@ -8,6 +8,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.poi.ss.usermodel.*;
 import org.apache.poi.xssf.streaming.SXSSFSheet;
 import org.apache.poi.xssf.streaming.SXSSFWorkbook;
@@ -101,11 +102,11 @@ public class TableStoreForXlsxFile implements TableStore {
       headerRow.createCell(entry.getValue()).setCellValue(entry.getKey());
     }
 
-    // rowNum lives outside the lambda, so a Consumer<Row> can still count rows
-    int[] rowNum = {1};
+    AtomicInteger rowNum = new AtomicInteger(1);
     rows.produce(
         row -> {
-          org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(rowNum[0]);
+          int currentRow = rowNum.getAndIncrement();
+          org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(currentRow);
           for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
             try {
               String cellValue = ExcelIOUtil.toExcelFormat(row, entry.getKey());
@@ -117,12 +118,11 @@ public class TableStoreForXlsxFile implements TableStore {
                       + "', column '"
                       + entry.getKey()
                       + "', at row "
-                      + rowNum[0]
+                      + currentRow
                       + ": "
                       + e.getMessage());
             }
           }
-          rowNum[0]++;
         });
     sheet.flushRows();
   }

--- a/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
+++ b/backend/molgenis-emx2-io/src/main/java/org/molgenis/emx2/io/tablestore/TableStoreForXlsxFile.java
@@ -50,6 +50,11 @@ public class TableStoreForXlsxFile implements TableStore {
 
   @Override
   public void writeTable(String name, List<String> columnNames, Iterable<Row> rows) {
+    writeTableStreaming(name, columnNames, rows::forEach);
+  }
+
+  @Override
+  public void writeTableStreaming(String name, List<String> columnNames, RowProducer rows) {
     SXSSFWorkbook wb;
     try {
       if (name.length() > 30)
@@ -64,11 +69,7 @@ public class TableStoreForXlsxFile implements TableStore {
             Files.move(excelFilePath, tempFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         wb = new SXSSFWorkbook(new XSSFWorkbook(temp.toFile()), ROW_ACCESS_WINDOW_SIZE);
       }
-      if (rows.iterator().hasNext()) {
-        writeRowsToSheet(name, columnNames, rows, wb);
-      } else {
-        writeHeaderOnlyToSheet(name, columnNames, wb);
-      }
+      writeRowsToSheet(name, columnNames, rows, wb);
       // write contents to a temp file and overwrite original
       try (FileOutputStream outputStream = new FileOutputStream(excelFilePath.toFile())) {
         wb.write(outputStream);
@@ -80,16 +81,8 @@ public class TableStoreForXlsxFile implements TableStore {
     }
   }
 
-  private void writeHeaderOnlyToSheet(String name, List<String> columnNames, Workbook wb) {
-    Sheet sheet = wb.createSheet(name);
-    org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(0);
-    for (int i = 0; i < columnNames.size(); i++) {
-      excelRow.createCell(i).setCellValue(columnNames.get(i));
-    }
-  }
-
   private void writeRowsToSheet(
-      String name, List<String> columnNames, Iterable<Row> rows, SXSSFWorkbook wb)
+      String name, List<String> columnNames, RowProducer rows, SXSSFWorkbook wb)
       throws IOException {
 
     // create the sheet
@@ -97,44 +90,40 @@ public class TableStoreForXlsxFile implements TableStore {
     // buffer the row so it gets flushed
     sheet.setRandomAccessWindowSize(wb.getRandomAccessWindowSize());
     Map<String, Integer> columnNameIndexMap = new LinkedHashMap<>();
-    int rowNum = 0;
-
-    // write the data
-    for (Row row : rows) {
-      // create header row
-      if (rowNum == 0) {
-        int columnIndex = 0;
-        // define the column indexes
-        for (String columnName : columnNames) {
-          columnNameIndexMap.put(columnName, columnIndex++);
-        }
-        // write a header row
-        org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(rowNum);
-        for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
-          excelRow.createCell(entry.getValue()).setCellValue(entry.getKey());
-        }
-        rowNum++;
-      }
-      // write a contents row
-      org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(rowNum);
-      for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
-        try {
-          String cellValue = ExcelIOUtil.toExcelFormat(row, entry.getKey());
-          excelRow.createCell(entry.getValue()).setCellValue(cellValue);
-        } catch (IllegalArgumentException e) {
-          throw new MolgenisException(
-              "Error writing table '"
-                  + name
-                  + "', column '"
-                  + entry.getKey()
-                  + "', at row "
-                  + rowNum
-                  + ": "
-                  + e.getMessage());
-        }
-      }
-      rowNum++;
+    int columnIndex = 0;
+    for (String columnName : columnNames) {
+      columnNameIndexMap.put(columnName, columnIndex++);
     }
+
+    // write a header row
+    org.apache.poi.ss.usermodel.Row headerRow = sheet.createRow(0);
+    for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
+      headerRow.createCell(entry.getValue()).setCellValue(entry.getKey());
+    }
+
+    // rowNum lives outside the lambda, so a Consumer<Row> can still count rows
+    int[] rowNum = {1};
+    rows.produce(
+        row -> {
+          org.apache.poi.ss.usermodel.Row excelRow = sheet.createRow(rowNum[0]);
+          for (Map.Entry<String, Integer> entry : columnNameIndexMap.entrySet()) {
+            try {
+              String cellValue = ExcelIOUtil.toExcelFormat(row, entry.getKey());
+              excelRow.createCell(entry.getValue()).setCellValue(cellValue);
+            } catch (IllegalArgumentException e) {
+              throw new MolgenisException(
+                  "Error writing table '"
+                      + name
+                      + "', column '"
+                      + entry.getKey()
+                      + "', at row "
+                      + rowNum[0]
+                      + ": "
+                      + e.getMessage());
+            }
+          }
+          rowNum[0]++;
+        });
     sheet.flushRows();
   }
 

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/CsvApi.java
@@ -264,7 +264,7 @@ public class CsvApi {
         .toList();
   }
 
-  private static Query getDownloadQuery(Context ctx, Table table) throws JsonProcessingException {
+  static Query getDownloadQuery(Context ctx, Table table) throws JsonProcessingException {
     Query query = table.query();
     // extract filter argument if exists
     if (ctx.queryParam(GraphqlConstants.FILTER_ARGUMENT) != null) {
@@ -277,13 +277,6 @@ public class CsvApi {
                   .readValue(ctx.queryParam(GraphqlConstants.FILTER_ARGUMENT), Map.class)));
     }
     return query;
-  }
-
-  public static List<Row> getDownloadRows(Context ctx, Table table) throws JsonProcessingException {
-    List<Row> rows = getDownloadQuery(ctx, table).retrieveRows();
-    List<Column> columns = table.getMetadata().getColumns();
-    ResolveComputedValue.apply(columns, rows);
-    return rows;
   }
 
   private static void tableUpdate(Context ctx) {

--- a/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ExcelApi.java
+++ b/backend/molgenis-emx2-webapi/src/main/java/org/molgenis/emx2/web/ExcelApi.java
@@ -2,7 +2,7 @@ package org.molgenis.emx2.web;
 
 import static org.molgenis.emx2.io.FileUtils.getTempFile;
 import static org.molgenis.emx2.web.CsvApi.getDownloadColumns;
-import static org.molgenis.emx2.web.CsvApi.getDownloadRows;
+import static org.molgenis.emx2.web.CsvApi.getDownloadQuery;
 import static org.molgenis.emx2.web.DownloadApiUtils.includeSystemColumns;
 import static org.molgenis.emx2.web.MolgenisWebservice.getSchema;
 import static org.molgenis.emx2.web.ZipApi.generateReportsToStore;
@@ -18,11 +18,13 @@ import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import org.molgenis.emx2.*;
 import org.molgenis.emx2.io.ImportExcelTask;
 import org.molgenis.emx2.io.MolgenisIO;
 import org.molgenis.emx2.io.tablestore.TableStore;
 import org.molgenis.emx2.io.tablestore.TableStoreForXlsxFile;
+import org.molgenis.emx2.sql.row.resolvers.ResolveComputedValue;
 import org.molgenis.emx2.tasks.Task;
 
 public class ExcelApi {
@@ -102,8 +104,17 @@ public class ExcelApi {
     tempDir.toFile().deleteOnExit();
     Path excelFile = tempDir.resolve("download.xlsx");
     TableStore excelStore = new TableStoreForXlsxFile(excelFile);
-    excelStore.writeTable(
-        table.getName(), getDownloadColumns(ctx, table), getDownloadRows(ctx, table));
+    List<Column> columns = table.getMetadata().getColumns();
+    Query query = getDownloadQuery(ctx, table);
+    excelStore.writeTableStreaming(
+        table.getName(),
+        getDownloadColumns(ctx, table),
+        consumer ->
+            query.retrieveRowsStreaming(
+                row -> {
+                  ResolveComputedValue.apply(columns, List.of(row));
+                  consumer.accept(row);
+                }));
     try (OutputStream outputStream = ctx.res().getOutputStream()) {
       ctx.contentType("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet");
       ctx.header(
@@ -114,7 +125,7 @@ public class ExcelApi {
               + table.getName()
               + System.currentTimeMillis()
               + ".xlsx");
-      outputStream.write(Files.readAllBytes(excelFile));
+      Files.copy(excelFile, outputStream);
       ctx.result("Export success");
     }
   }


### PR DESCRIPTION
Second suggestion on top of #6703, independent of #6744. Draft until CI is green, because the tests could not be run locally (see below).

### What this changes

The Excel table download no longer holds every row in heap. It reuses the `RowProducer` mechanism this branch introduces.

- `TableStoreForXlsxFile` overrides `writeTableStreaming`, so rows go into the SXSSF sheet as they arrive. `writeTable(Iterable)` delegates to it.
- `ExcelApi.getExcelTable` streams the query with `query::retrieveRowsStreaming` instead of materialising a list, and copies the finished workbook to the response with `Files.copy` instead of `Files.readAllBytes`.
- `CsvApi.getDownloadRows` had no callers left, so it is gone.

Net effect on the diff is negative: `writeHeaderOnlyToSheet` and the `rows.iterator().hasNext()` peek both disappear, because the header is now written up front rather than lazily on the first row.

### Why

POI already streams: `TableStoreForXlsxFile` uses `SXSSFWorkbook` with a row-access window, so the workbook itself was never the problem. The heap went to two other places, and this removes both.

The behaviour is meant to be identical. The header stays at sheet row 0 and data still starts at row 1, for an empty table as well as a populated one.

### Testing

`spotlessApply` and `compileJava` are green for `molgenis-emx2-io` and `molgenis-emx2-webapi`.

**The existing tests have not been run.** `TestExcelStore` and `TestReadWriteStores` call `Files.createTempDirectory()`, and the environment I built this in denies writes to the JVM's default temp directory, so they fail before reaching any assertion. Those tests cover exactly the part this change restructures, so please treat CI as the gate here rather than my word.
