### PR TITLE
perf(ci): stop test-e2e gating release, so a merge publishes in half the time

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -735,7 +735,6 @@ workflows:
        requires:
          - test-apps
          - test-backend
-         - test-e2e
        filters:
          branches:
            only: master


### PR DESCRIPTION
meaning developers should judge if their PR should be fully up to date or if a small difference wth master is ok