### PR TITLE
fix(cms): added view page link in the breadcrumbs

### DIFF
--- a/apps/ui/app/pages/[schema]/pages/[page]/configure.vue
+++ b/apps/ui/app/pages/[schema]/pages/[page]/configure.vue
@@ -27,7 +27,8 @@ const pageData = ref(await getPage(schema as string, page));
 const crumbs: Crumb[] = [
   { label: schema as string, url: `/${schema}` },
   { label: "Pages", url: `/${schema}/pages` },
-  { label: page as string, url: "" },
+  { label: page as string, url: `/${schema}/pages/${page}` },
+  { label: "edit", url: "" },
 ];
 
 const { isAdmin, session } = await useSession(schema);


### PR DESCRIPTION
### What are the main changes you did

In this PR, I fixed the breadcrumbs navigation to allow quick navigation between viewing and editing modes. This includes-

- [x] allow the page breadcrumb to redirect users to `/cms/pages/<page>`
- [x] the final element in the breadcrumbs is the current page (i.e., "edit" or the name of the page) 

This PR is part of molgenis/GCC#1143

### How to test

- Go to the preview and sign in as admin
- Go to the page gallery: `/apps/ui/cms/pages`
- Click the edit button for any of the pages. View the breadcrumbs. It should now read as-

```txt
cms  >  pages >  <page>  >  Edit
```

- Click the `<page>` link to go to enter view mode
- Compare with master

### Checklist

- [x] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [x] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
