### PR TITLE
fix(cms): increase clickable spaces in page gallery action elements

### DIFF
--- a/apps/tailwind-components/app/components/cms/gallery/PageGalleryCard.vue
+++ b/apps/tailwind-components/app/components/cms/gallery/PageGalleryCard.vue
@@ -89,14 +89,18 @@ async function deletePage() {
         <PageGalleryCardAction v-tooltip.bottom="`Edit`">
           <NuxtLink
             :to="setCmsEditorUrl(schema, (container.mg_tableclass as string), container.name)"
-            class="hover:underline cursor-pointer"
+            class="hover:underline cursor-pointer h-10 w-10 p-2.5"
           >
             <BaseIcon name="Edit" :width="18" />
             <span class="sr-only">edit page</span>
           </NuxtLink>
         </PageGalleryCardAction>
         <PageGalleryCardAction v-tooltip.bottom="`Delete`">
-          <button id="deletePage" @click="showDeleteModal = true">
+          <button
+            id="deletePage"
+            @click="showDeleteModal = true"
+            class="hover:underline cursor-pointer h-10 w-10 p-2.5"
+          >
             <BaseIcon name="Trash" :width="18" />
             <span class="sr-only">delete page</span>
           </button>

--- a/apps/tailwind-components/app/components/cms/gallery/PageGalleryCardAction.vue
+++ b/apps/tailwind-components/app/components/cms/gallery/PageGalleryCardAction.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="p-2.5 h-10 w-10 flex justify-center items-center border border-transparent rounded-full hover:bg-button-primary-hover hover:text-button-primary-hover hover:border-button-primary-hover"
+    class="flex justify-center items-center border border-transparent rounded-full hover:bg-button-primary-hover hover:text-button-primary-hover hover:border-button-primary-hover"
   >
     <slot></slot>
   </div>

--- a/apps/tailwind-components/app/components/cms/gallery/PageSelector.vue
+++ b/apps/tailwind-components/app/components/cms/gallery/PageSelector.vue
@@ -1,6 +1,6 @@
 <template>
   <div
-    class="border-2 border-default p-7.5 text-title-contrast rounded-base has-[>input:checked]:border-button-primary has-[>input:checked]:bg-button-secondary"
+    class="border-2 border-default text-title-contrast rounded-base has-[>input:checked]:border-button-primary has-[>input:checked]:bg-button-secondary"
   >
     <slot></slot>
   </div>

--- a/apps/ui/app/pages/[schema]/pages/index.vue
+++ b/apps/ui/app/pages/[schema]/pages/index.vue
@@ -225,13 +225,16 @@ function closeStatusModal() {
               v-model="pageType"
             />
             <div class="group">
-              <label for="LandingPageInput" class="hover:cursor-pointer">
+              <label
+                for="LandingPageInput"
+                class="block hover:cursor-pointer p-7.5"
+              >
                 <BaseIcon name="Docs" :width="32" />
                 <span class="font-bold">Landing page</span>
-                <p id="LandingPageDefinition">
+                <span class="block" id="LandingPageDefinition">
                   Create a generic page to display general information such as
                   an contact page or a home page.
-                </p>
+                </span>
               </label>
             </div>
           </PageSelector>
@@ -245,13 +248,16 @@ function closeStatusModal() {
               class="sr-only"
               v-model="pageType"
             />
-            <label for="DeveloperPageInput" class="hover:cursor-pointer">
+            <label
+              for="DeveloperPageInput"
+              class="block p-7.5 hover:cursor-pointer"
+            >
               <BaseIcon name="CodeBlocks" :width="32" />
               <span class="font-bold">Developer page</span>
-              <p id="DeveloperPageDefinition">
+              <span class="block" id="DeveloperPageDefinition">
                 Build your own page from scratch using HTML, CSS, and
                 JavaScript.
-              </p>
+              </span>
             </label>
           </PageSelector>
         </fieldset>


### PR DESCRIPTION
### What are the main changes you did

This PR addresses a few issues raised in the [page delete PR](https://github.com/molgenis/GCC/issues/3480). 

- [x] Gallery cards: increase clickable area in card action buttons
- [x] Page selector menu: maximise clickable space in page type inputs

#### Original request

> - in 'Page selector' the 'Landing page' and 'Developer page' buttons have some deadzones. I think the whole button needs to be clickable
> - On the 'pages' overview the edit and delete button only work if clicking on the icon, not if you click on the blue circle around it.

### How to test

- Go to the preview and sign in as admin
- Go to the page gallery: `/apps/ui/cms/pages`
- Hover on a card's edit or delete button. This is now clickable anywhere
- Click the "Add new page" button
- Select a page: try clicking as close to the edge as possible. It should now be clickable
- Compare with master

### Checklist

- [x] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [x] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
