### PR TITLE
feat: graphql database implementation

### DIFF
--- a/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/endpoints/filteringterms/FilteringTermsFetcher.java
+++ b/backend/molgenis-emx2-beacon-v2/src/main/java/org/molgenis/emx2/beaconv2/endpoints/filteringterms/FilteringTermsFetcher.java
@@ -67,7 +67,8 @@ public class FilteringTermsFetcher {
       String schemaName, String tableToQuery, Collection<String> tableNamesInSchema) {
     Set<FilteringTerm> filteringTerms = new HashSet<>();
     if (tableNamesInSchema.contains(tableToQuery)) {
-      TableMetadata metadata = database.getSchema(schemaName).getTable(tableToQuery).getMetadata();
+      TableMetadata metadata =
+          database.getSchemaMetadata(schemaName).getTableMetadata(tableToQuery);
       // todo: now extended columns are ignored because make the query super complicated
       for (Column column : metadata.getLocalColumns()) {
         if (column.getColumnType().isAtomicType() && !column.getIdentifier().startsWith("mg_")) {

--- a/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/client/GraphqlDatabase.java
+++ b/backend/molgenis-emx2-fairmapper/src/main/java/org/molgenis/emx2/fairmapper/client/GraphqlDatabase.java
@@ -1,0 +1,344 @@
+package org.molgenis.emx2.fairmapper.client;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.*;
+import java.util.function.Supplier;
+import org.molgenis.emx2.*;
+import org.molgenis.emx2.json.JsonUtil;
+
+public class GraphqlDatabase implements Database {
+
+  private static final String SCHEMAS_FIELD = "_schemas";
+  private static final JsonMapper MAPPER = new JsonMapper();
+
+  private final GraphqlClient client;
+
+  public GraphqlDatabase(GraphqlClient client) {
+    this.client = client;
+  }
+
+  @Override
+  public void tx(Transaction transaction) {
+    transaction.run(this);
+  }
+
+  @Override
+  public void init() {
+    // no-op
+  }
+
+  @Override
+  public Schema createSchema(String name) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Schema createSchema(String name, String description) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Schema updateSchema(String name, String description) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Schema dropCreateSchema(String name) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Schema dropCreateSchema(String name, String description) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void dropSchemaIfExists(String name) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void dropSchema(String name) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Collection<String> getSchemaNames() {
+    String query = readFile("schema-names-query.graphql");
+    JsonNode result = client.sendQuery(query);
+
+    if (!result.has(SCHEMAS_FIELD)) {
+      throw new MolgenisException("No schema returned in graphql response: " + result);
+    }
+
+    return result.get(SCHEMAS_FIELD).valueStream().map(node -> node.get("name").asText()).toList();
+  }
+
+  @Override
+  public Collection<SchemaInfo> getSchemaInfos() {
+    String query = readFile("schema-info-query.graphql");
+    JsonNode result = client.sendQuery(query);
+
+    if (!result.has(SCHEMAS_FIELD)) {
+      throw new MolgenisException("No schema returned in graphql response: " + result);
+    }
+
+    try {
+      return MAPPER.readerForListOf(SchemaInfo.class).readValue(result.get(SCHEMAS_FIELD));
+    } catch (IOException e) {
+      throw new MolgenisException("Unable to map schema infos from graphql response", e);
+    }
+  }
+
+  @Override
+  public SchemaInfo getSchemaInfo(String schemaName) {
+    return getSchemaInfos().stream()
+        .filter(schemaInfo -> schemaInfo.tableSchema().equals(schemaName))
+        .findFirst()
+        .orElse(null);
+  }
+
+  @Override
+  public Schema getSchema(String name) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public SchemaMetadata getSchemaMetadata(String schemaName) {
+    String query = readFile("schema-query.graphql");
+    JsonNode result = client.sendSchemaQuery(schemaName, query);
+    if (!result.has("_schema")) {
+      throw new MolgenisException("No schema returned in graphql response: " + result);
+    }
+
+    try {
+      SchemaMetadata schema = JsonUtil.jsonToSchema(result.get("_schema").toString());
+      schema.setDatabase(this);
+      schema.setName(schemaName);
+      return schema;
+    } catch (IOException e) {
+      throw new MolgenisException("Unable to map query result to SchemaMetaData", e);
+    }
+  }
+
+  @Override
+  public List<Table> getTablesFromAllSchemas(String tableId) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public User addUser(String name) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public boolean checkUserPassword(String name, String password) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void setUserPassword(String name, String password) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public boolean hasUser(String user) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public List<User> getUsers(int limit, int offset) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void removeUser(String name) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void setEnabledUser(String name, boolean enabled) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void setAdminUser(String name, boolean admin) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void setActiveUser(String username) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public String getActiveUser() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void clearActiveUser() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void grantCreateSchema(String user) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void setListener(DatabaseListener listener) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public DatabaseListener getListener() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public boolean inTx() {
+    return false;
+  }
+
+  @Override
+  public void clearCache() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Integer getDatabaseVersion() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public int countUsers() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public String getAdminUserName() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public boolean isAdmin() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void becomeAdmin() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public boolean isOidcEnabled() {
+    return false;
+  }
+
+  @Override
+  public boolean hasSchema(String catalogueOntologies) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public User getUser(String userName) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void saveUser(User user) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public boolean isAnonymous() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Database setBindings(Map<String, Supplier<Object>> bindings) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Map<String, Supplier<Object>> getJavaScriptBindings() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public List<LastUpdate> getLastUpdated() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public List<Member> loadUserRoles() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void revokeRoles(String userName, List<Map<String, String>> revokedRoles) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public void updateRoles(String userName, List<Map<String, String>> roles) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public String resolveJwtSharedSecret() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Database clearSettings() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Database setSettings(Map<String, String> settings) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Database removeSetting(String key) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Database setSetting(String key, String value) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public String getSetting(String key) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Map<String, String> getSettings() {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Database changeSettings(Map<String, String> settings) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  @Override
+  public Optional<String> findSettingValue(String cssURL) {
+    throw new UnsupportedOperationException("Unsupported");
+  }
+
+  private String readFile(String fileName) {
+    try (InputStream inputStream = GraphqlDatabase.class.getResourceAsStream(fileName)) {
+      return new String(Objects.requireNonNull(inputStream).readAllBytes());
+    } catch (IOException e) {
+      throw new MolgenisException("Unable to read query from file: " + fileName, e);
+    }
+  }
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/client/schema-info-query-by-name.graphql
+++ b/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/client/schema-info-query-by-name.graphql
@@ -1,0 +1,6 @@
+query {
+    _schemas {
+        tableSchema: name
+        description
+    }
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/client/schema-info-query.graphql
+++ b/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/client/schema-info-query.graphql
@@ -1,0 +1,6 @@
+query {
+    _schemas {
+        tableSchema: name
+        description
+    }
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/client/schema-names-query.graphql
+++ b/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/client/schema-names-query.graphql
@@ -1,0 +1,5 @@
+query {
+    _schemas {
+        name
+    }
+}

--- a/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/client/schema-query.graphql
+++ b/backend/molgenis-emx2-fairmapper/src/main/resources/org/molgenis/emx2/fairmapper/client/schema-query.graphql
@@ -1,0 +1,72 @@
+query {
+    _schema {
+        name
+        tables {
+            schemaId
+            name
+            label
+            description
+            inheritId
+            inheritName
+            inheritSchemaName
+            semantics
+            id
+            tableType
+            labels {
+                locale
+                value
+            }
+            descriptions {
+                locale
+                value
+            }
+            columns {
+                table
+                id
+                name
+                label
+                section
+                heading
+                description
+                formLabel
+                key
+                required
+                readonly
+                defaultValue
+                refSchemaId
+                refSchemaName
+                refTableId
+                refTableName
+                refLinkId
+                refLinkName
+                refBackId
+                refBackName
+                refLabel
+                refLabelDefault
+                position
+                validation
+                visible
+                computed
+                labels {
+                    locale
+                    value
+                }
+                descriptions {
+                    locale
+                    value
+                }
+                columnType
+                semantics
+                inherited
+            }
+            settings {
+                key
+                value
+            }
+        }
+        settings {
+            key
+            value
+        }
+    }
+}

--- a/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/client/GraphqlDatabaseTest.java
+++ b/backend/molgenis-emx2-fairmapper/src/test/java/org/molgenis/emx2/fairmapper/client/GraphqlDatabaseTest.java
@@ -1,0 +1,103 @@
+package org.molgenis.emx2.fairmapper.client;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.molgenis.emx2.*;
+import org.molgenis.emx2.sql.JWTgenerator;
+import org.molgenis.emx2.web.ApiTestBase;
+
+class GraphqlDatabaseTest extends ApiTestBase {
+
+  private static final String SCHEMA_NAME = GraphqlDatabaseTest.class.getSimpleName();
+
+  private GraphqlDatabase graphqlDatabase;
+  private SchemaMetadata schema;
+
+  @BeforeEach
+  void setupSchema() {
+    String token = JWTgenerator.createTemporaryToken(database);
+    GraphqlClient client = new GraphqlClient("http://localhost:" + port, token);
+    graphqlDatabase = new GraphqlDatabase(client);
+
+    schema = database.dropCreateSchema(SCHEMA_NAME, "GraphQL Database test schema").getMetadata();
+  }
+
+  @Test
+  void shouldGetSchemaNames() {
+    assertTrue(graphqlDatabase.getSchemaNames().contains(SCHEMA_NAME));
+  }
+
+  @Test
+  void shouldGetSchemaInfos() {
+    assertTrue(
+        graphqlDatabase
+            .getSchemaInfos()
+            .contains(new SchemaInfo(SCHEMA_NAME, "GraphQL Database test schema")));
+  }
+
+  @Test
+  void shouldGetSchemaInfoByName() {
+    assertNull(graphqlDatabase.getSchemaInfo("non-existent-schema"));
+    assertEquals(
+        new SchemaInfo(SCHEMA_NAME, "GraphQL Database test schema"),
+        graphqlDatabase.getSchemaInfo(SCHEMA_NAME));
+  }
+
+  @Nested
+  class SchemaMetaDataTest {
+
+    @BeforeEach
+    void setupSchema() {
+      schema.create(
+          new TableMetadata("Product")
+              .add(
+                  Column.column("id", ColumnType.INT).setPkey(),
+                  Column.column("name", ColumnType.STRING)),
+          new TableMetadata("Order")
+              .add(
+                  Column.column("id", ColumnType.INT).setPkey(),
+                  Column.column("products", ColumnType.REF_ARRAY).setRefTable("Product")));
+    }
+
+    /** One fails because the schema is cached? */
+    @Test
+    void shouldGetSchemaMetaData() {
+      SchemaMetadata retrieved = graphqlDatabase.getSchemaMetadata(SCHEMA_NAME);
+      org.molgenis.emx2.json.Schema actual = new org.molgenis.emx2.json.Schema(retrieved);
+      org.molgenis.emx2.json.Schema expected = new org.molgenis.emx2.json.Schema(schema);
+
+      assertEquals(expected, actual);
+    }
+
+    @Test
+    void shouldHandleCrossSchemaReferences() {
+      String refSchemaName = SCHEMA_NAME + "_ref";
+      Schema refSchema = database.dropCreateSchema(refSchemaName);
+      TableMetadata supplier =
+          refSchema
+              .create(
+                  TableMetadata.table("Supplier")
+                      .add(Column.column("name", ColumnType.STRING).setPkey()))
+              .getMetadata();
+
+      schema
+          .getTableMetadata("Product")
+          .add(
+              Column.column("supplier", ColumnType.REF)
+                  .setRefSchemaName(refSchemaName)
+                  .setRefTable("Supplier"));
+
+      SchemaMetadata schemaMetadata = graphqlDatabase.getSchemaMetadata(SCHEMA_NAME);
+      TableMetadata product = schemaMetadata.getTableMetadata("Product");
+
+      TableMetadata ref = product.getColumn("supplier").getRefTable();
+      org.molgenis.emx2.json.Table actual = new org.molgenis.emx2.json.Table(ref);
+
+      org.molgenis.emx2.json.Table expected = new org.molgenis.emx2.json.Table(supplier);
+      assertEquals(expected, actual);
+    }
+  }
+}

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Column.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Column.java
@@ -3,7 +3,9 @@ package org.molgenis.emx2.json;
 import static java.util.Arrays.stream;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 import org.molgenis.emx2.ColumnType;
 import org.molgenis.emx2.MolgenisException;
@@ -66,7 +68,7 @@ public class Column {
     this.name = column.getName();
     this.labels =
         column.getLabels().entrySet().stream()
-            .filter(entry -> entry.getValue() != null && entry.getValue().trim().length() > 0)
+            .filter(entry -> entry.getValue() != null && !entry.getValue().trim().isEmpty())
             .map(entry -> new LanguageValue(entry.getKey(), entry.getValue()))
             .toList();
     this.formLabel = column.getFormLabel();
@@ -109,7 +111,7 @@ public class Column {
     this.defaultValue = column.getDefaultValue();
     this.descriptions =
         column.getDescriptions().entrySet().stream()
-            .filter(entry -> entry.getValue() != null && entry.getValue().trim().length() > 0)
+            .filter(entry -> entry.getValue() != null && !entry.getValue().trim().isEmpty())
             .map(entry -> new LanguageValue(entry.getKey(), entry.getValue()))
             .toList();
     this.semantics =
@@ -446,5 +448,186 @@ public class Column {
 
   public void setFormLabel(String formLabel) {
     this.formLabel = formLabel;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Column column = (Column) o;
+    return drop == column.drop
+        && inherited == column.inherited
+        && Objects.equals(table, column.table)
+        && Objects.equals(id, column.id)
+        && Objects.equals(name, column.name)
+        && Objects.equals(label, column.label)
+        && Objects.equals(section, column.section)
+        && Objects.equals(heading, column.heading)
+        && Objects.equals(description, column.description)
+        && Objects.equals(labels, column.labels)
+        && Objects.equals(formLabel, column.formLabel)
+        && Objects.equals(oldName, column.oldName)
+        && Objects.equals(key, column.key)
+        && Objects.equals(required, column.required)
+        && Objects.equals(readonly, column.readonly)
+        && Objects.equals(defaultValue, column.defaultValue)
+        && Objects.equals(refSchemaId, column.refSchemaId)
+        && Objects.equals(refSchemaName, column.refSchemaName)
+        && Objects.equals(refTableId, column.refTableId)
+        && Objects.equals(refTableName, column.refTableName)
+        && Objects.equals(refLinkId, column.refLinkId)
+        && Objects.equals(refLinkName, column.refLinkName)
+        && Objects.equals(refBackId, column.refBackId)
+        && Objects.equals(refBackName, column.refBackName)
+        && Objects.equals(refLabel, column.refLabel)
+        && Objects.equals(refLabelDefault, column.refLabelDefault)
+        && Objects.equals(position, column.position)
+        && Objects.equals(cascadeDelete, column.cascadeDelete)
+        && Objects.equals(validation, column.validation)
+        && Objects.equals(visible, column.visible)
+        && Objects.equals(computed, column.computed)
+        && Objects.equals(descriptions, column.descriptions)
+        && columnType == column.columnType
+        && Objects.deepEquals(semantics, column.semantics)
+        && Objects.deepEquals(profiles, column.profiles);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        table,
+        id,
+        name,
+        label,
+        section,
+        heading,
+        description,
+        labels,
+        formLabel,
+        drop,
+        oldName,
+        key,
+        required,
+        readonly,
+        defaultValue,
+        refSchemaId,
+        refSchemaName,
+        refTableId,
+        refTableName,
+        refLinkId,
+        refLinkName,
+        refBackId,
+        refBackName,
+        refLabel,
+        refLabelDefault,
+        position,
+        cascadeDelete,
+        validation,
+        visible,
+        computed,
+        descriptions,
+        columnType,
+        Arrays.hashCode(semantics),
+        Arrays.hashCode(profiles),
+        inherited);
+  }
+
+  @Override
+  public String toString() {
+    return "Column{"
+        + "table='"
+        + table
+        + '\''
+        + ", id='"
+        + id
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", label='"
+        + label
+        + '\''
+        + ", section='"
+        + section
+        + '\''
+        + ", heading='"
+        + heading
+        + '\''
+        + ", description='"
+        + description
+        + '\''
+        + ", labels="
+        + labels
+        + ", formLabel='"
+        + formLabel
+        + '\''
+        + ", drop="
+        + drop
+        + ", oldName='"
+        + oldName
+        + '\''
+        + ", key="
+        + key
+        + ", required='"
+        + required
+        + '\''
+        + ", readonly="
+        + readonly
+        + ", defaultValue='"
+        + defaultValue
+        + '\''
+        + ", refSchemaId='"
+        + refSchemaId
+        + '\''
+        + ", refSchemaName='"
+        + refSchemaName
+        + '\''
+        + ", refTableId='"
+        + refTableId
+        + '\''
+        + ", refTableName='"
+        + refTableName
+        + '\''
+        + ", refLinkId='"
+        + refLinkId
+        + '\''
+        + ", refLinkName='"
+        + refLinkName
+        + '\''
+        + ", refBackId='"
+        + refBackId
+        + '\''
+        + ", refBackName='"
+        + refBackName
+        + '\''
+        + ", refLabel='"
+        + refLabel
+        + '\''
+        + ", refLabelDefault='"
+        + refLabelDefault
+        + '\''
+        + ", position="
+        + position
+        + ", cascadeDelete="
+        + cascadeDelete
+        + ", validation='"
+        + validation
+        + '\''
+        + ", visible='"
+        + visible
+        + '\''
+        + ", computed='"
+        + computed
+        + '\''
+        + ", descriptions="
+        + descriptions
+        + ", columnType="
+        + columnType
+        + ", semantics="
+        + Arrays.toString(semantics)
+        + ", profiles="
+        + Arrays.toString(profiles)
+        + ", inherited="
+        + inherited
+        + '}';
   }
 }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Schema.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Schema.java
@@ -11,6 +11,7 @@ import org.molgenis.emx2.TableMetadata;
 
 public class Schema {
 
+  private String name;
   private List<Table> tables = new ArrayList<>();
   private List<Setting> settings = new ArrayList<>();
 
@@ -39,7 +40,7 @@ public class Schema {
   }
 
   public SchemaMetadata getSchemaMetadata() {
-    SchemaMetadata s = new SchemaMetadata();
+    SchemaMetadata s = new SchemaMetadata(name);
     s.setSettings(
         this.settings.stream()
             .filter(d -> d.value() != null)
@@ -80,6 +81,14 @@ public class Schema {
     return s;
   }
 
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
   public List<Table> getTables() {
     return tables;
   }
@@ -94,5 +103,32 @@ public class Schema {
 
   public void setSettings(List<Setting> settings) {
     this.settings = settings;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Schema schema = (Schema) o;
+    return Objects.equals(name, schema.name)
+        && Objects.equals(tables, schema.tables)
+        && Objects.equals(settings, schema.settings);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(name, tables, settings);
+  }
+
+  @Override
+  public String toString() {
+    return "Schema{"
+        + "name='"
+        + name
+        + '\''
+        + ", tables="
+        + tables
+        + ", settings="
+        + settings
+        + '}';
   }
 }

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Schema.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Schema.java
@@ -24,6 +24,7 @@ public class Schema {
   }
 
   public Schema(SchemaMetadata schema, boolean minimal) {
+    this.name = schema.getName();
     this.settings =
         schema.getSettings().entrySet().stream()
             .filter(entry -> !MOLGENIS_JWT_SHARED_SECRET.equals(entry.getKey()))
@@ -40,7 +41,10 @@ public class Schema {
   }
 
   public SchemaMetadata getSchemaMetadata() {
-    SchemaMetadata s = new SchemaMetadata(name);
+    SchemaMetadata s = new SchemaMetadata();
+    if (name != null) {
+      s.setName(name);
+    }
     s.setSettings(
         this.settings.stream()
             .filter(d -> d.value() != null)

--- a/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Table.java
+++ b/backend/molgenis-emx2-graphql/src/main/java/org/molgenis/emx2/json/Table.java
@@ -3,9 +3,7 @@ package org.molgenis.emx2.json;
 import static java.util.Arrays.stream;
 import static org.molgenis.emx2.utils.TypeUtils.convertToPascalCase;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
+import java.util.*;
 import org.molgenis.emx2.*;
 
 public class Table {
@@ -44,7 +42,7 @@ public class Table {
     this.description = tableMetadata.getDescription();
     this.labels =
         tableMetadata.getLabels().entrySet().stream()
-            .filter(entry -> entry.getValue() != null && entry.getValue().trim().length() > 0)
+            .filter(entry -> entry.getValue() != null && !entry.getValue().trim().isEmpty())
             .map(entry -> new LanguageValue(entry.getKey(), entry.getValue()))
             .toList();
     this.id = tableMetadata.getIdentifier();
@@ -57,7 +55,7 @@ public class Table {
     }
     this.descriptions =
         tableMetadata.getDescriptions().entrySet().stream()
-            .filter(entry -> entry.getValue() != null && entry.getValue().trim().length() > 0)
+            .filter(entry -> entry.getValue() != null && !entry.getValue().trim().isEmpty())
             .map(entry -> new LanguageValue(entry.getKey(), entry.getValue()))
             .toList();
     this.semantics =
@@ -83,8 +81,8 @@ public class Table {
       this.columns.add(jsonColumn);
     }
     // should always have a section as first column
-    if (this.columns.size() > 0
-        && !this.columns.get(0).getColumnType().equals(ColumnType.SECTION)) {
+    if (!this.columns.isEmpty()
+        && !this.columns.getFirst().getColumnType().equals(ColumnType.SECTION)) {
       Column firstHeading = new Column();
       firstHeading.setId(Constants.MG_TOP_OF_FORM);
       firstHeading.setName(Constants.MG_TOP_OF_FORM);
@@ -92,7 +90,7 @@ public class Table {
       firstHeading.setColumnType(ColumnType.SECTION);
       firstHeading.setSection(Constants.MG_TOP_OF_FORM);
       firstHeading.setTable(this.name);
-      this.columns.add(0, firstHeading);
+      this.columns.addFirst(firstHeading);
     }
     this.tableType = tableMetadata.getTableType();
     this.profiles = tableMetadata.getProfiles();
@@ -248,5 +246,107 @@ public class Table {
 
   public void setSchemaId(String schemaId) {
     this.schemaId = schemaId;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    Table table = (Table) o;
+    return drop == table.drop
+        && Objects.equals(schemaId, table.schemaId)
+        && Objects.equals(name, table.name)
+        && Objects.equals(label, table.label)
+        && Objects.equals(description, table.description)
+        && Objects.equals(oldName, table.oldName)
+        && Objects.deepEquals(pkey, table.pkey)
+        && Objects.equals(inheritId, table.inheritId)
+        && Objects.equals(inheritName, table.inheritName)
+        && Objects.equals(inheritSchemaName, table.inheritSchemaName)
+        && Objects.equals(labels, table.labels)
+        && Objects.equals(descriptions, table.descriptions)
+        && Objects.equals(unique, table.unique)
+        && Objects.equals(columns, table.columns)
+        && Objects.equals(settings, table.settings)
+        && Objects.deepEquals(semantics, table.semantics)
+        && Objects.deepEquals(profiles, table.profiles)
+        && Objects.equals(id, table.id)
+        && tableType == table.tableType;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(
+        schemaId,
+        name,
+        label,
+        description,
+        oldName,
+        drop,
+        Arrays.hashCode(pkey),
+        inheritId,
+        inheritName,
+        inheritSchemaName,
+        labels,
+        descriptions,
+        unique,
+        columns,
+        settings,
+        Arrays.hashCode(semantics),
+        Arrays.hashCode(profiles),
+        id,
+        tableType);
+  }
+
+  @Override
+  public String toString() {
+    return "Table{"
+        + "schemaId='"
+        + schemaId
+        + '\''
+        + ", name='"
+        + name
+        + '\''
+        + ", label='"
+        + label
+        + '\''
+        + ", description='"
+        + description
+        + '\''
+        + ", oldName='"
+        + oldName
+        + '\''
+        + ", drop="
+        + drop
+        + ", pkey="
+        + Arrays.toString(pkey)
+        + ", inheritId='"
+        + inheritId
+        + '\''
+        + ", inheritName='"
+        + inheritName
+        + '\''
+        + ", inheritSchemaName='"
+        + inheritSchemaName
+        + '\''
+        + ", labels="
+        + labels
+        + ", descriptions="
+        + descriptions
+        + ", unique="
+        + unique
+        + ", columns="
+        + columns
+        + ", settings="
+        + settings
+        + ", semantics="
+        + Arrays.toString(semantics)
+        + ", profiles="
+        + Arrays.toString(profiles)
+        + ", id='"
+        + id
+        + '\''
+        + ", tableType="
+        + tableType
+        + '}';
   }
 }

--- a/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlSchemaFields.java
+++ b/backend/molgenis-emx2-graphql/src/test/java/org/molgenis/emx2/graphql/TestGraphqlSchemaFields.java
@@ -742,13 +742,13 @@ class TestGraphqlSchemaFields {
   @Test
   void testAddAlterDropColumn() throws IOException {
     execute("mutation{change(columns:{table:\"Pet\",name:\"test\"}){message}}");
-    assertNotNull(database.getSchema(schemaName).getTable("Pet").getMetadata().getColumn("test"));
+    assertNotNull(database.getSchemaMetadata(schemaName).getTableMetadata("Pet").getColumn("test"));
     execute(
         "mutation{change(columns:{table:\"Pet\", oldName:\"test\",name:\"test2\", key:3, columnType:\"INT\"}){message}}");
 
     database.clearCache(); // cannot know here, server clears caches
 
-    assertNull(database.getSchema(schemaName).getTable("Pet").getMetadata().getColumn("test"));
+    assertNull(database.getSchemaMetadata(schemaName).getTableMetadata("Pet").getColumn("test"));
     assertEquals(
         ColumnType.INT,
         database
@@ -762,7 +762,7 @@ class TestGraphqlSchemaFields {
 
     database.clearCache(); // cannot know here, server clears caches
 
-    assertNull(database.getSchema(schemaName).getTable("Pet").getMetadata().getColumn("test2"));
+    assertNull(database.getSchemaMetadata(schemaName).getTableMetadata("Pet").getColumn("test2"));
 
     execute(
         "mutation{change(columns:{table:\"Pet\", name:\"test2\", columnType:\"STRING\", visible:\"blaat\"}){message}}");

--- a/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
+++ b/backend/molgenis-emx2-rdf/src/test/java/org/molgenis/emx2/rdf/generators/query/SparqlQueryingExampleTest.java
@@ -31,7 +31,7 @@ class SparqlQueryingExampleTest {
               .run();
 
           SchemaMetadata schema =
-              TestDatabaseFactory.getTestDatabase().getSchema("harvesting").getMetadata();
+              TestDatabaseFactory.getTestDatabase().getSchemaMetadata("harvesting");
           TableQueryGenerator generator = new TableQueryGenerator();
           String query = generator.generate(schema.getTableMetadata("Collections"));
           System.out.println(query);

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/ChangeLogUtils.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/ChangeLogUtils.java
@@ -62,7 +62,7 @@ public class ChangeLogUtils {
   public static boolean isChangeSchema(Database db, String schemaName) {
     return TRUE.equals(
         TypeUtils.toBool(
-            db.getSchema(schemaName).getMetadata().getSetting(Constants.IS_CHANGELOG_ENABLED)));
+            db.getSchemaMetadata(schemaName).getSetting(Constants.IS_CHANGELOG_ENABLED)));
   }
 
   private static String buildFunctionName(String tableName) {

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlColumnExecutor.java
@@ -280,7 +280,7 @@ public class SqlColumnExecutor {
         throw new MolgenisException(
             "refSchema '" + column.getRefSchemaName() + "' does not exist or permission denied");
       }
-      refSchema = schema.getDatabase().getSchema(column.getRefSchemaName()).getMetadata();
+      refSchema = schema.getDatabase().getSchemaMetadata(column.getRefSchemaName());
     }
     if (refSchema.getTableMetadata(column.getRefTableName()) == null) {
       TableMetadata tm =

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlRoleManager.java
@@ -173,7 +173,7 @@ public class SqlRoleManager {
 
   private void assertNoMgRolesReference(
       DSLContext jooq, String schemaName, String roleName, Collection<String> tableNames) {
-    SchemaMetadata schemaMetadata = database.getSchema(schemaName).getMetadata();
+    SchemaMetadata schemaMetadata = database.getSchemaMetadata(schemaName);
     for (String tableName : tableNames) {
       if (schemaMetadata.getTableMetadata(tableName).getColumn(MG_ROLES) == null) {
         continue;
@@ -298,7 +298,7 @@ public class SqlRoleManager {
     if (!database.getSchema(schemaName).getTableNames().contains(tableName)) {
       throw new MolgenisException("Table does not exist: " + tableName);
     }
-    TableMetadata meta = database.getSchema(schemaName).getMetadata().getTableMetadata(tableName);
+    TableMetadata meta = database.getSchemaMetadata(schemaName).getTableMetadata(tableName);
     if (meta.getInheritName() != null) {
       throw new MolgenisException(
           "Cannot grant custom permission on inherited table '"
@@ -613,7 +613,7 @@ public class SqlRoleManager {
     List<TablePermission> permissions = getPermissions(schemaName, roleName);
     if (!system) {
       Set<String> rootTables =
-          database.getSchema(schemaName).getMetadata().getRootTables().stream()
+          database.getSchemaMetadata(schemaName).getRootTables().stream()
               .map(TableMetadata::getTableName)
               .collect(Collectors.toSet());
       permissions =

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlSchemaMetadata.java
@@ -165,7 +165,7 @@ public class SqlSchemaMetadata extends SchemaMetadata {
   }
 
   private SqlSchemaMetadata dropTransaction(String tableName, Database database) {
-    SqlSchemaMetadata sm = (SqlSchemaMetadata) database.getSchema(getName()).getMetadata();
+    SqlSchemaMetadata sm = (SqlSchemaMetadata) database.getSchemaMetadata(getName());
     sm.getTableMetadata(tableName).drop();
     sm.tables.remove(tableName);
     return sm;

--- a/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
+++ b/backend/molgenis-emx2-sql/src/main/java/org/molgenis/emx2/sql/SqlTableMetadata.java
@@ -33,7 +33,7 @@ class SqlTableMetadata extends TableMetadata {
   private static SqlTableMetadata addTransaction(
       Database db, String schemaName, String tableName, Column[] column) {
     SqlTableMetadata tm =
-        (SqlTableMetadata) db.getSchema(schemaName).getMetadata().getTableMetadata(tableName);
+        (SqlTableMetadata) db.getSchemaMetadata(schemaName).getTableMetadata(tableName);
 
     // first per-column actions, then multi-column action such as composite keys/refs
     int position = MetadataUtils.getMaxPosition(tm.getJooq(), schemaName) + 1;
@@ -125,7 +125,7 @@ class SqlTableMetadata extends TableMetadata {
   // ensure the transaction has no side effects on 'this' until completed
   private static SqlTableMetadata alterNameTransaction(
       Database db, String schemaName, String tableName, String newName) {
-    SqlSchemaMetadata sm = (SqlSchemaMetadata) db.getSchema(schemaName).getMetadata();
+    SqlSchemaMetadata sm = (SqlSchemaMetadata) db.getSchemaMetadata(schemaName);
     SqlTableMetadata tm = sm.getTableMetadata(tableName);
 
     validateTableIdentifierIsUnique(sm, new TableMetadata(newName));
@@ -143,7 +143,7 @@ class SqlTableMetadata extends TableMetadata {
     List<Column> refbackColumns =
         tm.getColumns().stream()
             .filter(c -> c.getReferenceRefback() != null)
-            .map(c -> c.getReferenceRefback())
+            .map(Column::getReferenceRefback)
             .toList();
 
     // rename table and triggers
@@ -233,7 +233,7 @@ class SqlTableMetadata extends TableMetadata {
   private static SqlTableMetadata alterColumnTransaction(
       String schemaName, String tableName, String columnName, Column column, Database db) {
     SqlTableMetadata tm =
-        (SqlTableMetadata) db.getSchema(schemaName).getMetadata().getTableMetadata(tableName);
+        (SqlTableMetadata) db.getSchemaMetadata(schemaName).getTableMetadata(tableName);
     Column newColumn = new Column(tm, column);
     Column oldColumn = tm.getColumn(columnName);
 
@@ -339,7 +339,7 @@ class SqlTableMetadata extends TableMetadata {
   private static SqlTableMetadata dropColumnTransaction(
       Database db, String schemaName, String tableName, String columnName) {
     SqlTableMetadata tm =
-        (SqlTableMetadata) db.getSchema(schemaName).getTable(tableName).getMetadata();
+        (SqlTableMetadata) db.getSchemaMetadata(schemaName).getTableMetadata(tableName);
     DSLContext jooq = ((SqlDatabase) db).getJooq();
     SqlColumnExecutor.executeRemoveColumn(jooq, tm.getColumn(columnName));
     tm.columns.remove(columnName);
@@ -471,7 +471,7 @@ class SqlTableMetadata extends TableMetadata {
 
   private static void dropTransaction(Database db, String schemaName, String tableName) {
     DSLContext jooq = ((SqlDatabase) db).getJooq();
-    TableMetadata tm = db.getSchema(schemaName).getTable(tableName).getMetadata();
+    TableMetadata tm = db.getSchemaMetadata(schemaName).getTableMetadata(tableName);
     executeDropTable(jooq, tm);
     MetadataUtils.deleteTable(jooq, tm);
   }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/ChangeLogExecutorTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/ChangeLogExecutorTest.java
@@ -36,7 +36,7 @@ class ChangeLogExecutorTest {
     settings.put(IS_CHANGELOG_ENABLED, "true");
     schemaA = sqlDatabase.getSchema("ChangeLogExecutorTestA");
     schemaA.getMetadata().setSettings(settings);
-    sqlDatabase.getSchema("ChangeLogExecutorTestB").getMetadata().setSettings(settings);
+    sqlDatabase.getSchemaMetadata("ChangeLogExecutorTestB").setSettings(settings);
 
     schemaA.create(table("test", column("A").setPkey(), column("B")));
     schemaA.getTable("test").insert(List.of(row("A", "a1", "B", "B")));

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/SqlDatabaseTest.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/SqlDatabaseTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.molgenis.emx2.Constants;
+import org.molgenis.emx2.MolgenisException;
 import uk.org.webcompere.systemstubs.environment.EnvironmentVariables;
 import uk.org.webcompere.systemstubs.jupiter.SystemStub;
 import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
@@ -40,5 +41,16 @@ class SqlDatabaseTest {
     settings.put(Constants.IS_OIDC_ENABLED, "false");
     sqlDatabase.setSettings(settings);
     assertFalse(sqlDatabase.isOidcEnabled());
+  }
+
+  @Test
+  void whenSchemaMetadataDoesNotExist_thenThrowMolgenisException() {
+    assertThrows(
+        MolgenisException.class, () -> sqlDatabase.getSchemaMetadata("non-existent-schema"));
+  }
+
+  @Test
+  void whenSchemaDoesNotExist_thenReturnNull() {
+    assertNull(sqlDatabase.getSchema("non-existent-schema"));
   }
 }

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestBatchRequestsForSpeed.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestBatchRequestsForSpeed.java
@@ -154,7 +154,7 @@ public class TestBatchRequestsForSpeed {
     assertEquals(8, personTable.getMetadata().getColumns().size());
 
     // drop a fromTable
-    db.getSchema("testCreate").getMetadata().drop(personTable.getName());
+    db.getSchemaMetadata("testCreate").drop(personTable.getName());
     assertNull(db.getSchema("testCreate").getTable(personTable.getName()));
 
     // make sure nothing was left behind in backend

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestInherits.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestInherits.java
@@ -87,12 +87,8 @@ class TestInherits {
                 .add(column("directs").setType(REF_ARRAY).setRefTable("Employee")));
 
     Schema otherSchema = db.createSchema(TestInherits.class.getSimpleName() + "1");
-    Table ceo =
-        otherSchema.create(
-            table("CEO")
-                .setInheritName("Manager")
-                .setImportSchema(s.getName())
-                .add(column("title")));
+    otherSchema.create(
+        table("CEO").setInheritName("Manager").setImportSchema(s.getName()).add(column("title")));
 
     // try to add column that already exists in parent
     try {
@@ -515,7 +511,7 @@ class TestInherits {
         exception.getMessage());
     assertEquals(
         parentA,
-        db.getSchema(childSchemaName).getMetadata().getTableMetadata("MyShape").getImportSchema());
+        db.getSchemaMetadata(childSchemaName).getTableMetadata("MyShape").getImportSchema());
     db.getSchema(childSchemaName).getTable("MyShape").insert(row("name", "s1", "size", 3));
     assertEquals(1, db.getSchema(childSchemaName).getTable("MyShape").retrieveRows().size());
     assertDoesNotThrow(() -> db.dropSchema(childSchemaName));
@@ -545,7 +541,7 @@ class TestInherits {
                     + schemaName
                     + ".MyShape': inheritance cannot be changed after the table is created."),
         exception.getMessage());
-    TableMetadata after = db.getSchema(schemaName).getMetadata().getTableMetadata("MyShape");
+    TableMetadata after = db.getSchemaMetadata(schemaName).getTableMetadata("MyShape");
     assertEquals("Shape", after.getInheritName());
     assertTrue(after.getColumnNames().contains("name"), after.getColumnNames().toString());
     db.getSchema(schemaName).getTable("MyShape").insert(row("name", "s1", "size", 3));
@@ -576,7 +572,7 @@ class TestInherits {
                     + ".MyShape': inheritance cannot be changed after the table is created."),
         exception.getMessage());
 
-    TableMetadata after = db.getSchema(schemaName).getMetadata().getTableMetadata("MyShape");
+    TableMetadata after = db.getSchemaMetadata(schemaName).getTableMetadata("MyShape");
     assertNull(after.getInheritName());
     assertFalse(after.getColumnNames().contains("name"), after.getColumnNames().toString());
     db.getSchema(schemaName).getTable("MyShape").insert(row("myid", "m1", "size", 3));
@@ -607,7 +603,7 @@ class TestInherits {
         exception.getMessage());
     assertFalse(exception.getMessage().contains("already exists"), exception.getMessage());
 
-    TableMetadata after = db.getSchema(schemaName).getMetadata().getTableMetadata("MyShape");
+    TableMetadata after = db.getSchemaMetadata(schemaName).getTableMetadata("MyShape");
     assertNull(after.getInheritName());
     assertTrue(after.getColumnNames().contains("name"), after.getColumnNames().toString());
     db.getSchema(schemaName).getTable("MyShape").insert(row("name", "s1", "size", 3));
@@ -644,7 +640,7 @@ class TestInherits {
                     + ".MyShape': inheritance cannot be changed after the table is created."),
         exception.getMessage());
 
-    TableMetadata after = db.getSchema(schemaName).getMetadata().getTableMetadata("MyShape");
+    TableMetadata after = db.getSchemaMetadata(schemaName).getTableMetadata("MyShape");
     assertNull(after.getImportSchema());
     assertEquals("Shape", after.getInheritName());
     db.getSchema(schemaName).getTable("MyShape").insert(row("name", "s1", "size", 3));
@@ -675,7 +671,7 @@ class TestInherits {
                     + ".MyShape': inheritance cannot be changed after the table is created."),
         exception.getMessage());
 
-    TableMetadata after = db.getSchema(schemaName).getMetadata().getTableMetadata("MyShape");
+    TableMetadata after = db.getSchemaMetadata(schemaName).getTableMetadata("MyShape");
     assertEquals("Shape", after.getInheritName());
     db.getSchema(schemaName).getTable("MyShape").insert(row("name", "s1", "size", 3));
     assertEquals(1, db.getSchema(schemaName).getTable("MyShape").retrieveRows().size());
@@ -694,8 +690,7 @@ class TestInherits {
             .setImportSchema(parentSchemaName)
             .setInheritName("Shape"));
 
-    TableMetadata parentTable =
-        db.getSchema(parentSchemaName).getMetadata().getTableMetadata("Shape");
+    TableMetadata parentTable = db.getSchemaMetadata(parentSchemaName).getTableMetadata("Shape");
 
     MolgenisException exception =
         assertThrows(MolgenisException.class, () -> parentTable.alterName("Renamed"));
@@ -712,7 +707,7 @@ class TestInherits {
                     + RENAME_NOT_SUPPORTED_YET),
         exception.getMessage());
 
-    assertNotNull(db.getSchema(parentSchemaName).getMetadata().getTableMetadata("Shape"));
+    assertNotNull(db.getSchemaMetadata(parentSchemaName).getTableMetadata("Shape"));
     db.getSchema(childSchemaName).getTable("MyShape").insert(row("name", "s1", "size", 3));
     assertEquals(1, db.getSchema(childSchemaName).getTable("MyShape").retrieveRows().size());
     assertDoesNotThrow(() -> db.dropSchema(childSchemaName));
@@ -743,7 +738,7 @@ class TestInherits {
                     + RENAME_NOT_SUPPORTED_YET),
         exception.getMessage());
 
-    assertNotNull(db.getSchema(schemaName).getMetadata().getTableMetadata("Shape"));
+    assertNotNull(db.getSchemaMetadata(schemaName).getTableMetadata("Shape"));
     db.getSchema(schemaName).getTable("MyShape").insert(row("name", "s1", "size", 3));
     assertEquals(1, db.getSchema(schemaName).getTable("MyShape").retrieveRows().size());
     assertDoesNotThrow(() -> db.dropSchema(schemaName));
@@ -760,7 +755,7 @@ class TestInherits {
         () -> schema.getMetadata().getTableMetadata("MyShape").alterName("MyRenamedShape"));
 
     assertNotNull(
-        db.getSchema(schemaName).getMetadata().getTableMetadata("MyRenamedShape"),
+        db.getSchemaMetadata(schemaName).getTableMetadata("MyRenamedShape"),
         "renaming a child is not blocked by the parent-rename guard");
     assertDoesNotThrow(() -> db.dropSchema(schemaName));
   }
@@ -796,7 +791,7 @@ class TestInherits {
                     + RENAME_NOT_SUPPORTED_YET),
         exception.getMessage());
 
-    assertNotNull(db.getSchema(parentSchemaName).getMetadata().getTableMetadata("Shape"));
+    assertNotNull(db.getSchemaMetadata(parentSchemaName).getTableMetadata("Shape"));
     db.getSchema(childSchemaName).getTable("MyShape").insert(row("name", "s1", "size", 3));
     assertEquals(1, db.getSchema(childSchemaName).getTable("MyShape").retrieveRows().size());
     assertDoesNotThrow(() -> db.dropSchema(childSchemaName));

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSettings.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestSettings.java
@@ -52,11 +52,11 @@ public class TestSettings {
 
           assertEquals("value", schema.getMetadata().getSetting("key"));
 
-          assertEquals("value", db.getSchema("testSchemaSettings").getMetadata().getSetting("key"));
+          assertEquals("value", db.getSchemaMetadata("testSchemaSettings").getSetting("key"));
 
           db.clearCache();
 
-          assertEquals("value", db.getSchema("testSchemaSettings").getMetadata().getSetting("key"));
+          assertEquals("value", db.getSchemaMetadata("testSchemaSettings").getSetting("key"));
 
           db.becomeAdmin();
         });
@@ -97,13 +97,13 @@ public class TestSettings {
 
           db.clearCache();
           Map<String, String> test =
-              db.getSchema("testTableSettings").getTable("test").getMetadata().getSettings();
+              db.getSchemaMetadata("testTableSettings").getTableMetadata("test").getSettings();
           assertEquals(1, test.size());
           assertEquals("value", test.get("key"));
 
           assertEquals(
               "value",
-              db.getSchema("testTableSettings").getTable("test").getMetadata().getSetting("key"));
+              db.getSchemaMetadata("testTableSettings").getTableMetadata("test").getSetting("key"));
 
           db.becomeAdmin();
         });

--- a/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestTableAndColumnMetadataNotTestedElseWhere.java
+++ b/backend/molgenis-emx2-sql/src/test/java/org/molgenis/emx2/sql/TestTableAndColumnMetadataNotTestedElseWhere.java
@@ -46,7 +46,7 @@ public class TestTableAndColumnMetadataNotTestedElseWhere {
     assertEquals((Integer) 2, t.getColumn("col3").getPosition());
     db.clearCache();
 
-    t = db.getSchema("testColumnPosition").getTable("test").getMetadata();
+    t = db.getSchemaMetadata("testColumnPosition").getTableMetadata("test");
     assertEquals("col1", new ArrayList<>(t.getColumnNames()).get(0));
     assertEquals((Integer) 2, t.getColumn("col3").getPosition());
 
@@ -56,13 +56,13 @@ public class TestTableAndColumnMetadataNotTestedElseWhere {
     // when alter without position given then position should be untouched
     t.alterColumn("col3", column("col3").setType(ColumnType.TEXT));
     db.clearCache();
-    t = db.getSchema("testColumnPosition").getTable("test").getMetadata();
+    t = db.getSchemaMetadata("testColumnPosition").getTableMetadata("test");
     assertEquals((Integer) 1, t.getColumn("col3").getPosition());
 
     t.alterColumn("col1", column("col1").setPosition(2));
     assertEquals(new ArrayList<>(t.getColumnNames()).get(0), "col2");
     db.clearCache();
-    t = db.getSchema("testColumnPosition").getTable("test").getMetadata();
+    t = db.getSchemaMetadata("testColumnPosition").getTableMetadata("test");
     assertEquals(new ArrayList<>(t.getColumnNames()).get(0), "col2");
   }
 }

--- a/backend/molgenis-emx2-webapi/src/testFixtures/java/org/molgenis/emx2/web/ApiTestBase.java
+++ b/backend/molgenis-emx2-webapi/src/testFixtures/java/org/molgenis/emx2/web/ApiTestBase.java
@@ -6,6 +6,7 @@ import static org.molgenis.emx2.Constants.MOLGENIS_METRICS_ENABLED;
 import io.restassured.RestAssured;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.molgenis.emx2.Database;
 import org.molgenis.emx2.sql.TestDatabaseFactory;
@@ -44,11 +45,13 @@ import uk.org.webcompere.systemstubs.jupiter.SystemStubsExtension;
 @ExtendWith(SystemStubsExtension.class)
 public abstract class ApiTestBase {
 
+  private static final int OS_ASSIGNED_PORT = 0;
+
+  private static MolgenisWebservice service;
+
   protected static String sessionId;
   protected static Database database;
-  private static final int OS_ASSIGNED_PORT = 0;
   protected static int port;
-  private static MolgenisWebservice service;
 
   @BeforeAll
   static void setupService() throws Exception {
@@ -62,15 +65,17 @@ public abstract class ApiTestBase {
     RestAssured.baseURI = "http://localhost";
   }
 
+  @BeforeEach
+  void clearCache() {
+    ApplicationCachePerUser.getInstance().clearAllCaches();
+  }
+
   static MolgenisWebservice startWebservice() throws Exception {
     MolgenisWebservice startedService = new MolgenisWebservice();
 
     // start web service for testing, including env variables
     new EnvironmentVariables(MOLGENIS_METRICS_ENABLED, Boolean.TRUE.toString())
-        .execute(
-            () -> {
-              startedService.start(OS_ASSIGNED_PORT);
-            });
+        .execute(() -> startedService.start(OS_ASSIGNED_PORT));
 
     return startedService;
   }

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Column.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Column.java
@@ -210,7 +210,7 @@ public class Column extends HasLabelsDescriptionsAndSettings<Column>
     SchemaMetadata schema = getSchema();
     if (this.refSchemaName != null) {
       try {
-        schema = getSchema().getDatabase().getSchema(this.refSchemaName).getMetadata();
+        schema = getSchema().getDatabase().getSchemaMetadata(this.refSchemaName);
       } catch (Exception e) {
         throw new MolgenisException(
             "refSchema '"

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Database.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/Database.java
@@ -33,6 +33,15 @@ public interface Database extends HasSettingsInterface<Database> {
 
   Schema getSchema(String name);
 
+  default SchemaMetadata getSchemaMetadata(String schemaName) {
+    Schema schema = getSchema(schemaName);
+    if (schema == null) {
+      throw new MolgenisException("Could not find schema metadata with name " + schemaName);
+    }
+
+    return schema.getMetadata();
+  }
+
   List<Table> getTablesFromAllSchemas(String tableId);
 
   User addUser(String name);

--- a/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
+++ b/backend/molgenis-emx2/src/main/java/org/molgenis/emx2/TableMetadata.java
@@ -297,7 +297,7 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
     // add meta behind non-meta
     List<Column> metaList =
         new ArrayList<>(
-            columns.values().stream().filter(c -> c.isSystemColumn()).collect(Collectors.toList()));
+            columns.values().stream().filter(Column::isSystemColumn).collect(Collectors.toList()));
     columnList.addAll(metaList);
 
     for (Column c : columnList) {
@@ -310,7 +310,7 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
   }
 
   public List<String> getColumnNames() {
-    return getColumns().stream().map(c -> c.getName()).collect(Collectors.toList());
+    return getColumns().stream().map(Column::getName).collect(Collectors.toList());
   }
 
   public List<String> getNonInheritedColumnNames() {
@@ -624,8 +624,8 @@ public class TableMetadata extends HasLabelsDescriptionsAndSettings<TableMetadat
 
   @Override
   public int compareTo(Object o) {
-    if (o instanceof TableMetadata) {
-      return getTableName().compareTo(((TableMetadata) o).getTableName());
+    if (o instanceof TableMetadata metadata) {
+      return getTableName().compareTo((metadata).getTableName());
     }
     return 0;
   }


### PR DESCRIPTION
### What are the main changes you did
Addresses: https://github.com/molgenis/molgenis-emx2/issues/6658

**goal:** this new database will be used as the main database in the FairMapper CLI in order to harvest and write data remotely. 

Integrating this in the harvesting pipeline will be done in a later PR.

- added a GraphQL database implementation:
  - a read-only Database implementation that fetches schema names, schema infos, and schema metadata over GraphQL. All other methods of the interface throw an UnsupportedOperationException
- updated schema json model
  - Added Schema.name
  - Resolved sonar warnings/suggestions
  - Added equals, hashcode and toString methods to Column, Schema and Table
  - Include schema name in JSON output for consistency with model

Small fix: clear the per-user application cache before each ApiTestBase test to prevent cache state leaking between tests.

### How to test

- Unit tests
- output a schema to json and yaml, they both should output the name of a schema

### Checklist

- [ ] checked that code complies with the [dev guidelines](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_guidelines.md)
- [ ] frontend code follows good semantic HTML practices and meets accessibility guidelines [Accessibility guide](https://github.com/molgenis/molgenis-emx2/blob/master/docs/molgenis/dev_accessibility.md)
- [ ] updated docs in case of new feature
- [X] added/updated tests
- [ ] added/updated testplan to include a test for this fix, including ref to bug using # notation

By creating this pull request I have agreed with the [contributor terms](https://github.com/molgenis/molgenis-emx2/blob/master/CONTRIBUTING.md)
