### PR TITLE
perf(ci): deploy the PR preview from build-preview-images to not waste a minute on booting next image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -161,6 +161,13 @@ jobs:
           docker push molgenis/ssr-catalogue-snapshot --all-tags
 
     - run:
+        name: Start preview in limited resources mode
+        command: |
+          export $( cat build/ci.properties | xargs )
+          bash ci/set_kubectl_config-azure.sh molgenis-emx2-13.79.1-SNAPSHOT-all.jar molgenis-emx2-13.79.1-SNAPSHOT-all.jar
+          bash ci/create_or_update_k8s-azure.sh "preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}" ${TAG_NAME} true false
+
+    - run:
         name: Docker-Scout scanning on cve's, break on critical.
         command: |
           export $( cat build/ci.properties | xargs )
@@ -501,20 +508,9 @@ jobs:
 
   pr-preview:
     <<: *build_config
+    resource_class: small
 
     steps:
-    - pre_steps
-
-    - attach_workspace:
-        at: .
-
-    - run:
-        name: Start preview in limited resources mode
-        command: |
-          export $( cat build/ci.properties | xargs )
-          bash ci/set_kubectl_config-azure.sh molgenis-emx2-13.79.1-SNAPSHOT-all.jar molgenis-emx2-13.79.1-SNAPSHOT-all.jar
-          bash ci/create_or_update_k8s-azure.sh "preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}" ${TAG_NAME} true false
-
     - run:
         name: Wait for pr preview restart, poll every 10 seconds
         command: |
@@ -535,7 +531,6 @@ jobs:
     - run:
         name: message slack about preview
         command: |
-          export $( cat build/ci.properties | xargs )
           curl -d "token=${SLACK_TOKEN}" \
           -d "text=*<${CIRCLE_PULL_REQUEST}|Circle-CI » Molgenis » Molgenis-emx2 » PR-${CIRCLE_PULL_REQUEST##*/} #${CIRCLE_BUILD_NUM}>*
           PR Preview available on https://preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}.dev.molgenis.org" \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,7 @@ jobs:
         name: Start preview in limited resources mode
         command: |
           export $( cat build/ci.properties | xargs )
-          bash ci/set_kubectl_config-azure.sh molgenis-emx2-13.79.1-SNAPSHOT-all.jar molgenis-emx2-13.79.1-SNAPSHOT-all.jar
+          bash ci/set_kubectl_config-azure.sh
           bash ci/create_or_update_k8s-azure.sh "preview-emx2-pr-${CIRCLE_PULL_REQUEST##*/}" ${TAG_NAME} true false
 
     - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -656,6 +656,7 @@ workflows:
        requires:
          - test-apps
          - test-backend
+         - test-e2e
        filters:
          branches:
            only: master

--- a/apps/directory/src/components/Footer.vue
+++ b/apps/directory/src/components/Footer.vue
@@ -34,7 +34,7 @@
       >
         {{ session?.manifest.SpecificationVersion }}
       </a>
-      .
+      (git:{{ session?.manifest.ImplementationVersion }}).
       <span v-if="session?.manifest.DatabaseVersion">
         Database version: {{ session?.manifest.DatabaseVersion }}.
       </span>

--- a/apps/directory/src/components/Footer.vue
+++ b/apps/directory/src/components/Footer.vue
@@ -26,12 +26,7 @@
     </div>
     <div v-if="session?.manifest">
       Software version:
-      <a
-        :href="
-          'https://github.com/molgenis/molgenis-emx2/releases/tag/' +
-          session?.manifest.SpecificationVersion
-        "
-      >
+      <a :href="versionHref">
         {{ session?.manifest.SpecificationVersion }}
       </a>
       (git:{{ session?.manifest.ImplementationVersion }}).
@@ -43,9 +38,19 @@
 </template>
 
 <script setup lang="ts">
+import { computed } from "vue";
+
 const props = defineProps<{
   session?: any;
 }>();
