### PR TITLE
fix(backend): stop TableMetadata.getSchemaName throwing NPE on a detached table 

### DIFF
--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -483,7 +483,7 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
   }
 
   protected String qualifiedTableName() {
-    if (getSchemaName() != null) {
+    if (getSchema() != null && getSchemaName() != null) {
       return getSchemaName() + "." + getTableName();
     }
     return getTableName();
@@ -523,6 +523,9 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
   }
 
   public String getSchemaName() {
+    if (getSchema() == null) {
+      throw new MolgenisException("Table '" + getTableName() + "' is not attached to a schema");
+    }
     return getSchema().getName();
   }
 

--- a/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTableMetadata.java
+++ b/backend/molgenis-emx2/src/test/java/org/molgenis/emx2/TestTableMetadata.java
@@ -192,6 +192,23 @@ class TestTableMetadata {
   }
 
   @Test
+  void detachedTableRequireInheritedTableThrowsMolgenisExceptionNotNpe() {
+    TableMetadata detached = table("Employee").setInheritName("Contact");
+
+    MolgenisException exception =
+        assertThrows(MolgenisException.class, detached::requireInheritedTable);
+
+    assertTrue(exception.getMessage().contains("cannot inherit"));
+  }
+
+  @Test
+  void detachedTableGetSchemaNameThrowsMolgenisException() {
+    TableMetadata detached = table("Employee");
+
+    assertThrows(MolgenisException.class, detached::getSchemaName);
+  }
+
+  @Test
   void testRetrieveColumnByIdentifier() {
     SchemaMetadata schema = new SchemaMetadata("schema name");
 


### PR DESCRIPTION
so sonar stops complaining on master build