### PR TITLE
fix(cranio): change CLP Level 1 primary categories

### DIFF
--- a/apps/cranio-provider/src/types/index.ts
+++ b/apps/cranio-provider/src/types/index.ts
@@ -25,7 +25,7 @@ export interface IValueLabel {
 }
 
 export interface ICleftTypes {
-  "All patients": number;
+  All: number;
   CL: number;
   CP: number;
   CLA: number;

--- a/apps/cranio-provider/src/views/cleft_lip_palate/level_1.vue
+++ b/apps/cranio-provider/src/views/cleft_lip_palate/level_1.vue
@@ -12,14 +12,14 @@ import type { IAppPage, ISiteErnCleftTypeCounts } from "../../types";
 const props = defineProps<IAppPage>();
 const patientsByCleftType = ref<ISiteErnCleftTypeCounts>({
   center: {
-    "All patients": 0,
+    All: 0,
     CL: 0,
     CP: 0,
     CLA: 0,
     CLAP: 0,
   },
   ern: {
-    "All patients": 0,
+    All: 0,
     CL: 0,
     CP: 0,
     CLA: 0,
@@ -59,8 +59,8 @@ async function getData() {
     });
 
     patientsByCleftType.value.center = Object.fromEntries(centerCountValues);
-    patientsByCleftType.value.center["All patients"] = totalCountAtCenter
-      .dataPoints?.[0]?.value as number;
+    patientsByCleftType.value.center["All"] = totalCountAtCenter.dataPoints?.[0]
+      ?.value as number;
   }
 
   if (ernCounts.dataPoints && totalCountInErn.dataPoints) {
@@ -68,8 +68,8 @@ async function getData() {
       return [row.name, row.value];
     });
     patientsByCleftType.value.ern = Object.fromEntries(ernCountValues);
-    patientsByCleftType.value.ern["All patients"] = totalCountInErn
-      .dataPoints?.[0]?.value as number;
+    patientsByCleftType.value.ern["All"] = totalCountInErn.dataPoints?.[0]
+      ?.value as number;
   }
 }
 


### PR DESCRIPTION
### What are the main changes you did

This PR fixes the chart titles for the CLP Level 1 template. As it stands in production now, we have a category for "All patients", but the title also has "patients" in it. As a result, we get "All patients patients". Since these are defined in the typescript, we cannot update the labels in the dataset. This PR safely updates the categories, filters, and titles.

- [x] Update typescript interface
- [x] Adjust data handling steps (replace "All patients" with "All")
- [x] Update demo data (stored in google drive)

### How to test

- Go to the preview
- Click on the AT1 schema
- Go to the Cleft Lip and Palate Level 1 Template
- Observe the new filter ("All") and chart titles (should now read: "All patients ..." instead of "All patients patients...")

### Checklist

- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
