### PR TITLE
fix(cms): updated paragraph is centered prop in older views

### DIFF
--- a/apps/tailwind-components/app/components/cms/PageComponent.vue
+++ b/apps/tailwind-components/app/components/cms/PageComponent.vue
@@ -200,7 +200,7 @@ async function handleMoveEvent(action: "up" | "down" | "grab" | "release") {
     v-else-if="mg_tableclass.endsWith('.Paragraphs')"
     class="mb-2.5 last:mb-0"
     :id="component.id"
-    :paragraph-is-centered="component.paragraphIsCentered"
+    :paragraphIsCentered="component.paragraphIsCentered"
     :text="parsePageText(component.text)"
     :isEditable="editingIsEnabled"
     @edit="showEditModal = true"

--- a/apps/tailwind-components/app/pages/cms/Paragraph.story.vue
+++ b/apps/tailwind-components/app/pages/cms/Paragraph.story.vue
@@ -13,7 +13,7 @@ import TextParagraph from "../../components/cms/Paragraph.vue";
     />
     <TextParagraph
       id="paragraph-centered"
-      :is-centered="true"
+      :paragraphIsCentered="true"
       text="<strong>This a centered paragraph</strong>. Ex culpa minim irure sunt ut
       dolor laborum tempor consequat cupidatat laboris. Duis veniam esse
       deserunt dolor exercitation culpa reprehenderit. Exercitation eiusmod est


### PR DESCRIPTION
### What are the main changes you did

The purpose of this PR is to fix the `paragraphIsCentered` prop. In some of the older views (specifically the stories), the old prop name is used `is-centered`; as a result, the paragraph is not centered.

- [x] Change prop name in the paragraph.story

This PR is part of molgenis/GCC#1143

### How to test

- Go to the preview and go to the tailwind-components gallery
- Click on the CmsParagraph story
- One paragraph should be centered and the other should not

### Checklist

- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [ ] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
