### PR TITLE
perf(ci): drop the dev-only .env check from test-backend, which cost 1m20 a run

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -426,29 +426,6 @@ jobs:
 
     - post_steps
 
-    # LAST step of this job on purpose: it writes a repo-root .env, which would otherwise change the
-    # gradle and turbo input hashes of every step after it. PR #6717 takes .env out of those hashes,
-    # so this step can move once that lands.
-    - run:
-        name: <dev> a repo-root .env reaches the forked dev JVM
-        command: |
-          set -eo pipefail
-          printf '%s\n' \
-            'MOLGENIS_HTTP_PORT=19345' \
-            'MOLGENIS_JVM_XMX=333m' \
-            'MOLGENIS_POSTGRES_PASS=ci-guardrail-secret' > .env
-          export MOLGENIS_HTTP_PORT=19999
-          ./gradlew -q --console=plain --no-daemon printDevConfig -DMOLGENIS_CI_PROBE=probe-value \
-            | tee printDevConfig.out
-          grep -Fxq 'molgenis.dev.systemProperty.MOLGENIS_HTTP_PORT=19345' printDevConfig.out
-          grep -Fxq 'molgenis.dev.systemProperty.MOLGENIS_CI_PROBE=probe-value' printDevConfig.out
-          grep -Fxq 'molgenis.dev.systemProperty.MOLGENIS_POSTGRES_PASS=<HIDDEN>' printDevConfig.out
-          grep -Fxq 'molgenis.dev.maxHeapSize=333m' printDevConfig.out
-    - run:
-        name: <dev> remove the temporary .env
-        command: rm -f .env printDevConfig.out
-        when: always
-
   release:
     <<: *release_config
 


### PR DESCRIPTION
.env is something devs using it will find out when needed, so not worth time for everybody on every run. Sorry, didn't realize the timings. (note, this is only uncached)

Master
<img width="247" height="63" alt="image" src="https://github.com/user-attachments/assets/40b6af73-05e4-4dba-b1df-ea31946fa5b5" />
esp
<img width="990" height="77" alt="image" src="https://github.com/user-attachments/assets/b6d18216-d9cb-43cc-913d-13b1492f04a1" />

This PR
<img width="412" height="88" alt="image" src="https://github.com/user-attachments/assets/6043b371-6e59-44a6-9171-b25a0e38661b" />
doesn't have this step
