### PR TITLE
fix: revert "fix(scripts): use `uv` for Python tasks (#6397)"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,7 +20,7 @@ orbs:
 definitions:
   build_config: &build_config
     docker:
-    - image: molgenis/ci-build:1.6.4
+    - image: molgenis/ci-build:1.6.3
     working_directory: ~/repo
     resource_class: large
     environment:
@@ -29,7 +29,7 @@ definitions:
       TERM: dumb
   test_config: &test_config
     docker:
-    - image: molgenis/ci-build:1.6.4
+    - image: molgenis/ci-build:1.6.3
     - image: postgres:15-alpine
       environment:
         POSTGRES_USER: postgres
@@ -43,7 +43,7 @@ definitions:
       TERM: dumb
   release_config: &release_config
     docker:
-      - image: molgenis/ci-build:1.6.4
+      - image: molgenis/ci-build:1.6.3
     working_directory: ~/repo
     resource_class: large
     environment:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,9 @@
 FROM eclipse-temurin:21-jre-noble
 
-RUN apt update && \
-    apt install -y --no-install-recommends python3 pipx && \
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends python3 python3-pip python3-venv && \
     rm -rf /var/lib/apt/lists/* && \
     useradd -m molgenis
-
 
 COPY --link build/docker/deps/ /app/lib/
 COPY --link build/docker/app/ /app/lib/
@@ -13,8 +12,6 @@ COPY --link custom-app /app/lib/custom-app
 ENV CUSTOM_APP_PATH="/app/lib/custom-app"
 
 USER molgenis
-RUN pipx ensurepath && pipx install uv
-RUN pipx run uv --version
 EXPOSE 8080
 ENTRYPOINT ["java"]
 CMD ["-cp", "/app/lib/*", "org.molgenis.emx2.RunMolgenisEmx2"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -28,11 +28,8 @@ steps:
   fetchDepth: 0
   fetchTags: true
 - script: |
-    sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt-get update &&  sudo apt-get install postgresql-client python3.10 pipx -y
+    sudo add-apt-repository ppa:deadsnakes/ppa && sudo apt-get update &&  sudo apt-get install postgresql-client python3.10 python3.10-venv -y
   displayName: postgresql client python3
-- script: |
-    pipx ensurepath && pipx install uv
-  displayName: install uv
 - script: |
     psql -h localhost -p 5432 -U postgres < .circleci/initdb.sql
   displayName: initialize database

--- a/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/main/java/org/molgenis/emx2/tasks/ScriptTask.java
@@ -166,16 +166,70 @@ public class ScriptTask extends Task {
     Path tempScriptFile = Files.createFile(tempDir.resolve("script.py"));
     script = script.replace("${jobId}", this.getId());
     Files.writeString(tempScriptFile, this.script);
+    Path requirementsFile = Files.createFile(tempDir.resolve("requirements.txt"));
+    Files.writeString(requirementsFile, this.dependencies != null ? this.dependencies : "");
 
     if (this.extraFile != null && this.extraFile.get(EXTRA_FILE) != null) {
-      writeExtraFiles(tempDir);
+      String extraFileName = this.extraFile.get(EXTRA_FILE_FILENAME).toString();
+      List<String> forbiddenFiles = Arrays.asList("venv.zip", "requirements.txt", "script.py");
+      if (forbiddenFiles.contains(extraFileName)) {
+        throw new MolgenisException(
+            "Invalid file name '"
+                + extraFileName
+                + "'. "
+                + "Ensure the name of the extra file is not any of 'script.py', 'requirements.txt', or 'venv.zip'.");
+      }
+      byte[] extraFileContent = (byte[]) this.extraFile.get(EXTRA_FILE_CONTENTS);
+      Object extraFileExtension = this.extraFile.get(EXTRA_FILE_EXTENSION);
+      Path extraFilePath = tempDir.resolve(extraFileName);
+      checkForZipSlip(tempDir, extraFilePath.toFile());
+
+      try (FileOutputStream fos = new FileOutputStream(extraFilePath.toFile())) {
+        fos.write(extraFileContent);
+      }
+      if (extraFileExtension != null && extraFileExtension.toString().equalsIgnoreCase("zip")) {
+        try (ZipInputStream zis = new ZipInputStream(new FileInputStream(extraFilePath.toFile()))) {
+          byte[] buffer = new byte[1024];
+          ZipEntry entry;
+          while ((entry = zis.getNextEntry()) != null) {
+            File newFile = new File(tempDir.toFile(), entry.getName());
+            checkForZipSlip(tempDir, newFile);
+
+            if (entry.isDirectory()) {
+              newFile.mkdirs();
+            } else {
+              new File(newFile.getParent()).mkdirs();
+              try (FileOutputStream fos = new FileOutputStream(newFile)) {
+                int length;
+                while ((length = zis.read(buffer)) > 0) {
+                  fos.write(buffer, 0, length);
+                }
+              }
+            }
+          }
+        }
+      }
     }
 
-    String requirementsString =
-        this.dependencies != null ? "--with '" + this.dependencies.replace('\n', ',') + "'" : "";
+    // define commands (given tempDir as working directory)
+    String createVenvCommand = "python3 -m venv venv";
+    String activateCommand = "source venv/bin/activate";
+    String pipUpgradeCommand = "pip3 install --upgrade pip";
+    String installRequirementsCommand =
+        "pip3 install -r requirements.txt --quiet"; // don't check upgrade
+    String runScriptCommand = "python3 -u script.py";
     String escapedParameters = " " + escapeXSI(this.parameters);
 
-    return "pipx run uv run " + requirementsString + " script.py" + escapedParameters;
+    return createVenvCommand
+        + " && "
+        + activateCommand
+        + " && "
+        + pipUpgradeCommand
+        + " && "
+        + installRequirementsCommand
+        + " && "
+        + runScriptCommand
+        + escapedParameters;
   }
 
   /**
@@ -186,52 +240,6 @@ public class ScriptTask extends Task {
     if (!newFile.getCanonicalPath().startsWith(tempDir.toFile().getCanonicalPath())) {
       throw new MolgenisException(
           "ZIP archive contains files with illegal path: " + newFile.getCanonicalPath());
-    }
-  }
-
-  private void writeExtraFiles(Path tempDir) throws IOException {
-    String extraFileName = this.extraFile.get(EXTRA_FILE_FILENAME).toString();
-    if (Objects.equals(extraFileName, "script.py")) {
-      throw new MolgenisException("Extra file name cannot be 'script.py'.");
-    }
-    byte[] extraFileContent = (byte[]) this.extraFile.get(EXTRA_FILE_CONTENTS);
-    Object extraFileExtension = this.extraFile.get(EXTRA_FILE_EXTENSION);
-    Path extraFilePath = tempDir.resolve(extraFileName);
-    checkForZipSlip(tempDir, extraFilePath.toFile());
-
-    try (FileOutputStream fos = new FileOutputStream(extraFilePath.toFile())) {
-      fos.write(extraFileContent);
-    }
-    if (extraFileExtension != null && extraFileExtension.toString().equalsIgnoreCase("zip")) {
-      unpackZipFile(tempDir, extraFilePath);
-    }
-  }
-
-  private void unpackZipFile(Path tempDir, Path extraFilePath) throws IOException {
-    try (ZipInputStream zis = new ZipInputStream(new FileInputStream(extraFilePath.toFile()))) {
-      byte[] buffer = new byte[1024];
-      ZipEntry entry;
-      while ((entry = zis.getNextEntry()) != null) {
-        File newFile = new File(tempDir.toFile(), entry.getName());
-        checkForZipSlip(tempDir, newFile);
-
-        if (entry.isDirectory()) {
-          if (!newFile.isDirectory() && !newFile.mkdirs()) {
-            throw new MolgenisException("Failed to unpack attachment ZIP file.");
-          }
-        } else {
-          File parent = newFile.getParentFile();
-          if (!parent.isDirectory() && !parent.mkdirs()) {
-            throw new MolgenisException("Failed to unpack attachment ZIP file.");
-          }
-          try (FileOutputStream fos = new FileOutputStream(newFile)) {
-            int length;
-            while ((length = zis.read(buffer)) > 0) {
-              fos.write(buffer, 0, length);
-            }
-          }
-        }
-      }
     }
   }
 

--- a/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
+++ b/backend/molgenis-emx2-tasks/src/test/java/org/molgenis/emx2/tasks/TestScriptTask.java
@@ -146,31 +146,23 @@ print('unreachable')
 
     ClassLoader classLoader = getClass().getClassLoader();
     Path path =
-        new File(Objects.requireNonNull(classLoader.getResource("TestScriptTaskFail")).getFile())
+        new File(Objects.requireNonNull(classLoader.getResource("TestScriptTask")).getFile())
             .toPath();
     ImportDirectoryTask importDirectoryTask = new ImportDirectoryTask(path, schema, false);
     importDirectoryTask.run();
 
-    Task fileFailTask =
+    Task venvTask =
         taskService.getTask(
-            taskService.submit(taskService.getScript("Filename fail test").parameters("")));
-    TaskStatus fileFailTaskStatus = fileFailTask.getStatus();
-    while (fileFailTaskStatus != COMPLETED && fileFailTaskStatus != ERROR) {
+            taskService.submit(taskService.getScript("Invalid filename test").parameters("")));
+    TaskStatus venvTaskStatus = venvTask.getStatus();
+    while (venvTaskStatus != COMPLETED && venvTaskStatus != ERROR) {
       Thread.sleep(1000);
-      fileFailTaskStatus = fileFailTask.getStatus();
+      venvTaskStatus = venvTask.getStatus();
     }
-    assertEquals(ERROR, fileFailTask.getStatus());
-    assertTrue(fileFailTask.getDescription().contains("Extra file name cannot be 'script.py'."));
-
-    Task emptyScriptFailTask =
-        taskService.getTask(
-            taskService.submit(taskService.getScript("Empty script test").parameters("")));
-    TaskStatus emptyScriptFailTaskStatus = emptyScriptFailTask.getStatus();
-    while (emptyScriptFailTaskStatus != COMPLETED && emptyScriptFailTaskStatus != ERROR) {
-      Thread.sleep(1000);
-      emptyScriptFailTaskStatus = emptyScriptFailTask.getStatus();
-    }
-    assertEquals(ERROR, emptyScriptFailTask.getStatus());
-    assertTrue(emptyScriptFailTask.getDescription().contains("Script is required"));
+    assertTrue(
+        venvTask
+            .getDescription()
+            .contains(
+                "Script failed: Invalid file name 'venv.zip'. Ensure the name of the extra file is not any of 'script.py', 'requirements.txt', or 'venv.zip'."));
   }
 }

--- a/backend/molgenis-emx2-tasks/src/test/resources/TestScriptTaskFail/Scripts.csv
+++ b/backend/molgenis-emx2-tasks/src/test/resources/TestScriptTaskFail/Scripts.csv
@@ -1,5 +1,0 @@
-name,type,script,dependencies,extraFile,extraFile_filename,outputFileExtension,disabled,failureAddress,cron,mg_draft
-Filename fail test,python,"""""""
-                          Empty script.
-                          """"""",,script,script.py,,,,,
-Empty script test,python,,,,,,,,,

--- a/backend/molgenis-emx2-tasks/src/test/resources/TestScriptTaskFail/_files/script.py
+++ b/backend/molgenis-emx2-tasks/src/test/resources/TestScriptTaskFail/_files/script.py
@@ -1,3 +1,0 @@
-"""
-Dummy Python file for testing purposes.
-"""

--- a/ci-build-images/Dockerfile
+++ b/ci-build-images/Dockerfile
@@ -1,21 +1,18 @@
 # docker file for the ci
 # to build and publish (n.b. on apple silicon you need to set --platform)
-# docker buildx build -t molgenis/ci-build:x.y.z --platform linux/amd64 .
-# docker push molgenis/ci-build:x.y.z
+# docker buildx build -t molgenis/ci-build:1.2.2 --platform linux/amd64 .
+# docker push molgenis/ci-build:1.2.2
 
 FROM gradle:jdk21-noble
 RUN useradd -m molgenis
 
-# Python
-RUN apt update && apt install vim python3 pipx -y
-RUN pipx ensurepath && pipx install uv
+RUN apt-get update && apt-get install vim python3 python3-venv python3-pip python3-setuptools python3-setuptools-whl -y
+RUN python3 -m pip config set global.break-system-packages true
 RUN python3 --version
-RUN pipx run uv --version
-
 
 ENV NODE_VERSION=24.19.0
 RUN apt install -y curl
-USER molgenis
+USER molgenis 
 RUN curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.5/install.sh | bash
 ENV NVM_DIR=/home/molgenis/.nvm
 RUN . "$NVM_DIR/nvm.sh" && nvm install ${NODE_VERSION}
@@ -32,7 +29,7 @@ RUN corepack enable
 RUN corepack prepare pnpm@latest --activate
 RUN pnpm --version
 
-USER root
+USER root 
 
 
 RUN apt update
@@ -42,7 +39,7 @@ RUN install -m 0755 -d /etc/apt/keyrings
 ##docker
 RUN curl -sSL https://get.docker.com/ | sh
 RUN mkdir ~/.docker
-RUN curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s
+RUN curl -sSfL https://raw.githubusercontent.com/docker/scout-cli/main/install.sh | sh -s 
 
 # kubectl
 RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl
@@ -55,6 +52,7 @@ RUN curl -fsSL https://get.helm.sh/helm-v3.14.4-linux-amd64.tar.gz \
  && mv linux-amd64/helm /usr/local/bin/helm \
  && chmod +x /usr/local/bin/helm \
  && rm -rf linux-amd64
+#
 
 # Azure CLI Tools
 RUN mkdir -p /etc/apt/keyrings
@@ -68,6 +66,6 @@ RUN apt-get install azure-cli -y
 RUN apt-get install postgresql-client -y
 
 # GemTools & FPM For debian and redhat packages
-RUN apt-get install ruby-dev -y
+RUN apt-get install ruby-dev -y 
 RUN gem install fpm
 USER molgenis


### PR DESCRIPTION
This reverts commit 634fc8b9cf5d2573f5ec2a9342fdf2676e54c32b.

### What are the main changes you did

After #6397 EMX2 would now require `pipx` to be installed, which can not be guaranteed. Therefore the decision was made to rollback this change.



By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