+
+// A SNAPSHOT build has no release tag, so point those at the commit they were built from.
+const versionHref = computed(() => {
+  const manifest = props.session?.manifest;
+  return manifest?.SpecificationVersion?.includes("SNAPSHOT")
+    ? `https://github.com/molgenis/molgenis-emx2/commit/${manifest.ImplementationVersion}`
+    : `https://github.com/molgenis/molgenis-emx2/releases/tag/${manifest?.SpecificationVersion}`;
+});
 </script>
 
 <style scoped>

--- a/apps/molgenis-components/src/components/layout/Molgenis.vue
+++ b/apps/molgenis-components/src/components/layout/Molgenis.vue
@@ -46,7 +46,7 @@
           >
             {{ session.manifest.SpecificationVersion }}
           </a>
-          .
+          (git:{{ session.manifest.ImplementationVersion }}).
           <span v-if="session.manifest.DatabaseVersion">
             Database version: {{ session.manifest.DatabaseVersion }}.
           </span>

--- a/apps/molgenis-components/src/components/layout/Molgenis.vue
+++ b/apps/molgenis-components/src/components/layout/Molgenis.vue
@@ -38,12 +38,7 @@
       <MolgenisFooter v-else>
         <span v-if="session?.manifest">
           Software version:
-          <a
-            :href="
-              'https://github.com/molgenis/molgenis-emx2/releases/tag/' +
-              session.manifest.SpecificationVersion
-            "
-          >
+          <a :href="versionHref">
             {{ session.manifest.SpecificationVersion }}
           </a>
           (git:{{ session.manifest.ImplementationVersion }}).
@@ -141,6 +136,14 @@ const emit = defineEmits<{
 }>();
 
 const session = ref<Record<string, any> | null>(null);
+
+// A SNAPSHOT build has no release tag, so point those at the commit they were built from.
+const versionHref = computed(() => {
+  const manifest = session.value?.manifest;
+  return manifest?.SpecificationVersion?.includes("SNAPSHOT")
+    ? `https://github.com/molgenis/molgenis-emx2/commit/${manifest.ImplementationVersion}`
+    : `https://github.com/molgenis/molgenis-emx2/releases/tag/${manifest?.SpecificationVersion}`;
+});
 const logoURL = ref<string | null>(null);
 const timestamp = ref(Date.now());
 const analyticsId = ref<string | null>(null);

--- a/apps/molgenis-viz/src/components/layouts/PageFooterMolgenisCitation.vue
+++ b/apps/molgenis-viz/src/components/layouts/PageFooterMolgenisCitation.vue
@@ -4,7 +4,9 @@
       This database was created using
       <a href="https://www.molgenis.org/">MOLGENIS open source software</a>
       <span v-if="manifest.SpecificationVersion">
-        using version {{ manifest.SpecificationVersion }}</span
+        using version {{ manifest.SpecificationVersion }} (git:{{
+          manifest.ImplementationVersion
+        }})</span
       >
     </p>
   </div>

--- a/apps/tailwind-components/app/components/FooterVersion.vue
+++ b/apps/tailwind-components/app/components/FooterVersion.vue
@@ -18,7 +18,9 @@ const { data } = await $fetch("/api/graphql", {
 <template>
   <div class="mb-0 text-center lg:pb-5 text-title text-body-lg">
     <span v-if="data">
-      Software version: {{ data?._manifest.SpecificationVersion }}
+      Software version: {{ data?._manifest.SpecificationVersion }} (git:{{
+        data?._manifest.ImplementationVersion
+      }})
     </span>
   </div>
 </template>

--- a/ci/set_kubectl_config-azure.sh
+++ b/ci/set_kubectl_config-azure.sh
@@ -1,6 +1,3 @@
-KUBE_CLUSTER=$1
-KUBE_TOKEN=$2
-
 echo " logging in to azure with service principal and get kube config"
 az login --service-principal --tenant ${AZURE_SP_TENANT} -u ${AZURE_CLIENT_ID} -p ${AZURE_SECRET}
 az aks get-credentials -g ${RESOURCE_GROUP} -n ${RESOURCE_GROUP}


### PR DESCRIPTION
save some time by moving command to build preview step, and then start pr-preview polling (saving a minute waiting to boot

(I don't know why it was not like this in the first place).