### PR TITLE
fix(cms): remove multiple ref option

### DIFF
--- a/data/_models/specific/Pages.csv
+++ b/data/_models/specific/Pages.csv
@@ -60,21 +60,21 @@ Navigation cards,,description,string,,,,,,,,,,An optional description that provi
 Navigation cards,,url,hyperlink,,TRUE,,,,,,,,A link to an internal or external page,pages
 Navigation cards,,url label,string,,,,,,,,,,A label to display instead of the URL,pages
 Navigation cards,,url is external,bool,,,,,,,,FALSE,,"If true, the link will be rendered as an external link",pages
-Navigation cards,,displayed in navigation group,multiselect,,,Navigation groups,,,,,,,A reference to the navigation list,pages
+Navigation cards,,displayed in navigation group,select,,,Navigation groups,,,,,,,A reference to the navigation list,pages
 Navigation cards,,order,int,,TRUE,,,,,,0,,Order the card should appear in when used in a navigation group,pages
 Blocks,,Configuration,section,,,,,,,,,,,pages
 Blocks,,UI settings,heading,,,,,,,,,,,pages
 Blocks,,enable full screen width,bool,,,,,,,,FALSE,,"If true, content will be expanded to the fit the full width of the screen",pages
 Sections,,apply shaded background,bool,,,,,,,,FALSE,,"If true, a light background color will be applied to provide visual distinction between blocks",pages
 Blocks,,Component connections,heading,,,,,,,,,,Link components and set the order in which they display on page. ,pages
-Blocks,,in container,multiselect,,,Configurable pages,,,,,,,A link to the configurable page where the block is displayed,pages
+Blocks,,in container,select,,,Configurable pages,,,,,,,A link to the configurable page where the block is displayed,pages
 Blocks,,components,refback,,,Components,in block,,,,,,The elements that are displayed in a block,pages
 Blocks,,component order,refback,,,Component orders,block,,,,,,,pages
 Blocks,,Metadata,heading,,,,,,,,,,,pages
 Blocks,,id,auto_id,1,TRUE,,,,,,,,An auto ID used to generate UI elements,pages
 Components,,Configuration,section,,,,,,,,,,,pages
 Components,,Component connections,heading,,,,,,,,,,Create links between components and blocks,pages
-Components,,in block,multiselect,,,Blocks,,,,,,,A link to the block where the component is used,pages
+Components,,in block,select,,,Blocks,,,,,,,A link to the block where the component is used,pages
 Components,,Metadata,heading,,,,,,,,,,,pages
 Components,,id,auto_id,1,TRUE,,,,,,,,An auto ID used to generate UI elements,pages
 Block orders,,,,,,,,,,,,,"The order blocks (headers, sections, etc.) appear on a page",pages


### PR DESCRIPTION
### What are the main changes you did

The purpose of this PR is to remove the ability to use a component or block in multiple places. While working on the molgenis/GCC#3480, it was becoming increasingly challenging to identify and to safely remove references that indicate a component was used in multiple places. The order in which blocks and components needed to be removed never seemed to align. Even though it is possible to create pages in an excel file and import them, I would expect that not many people would do this and I would discourage it as it is far easier to build pages in the UI. To address this issue, I decided to replace all `multiple` column types with `select`.

 - [x] Use `select` column type instead of `multiselect`

This PR is part of molgenis/GCC#1143

### How to test

- explain here what to do to test this (or point to unit tests)

### Checklist

- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
